### PR TITLE
feat: add HealthMonitor + CircuitBreaker foundation

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import dev.aceclaw.core.agent.*;
 import dev.aceclaw.core.llm.LlmClient;
+import dev.aceclaw.infra.event.EventBus;
+import dev.aceclaw.infra.health.*;
 import dev.aceclaw.llm.LlmClientFactory;
 import dev.aceclaw.memory.AutoMemoryStore;
 import dev.aceclaw.memory.DailyJournal;
@@ -51,6 +53,8 @@ public final class AceClawDaemon {
     private final SessionHistoryStore historyStore;
     private final AutoMemoryStore memoryStore;
     private final MarkdownMemoryStore markdownStore;
+    private final EventBus eventBus;
+    private final HealthMonitor healthMonitor;
     private final RequestRouter router;
     private final ConnectionBridge connectionBridge;
     private final UdsListener udsListener;
@@ -69,6 +73,13 @@ public final class AceClawDaemon {
         // Infrastructure
         this.objectMapper = createObjectMapper();
         this.shutdownManager = new ShutdownManager();
+
+        // Event bus (async pub/sub for health events, agent events, etc.)
+        this.eventBus = new EventBus();
+        eventBus.start();
+
+        // Health monitor (aggregates per-component health checks)
+        this.healthMonitor = new HealthMonitor(eventBus);
 
         // Lock
         this.lock = new DaemonLock(homeDir.resolve("aceclaw.pid"));
@@ -122,8 +133,18 @@ public final class AceClawDaemon {
             apiKey = "not-configured";
         }
         String model = config.resolvedModel();
-        LlmClient llmClient = LlmClientFactory.create(
+        LlmClient rawLlmClient = LlmClientFactory.create(
                 config.provider(), apiKey, config.refreshToken(), config.baseUrl(), model);
+
+        // Wrap LLM client with circuit breaker for fault isolation
+        var cbConfig = CircuitBreakerConfig.defaultForLlm();
+        var circuitBreaker = new CircuitBreaker(cbConfig, eventBus);
+        LlmClient llmClient = new CircuitBreakerLlmClient(rawLlmClient, circuitBreaker);
+
+        // Register circuit breaker health check
+        healthMonitor.register(new CircuitBreakerHealthCheck(circuitBreaker));
+        log.info("LLM circuit breaker enabled: threshold={}, timeout={}s",
+                cbConfig.failureThreshold(), cbConfig.resetTimeout().toSeconds());
 
         // Resolve effective context window: explicit config > provider default
         int contextWindow = config.contextWindowTokens() > 0
@@ -334,9 +355,10 @@ public final class AceClawDaemon {
             });
         }
 
-        // Expose model name and provider info to health status endpoint
+        // Expose model name, provider info, and health monitor to status endpoint
         router.setModelName(model);
         router.setProviderInfo(config.provider(), contextWindow);
+        router.setHealthMonitor(healthMonitor);
 
         // Register model.list and model.switch RPC methods
         final var llmClientRef = llmClient;
@@ -411,6 +433,18 @@ public final class AceClawDaemon {
         });
 
         shutdownManager.register(new ShutdownManager.ShutdownParticipant() {
+            @Override public String name() { return "Health Monitor"; }
+            @Override public int priority() { return 92; }
+            @Override public void onShutdown() { healthMonitor.stop(); }
+        });
+
+        shutdownManager.register(new ShutdownManager.ShutdownParticipant() {
+            @Override public String name() { return "Event Bus"; }
+            @Override public int priority() { return 15; }
+            @Override public void onShutdown() { eventBus.stop(); }
+        });
+
+        shutdownManager.register(new ShutdownManager.ShutdownParticipant() {
             @Override public String name() { return "Daemon Lock"; }
             @Override public int priority() { return 10; }
             @Override public void onShutdown() { lock.release(); }
@@ -418,7 +452,10 @@ public final class AceClawDaemon {
 
         shutdownManager.installShutdownHook();
 
-        // 3. Start UDS listener
+        // 3. Start health monitor
+        healthMonitor.start();
+
+        // 4. Start UDS listener
         try {
             udsListener.start();
         } catch (Exception e) {
@@ -430,7 +467,7 @@ public final class AceClawDaemon {
         long bootMs = java.time.Duration.between(startedAt, Instant.now()).toMillis();
         log.info("AceClaw daemon ready (boot: {}ms, socket: {})", bootMs, homeDir.resolve("aceclaw.sock"));
 
-        // 4. Block until shutdown
+        // 5. Block until shutdown
         awaitShutdown();
     }
 

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/CircuitBreakerLlmClient.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/CircuitBreakerLlmClient.java
@@ -1,0 +1,83 @@
+package dev.aceclaw.daemon;
+
+import dev.aceclaw.core.llm.*;
+import dev.aceclaw.infra.health.CircuitBreaker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * LlmClient decorator that wraps calls with a {@link CircuitBreaker}.
+ *
+ * <p>The underlying client (e.g. AnthropicClient) already has internal retries.
+ * This circuit breaker opens only when the backend is truly down — after the
+ * inner client's retries are exhausted. When open, calls fail fast with a
+ * {@link LlmException} (status 503, retryable=false).
+ */
+final class CircuitBreakerLlmClient implements LlmClient {
+
+    private static final Logger log = LoggerFactory.getLogger(CircuitBreakerLlmClient.class);
+
+    private final LlmClient delegate;
+    private final CircuitBreaker circuitBreaker;
+
+    CircuitBreakerLlmClient(LlmClient delegate, CircuitBreaker circuitBreaker) {
+        this.delegate = delegate;
+        this.circuitBreaker = circuitBreaker;
+    }
+
+    @Override
+    public List<String> listModels() {
+        return delegate.listModels();
+    }
+
+    @Override
+    public LlmResponse sendMessage(LlmRequest request) throws LlmException {
+        try {
+            return circuitBreaker.executeChecked(() -> delegate.sendMessage(request));
+        } catch (CircuitBreaker.CircuitOpenException e) {
+            throw new LlmException(
+                    "LLM circuit breaker is open: " + e.getMessage(), 503);
+        }
+    }
+
+    @Override
+    public StreamSession streamMessage(LlmRequest request) throws LlmException {
+        try {
+            return circuitBreaker.executeChecked(() -> delegate.streamMessage(request));
+        } catch (CircuitBreaker.CircuitOpenException e) {
+            throw new LlmException(
+                    "LLM circuit breaker is open: " + e.getMessage(), 503);
+        }
+    }
+
+    @Override
+    public String provider() {
+        return delegate.provider();
+    }
+
+    @Override
+    public String defaultModel() {
+        return delegate.defaultModel();
+    }
+
+    @Override
+    public ProviderCapabilities capabilities() {
+        return delegate.capabilities();
+    }
+
+    /**
+     * Returns the underlying (unwrapped) LlmClient.
+     */
+    LlmClient delegate() {
+        return delegate;
+    }
+
+    /**
+     * Returns the circuit breaker protecting this client.
+     */
+    CircuitBreaker circuitBreaker() {
+        return circuitBreaker;
+    }
+}

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/RequestRouter.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/RequestRouter.java
@@ -3,6 +3,7 @@ package dev.aceclaw.daemon;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.aceclaw.infra.health.HealthMonitor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,6 +51,7 @@ public final class RequestRouter {
     private volatile String modelName;
     private volatile String providerName;
     private volatile int contextWindowTokens;
+    private volatile HealthMonitor healthMonitor;
 
     public RequestRouter(SessionManager sessionManager, ObjectMapper objectMapper) {
         this.sessionManager = sessionManager;
@@ -72,6 +74,13 @@ public final class RequestRouter {
     public void setProviderInfo(String provider, int contextWindowTokens) {
         this.providerName = provider;
         this.contextWindowTokens = contextWindowTokens;
+    }
+
+    /**
+     * Sets the health monitor for per-component health reporting.
+     */
+    public void setHealthMonitor(HealthMonitor healthMonitor) {
+        this.healthMonitor = healthMonitor;
     }
 
     /**
@@ -241,7 +250,30 @@ public final class RequestRouter {
 
     private Object handleHealthStatus(JsonNode params) {
         var result = objectMapper.createObjectNode();
-        result.put("status", "healthy");
+
+        var monitor = this.healthMonitor;
+        if (monitor != null) {
+            var snapshot = monitor.snapshot();
+            result.put("status", snapshot.status().name().toLowerCase());
+
+            // Per-component health breakdown
+            if (!snapshot.components().isEmpty()) {
+                var components = objectMapper.createObjectNode();
+                for (var entry : snapshot.components().entrySet()) {
+                    var comp = objectMapper.createObjectNode();
+                    comp.put("status", entry.getValue().status().name().toLowerCase());
+                    if (!entry.getValue().detail().isEmpty()) {
+                        comp.put("detail", entry.getValue().detail());
+                    }
+                    comp.put("timestamp", entry.getValue().timestamp().toString());
+                    components.set(entry.getKey(), comp);
+                }
+                result.set("components", components);
+            }
+        } else {
+            result.put("status", "healthy");
+        }
+
         result.put("activeSessions", sessionManager.sessionCount());
         result.put("timestamp", Instant.now().toString());
         result.put("version", "0.1.0-SNAPSHOT");

--- a/aceclaw-infra/src/main/java/dev/aceclaw/infra/health/CircuitBreaker.java
+++ b/aceclaw-infra/src/main/java/dev/aceclaw/infra/health/CircuitBreaker.java
@@ -1,0 +1,304 @@
+package dev.aceclaw.infra.health;
+
+import dev.aceclaw.infra.event.EventBus;
+import dev.aceclaw.infra.event.HealthEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+/**
+ * Thread-safe circuit breaker for protecting calls to external services.
+ *
+ * <p>State transitions:
+ * <pre>
+ *   CLOSED  —(failureThreshold reached)—→  OPEN
+ *   OPEN    —(resetTimeout elapsed)—→       HALF_OPEN
+ *   HALF_OPEN —(probe succeeds × halfOpenMaxProbes)—→  CLOSED
+ *   HALF_OPEN —(probe fails)—→              OPEN
+ * </pre>
+ *
+ * <p>Uses {@link AtomicReference} for lock-free thread safety. Publishes
+ * {@link HealthEvent.StatusChanged} on state transitions when an {@link EventBus}
+ * is provided.
+ */
+public final class CircuitBreaker {
+
+    private static final Logger log = LoggerFactory.getLogger(CircuitBreaker.class);
+
+    private final CircuitBreakerConfig config;
+    private final EventBus eventBus;
+    private final AtomicReference<CircuitBreakerState> state;
+
+    /**
+     * Functional interface for suppliers that throw checked exceptions.
+     *
+     * @param <T> the return type
+     * @param <E> the exception type
+     */
+    @FunctionalInterface
+    public interface CheckedSupplier<T, E extends Exception> {
+        T get() throws E;
+    }
+
+    /**
+     * Creates a circuit breaker with optional EventBus for health event publishing.
+     *
+     * @param config   circuit breaker configuration
+     * @param eventBus event bus for publishing transitions (may be null)
+     */
+    public CircuitBreaker(CircuitBreakerConfig config, EventBus eventBus) {
+        this.config = config;
+        this.eventBus = eventBus;
+        this.state = new AtomicReference<>(new CircuitBreakerState.Closed(0));
+    }
+
+    /**
+     * Creates a circuit breaker without EventBus (standalone, for testing).
+     */
+    public CircuitBreaker(CircuitBreakerConfig config) {
+        this(config, null);
+    }
+
+    /**
+     * Executes the supplier through the circuit breaker.
+     *
+     * @param supplier the operation to protect
+     * @param <T>      the return type
+     * @return the supplier's result
+     * @throws CircuitOpenException if the circuit is open
+     */
+    public <T> T execute(Supplier<T> supplier) {
+        checkState();
+        try {
+            T result = supplier.get();
+            recordSuccess();
+            return result;
+        } catch (Exception e) {
+            recordFailure();
+            throw e;
+        }
+    }
+
+    /**
+     * Executes a checked supplier through the circuit breaker.
+     *
+     * @param supplier the operation to protect
+     * @param <T>      the return type
+     * @param <E>      the checked exception type
+     * @return the supplier's result
+     * @throws E                    if the supplier throws
+     * @throws CircuitOpenException if the circuit is open (unchecked)
+     */
+    public <T, E extends Exception> T executeChecked(CheckedSupplier<T, E> supplier) throws E {
+        checkState();
+        try {
+            T result = supplier.get();
+            recordSuccess();
+            return result;
+        } catch (CircuitOpenException e) {
+            // Should not happen here (checkState throws before supplier), but be safe
+            throw e;
+        } catch (Exception e) {
+            recordFailure();
+            @SuppressWarnings("unchecked")
+            E typed = (E) e;
+            throw typed;
+        }
+    }
+
+    /**
+     * Returns the current circuit breaker state (snapshot).
+     */
+    public CircuitBreakerState currentState() {
+        return maybeTransitionToHalfOpen(state.get());
+    }
+
+    /**
+     * Returns the configuration.
+     */
+    public CircuitBreakerConfig config() {
+        return config;
+    }
+
+    /**
+     * Manually resets the circuit breaker to closed state.
+     */
+    public void reset() {
+        var prev = state.getAndSet(new CircuitBreakerState.Closed(0));
+        if (!(prev instanceof CircuitBreakerState.Closed c && c.consecutiveFailures() == 0)) {
+            log.info("[{}] Circuit breaker manually reset", config.name());
+            publishTransition(prev, new CircuitBreakerState.Closed(0));
+        }
+    }
+
+    private void checkState() {
+        while (true) {
+            var current = state.get();
+            switch (current) {
+                case CircuitBreakerState.Closed _ -> {
+                    return; // Allow through
+                }
+                case CircuitBreakerState.Open open -> {
+                    if (resetTimeoutElapsed(open)) {
+                        // Try to transition to half-open
+                        var halfOpen = new CircuitBreakerState.HalfOpen(0);
+                        if (state.compareAndSet(current, halfOpen)) {
+                            log.info("[{}] Circuit breaker transitioning OPEN -> HALF_OPEN", config.name());
+                            publishTransition(current, halfOpen);
+                            return; // Allow this call as a probe
+                        }
+                        // CAS failed — another thread transitioned; retry
+                        continue;
+                    }
+                    throw new CircuitOpenException(config.name(), config.resetTimeout());
+                }
+                case CircuitBreakerState.HalfOpen _ -> {
+                    return; // Allow through as probe
+                }
+            }
+        }
+    }
+
+    private void recordSuccess() {
+        while (true) {
+            var current = state.get();
+            switch (current) {
+                case CircuitBreakerState.Closed _ -> {
+                    // Reset failure count on success
+                    if (current instanceof CircuitBreakerState.Closed c && c.consecutiveFailures() > 0) {
+                        var reset = new CircuitBreakerState.Closed(0);
+                        if (state.compareAndSet(current, reset)) return;
+                        continue; // CAS failed, retry
+                    }
+                    return;
+                }
+                case CircuitBreakerState.HalfOpen halfOpen -> {
+                    int probes = halfOpen.successfulProbes() + 1;
+                    if (probes >= config.halfOpenMaxProbes()) {
+                        // Enough probes — close the circuit
+                        var closed = new CircuitBreakerState.Closed(0);
+                        if (state.compareAndSet(current, closed)) {
+                            log.info("[{}] Circuit breaker closing: {} probes succeeded", config.name(), probes);
+                            publishTransition(current, closed);
+                            return;
+                        }
+                        continue;
+                    }
+                    // More probes needed
+                    var updated = new CircuitBreakerState.HalfOpen(probes);
+                    if (state.compareAndSet(current, updated)) return;
+                    continue;
+                }
+                case CircuitBreakerState.Open _ -> {
+                    // Shouldn't happen (we wouldn't execute in open state), but ignore
+                    return;
+                }
+            }
+        }
+    }
+
+    private void recordFailure() {
+        while (true) {
+            var current = state.get();
+            switch (current) {
+                case CircuitBreakerState.Closed closed -> {
+                    int failures = closed.consecutiveFailures() + 1;
+                    if (failures >= config.failureThreshold()) {
+                        var open = new CircuitBreakerState.Open(Instant.now());
+                        if (state.compareAndSet(current, open)) {
+                            log.warn("[{}] Circuit breaker OPENED after {} consecutive failures",
+                                    config.name(), failures);
+                            publishTransition(current, open);
+                            return;
+                        }
+                        continue;
+                    }
+                    var updated = new CircuitBreakerState.Closed(failures);
+                    if (state.compareAndSet(current, updated)) return;
+                    continue;
+                }
+                case CircuitBreakerState.HalfOpen _ -> {
+                    // Probe failed — reopen
+                    var open = new CircuitBreakerState.Open(Instant.now());
+                    if (state.compareAndSet(current, open)) {
+                        log.warn("[{}] Circuit breaker reopened: half-open probe failed", config.name());
+                        publishTransition(current, open);
+                        return;
+                    }
+                    continue;
+                }
+                case CircuitBreakerState.Open _ -> {
+                    return; // Already open
+                }
+            }
+        }
+    }
+
+    private boolean resetTimeoutElapsed(CircuitBreakerState.Open open) {
+        return Duration.between(open.openedAt(), Instant.now()).compareTo(config.resetTimeout()) >= 0;
+    }
+
+    private CircuitBreakerState maybeTransitionToHalfOpen(CircuitBreakerState current) {
+        if (current instanceof CircuitBreakerState.Open open && resetTimeoutElapsed(open)) {
+            var halfOpen = new CircuitBreakerState.HalfOpen(0);
+            if (state.compareAndSet(current, halfOpen)) {
+                publishTransition(current, halfOpen);
+                return halfOpen;
+            }
+            return state.get();
+        }
+        return current;
+    }
+
+    private void publishTransition(CircuitBreakerState from, CircuitBreakerState to) {
+        if (eventBus == null) return;
+
+        var previous = stateToHealthStatus(from);
+        var current = stateToHealthStatus(to);
+        if (previous == current) return;
+
+        eventBus.publish(new HealthEvent.StatusChanged(
+                "circuit-breaker:" + config.name(),
+                previous, current,
+                "State: " + stateLabel(to),
+                Instant.now()));
+    }
+
+    static HealthEvent.Status stateToHealthStatus(CircuitBreakerState state) {
+        return switch (state) {
+            case CircuitBreakerState.Closed _ -> HealthEvent.Status.HEALTHY;
+            case CircuitBreakerState.HalfOpen _ -> HealthEvent.Status.DEGRADED;
+            case CircuitBreakerState.Open _ -> HealthEvent.Status.UNHEALTHY;
+        };
+    }
+
+    private static String stateLabel(CircuitBreakerState state) {
+        return switch (state) {
+            case CircuitBreakerState.Closed c -> "CLOSED(failures=" + c.consecutiveFailures() + ")";
+            case CircuitBreakerState.Open o -> "OPEN(since=" + o.openedAt() + ")";
+            case CircuitBreakerState.HalfOpen h -> "HALF_OPEN(probes=" + h.successfulProbes() + ")";
+        };
+    }
+
+    /**
+     * Thrown when a call is rejected because the circuit is open.
+     */
+    public static final class CircuitOpenException extends RuntimeException {
+
+        private final String circuitName;
+        private final Duration resetTimeout;
+
+        public CircuitOpenException(String circuitName, Duration resetTimeout) {
+            super("Circuit breaker '" + circuitName + "' is open; retry after " + resetTimeout);
+            this.circuitName = circuitName;
+            this.resetTimeout = resetTimeout;
+        }
+
+        public String circuitName() { return circuitName; }
+        public Duration resetTimeout() { return resetTimeout; }
+    }
+}

--- a/aceclaw-infra/src/main/java/dev/aceclaw/infra/health/CircuitBreakerConfig.java
+++ b/aceclaw-infra/src/main/java/dev/aceclaw/infra/health/CircuitBreakerConfig.java
@@ -1,0 +1,42 @@
+package dev.aceclaw.infra.health;
+
+import java.time.Duration;
+
+/**
+ * Configuration for a {@link CircuitBreaker}.
+ *
+ * @param name              human-readable name for logging and health checks
+ * @param failureThreshold  consecutive failures before opening the circuit
+ * @param resetTimeout      how long to stay open before transitioning to half-open
+ * @param halfOpenMaxProbes max successful probes in half-open before closing
+ */
+public record CircuitBreakerConfig(
+        String name,
+        int failureThreshold,
+        Duration resetTimeout,
+        int halfOpenMaxProbes
+) {
+
+    public CircuitBreakerConfig {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("name must not be blank");
+        }
+        if (failureThreshold <= 0) {
+            throw new IllegalArgumentException("failureThreshold must be > 0, got: " + failureThreshold);
+        }
+        if (resetTimeout == null || resetTimeout.isNegative() || resetTimeout.isZero()) {
+            throw new IllegalArgumentException("resetTimeout must be positive");
+        }
+        if (halfOpenMaxProbes <= 0) {
+            throw new IllegalArgumentException("halfOpenMaxProbes must be > 0, got: " + halfOpenMaxProbes);
+        }
+    }
+
+    /**
+     * Sensible defaults for wrapping LLM calls:
+     * 5 consecutive failures to open, 30s reset timeout, 2 probes to close.
+     */
+    public static CircuitBreakerConfig defaultForLlm() {
+        return new CircuitBreakerConfig("llm", 5, Duration.ofSeconds(30), 2);
+    }
+}

--- a/aceclaw-infra/src/main/java/dev/aceclaw/infra/health/CircuitBreakerHealthCheck.java
+++ b/aceclaw-infra/src/main/java/dev/aceclaw/infra/health/CircuitBreakerHealthCheck.java
@@ -1,0 +1,42 @@
+package dev.aceclaw.infra.health;
+
+/**
+ * Adapter that bridges a {@link CircuitBreaker}'s state to the {@link HealthCheck} interface.
+ *
+ * <p>State mapping:
+ * <ul>
+ *   <li>{@link CircuitBreakerState.Closed} → HEALTHY</li>
+ *   <li>{@link CircuitBreakerState.HalfOpen} → DEGRADED</li>
+ *   <li>{@link CircuitBreakerState.Open} → UNHEALTHY</li>
+ * </ul>
+ */
+public final class CircuitBreakerHealthCheck implements HealthCheck {
+
+    private final CircuitBreaker circuitBreaker;
+
+    public CircuitBreakerHealthCheck(CircuitBreaker circuitBreaker) {
+        this.circuitBreaker = circuitBreaker;
+    }
+
+    @Override
+    public String name() {
+        return "circuit-breaker:" + circuitBreaker.config().name();
+    }
+
+    @Override
+    public HealthCheckResult check() {
+        var state = circuitBreaker.currentState();
+        return switch (state) {
+            case CircuitBreakerState.Closed c -> {
+                if (c.consecutiveFailures() == 0) {
+                    yield HealthCheckResult.healthy("Circuit closed, no failures");
+                }
+                yield HealthCheckResult.healthy("Circuit closed, " + c.consecutiveFailures() + " recent failure(s)");
+            }
+            case CircuitBreakerState.HalfOpen h ->
+                    HealthCheckResult.degraded("Circuit half-open, " + h.successfulProbes() + " probe(s) succeeded");
+            case CircuitBreakerState.Open o ->
+                    HealthCheckResult.unhealthy("Circuit open since " + o.openedAt());
+        };
+    }
+}

--- a/aceclaw-infra/src/main/java/dev/aceclaw/infra/health/CircuitBreakerState.java
+++ b/aceclaw-infra/src/main/java/dev/aceclaw/infra/health/CircuitBreakerState.java
@@ -1,0 +1,45 @@
+package dev.aceclaw.infra.health;
+
+import java.time.Instant;
+
+/**
+ * Sealed state hierarchy for {@link CircuitBreaker}.
+ *
+ * <p>Use exhaustive pattern matching:
+ * <pre>{@code
+ * switch (state) {
+ *     case Closed c   -> "closed, failures=" + c.consecutiveFailures();
+ *     case Open o     -> "open since " + o.openedAt();
+ *     case HalfOpen h -> "half-open, probes=" + h.successfulProbes();
+ * }
+ * }</pre>
+ */
+public sealed interface CircuitBreakerState {
+
+    /** Circuit is closed (normal operation). Tracks consecutive failures. */
+    record Closed(int consecutiveFailures) implements CircuitBreakerState {
+        public Closed {
+            if (consecutiveFailures < 0) {
+                throw new IllegalArgumentException("consecutiveFailures must be >= 0");
+            }
+        }
+    }
+
+    /** Circuit is open (rejecting all calls). Records when it opened. */
+    record Open(Instant openedAt) implements CircuitBreakerState {
+        public Open {
+            if (openedAt == null) {
+                throw new IllegalArgumentException("openedAt must not be null");
+            }
+        }
+    }
+
+    /** Circuit is half-open (allowing limited probes). Tracks successful probes. */
+    record HalfOpen(int successfulProbes) implements CircuitBreakerState {
+        public HalfOpen {
+            if (successfulProbes < 0) {
+                throw new IllegalArgumentException("successfulProbes must be >= 0");
+            }
+        }
+    }
+}

--- a/aceclaw-infra/src/main/java/dev/aceclaw/infra/health/HealthCheck.java
+++ b/aceclaw-infra/src/main/java/dev/aceclaw/infra/health/HealthCheck.java
@@ -1,0 +1,23 @@
+package dev.aceclaw.infra.health;
+
+/**
+ * A named health check that reports the status of a component.
+ *
+ * <p>Implementations should be lightweight — the {@link HealthMonitor}
+ * invokes checks periodically on a virtual thread.
+ */
+public interface HealthCheck {
+
+    /**
+     * Returns the unique name of this health check (e.g. "llm", "memory-store").
+     */
+    String name();
+
+    /**
+     * Performs the health check and returns the result.
+     *
+     * <p>Implementations should not throw — capture errors into
+     * {@link HealthCheckResult#unhealthy(String)} instead.
+     */
+    HealthCheckResult check();
+}

--- a/aceclaw-infra/src/main/java/dev/aceclaw/infra/health/HealthCheckResult.java
+++ b/aceclaw-infra/src/main/java/dev/aceclaw/infra/health/HealthCheckResult.java
@@ -1,0 +1,45 @@
+package dev.aceclaw.infra.health;
+
+import dev.aceclaw.infra.event.HealthEvent;
+
+import java.time.Instant;
+
+/**
+ * The result of a single {@link HealthCheck} invocation.
+ *
+ * @param status    the health status
+ * @param detail    human-readable detail (may be empty)
+ * @param timestamp when the check was performed
+ */
+public record HealthCheckResult(
+        HealthEvent.Status status,
+        String detail,
+        Instant timestamp
+) {
+
+    public HealthCheckResult {
+        if (status == null) throw new IllegalArgumentException("status must not be null");
+        if (detail == null) detail = "";
+        if (timestamp == null) timestamp = Instant.now();
+    }
+
+    /** Creates a HEALTHY result with the given detail. */
+    public static HealthCheckResult healthy(String detail) {
+        return new HealthCheckResult(HealthEvent.Status.HEALTHY, detail, Instant.now());
+    }
+
+    /** Creates a HEALTHY result with no detail. */
+    public static HealthCheckResult healthy() {
+        return healthy("");
+    }
+
+    /** Creates a DEGRADED result with the given detail. */
+    public static HealthCheckResult degraded(String detail) {
+        return new HealthCheckResult(HealthEvent.Status.DEGRADED, detail, Instant.now());
+    }
+
+    /** Creates an UNHEALTHY result with the given detail. */
+    public static HealthCheckResult unhealthy(String detail) {
+        return new HealthCheckResult(HealthEvent.Status.UNHEALTHY, detail, Instant.now());
+    }
+}

--- a/aceclaw-infra/src/main/java/dev/aceclaw/infra/health/HealthMonitor.java
+++ b/aceclaw-infra/src/main/java/dev/aceclaw/infra/health/HealthMonitor.java
@@ -1,0 +1,197 @@
+package dev.aceclaw.infra.health;
+
+import dev.aceclaw.infra.event.EventBus;
+import dev.aceclaw.infra.event.HealthEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Aggregates {@link HealthCheck}s and provides an overall system health snapshot.
+ *
+ * <p>Runs a periodic virtual thread that invokes all registered checks,
+ * computes the aggregate status (worst-status-wins), and publishes
+ * {@link HealthEvent.StatusChanged} on transitions.
+ */
+public final class HealthMonitor {
+
+    private static final Logger log = LoggerFactory.getLogger(HealthMonitor.class);
+
+    private static final Duration DEFAULT_CHECK_INTERVAL = Duration.ofSeconds(15);
+
+    private final List<HealthCheck> checks = new CopyOnWriteArrayList<>();
+    private final EventBus eventBus;
+    private final Duration checkInterval;
+    private final AtomicBoolean running = new AtomicBoolean(false);
+    private final AtomicReference<HealthEvent.Status> lastAggregateStatus =
+            new AtomicReference<>(HealthEvent.Status.HEALTHY);
+    private final Map<String, HealthCheckResult> lastResults = new ConcurrentHashMap<>();
+    private volatile Thread monitorThread;
+
+    /**
+     * Creates a HealthMonitor with optional EventBus and custom check interval.
+     *
+     * @param eventBus      event bus for publishing transitions (may be null)
+     * @param checkInterval how often to run health checks
+     */
+    public HealthMonitor(EventBus eventBus, Duration checkInterval) {
+        this.eventBus = eventBus;
+        this.checkInterval = checkInterval != null ? checkInterval : DEFAULT_CHECK_INTERVAL;
+    }
+
+    /**
+     * Creates a HealthMonitor with optional EventBus and default interval.
+     */
+    public HealthMonitor(EventBus eventBus) {
+        this(eventBus, DEFAULT_CHECK_INTERVAL);
+    }
+
+    /**
+     * Creates a standalone HealthMonitor (no EventBus, default interval).
+     */
+    public HealthMonitor() {
+        this(null, DEFAULT_CHECK_INTERVAL);
+    }
+
+    /**
+     * Registers a health check.
+     */
+    public void register(HealthCheck check) {
+        checks.add(check);
+        log.debug("Registered health check: {}", check.name());
+    }
+
+    /**
+     * Starts the periodic monitoring thread.
+     */
+    public void start() {
+        if (running.compareAndSet(false, true)) {
+            // Run an initial check immediately
+            runChecks();
+            monitorThread = Thread.ofVirtual()
+                    .name("health-monitor")
+                    .start(this::monitorLoop);
+            log.info("Health monitor started (interval: {}s, checks: {})",
+                    checkInterval.toSeconds(), checks.size());
+        }
+    }
+
+    /**
+     * Stops the monitoring thread.
+     */
+    public void stop() {
+        if (running.compareAndSet(true, false)) {
+            if (monitorThread != null) {
+                monitorThread.interrupt();
+            }
+            log.info("Health monitor stopped");
+        }
+    }
+
+    /**
+     * Returns whether the monitor is running.
+     */
+    public boolean isRunning() {
+        return running.get();
+    }
+
+    /**
+     * Takes an immediate health snapshot (does NOT trigger a new check round;
+     * returns the latest cached results).
+     */
+    public HealthSnapshot snapshot() {
+        var results = Map.copyOf(lastResults);
+        var aggregate = computeAggregateStatus(results);
+        return new HealthSnapshot(aggregate, results, Instant.now());
+    }
+
+    /**
+     * Forces an immediate check round and returns the snapshot.
+     */
+    public HealthSnapshot checkNow() {
+        runChecks();
+        return snapshot();
+    }
+
+    /**
+     * Returns the number of registered health checks.
+     */
+    public int checkCount() {
+        return checks.size();
+    }
+
+    private void monitorLoop() {
+        while (running.get()) {
+            try {
+                Thread.sleep(checkInterval.toMillis());
+                if (running.get()) {
+                    runChecks();
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+    }
+
+    private void runChecks() {
+        for (var check : checks) {
+            try {
+                var result = check.check();
+                lastResults.put(check.name(), result);
+            } catch (Exception e) {
+                log.error("Health check '{}' threw unexpectedly: {}", check.name(), e.getMessage(), e);
+                lastResults.put(check.name(), HealthCheckResult.unhealthy("Check failed: " + e.getMessage()));
+            }
+        }
+
+        var newAggregate = computeAggregateStatus(lastResults);
+        var previous = lastAggregateStatus.getAndSet(newAggregate);
+        if (previous != newAggregate) {
+            log.info("Health status changed: {} -> {}", previous, newAggregate);
+            if (eventBus != null) {
+                eventBus.publish(new HealthEvent.StatusChanged(
+                        "system", previous, newAggregate,
+                        "Aggregate health changed",
+                        Instant.now()));
+            }
+        }
+    }
+
+    private static HealthEvent.Status computeAggregateStatus(Map<String, HealthCheckResult> results) {
+        if (results.isEmpty()) return HealthEvent.Status.HEALTHY;
+
+        var worst = HealthEvent.Status.HEALTHY;
+        for (var result : results.values()) {
+            if (result.status().compareTo(worst) > 0) {
+                worst = result.status();
+            }
+        }
+        return worst;
+    }
+
+    /**
+     * An immutable snapshot of the system's health at a point in time.
+     *
+     * @param status     aggregate status (worst-status-wins)
+     * @param components per-component results
+     * @param timestamp  when the snapshot was taken
+     */
+    public record HealthSnapshot(
+            HealthEvent.Status status,
+            Map<String, HealthCheckResult> components,
+            Instant timestamp
+    ) {
+        public HealthSnapshot {
+            components = Map.copyOf(components);
+        }
+    }
+}

--- a/aceclaw-infra/src/test/java/dev/aceclaw/infra/health/CircuitBreakerHealthCheckTest.java
+++ b/aceclaw-infra/src/test/java/dev/aceclaw/infra/health/CircuitBreakerHealthCheckTest.java
@@ -1,0 +1,82 @@
+package dev.aceclaw.infra.health;
+
+import dev.aceclaw.infra.event.HealthEvent;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CircuitBreakerHealthCheckTest {
+
+    private CircuitBreakerConfig config() {
+        return new CircuitBreakerConfig("test-cb", 2, Duration.ofMillis(50), 1);
+    }
+
+    @Test
+    void closedCircuitReportsHealthy() {
+        var cb = new CircuitBreaker(config());
+        var hc = new CircuitBreakerHealthCheck(cb);
+
+        var result = hc.check();
+        assertThat(result.status()).isEqualTo(HealthEvent.Status.HEALTHY);
+        assertThat(result.detail()).contains("no failures");
+    }
+
+    @Test
+    void closedWithFailuresStillReportsHealthy() {
+        var cb = new CircuitBreaker(config());
+        try {
+            cb.execute(() -> { throw new RuntimeException("fail"); });
+        } catch (RuntimeException ignored) {}
+
+        var hc = new CircuitBreakerHealthCheck(cb);
+        var result = hc.check();
+        assertThat(result.status()).isEqualTo(HealthEvent.Status.HEALTHY);
+        assertThat(result.detail()).contains("1 recent failure");
+    }
+
+    @Test
+    void openCircuitReportsUnhealthy() {
+        var cb = new CircuitBreaker(config());
+        // Reach threshold (2)
+        for (int i = 0; i < 2; i++) {
+            try { cb.execute(() -> { throw new RuntimeException("fail"); }); }
+            catch (RuntimeException ignored) {}
+        }
+
+        var hc = new CircuitBreakerHealthCheck(cb);
+        var result = hc.check();
+        assertThat(result.status()).isEqualTo(HealthEvent.Status.UNHEALTHY);
+        assertThat(result.detail()).contains("Circuit open");
+    }
+
+    @Test
+    void halfOpenCircuitReportsDegraded() {
+        var cb = new CircuitBreaker(config());
+        // Open it
+        for (int i = 0; i < 2; i++) {
+            try { cb.execute(() -> { throw new RuntimeException("fail"); }); }
+            catch (RuntimeException ignored) {}
+        }
+
+        // Wait for timeout to transition to half-open
+        sleep(100);
+
+        var hc = new CircuitBreakerHealthCheck(cb);
+        var result = hc.check();
+        assertThat(result.status()).isEqualTo(HealthEvent.Status.DEGRADED);
+        assertThat(result.detail()).contains("half-open");
+    }
+
+    @Test
+    void nameIncludesCircuitBreakerName() {
+        var cb = new CircuitBreaker(config());
+        var hc = new CircuitBreakerHealthCheck(cb);
+        assertThat(hc.name()).isEqualTo("circuit-breaker:test-cb");
+    }
+
+    private static void sleep(long millis) {
+        try { Thread.sleep(millis); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+    }
+}

--- a/aceclaw-infra/src/test/java/dev/aceclaw/infra/health/CircuitBreakerTest.java
+++ b/aceclaw-infra/src/test/java/dev/aceclaw/infra/health/CircuitBreakerTest.java
@@ -1,0 +1,286 @@
+package dev.aceclaw.infra.health;
+
+import dev.aceclaw.infra.event.EventBus;
+import dev.aceclaw.infra.event.HealthEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CircuitBreakerTest {
+
+    private EventBus eventBus;
+
+    @BeforeEach
+    void setUp() {
+        eventBus = new EventBus();
+        eventBus.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        eventBus.stop();
+    }
+
+    private CircuitBreakerConfig config(int threshold, Duration timeout, int probes) {
+        return new CircuitBreakerConfig("test", threshold, timeout, probes);
+    }
+
+    @Test
+    void startsInClosedState() {
+        var cb = new CircuitBreaker(config(3, Duration.ofSeconds(10), 1));
+        assertThat(cb.currentState()).isInstanceOf(CircuitBreakerState.Closed.class);
+    }
+
+    @Test
+    void successKeepsCircuitClosed() {
+        var cb = new CircuitBreaker(config(3, Duration.ofSeconds(10), 1));
+        var result = cb.execute(() -> "ok");
+        assertThat(result).isEqualTo("ok");
+        assertThat(cb.currentState()).isInstanceOf(CircuitBreakerState.Closed.class);
+    }
+
+    @Test
+    void failuresBelowThresholdKeepCircuitClosed() {
+        var cb = new CircuitBreaker(config(3, Duration.ofSeconds(10), 1));
+
+        for (int i = 0; i < 2; i++) {
+            try {
+                cb.execute(() -> { throw new RuntimeException("fail"); });
+            } catch (RuntimeException ignored) {}
+        }
+
+        var state = cb.currentState();
+        assertThat(state).isInstanceOf(CircuitBreakerState.Closed.class);
+        assertThat(((CircuitBreakerState.Closed) state).consecutiveFailures()).isEqualTo(2);
+    }
+
+    @Test
+    void failuresAtThresholdOpenCircuit() {
+        var cb = new CircuitBreaker(config(3, Duration.ofSeconds(10), 1));
+
+        for (int i = 0; i < 3; i++) {
+            try {
+                cb.execute(() -> { throw new RuntimeException("fail"); });
+            } catch (RuntimeException ignored) {}
+        }
+
+        assertThat(cb.currentState()).isInstanceOf(CircuitBreakerState.Open.class);
+    }
+
+    @Test
+    void openCircuitRejectsCallsWithCircuitOpenException() {
+        var cb = new CircuitBreaker(config(1, Duration.ofSeconds(60), 1));
+
+        try {
+            cb.execute(() -> { throw new RuntimeException("fail"); });
+        } catch (RuntimeException ignored) {}
+
+        assertThatThrownBy(() -> cb.execute(() -> "should not run"))
+                .isInstanceOf(CircuitBreaker.CircuitOpenException.class)
+                .hasMessageContaining("test");
+    }
+
+    @Test
+    void openTransitionsToHalfOpenAfterTimeout() {
+        var cb = new CircuitBreaker(config(1, Duration.ofMillis(50), 1));
+
+        try {
+            cb.execute(() -> { throw new RuntimeException("fail"); });
+        } catch (RuntimeException ignored) {}
+
+        assertThat(cb.currentState()).isInstanceOf(CircuitBreakerState.Open.class);
+
+        // Wait for reset timeout
+        sleep(100);
+
+        // currentState() should trigger the transition
+        assertThat(cb.currentState()).isInstanceOf(CircuitBreakerState.HalfOpen.class);
+    }
+
+    @Test
+    void halfOpenClosesAfterSuccessfulProbes() {
+        var cb = new CircuitBreaker(config(1, Duration.ofMillis(50), 2));
+
+        // Open the circuit
+        try {
+            cb.execute(() -> { throw new RuntimeException("fail"); });
+        } catch (RuntimeException ignored) {}
+
+        sleep(100);
+
+        // First probe
+        cb.execute(() -> "probe1");
+        assertThat(cb.currentState()).isInstanceOf(CircuitBreakerState.HalfOpen.class);
+
+        // Second probe — should close
+        cb.execute(() -> "probe2");
+        assertThat(cb.currentState()).isInstanceOf(CircuitBreakerState.Closed.class);
+    }
+
+    @Test
+    void halfOpenReopensOnProbeFailure() {
+        var cb = new CircuitBreaker(config(1, Duration.ofMillis(50), 2));
+
+        // Open the circuit
+        try {
+            cb.execute(() -> { throw new RuntimeException("fail"); });
+        } catch (RuntimeException ignored) {}
+
+        sleep(100);
+
+        // Probe that fails
+        try {
+            cb.execute(() -> { throw new RuntimeException("probe fail"); });
+        } catch (RuntimeException ignored) {}
+
+        assertThat(cb.currentState()).isInstanceOf(CircuitBreakerState.Open.class);
+    }
+
+    @Test
+    void successResetsFailureCount() {
+        var cb = new CircuitBreaker(config(3, Duration.ofSeconds(10), 1));
+
+        // 2 failures
+        for (int i = 0; i < 2; i++) {
+            try {
+                cb.execute(() -> { throw new RuntimeException("fail"); });
+            } catch (RuntimeException ignored) {}
+        }
+
+        // 1 success resets
+        cb.execute(() -> "ok");
+
+        var state = (CircuitBreakerState.Closed) cb.currentState();
+        assertThat(state.consecutiveFailures()).isZero();
+    }
+
+    @Test
+    void manualResetClosesCircuit() {
+        var cb = new CircuitBreaker(config(1, Duration.ofSeconds(60), 1));
+
+        try {
+            cb.execute(() -> { throw new RuntimeException("fail"); });
+        } catch (RuntimeException ignored) {}
+
+        assertThat(cb.currentState()).isInstanceOf(CircuitBreakerState.Open.class);
+
+        cb.reset();
+
+        assertThat(cb.currentState()).isInstanceOf(CircuitBreakerState.Closed.class);
+        // Should accept calls again
+        assertThat(cb.execute(() -> "ok")).isEqualTo("ok");
+    }
+
+    @Test
+    void executeCheckedPropagatesCheckedException() {
+        var cb = new CircuitBreaker(config(3, Duration.ofSeconds(10), 1));
+
+        assertThatThrownBy(() ->
+                cb.executeChecked(() -> { throw new java.io.IOException("disk full"); }))
+                .isInstanceOf(java.io.IOException.class)
+                .hasMessage("disk full");
+    }
+
+    @Test
+    void publishesEventOnStateTransition() throws Exception {
+        var latch = new CountDownLatch(1);
+        var captured = new AtomicReference<HealthEvent.StatusChanged>();
+
+        eventBus.subscribe(HealthEvent.class, event -> {
+            if (event instanceof HealthEvent.StatusChanged sc) {
+                captured.set(sc);
+                latch.countDown();
+            }
+        });
+
+        var cb = new CircuitBreaker(config(1, Duration.ofSeconds(60), 1), eventBus);
+
+        try {
+            cb.execute(() -> { throw new RuntimeException("fail"); });
+        } catch (RuntimeException ignored) {}
+
+        assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
+
+        var event = captured.get();
+        assertThat(event.component()).isEqualTo("circuit-breaker:test");
+        assertThat(event.previous()).isEqualTo(HealthEvent.Status.HEALTHY);
+        assertThat(event.current()).isEqualTo(HealthEvent.Status.UNHEALTHY);
+    }
+
+    @Test
+    void concurrentAccessIsSafe() throws Exception {
+        var cb = new CircuitBreaker(config(100, Duration.ofMillis(50), 5));
+        int threadCount = 20;
+        var startLatch = new CountDownLatch(1);
+        var doneLatch = new CountDownLatch(threadCount);
+        var errors = new AtomicInteger(0);
+
+        for (int i = 0; i < threadCount; i++) {
+            final int idx = i;
+            Thread.ofVirtual().start(() -> {
+                try {
+                    startLatch.await();
+                    for (int j = 0; j < 50; j++) {
+                        try {
+                            if (idx % 2 == 0) {
+                                cb.execute(() -> "ok");
+                            } else {
+                                cb.execute(() -> { throw new RuntimeException("fail"); });
+                            }
+                        } catch (RuntimeException ignored) {}
+                    }
+                } catch (Exception e) {
+                    errors.incrementAndGet();
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        assertThat(doneLatch.await(10, TimeUnit.SECONDS)).isTrue();
+        assertThat(errors.get()).isZero();
+
+        // State should be valid (one of the three states)
+        var state = cb.currentState();
+        assertThat(state).isInstanceOfAny(
+                CircuitBreakerState.Closed.class,
+                CircuitBreakerState.Open.class,
+                CircuitBreakerState.HalfOpen.class);
+    }
+
+    @Test
+    void configValidation() {
+        assertThatThrownBy(() -> new CircuitBreakerConfig("", 1, Duration.ofSeconds(1), 1))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new CircuitBreakerConfig("x", 0, Duration.ofSeconds(1), 1))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new CircuitBreakerConfig("x", 1, Duration.ZERO, 1))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new CircuitBreakerConfig("x", 1, Duration.ofSeconds(1), 0))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void defaultForLlmCreatesValidConfig() {
+        var config = CircuitBreakerConfig.defaultForLlm();
+        assertThat(config.name()).isEqualTo("llm");
+        assertThat(config.failureThreshold()).isEqualTo(5);
+        assertThat(config.resetTimeout()).isEqualTo(Duration.ofSeconds(30));
+        assertThat(config.halfOpenMaxProbes()).isEqualTo(2);
+    }
+
+    private static void sleep(long millis) {
+        try { Thread.sleep(millis); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+    }
+}

--- a/aceclaw-infra/src/test/java/dev/aceclaw/infra/health/HealthMonitorTest.java
+++ b/aceclaw-infra/src/test/java/dev/aceclaw/infra/health/HealthMonitorTest.java
@@ -1,0 +1,168 @@
+package dev.aceclaw.infra.health;
+
+import dev.aceclaw.infra.event.EventBus;
+import dev.aceclaw.infra.event.HealthEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HealthMonitorTest {
+
+    private EventBus eventBus;
+
+    @BeforeEach
+    void setUp() {
+        eventBus = new EventBus();
+        eventBus.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        eventBus.stop();
+    }
+
+    @Test
+    void emptyMonitorReportsHealthy() {
+        var monitor = new HealthMonitor();
+        var snapshot = monitor.checkNow();
+        assertThat(snapshot.status()).isEqualTo(HealthEvent.Status.HEALTHY);
+        assertThat(snapshot.components()).isEmpty();
+    }
+
+    @Test
+    void singleHealthyCheckReportsHealthy() {
+        var monitor = new HealthMonitor();
+        monitor.register(staticCheck("comp-a", HealthCheckResult.healthy("all good")));
+
+        var snapshot = monitor.checkNow();
+        assertThat(snapshot.status()).isEqualTo(HealthEvent.Status.HEALTHY);
+        assertThat(snapshot.components()).containsKey("comp-a");
+        assertThat(snapshot.components().get("comp-a").status()).isEqualTo(HealthEvent.Status.HEALTHY);
+    }
+
+    @Test
+    void worstStatusWinsAggregation() {
+        var monitor = new HealthMonitor();
+        monitor.register(staticCheck("healthy", HealthCheckResult.healthy()));
+        monitor.register(staticCheck("degraded", HealthCheckResult.degraded("slow")));
+        monitor.register(staticCheck("unhealthy", HealthCheckResult.unhealthy("down")));
+
+        var snapshot = monitor.checkNow();
+        assertThat(snapshot.status()).isEqualTo(HealthEvent.Status.UNHEALTHY);
+        assertThat(snapshot.components()).hasSize(3);
+    }
+
+    @Test
+    void degradedWinsOverHealthy() {
+        var monitor = new HealthMonitor();
+        monitor.register(staticCheck("a", HealthCheckResult.healthy()));
+        monitor.register(staticCheck("b", HealthCheckResult.degraded("slow")));
+
+        var snapshot = monitor.checkNow();
+        assertThat(snapshot.status()).isEqualTo(HealthEvent.Status.DEGRADED);
+    }
+
+    @Test
+    void publishesEventOnAggregateTransition() throws Exception {
+        var latch = new CountDownLatch(1);
+        var captured = new AtomicReference<HealthEvent.StatusChanged>();
+
+        eventBus.subscribe(HealthEvent.class, event -> {
+            if (event instanceof HealthEvent.StatusChanged sc && "system".equals(sc.component())) {
+                captured.set(sc);
+                latch.countDown();
+            }
+        });
+
+        var mutableStatus = new AtomicReference<>(HealthCheckResult.healthy());
+        var monitor = new HealthMonitor(eventBus);
+        monitor.register(new HealthCheck() {
+            @Override public String name() { return "mutable"; }
+            @Override public HealthCheckResult check() { return mutableStatus.get(); }
+        });
+
+        // First check establishes baseline (HEALTHY)
+        monitor.checkNow();
+
+        // Change to unhealthy
+        mutableStatus.set(HealthCheckResult.unhealthy("broken"));
+        monitor.checkNow();
+
+        assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
+        assertThat(captured.get().previous()).isEqualTo(HealthEvent.Status.HEALTHY);
+        assertThat(captured.get().current()).isEqualTo(HealthEvent.Status.UNHEALTHY);
+    }
+
+    @Test
+    void periodicCheckRunsAutomatically() throws Exception {
+        var monitor = new HealthMonitor(null, Duration.ofMillis(100));
+        var callCount = new java.util.concurrent.atomic.AtomicInteger(0);
+
+        monitor.register(new HealthCheck() {
+            @Override public String name() { return "counter"; }
+            @Override public HealthCheckResult check() {
+                callCount.incrementAndGet();
+                return HealthCheckResult.healthy();
+            }
+        });
+
+        monitor.start();
+        try {
+            // Wait for a few periodic checks (initial + periodic)
+            Thread.sleep(350);
+            // Should have been called at least 3 times (initial + ~3 periodic)
+            assertThat(callCount.get()).isGreaterThanOrEqualTo(3);
+        } finally {
+            monitor.stop();
+        }
+    }
+
+    @Test
+    void snapshotIsImmutable() {
+        var monitor = new HealthMonitor();
+        monitor.register(staticCheck("a", HealthCheckResult.healthy()));
+        var snapshot = monitor.checkNow();
+
+        assertThat(snapshot.components()).hasSize(1);
+        // Map.copyOf makes it unmodifiable
+        org.junit.jupiter.api.Assertions.assertThrows(UnsupportedOperationException.class,
+                () -> snapshot.components().put("b", HealthCheckResult.healthy()));
+    }
+
+    @Test
+    void throwingCheckProducesUnhealthyResult() {
+        var monitor = new HealthMonitor();
+        monitor.register(new HealthCheck() {
+            @Override public String name() { return "boom"; }
+            @Override public HealthCheckResult check() { throw new RuntimeException("unexpected"); }
+        });
+
+        var snapshot = monitor.checkNow();
+        assertThat(snapshot.status()).isEqualTo(HealthEvent.Status.UNHEALTHY);
+        assertThat(snapshot.components().get("boom").detail()).contains("Check failed");
+    }
+
+    @Test
+    void checkCountTracksRegistration() {
+        var monitor = new HealthMonitor();
+        assertThat(monitor.checkCount()).isZero();
+        monitor.register(staticCheck("a", HealthCheckResult.healthy()));
+        assertThat(monitor.checkCount()).isEqualTo(1);
+        monitor.register(staticCheck("b", HealthCheckResult.healthy()));
+        assertThat(monitor.checkCount()).isEqualTo(2);
+    }
+
+    private static HealthCheck staticCheck(String name, HealthCheckResult result) {
+        return new HealthCheck() {
+            @Override public String name() { return name; }
+            @Override public HealthCheckResult check() { return result; }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Closes #31

- Add thread-safe `CircuitBreaker` (lock-free `AtomicReference`, configurable thresholds) with `HealthEvent` publishing on state transitions
- Add `HealthMonitor` that aggregates per-component `HealthCheck`s via periodic virtual thread, publishes events on aggregate status changes (worst-status-wins)
- Add `CircuitBreakerLlmClient` decorator wrapping LLM calls with the circuit breaker; maps `CircuitOpenException` to `LlmException(503)`
- Wire `EventBus` + `HealthMonitor` + `CircuitBreaker` into `AceClawDaemon` boot sequence with proper shutdown ordering
- Enhance `RequestRouter.handleHealthStatus()` to return real per-component health breakdown from `HealthMonitor` snapshot instead of hardcoded `"healthy"`

### New files (8)

| Module | File | Purpose |
|--------|------|---------|
| infra | `CircuitBreakerConfig` | Config record (name, failureThreshold, resetTimeout, halfOpenMaxProbes) |
| infra | `CircuitBreakerState` | Sealed interface: `Closed`, `Open`, `HalfOpen` |
| infra | `CircuitBreaker` | Thread-safe CB with `execute()`/`executeChecked()`, EventBus publishing |
| infra | `HealthCheck` | Interface: `name()` + `check()` |
| infra | `HealthCheckResult` | Record with status + detail + timestamp, factory methods |
| infra | `HealthMonitor` | Aggregator with periodic virtual thread, nested `HealthSnapshot` record |
| infra | `CircuitBreakerHealthCheck` | Adapter: CB state to HealthCheck |
| daemon | `CircuitBreakerLlmClient` | LlmClient decorator wrapping calls with CircuitBreaker |

### Modified files (2)

- `AceClawDaemon` - EventBus + HealthMonitor creation, CB wrapping of LlmClient, shutdown participants
- `RequestRouter` - `setHealthMonitor()` setter, real health status from HealthMonitor snapshot

## Test plan

- [x] `CircuitBreakerTest` - 15 tests: state transitions, fail-fast, reset, checked exceptions, event publishing, concurrency safety, config validation
- [x] `HealthMonitorTest` - 9 tests: aggregation logic, periodic checks, event on transition, snapshot immutability, throwing checks
- [x] `CircuitBreakerHealthCheckTest` - 5 tests: state-to-status mapping for all three states
- [x] All existing tests pass (64 Gradle tasks, 0 failures)
- [x] `./gradlew clean build` succeeds

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added circuit breaker protection for the LLM client to prevent cascading failures during outages.
  * Introduced health monitoring system with periodic health checks and aggregated status reporting.
  * Enhanced health status endpoint to display per-component health breakdown including status details and timestamps.
  * Added event publishing on health status transitions for better observability.

* **Tests**
  * Added comprehensive test coverage for circuit breaker and health monitoring components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->