### PR TITLE
feat(cli): add provider selection to dev.sh

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -6,8 +6,15 @@
 set -e
 
 PROVIDER="${1:-}"
+VALID_PROVIDERS="anthropic openai ollama copilot groq"
 
-export JAVA_HOME="${JAVA_HOME:-$(brew --prefix openjdk@21 2>/dev/null)/libexec/openjdk.jdk/Contents/Home}"
+# Auto-detect JAVA_HOME if not set
+if [ -z "$JAVA_HOME" ]; then
+    BREW_JDK="$(brew --prefix openjdk@21 2>/dev/null)/libexec/openjdk.jdk/Contents/Home"
+    if [ -d "$BREW_JDK" ]; then
+        export JAVA_HOME="$BREW_JDK"
+    fi
+fi
 
 ./gradlew :aceclaw-cli:installDist -q
 
@@ -22,8 +29,12 @@ if [ -f ~/.aceclaw/aceclaw.pid ]; then
     sleep 0.3
 fi
 
-# Set provider via env if specified
+# Validate and set provider via env if specified
 if [ -n "$PROVIDER" ]; then
+    case " $VALID_PROVIDERS " in
+        *" $PROVIDER "*) ;;
+        *) echo "❌ Invalid provider: $PROVIDER"; echo "Valid: $VALID_PROVIDERS"; exit 1 ;;
+    esac
     export ACECLAW_PROVIDER="$PROVIDER"
     echo "🔧 Provider: $PROVIDER"
 fi


### PR DESCRIPTION
Add optional provider argument to dev.sh for quick provider switching during development.

```bash
./dev.sh              # default (anthropic)
./dev.sh openai       # OpenAI
./dev.sh ollama       # local Ollama
./dev.sh copilot      # GitHub Copilot
./dev.sh groq         # Groq
```

Sets `ACECLAW_PROVIDER` env var. Also auto-detects `JAVA_HOME` if not set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Development script supports an optional provider parameter with validation and exports the chosen provider for subsequent commands.

* **Chores**
  * Added usage documentation to the development script.
  * Improved default Java Home detection to prefer Homebrew OpenJDK 21 when unset.
  * Added a best-effort shutdown of any existing background daemon (with a fallback termination) before launching the CLI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->