### PR TITLE
test(llm,cli): add AnthropicMapper, OpenAIMapper, and slash command tests

### DIFF
--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
@@ -286,7 +286,7 @@ public final class TerminalRepl {
     /**
      * @return true if the REPL should exit after this command
      */
-    private boolean handleSlashCommand(PrintWriter out, String input) {
+    boolean handleSlashCommand(PrintWriter out, String input) {
         String[] parts = input.split("\\s+", 2);
         String command = parts[0].toLowerCase();
         String arg = parts.length > 1 ? parts[1].trim() : "";

--- a/aceclaw-cli/src/test/java/dev/aceclaw/cli/TerminalReplTest.java
+++ b/aceclaw-cli/src/test/java/dev/aceclaw/cli/TerminalReplTest.java
@@ -1,0 +1,107 @@
+package dev.aceclaw.cli;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests slash command handling in {@link TerminalRepl}.
+ *
+ * <p>Since the REPL is tightly coupled to JLine for I/O, we test the
+ * slash command dispatch directly via the package-private
+ * {@code handleSlashCommand} method.
+ */
+class TerminalReplTest {
+
+    private TerminalRepl repl;
+    private StringWriter outputBuffer;
+    private PrintWriter out;
+
+    @BeforeEach
+    void setUp() {
+        // DaemonClient is needed but slash commands that don't touch it won't fail
+        // We pass null — commands that need it (/tools, /compact) will NPE,
+        // but we only test commands that don't require the client
+        var sessionInfo = new TerminalRepl.SessionInfo("1.0.0", "claude-sonnet-4-5-20250929",
+                "/tmp/project", 200_000, "main");
+        repl = new TerminalRepl(null, "test-session", sessionInfo);
+        outputBuffer = new StringWriter();
+        out = new PrintWriter(outputBuffer);
+    }
+
+    @Test
+    void help_producesHelpOutput() {
+        boolean shouldExit = repl.handleSlashCommand(out, "/help");
+        assertThat(shouldExit).isFalse();
+        String output = outputBuffer.toString();
+        assertThat(output).contains("Available commands");
+        assertThat(output).contains("/help");
+        assertThat(output).contains("/exit");
+        assertThat(output).contains("/model");
+        assertThat(output).contains("/tools");
+    }
+
+    @Test
+    void questionMark_isHelpAlias() {
+        boolean shouldExit = repl.handleSlashCommand(out, "/?");
+        assertThat(shouldExit).isFalse();
+        assertThat(outputBuffer.toString()).contains("Available commands");
+    }
+
+    @Test
+    void clear_returnsFalse() {
+        boolean shouldExit = repl.handleSlashCommand(out, "/clear");
+        assertThat(shouldExit).isFalse();
+        // Outputs ANSI clear screen sequence
+        assertThat(outputBuffer.toString()).contains("\033[2J");
+    }
+
+    @Test
+    void modelWithNoArg_showsCurrentModel() {
+        boolean shouldExit = repl.handleSlashCommand(out, "/model");
+        assertThat(shouldExit).isFalse();
+        assertThat(outputBuffer.toString()).contains("claude-sonnet-4-5-20250929");
+    }
+
+    @Test
+    void modelWithArg_showsSwitchMessage() {
+        boolean shouldExit = repl.handleSlashCommand(out, "/model gpt-4o");
+        assertThat(shouldExit).isFalse();
+        String output = outputBuffer.toString();
+        assertThat(output).contains("gpt-4o");
+    }
+
+    @Test
+    void exit_returnsTrue() {
+        boolean shouldExit = repl.handleSlashCommand(out, "/exit");
+        assertThat(shouldExit).isTrue();
+        assertThat(outputBuffer.toString()).contains("Goodbye");
+    }
+
+    @Test
+    void quit_returnsTrue() {
+        boolean shouldExit = repl.handleSlashCommand(out, "/quit");
+        assertThat(shouldExit).isTrue();
+    }
+
+    @Test
+    void unknownCommand_showsWarning() {
+        boolean shouldExit = repl.handleSlashCommand(out, "/foo");
+        assertThat(shouldExit).isFalse();
+        assertThat(outputBuffer.toString()).contains("Unknown command");
+    }
+
+    @Test
+    void status_showsSessionInfo() {
+        boolean shouldExit = repl.handleSlashCommand(out, "/status");
+        assertThat(shouldExit).isFalse();
+        String output = outputBuffer.toString();
+        assertThat(output).contains("Session Status");
+        assertThat(output).contains("claude-sonnet-4-5-20250929");
+        assertThat(output).contains("/tmp/project");
+    }
+}

--- a/aceclaw-llm/src/test/java/dev/aceclaw/llm/anthropic/AnthropicMapperTest.java
+++ b/aceclaw-llm/src/test/java/dev/aceclaw/llm/anthropic/AnthropicMapperTest.java
@@ -1,0 +1,259 @@
+package dev.aceclaw.llm.anthropic;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.aceclaw.core.llm.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AnthropicMapperTest {
+
+    private ObjectMapper objectMapper;
+    private AnthropicMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper = new AnthropicMapper(objectMapper);
+    }
+
+    private LlmRequest.Builder baseRequest() {
+        return LlmRequest.builder()
+                .model("claude-sonnet-4-5-20250929")
+                .addMessage(Message.user("Hello"));
+    }
+
+    // --- toRequestJson tests ---
+
+    @Test
+    void toRequestJson_producesValidStructure() throws Exception {
+        var schema = objectMapper.createObjectNode();
+        schema.put("type", "object");
+        var tool = new ToolDefinition("read_file", "Read a file", schema);
+
+        var request = baseRequest().addTool(tool).build();
+        String json = mapper.toRequestJson(request, false);
+        JsonNode root = objectMapper.readTree(json);
+
+        assertThat(root.get("model").asText()).isEqualTo("claude-sonnet-4-5-20250929");
+        assertThat(root.get("max_tokens").asInt()).isGreaterThan(0);
+        assertThat(root.get("messages").isArray()).isTrue();
+        assertThat(root.get("messages")).hasSize(1);
+        assertThat(root.get("tools").isArray()).isTrue();
+        assertThat(root.get("tools")).hasSize(1);
+        assertThat(root.has("stream")).isFalse();
+    }
+
+    @Test
+    void systemPrompt_getsCacheControlEphemeral() throws Exception {
+        var request = baseRequest().systemPrompt("You are helpful").build();
+        JsonNode root = objectMapper.readTree(mapper.toRequestJson(request, false));
+
+        JsonNode system = root.get("system");
+        assertThat(system.isArray()).isTrue();
+        assertThat(system).hasSize(1);
+        assertThat(system.get(0).get("type").asText()).isEqualTo("text");
+        assertThat(system.get(0).get("text").asText()).isEqualTo("You are helpful");
+        assertThat(system.get(0).path("cache_control").path("type").asText()).isEqualTo("ephemeral");
+    }
+
+    @Test
+    void lastUserMessage_getsCacheControlOnLastBlock() throws Exception {
+        var request = LlmRequest.builder()
+                .model("test")
+                .addMessage(Message.user("First"))
+                .addMessage(Message.assistant("Reply"))
+                .addMessage(Message.user("Second"))
+                .build();
+        JsonNode root = objectMapper.readTree(mapper.toRequestJson(request, false));
+
+        JsonNode messages = root.get("messages");
+        // First user message (index 0) should NOT have cache_control
+        JsonNode firstUserContent = messages.get(0).get("content");
+        assertThat(firstUserContent.get(firstUserContent.size() - 1).has("cache_control")).isFalse();
+
+        // Last user message (index 2) should have cache_control
+        JsonNode lastUserContent = messages.get(2).get("content");
+        assertThat(lastUserContent.get(lastUserContent.size() - 1)
+                .path("cache_control").path("type").asText()).isEqualTo("ephemeral");
+    }
+
+    @Test
+    void lastToolDefinition_getsCacheControl() throws Exception {
+        var schema = objectMapper.createObjectNode().put("type", "object");
+        var request = baseRequest()
+                .addTool(new ToolDefinition("tool1", "desc1", schema))
+                .addTool(new ToolDefinition("tool2", "desc2", schema))
+                .build();
+        JsonNode root = objectMapper.readTree(mapper.toRequestJson(request, false));
+
+        JsonNode tools = root.get("tools");
+        assertThat(tools.get(0).has("cache_control")).isFalse();
+        assertThat(tools.get(1).path("cache_control").path("type").asText()).isEqualTo("ephemeral");
+    }
+
+    @Test
+    void streamFlag_setsStreamTrue() throws Exception {
+        var request = baseRequest().build();
+        JsonNode root = objectMapper.readTree(mapper.toRequestJson(request, true));
+        assertThat(root.get("stream").asBoolean()).isTrue();
+    }
+
+    @Test
+    void extendedThinking_addsThinkingAndOmitsTemperature() throws Exception {
+        var request = baseRequest().thinkingBudget(5000).build();
+        JsonNode root = objectMapper.readTree(mapper.toRequestJson(request, false));
+
+        assertThat(root.has("thinking")).isTrue();
+        assertThat(root.get("thinking").get("type").asText()).isEqualTo("enabled");
+        assertThat(root.get("thinking").get("budget_tokens").asInt()).isEqualTo(5000);
+        assertThat(root.has("temperature")).isFalse();
+    }
+
+    @Test
+    void toolUseBlock_serializesInputAsJsonObject() throws Exception {
+        var toolUse = new ContentBlock.ToolUse("id1", "read_file", "{\"path\":\"/tmp/x\"}");
+        var request = LlmRequest.builder()
+                .model("test")
+                .addMessage(new Message.AssistantMessage(List.of(toolUse)))
+                .build();
+        JsonNode root = objectMapper.readTree(mapper.toRequestJson(request, false));
+
+        JsonNode input = root.get("messages").get(0).get("content").get(0).get("input");
+        assertThat(input.isObject()).isTrue();
+        assertThat(input.get("path").asText()).isEqualTo("/tmp/x");
+    }
+
+    @Test
+    void thinkingBlocks_areSkippedInOutgoingMessages() throws Exception {
+        var request = LlmRequest.builder()
+                .model("test")
+                .addMessage(new Message.AssistantMessage(List.of(
+                        new ContentBlock.Thinking("internal thought"),
+                        new ContentBlock.Text("visible text")
+                )))
+                .build();
+        JsonNode root = objectMapper.readTree(mapper.toRequestJson(request, false));
+
+        JsonNode content = root.get("messages").get(0).get("content");
+        assertThat(content).hasSize(1);
+        assertThat(content.get(0).get("type").asText()).isEqualTo("text");
+    }
+
+    // --- toResponse tests ---
+
+    @Test
+    void toResponse_parsesTextAndToolUseBlocks() throws Exception {
+        String json = """
+                {
+                  "id": "msg_123",
+                  "model": "claude-sonnet-4-5-20250929",
+                  "stop_reason": "tool_use",
+                  "usage": {"input_tokens": 100, "output_tokens": 50},
+                  "content": [
+                    {"type": "text", "text": "Let me read that file."},
+                    {"type": "tool_use", "id": "tu_1", "name": "read_file", "input": {"path": "/tmp/x"}}
+                  ]
+                }
+                """;
+        LlmResponse response = mapper.toResponse(json);
+
+        assertThat(response.id()).isEqualTo("msg_123");
+        assertThat(response.model()).isEqualTo("claude-sonnet-4-5-20250929");
+        assertThat(response.stopReason()).isEqualTo(StopReason.TOOL_USE);
+        assertThat(response.content()).hasSize(2);
+        assertThat(response.content().get(0)).isInstanceOf(ContentBlock.Text.class);
+        assertThat(((ContentBlock.Text) response.content().get(0)).text()).isEqualTo("Let me read that file.");
+        assertThat(response.content().get(1)).isInstanceOf(ContentBlock.ToolUse.class);
+        assertThat(((ContentBlock.ToolUse) response.content().get(1)).name()).isEqualTo("read_file");
+    }
+
+    @Test
+    void toResponse_parsesStopReasons() throws Exception {
+        for (var entry : List.of(
+                new String[]{"end_turn", "END_TURN"},
+                new String[]{"tool_use", "TOOL_USE"},
+                new String[]{"max_tokens", "MAX_TOKENS"}
+        )) {
+            String json = """
+                    {"id":"x","model":"m","stop_reason":"%s","usage":{},"content":[]}
+                    """.formatted(entry[0]);
+            LlmResponse response = mapper.toResponse(json);
+            assertThat(response.stopReason().name()).isEqualTo(entry[1]);
+        }
+    }
+
+    @Test
+    void parseUsage_handlesMissingAndZeroValues() {
+        // Missing node
+        Usage usage1 = mapper.parseUsage(objectMapper.missingNode());
+        assertThat(usage1.inputTokens()).isZero();
+        assertThat(usage1.outputTokens()).isZero();
+
+        // Empty object
+        Usage usage2 = mapper.parseUsage(objectMapper.createObjectNode());
+        assertThat(usage2.inputTokens()).isZero();
+        assertThat(usage2.outputTokens()).isZero();
+
+        // Null
+        Usage usage3 = mapper.parseUsage(null);
+        assertThat(usage3.inputTokens()).isZero();
+    }
+
+    @Test
+    void parseContentBlock_returnsNullForUnknownTypes() throws Exception {
+        JsonNode node = objectMapper.readTree("{\"type\": \"unknown_type\"}");
+        assertThat(mapper.parseContentBlock(node)).isNull();
+    }
+
+    @Test
+    void toolUse_withNullOrMalformedInput_fallsBackToEmptyObject() throws Exception {
+        // null inputJson
+        var toolUse1 = new ContentBlock.ToolUse("id1", "tool", null);
+        var request1 = LlmRequest.builder().model("m")
+                .addMessage(new Message.AssistantMessage(List.of(toolUse1))).build();
+        JsonNode root1 = objectMapper.readTree(mapper.toRequestJson(request1, false));
+        JsonNode input1 = root1.get("messages").get(0).get("content").get(0).get("input");
+        assertThat(input1.isObject()).isTrue();
+        assertThat(input1.isEmpty()).isTrue();
+
+        // empty string
+        var toolUse2 = new ContentBlock.ToolUse("id2", "tool", "");
+        var request2 = LlmRequest.builder().model("m")
+                .addMessage(new Message.AssistantMessage(List.of(toolUse2))).build();
+        JsonNode root2 = objectMapper.readTree(mapper.toRequestJson(request2, false));
+        JsonNode input2 = root2.get("messages").get(0).get("content").get(0).get("input");
+        assertThat(input2.isObject()).isTrue();
+
+        // malformed JSON
+        var toolUse3 = new ContentBlock.ToolUse("id3", "tool", "not json");
+        var request3 = LlmRequest.builder().model("m")
+                .addMessage(new Message.AssistantMessage(List.of(toolUse3))).build();
+        JsonNode root3 = objectMapper.readTree(mapper.toRequestJson(request3, false));
+        JsonNode input3 = root3.get("messages").get(0).get("content").get(0).get("input");
+        assertThat(input3.isObject()).isTrue();
+        assertThat(input3.isEmpty()).isTrue();
+    }
+
+    @Test
+    void noSystemPrompt_omitsSystemField() throws Exception {
+        var request = LlmRequest.builder().model("m").addMessage(Message.user("hi")).build();
+        JsonNode root = objectMapper.readTree(mapper.toRequestJson(request, false));
+        assertThat(root.has("system")).isFalse();
+    }
+
+    @Test
+    void noThinking_includesTemperature() throws Exception {
+        var request = baseRequest().thinkingBudget(0).temperature(0.7).build();
+        JsonNode root = objectMapper.readTree(mapper.toRequestJson(request, false));
+        assertThat(root.get("temperature").asDouble()).isEqualTo(0.7);
+        assertThat(root.has("thinking")).isFalse();
+    }
+}

--- a/aceclaw-llm/src/test/java/dev/aceclaw/llm/openai/OpenAIMapperTest.java
+++ b/aceclaw-llm/src/test/java/dev/aceclaw/llm/openai/OpenAIMapperTest.java
@@ -1,0 +1,206 @@
+package dev.aceclaw.llm.openai;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.aceclaw.core.llm.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OpenAIMapperTest {
+
+    private ObjectMapper objectMapper;
+    private OpenAIMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper = new OpenAIMapper(objectMapper);
+    }
+
+    private LlmRequest.Builder baseRequest() {
+        return LlmRequest.builder()
+                .model("gpt-4o")
+                .addMessage(Message.user("Hello"));
+    }
+
+    @Test
+    void toRequestJson_producesValidStructure() throws Exception {
+        var schema = objectMapper.createObjectNode().put("type", "object");
+        var request = baseRequest()
+                .addTool(new ToolDefinition("read_file", "Read", schema))
+                .build();
+        JsonNode root = objectMapper.readTree(mapper.toRequestJson(request, false));
+
+        assertThat(root.get("model").asText()).isEqualTo("gpt-4o");
+        assertThat(root.get("max_completion_tokens").asInt()).isGreaterThan(0);
+        assertThat(root.get("messages").isArray()).isTrue();
+        assertThat(root.get("tools").isArray()).isTrue();
+        assertThat(root.get("tool_choice").asText()).isEqualTo("auto");
+        assertThat(root.has("stream")).isFalse();
+    }
+
+    @Test
+    void systemPrompt_isFirstMessage() throws Exception {
+        var request = baseRequest().systemPrompt("Be helpful").build();
+        JsonNode root = objectMapper.readTree(mapper.toRequestJson(request, false));
+        JsonNode messages = root.get("messages");
+
+        assertThat(messages.get(0).get("role").asText()).isEqualTo("system");
+        assertThat(messages.get(0).get("content").asText()).isEqualTo("Be helpful");
+        assertThat(messages.get(1).get("role").asText()).isEqualTo("user");
+    }
+
+    @Test
+    void streamFlag_setsStreamAndOptions() throws Exception {
+        JsonNode root = objectMapper.readTree(mapper.toRequestJson(baseRequest().build(), true));
+        assertThat(root.get("stream").asBoolean()).isTrue();
+        assertThat(root.get("stream_options").get("include_usage").asBoolean()).isTrue();
+    }
+
+    @Test
+    void toolUseInAssistantMessage_usesToolCallsArray() throws Exception {
+        var toolUse = new ContentBlock.ToolUse("call_1", "read_file", "{\"path\":\"/tmp\"}");
+        var request = LlmRequest.builder()
+                .model("gpt-4o")
+                .addMessage(new Message.AssistantMessage(List.of(toolUse)))
+                .build();
+        JsonNode root = objectMapper.readTree(mapper.toRequestJson(request, false));
+
+        JsonNode msg = root.get("messages").get(0);
+        assertThat(msg.get("role").asText()).isEqualTo("assistant");
+        JsonNode tc = msg.get("tool_calls").get(0);
+        assertThat(tc.get("id").asText()).isEqualTo("call_1");
+        assertThat(tc.get("type").asText()).isEqualTo("function");
+        assertThat(tc.get("function").get("name").asText()).isEqualTo("read_file");
+        assertThat(tc.get("function").get("arguments").asText()).isEqualTo("{\"path\":\"/tmp\"}");
+    }
+
+    @Test
+    void toolResult_mappedAsToolRoleMessage() throws Exception {
+        var result = new ContentBlock.ToolResult("call_1", "file contents", false);
+        var request = LlmRequest.builder()
+                .model("gpt-4o")
+                .addMessage(new Message.UserMessage(List.of(result)))
+                .build();
+        JsonNode root = objectMapper.readTree(mapper.toRequestJson(request, false));
+
+        JsonNode msg = root.get("messages").get(0);
+        assertThat(msg.get("role").asText()).isEqualTo("tool");
+        assertThat(msg.get("tool_call_id").asText()).isEqualTo("call_1");
+        assertThat(msg.get("content").asText()).isEqualTo("file contents");
+    }
+
+    @Test
+    void thinkingBlocks_areStripped() throws Exception {
+        var request = LlmRequest.builder()
+                .model("gpt-4o")
+                .addMessage(new Message.AssistantMessage(List.of(
+                        new ContentBlock.Thinking("hmm"),
+                        new ContentBlock.Text("answer")
+                )))
+                .build();
+        JsonNode root = objectMapper.readTree(mapper.toRequestJson(request, false));
+        JsonNode msg = root.get("messages").get(0);
+        assertThat(msg.get("content").asText()).isEqualTo("answer");
+        assertThat(msg.has("tool_calls")).isFalse();
+    }
+
+    @Test
+    void toolDefinition_wrappedInFunctionType() throws Exception {
+        var schema = objectMapper.createObjectNode().put("type", "object");
+        var request = baseRequest()
+                .addTool(new ToolDefinition("my_tool", "does stuff", schema))
+                .build();
+        JsonNode root = objectMapper.readTree(mapper.toRequestJson(request, false));
+        JsonNode tool = root.get("tools").get(0);
+        assertThat(tool.get("type").asText()).isEqualTo("function");
+        assertThat(tool.get("function").get("name").asText()).isEqualTo("my_tool");
+        assertThat(tool.get("function").get("description").asText()).isEqualTo("does stuff");
+    }
+
+    // --- Response parsing ---
+
+    @Test
+    void toResponse_parsesTextAndToolCalls() throws Exception {
+        String json = """
+                {
+                  "id": "chatcmpl-123",
+                  "model": "gpt-4o",
+                  "choices": [{
+                    "finish_reason": "tool_calls",
+                    "message": {
+                      "content": "Let me check.",
+                      "tool_calls": [{
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": "{\\"path\\":\\"/tmp\\"}"}
+                      }]
+                    }
+                  }],
+                  "usage": {"prompt_tokens": 10, "completion_tokens": 20}
+                }
+                """;
+        LlmResponse response = mapper.toResponse(json);
+        assertThat(response.id()).isEqualTo("chatcmpl-123");
+        assertThat(response.stopReason()).isEqualTo(StopReason.TOOL_USE);
+        assertThat(response.content()).hasSize(2);
+        assertThat(response.content().get(0)).isInstanceOf(ContentBlock.Text.class);
+        assertThat(response.content().get(1)).isInstanceOf(ContentBlock.ToolUse.class);
+        assertThat(response.usage().inputTokens()).isEqualTo(10);
+        assertThat(response.usage().outputTokens()).isEqualTo(20);
+    }
+
+    @Test
+    void toResponse_extractsThinkTags() throws Exception {
+        String json = """
+                {
+                  "id": "x", "model": "m",
+                  "choices": [{"finish_reason": "stop", "message": {"content": "<think>reasoning here</think>Final answer"}}],
+                  "usage": {}
+                }
+                """;
+        LlmResponse response = mapper.toResponse(json);
+        assertThat(response.content()).hasSize(2);
+        assertThat(response.content().get(0)).isInstanceOf(ContentBlock.Thinking.class);
+        assertThat(((ContentBlock.Thinking) response.content().get(0)).text()).isEqualTo("reasoning here");
+        assertThat(((ContentBlock.Text) response.content().get(1)).text()).isEqualTo("Final answer");
+    }
+
+    @Test
+    void toResponse_extractsReasoningField() throws Exception {
+        String json = """
+                {
+                  "id": "x", "model": "m",
+                  "choices": [{"finish_reason": "stop", "message": {"reasoning_content": "deep thought", "content": "42"}}],
+                  "usage": {}
+                }
+                """;
+        LlmResponse response = mapper.toResponse(json);
+        assertThat(response.content()).hasSize(2);
+        assertThat(response.content().get(0)).isInstanceOf(ContentBlock.Thinking.class);
+        assertThat(((ContentBlock.Thinking) response.content().get(0)).text()).isEqualTo("deep thought");
+    }
+
+    @Test
+    void toResponse_emptyChoices_returnsError() throws Exception {
+        String json = """
+                {"id": "x", "model": "m", "choices": [], "usage": {}}
+                """;
+        LlmResponse response = mapper.toResponse(json);
+        assertThat(response.stopReason()).isEqualTo(StopReason.ERROR);
+        assertThat(response.content()).isEmpty();
+    }
+
+    @Test
+    void parseUsage_handlesMissing() {
+        Usage usage = mapper.parseUsage(objectMapper.missingNode());
+        assertThat(usage.inputTokens()).isZero();
+        assertThat(usage.outputTokens()).isZero();
+    }
+}


### PR DESCRIPTION
Tests that were lost during squash merge of PR #5. Adds 36 tests across 3 files:
- AnthropicMapperTest (15): request/response JSON mapping, cache_control, thinking, edge cases
- OpenAIMapperTest (12): request/response mapping, think tags, tool calls
- TerminalReplTest (9): slash command handling (/help, /model, /tools, /exit, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test coverage for Terminal REPL slash command handling, including help, model selection, clear, status, and exit commands.
  * Added unit test suites for API mapper functionality to validate request serialization and response parsing for both Anthropic and OpenAI integrations.

* **Refactor**
  * Adjusted internal code access modifiers for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->