### PR TITLE
feat: add web tools DDG fallback + dynamic tool guidance in system prompt (#42)

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -194,9 +194,11 @@ public final class AceClawDaemon {
             toolRegistry.register(new ScreenCaptureTool(workingDir));
         }
 
-        // Web search (requires Brave Search API key)
+        // Web search (Brave when API key set, DuckDuckGo Lite fallback otherwise)
         if (config.braveSearchApiKey() != null) {
             toolRegistry.register(new WebSearchTool(workingDir, config.braveSearchApiKey()));
+        } else {
+            toolRegistry.register(new WebSearchTool(workingDir));
         }
 
         // MCP servers (config-driven external tool providers)
@@ -278,8 +280,14 @@ public final class AceClawDaemon {
         log.info("System prompt budget: {}K per tier, {}K total (context={}K, maxOutput={}K)",
                 promptBudget.maxPerTierChars() / 1000, promptBudget.maxTotalChars() / 1000,
                 contextWindow / 1000, config.maxTokens() / 1000);
+
+        // Collect registered tool names for dynamic tool guidance in system prompt
+        var toolNames = toolRegistry.all().stream()
+                .map(dev.aceclaw.core.agent.Tool::name)
+                .collect(java.util.stream.Collectors.toSet());
         String systemPrompt = SystemPromptLoader.load(
-                workingDir, memoryStore, journal, markdownStore, model, config.provider(), promptBudget);
+                workingDir, memoryStore, journal, markdownStore, model, config.provider(), promptBudget,
+                toolNames, config.braveSearchApiKey() != null);
 
         // 5b. Inject skill descriptions into system prompt so the LLM knows
         //     what each skill does and when to invoke it proactively.

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/SystemPromptLoader.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/SystemPromptLoader.java
@@ -13,6 +13,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Set;
 
 /**
  * Loads and assembles the system prompt for the agent.
@@ -103,6 +104,45 @@ public final class SystemPromptLoader {
      * @param budget        the system prompt size budget
      * @return the assembled system prompt
      */
+    /**
+     * Loads the full system prompt with dynamic tool guidance.
+     *
+     * <p>This overload generates tool-specific guidance sections based on which
+     * tools are actually registered, avoiding references to unavailable tools.
+     *
+     * @param projectPath        the project working directory
+     * @param memoryStore        optional auto-memory store (may be null)
+     * @param journal            optional daily journal (may be null)
+     * @param markdownStore      optional markdown memory store (may be null)
+     * @param model              the LLM model name (may be null)
+     * @param provider           the LLM provider name (may be null)
+     * @param budget             the system prompt size budget
+     * @param registeredToolNames the set of tool names currently registered (may be null)
+     * @param hasBraveApiKey     whether a Brave Search API key is configured
+     * @return the assembled system prompt
+     */
+    public static String load(Path projectPath, AutoMemoryStore memoryStore,
+                              DailyJournal journal, MarkdownMemoryStore markdownStore,
+                              String model, String provider, SystemPromptBudget budget,
+                              Set<String> registeredToolNames, boolean hasBraveApiKey) {
+        String prompt = load(projectPath, memoryStore, journal, markdownStore, model, provider, budget);
+
+        // Inject dynamic tool guidance if tool names are provided
+        if (registeredToolNames != null && !registeredToolNames.isEmpty()) {
+            String guidance = ToolGuidanceGenerator.generate(registeredToolNames, hasBraveApiKey);
+            // Insert guidance at the placeholder comment location
+            String placeholder = "<!-- Dynamic tool guidance (priority, tool-specific guidelines, fallback chain) injected by ToolGuidanceGenerator -->";
+            if (prompt.contains(placeholder)) {
+                prompt = prompt.replace(placeholder, guidance);
+            } else {
+                // Fallback: append after base prompt section
+                prompt = prompt + guidance;
+            }
+        }
+
+        return prompt;
+    }
+
     public static String load(Path projectPath, AutoMemoryStore memoryStore,
                               DailyJournal journal, MarkdownMemoryStore markdownStore,
                               String model, String provider, SystemPromptBudget budget) {

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/ToolGuidanceGenerator.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/ToolGuidanceGenerator.java
@@ -1,0 +1,157 @@
+package dev.aceclaw.daemon;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+
+/**
+ * Generates dynamic tool guidance sections for the system prompt based on
+ * which tools are actually registered.
+ *
+ * <p>This prevents the system prompt from referencing tools that don't exist
+ * (e.g., web_search without API key, screen_capture on Linux), which can
+ * confuse the agent and cause it to attempt unavailable tools.
+ */
+public final class ToolGuidanceGenerator {
+
+    private static final Logger log = LoggerFactory.getLogger(ToolGuidanceGenerator.class);
+
+    private static final String COMPOSITION_RESOURCE = "/tool-guidance-composition.md";
+
+    private ToolGuidanceGenerator() {}
+
+    /**
+     * Generates dynamic tool guidance based on which tools are registered.
+     *
+     * @param registeredToolNames the set of tool names currently registered
+     * @param hasBraveApiKey      whether a Brave Search API key is configured
+     * @return the generated guidance text to inject into the system prompt
+     */
+    public static String generate(Set<String> registeredToolNames, boolean hasBraveApiKey) {
+        var sb = new StringBuilder();
+
+        sb.append("\n\n## Tool Priority: Always Prefer Text Over Images\n\n");
+        sb.append("CRITICAL: When fetching information from the web, **always return TEXT results ");
+        sb.append("directly to the user**. Do NOT save results as images/screenshots and do NOT ");
+        sb.append("ask the user to look at files. The user sees your text output — give them ");
+        sb.append("the answer directly.\n\n");
+
+        // Priority order — only list tools that actually exist
+        sb.append("**Priority order for getting web information:**\n");
+        int priority = 1;
+        if (registeredToolNames.contains("web_search")) {
+            sb.append(priority++).append(". **web_search** — fastest, returns text results directly. ");
+            sb.append("Try this first for any real-time information (weather, news, prices, docs, etc.)\n");
+        }
+        if (registeredToolNames.contains("web_fetch")) {
+            sb.append(priority++).append(". **web_fetch** — fetch a specific URL and extract text content. ");
+            sb.append("Use when you know the URL");
+            if (registeredToolNames.contains("web_search")) {
+                sb.append(" or found one via web_search");
+            }
+            sb.append(".\n");
+        }
+        if (registeredToolNames.contains("browser")) {
+            sb.append(priority++).append(". **browser** with get_text — when web_fetch fails ");
+            sb.append("(JavaScript-rendered pages, login walls). Launch browser, navigate, ");
+            sb.append("then use get_text to extract text.\n");
+        }
+        if (registeredToolNames.contains("screen_capture")) {
+            sb.append(priority++).append(". **screen_capture** — LAST RESORT ONLY. Never use ");
+            sb.append("screen_capture to get information that can be obtained as text. ");
+            sb.append("Only use for tasks that inherently require visual output ");
+            sb.append("(UI debugging, visual verification).\n");
+        }
+
+        sb.append("\n**NEVER do this:** Take a screenshot of a website and give the user a PNG file. ");
+        sb.append("Instead, fetch the data as text and present it directly.\n");
+
+        // Tool-specific guidelines — only for registered tools
+        sb.append("\n## Tool-specific guidelines\n\n");
+        if (registeredToolNames.contains("web_fetch")) {
+            sb.append("- **web_fetch**: Prefer over bash with curl. Good for documentation, APIs, static pages.\n");
+        }
+        if (registeredToolNames.contains("web_search")) {
+            sb.append("- **web_search**: Good for real-time information — weather, news, current events, finding URLs.");
+            if (hasBraveApiKey) {
+                sb.append(" Using Brave Search API.\n");
+            } else {
+                sb.append(" Using DuckDuckGo (free). For better results, configure BRAVE_SEARCH_API_KEY.\n");
+            }
+        }
+        if (registeredToolNames.contains("browser")) {
+            sb.append("- **browser**: Only for pages that require JavaScript rendering or interaction ");
+            sb.append("(clicking, typing, form submission). Always use get_text to extract text content, ");
+            sb.append("not screenshot.\n");
+        }
+        if (registeredToolNames.contains("list_directory")) {
+            sb.append("- **list_directory**: Use instead of bash with ls.\n");
+        }
+        if (registeredToolNames.contains("applescript")) {
+            sb.append("- **applescript**: macOS automation — controlling applications, system dialogs, ");
+            sb.append("Finder operations. Only available on macOS.\n");
+        }
+        if (registeredToolNames.contains("screen_capture")) {
+            sb.append("- **screen_capture**: ONLY for visual tasks (UI screenshots, visual debugging). ");
+            sb.append("Never use to \"read\" information that can be fetched as text.\n");
+        }
+
+        // Fallback chain — adapts based on available web tools
+        sb.append("\n## Mandatory Fallback Chain for Web Information\n\n");
+        generateFallbackChain(sb, registeredToolNames);
+
+        // Availability notes
+        if (!hasBraveApiKey && registeredToolNames.contains("web_search")) {
+            sb.append("\n**Note:** web_search is using DuckDuckGo (free, no API key needed). ");
+            sb.append("For higher-quality results, configure BRAVE_SEARCH_API_KEY in ");
+            sb.append("~/.aceclaw/config.json or as an environment variable.\n");
+        }
+
+        // Tool composition guidance (always appended)
+        sb.append(loadCompositionGuidance());
+
+        return sb.toString();
+    }
+
+    private static void generateFallbackChain(StringBuilder sb, Set<String> tools) {
+        boolean hasWebSearch = tools.contains("web_search");
+        boolean hasWebFetch = tools.contains("web_fetch");
+        boolean hasBrowser = tools.contains("browser");
+        boolean hasBash = tools.contains("bash");
+
+        sb.append("If one approach fails, immediately try the next — NEVER stop and ask the user:\n");
+
+        var chain = new java.util.ArrayList<String>();
+        if (hasWebSearch) chain.add("web_search");
+        if (hasWebFetch) chain.add("web_fetch with a known URL");
+        if (hasWebFetch) chain.add("web_fetch with a different URL");
+        if (hasBrowser) chain.add("browser (launch -> navigate -> get_text)");
+        if (hasBash) chain.add("bash with curl");
+
+        for (int i = 0; i < chain.size(); i++) {
+            if (i == 0) {
+                sb.append("Try ").append(chain.get(i));
+            } else {
+                sb.append(" -> if that fails, try ").append(chain.get(i));
+            }
+        }
+        if (!chain.isEmpty()) {
+            sb.append(" -> only THEN report failure with all attempts listed.\n");
+        }
+    }
+
+    private static String loadCompositionGuidance() {
+        try (InputStream is = ToolGuidanceGenerator.class.getResourceAsStream(COMPOSITION_RESOURCE)) {
+            if (is != null) {
+                return "\n\n" + new String(is.readAllBytes(), StandardCharsets.UTF_8);
+            }
+        } catch (IOException e) {
+            log.warn("Failed to load tool composition guidance: {}", e.getMessage());
+        }
+        return "";
+    }
+}

--- a/aceclaw-daemon/src/main/resources/system-prompt.md
+++ b/aceclaw-daemon/src/main/resources/system-prompt.md
@@ -64,26 +64,7 @@ The user will primarily request you to perform software engineering tasks — so
 - **Reserve bash exclusively for system commands** (git, build tools, docker, curl). If a dedicated tool exists, always prefer it.
 - **You have up to 25 tool calls per turn.** For complex tasks, plan your tool usage to stay within budget.
 
-## Tool Priority: Always Prefer Text Over Images
-
-CRITICAL: When fetching information from the web, **always return TEXT results directly to the user**. Do NOT save results as images/screenshots and do NOT ask the user to look at files. The user sees your text output — give them the answer directly.
-
-**Priority order for getting web information:**
-1. **web_search** — fastest, returns text results directly. Try this first for any real-time information (weather, news, prices, docs, etc.)
-2. **web_fetch** — fetch a specific URL and extract text content. Use when you know the URL or found one via web_search.
-3. **browser** with get_text — when web_fetch fails (JavaScript-rendered pages, login walls). Launch browser, navigate, then use get_text to extract text.
-4. **screen_capture** — LAST RESORT ONLY. Never use screen_capture to get information that can be obtained as text. Only use for tasks that inherently require visual output (UI debugging, visual verification).
-
-**NEVER do this:** Take a screenshot of a weather website and give the user a PNG file. Instead, fetch the weather data as text and present it directly.
-
-## Tool-specific guidelines
-
-- **web_fetch**: Prefer over bash with curl. Good for documentation, APIs, static pages.
-- **web_search**: Good for real-time information — weather, news, current events, finding URLs.
-- **browser**: Only for pages that require JavaScript rendering or interaction (clicking, typing, form submission). Always use get_text to extract text content, not screenshot.
-- **list_directory**: Use instead of bash with ls.
-- **applescript**: macOS automation — controlling applications, system dialogs, Finder operations. Only available on macOS.
-- **screen_capture**: ONLY for visual tasks (UI screenshots, visual debugging). Never use to "read" information that can be fetched as text.
+<!-- Dynamic tool guidance (priority, tool-specific guidelines, fallback chain) injected by ToolGuidanceGenerator -->
 
 # Be Autonomous — NEVER Give Up, NEVER Ask, Just Do It
 
@@ -95,16 +76,6 @@ CRITICAL: You are a fully autonomous agent. You must keep working until the goal
 3. **NEVER output a partial result and ask if the user wants more.** Deliver the complete answer.
 4. **NEVER tell the user about intermediate failures** unless you have exhausted ALL approaches. The user only cares about the final result.
 5. **Only ask the user a question** when you genuinely need information that only they can provide (credentials, ambiguous requirements).
-
-**Mandatory fallback chain for web information:**
-If web_search fails → try web_fetch with a known URL → try web_fetch with a different URL → try browser (launch → navigate → get_text) → try bash with curl → only THEN report failure with all attempts listed.
-
-**Example — "What's the weather in Berlin?":**
-- Step 1: web_search "Berlin weather" → extract and present text results. DONE.
-- If web_search unavailable: web_fetch "https://wttr.in/Berlin?format=3" → present text. DONE.
-- If that fails: web_fetch "https://wttr.in/Berlin" → present text. DONE.
-- If that fails: browser launch → navigate to weather site → get_text → present. DONE.
-- NEVER: take a screenshot and give the user a PNG file.
 
 **The user should NEVER see these patterns:**
 - "Would you like me to try another approach?" → You already tried it.

--- a/aceclaw-daemon/src/main/resources/tool-guidance-composition.md
+++ b/aceclaw-daemon/src/main/resources/tool-guidance-composition.md
@@ -1,0 +1,29 @@
+## Creative Tool Composition
+
+When a dedicated tool is not available for a task, compose existing tools creatively. NEVER give up because a specific tool is missing — always find a way using what you have.
+
+**Web data retrieval (when web_search/web_fetch are insufficient):**
+- `bash` + `curl` for REST APIs: `curl -s 'https://api.example.com/data' | jq '.results'`
+- `bash` + `curl` for simple page fetches: `curl -sL 'https://example.com' | head -200`
+- `write_file` to save a Python/Node script + `bash` to run it for complex scraping
+
+**Script writing for ad-hoc automation:**
+- `write_file` a shell/Python/Node script + `bash` to execute it
+- Use this for data transformations, batch operations, or complex parsing
+- Always clean up temporary scripts after use
+
+**API calling patterns:**
+- `bash` + `curl` for REST endpoints with headers: `curl -s -H 'Authorization: Bearer ...' URL`
+- `bash` + `curl` for POST requests: `curl -s -X POST -d '{"key":"val"}' URL`
+- Chain with `jq` for JSON processing: `curl -s URL | jq '.items[] | .name'`
+
+**File processing pipelines:**
+- `read_file` to inspect + `bash` with standard Unix tools for transformation
+- `glob` to find files + `bash` with xargs for batch operations
+- `write_file` a script + `bash` to process multiple files
+
+**Anti-patterns — NEVER do these:**
+- NEVER ask the user to provide a URL when you can search for it yourself
+- NEVER stop because a specific tool is unavailable — compose alternatives
+- NEVER tell the user "I don't have a tool for that" — use bash + curl, write a script, or find another way
+- NEVER suggest the user install a tool when you can accomplish the task with existing tools

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/ToolGuidanceGeneratorTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/ToolGuidanceGeneratorTest.java
@@ -1,0 +1,102 @@
+package dev.aceclaw.daemon;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ToolGuidanceGeneratorTest {
+
+    @Test
+    void fullToolSetMentionsAllWebTools() {
+        var tools = Set.of("read_file", "write_file", "edit_file", "bash", "glob", "grep",
+                "list_directory", "web_fetch", "web_search", "browser", "screen_capture", "applescript");
+
+        var result = ToolGuidanceGenerator.generate(tools, true);
+
+        assertThat(result).contains("web_search");
+        assertThat(result).contains("web_fetch");
+        assertThat(result).contains("browser");
+        assertThat(result).contains("screen_capture");
+        assertThat(result).contains("applescript");
+        assertThat(result).contains("list_directory");
+        assertThat(result).contains("Brave Search API");
+    }
+
+    @Test
+    void minimalToolSetOmitsWebReferences() {
+        var tools = Set.of("read_file", "write_file", "edit_file", "bash", "glob", "grep");
+
+        var result = ToolGuidanceGenerator.generate(tools, false);
+
+        assertThat(result).doesNotContain("**web_search**");
+        assertThat(result).doesNotContain("**web_fetch**");
+        assertThat(result).doesNotContain("**browser**");
+        assertThat(result).doesNotContain("**screen_capture**");
+        assertThat(result).doesNotContain("**applescript**");
+    }
+
+    @Test
+    void noBraveKeyShowsDdgNote() {
+        var tools = Set.of("read_file", "bash", "web_search", "web_fetch");
+
+        var result = ToolGuidanceGenerator.generate(tools, false);
+
+        assertThat(result).contains("DuckDuckGo");
+        assertThat(result).contains("BRAVE_SEARCH_API_KEY");
+    }
+
+    @Test
+    void withBraveKeyDoesNotShowDdgNote() {
+        var tools = Set.of("read_file", "bash", "web_search", "web_fetch");
+
+        var result = ToolGuidanceGenerator.generate(tools, true);
+
+        // Should mention Brave, not DDG fallback note
+        assertThat(result).contains("Brave Search API");
+        // Should not show the availability note about DDG
+        assertThat(result).doesNotContain("web_search is using DuckDuckGo");
+    }
+
+    @Test
+    void noScreenCaptureDoesNotMentionIt() {
+        var tools = Set.of("read_file", "bash", "web_search", "web_fetch", "browser");
+
+        var result = ToolGuidanceGenerator.generate(tools, false);
+
+        assertThat(result).doesNotContain("**screen_capture**");
+    }
+
+    @Test
+    void fallbackChainAdaptsToAvailableTools() {
+        var tools = Set.of("web_fetch", "bash");
+
+        var result = ToolGuidanceGenerator.generate(tools, false);
+
+        // Should start with web_fetch, not web_search
+        assertThat(result).contains("web_fetch with a known URL");
+        assertThat(result).contains("bash with curl");
+        assertThat(result).doesNotContain("Try web_search");
+    }
+
+    @Test
+    void compositionGuidanceAlwaysIncluded() {
+        var tools = Set.of("read_file", "bash");
+
+        var result = ToolGuidanceGenerator.generate(tools, false);
+
+        assertThat(result).contains("Creative Tool Composition");
+        assertThat(result).contains("NEVER ask the user to provide a URL");
+    }
+
+    @Test
+    void emptyToolSetStillGenerates() {
+        var result = ToolGuidanceGenerator.generate(Set.of(), false);
+
+        // Should still produce composition guidance
+        assertThat(result).contains("Creative Tool Composition");
+        // No tool-specific lines
+        assertThat(result).doesNotContain("**web_search**");
+    }
+}

--- a/aceclaw-tools/src/main/java/dev/aceclaw/tools/WebSearchTool.java
+++ b/aceclaw-tools/src/main/java/dev/aceclaw/tools/WebSearchTool.java
@@ -3,6 +3,9 @@ package dev.aceclaw.tools;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.aceclaw.core.agent.Tool;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,12 +17,15 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
- * Performs web searches using the Brave Search API.
+ * Performs web searches using Brave Search API or DuckDuckGo Lite as fallback.
  *
- * <p>Only registered when a Brave Search API key is configured. Returns a
- * numbered list of results with title, URL, and snippet.
+ * <p>When a Brave Search API key is configured, uses the Brave API for
+ * higher-quality results. Otherwise, falls back to DuckDuckGo Lite (free,
+ * no API key required).
  */
 public final class WebSearchTool implements Tool {
 
@@ -27,20 +33,37 @@ public final class WebSearchTool implements Tool {
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private static final String BRAVE_SEARCH_URL = "https://api.search.brave.com/res/v1/web/search";
+    private static final String DDG_LITE_URL = "https://lite.duckduckgo.com/lite/";
     private static final int TIMEOUT_SECONDS = 30;
     private static final int DEFAULT_MAX_RESULTS = 5;
     private static final int MAX_RESULTS_LIMIT = 20;
 
     private final Path workingDir;
-    private final String apiKey;
+    private final String apiKey; // nullable — null means DDG fallback
     private final HttpClient httpClient;
 
+    /**
+     * Creates a WebSearchTool with Brave Search API key.
+     *
+     * @param workingDir the working directory
+     * @param apiKey     the Brave Search API key (may be null for DDG fallback)
+     */
     public WebSearchTool(Path workingDir, String apiKey) {
         this.workingDir = workingDir;
         this.apiKey = apiKey;
         this.httpClient = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(TIMEOUT_SECONDS))
+                .followRedirects(HttpClient.Redirect.NORMAL)
                 .build();
+    }
+
+    /**
+     * Creates a WebSearchTool without a Brave API key (uses DuckDuckGo Lite).
+     *
+     * @param workingDir the working directory
+     */
+    public WebSearchTool(Path workingDir) {
+        this(workingDir, null);
     }
 
     @Override
@@ -77,10 +100,15 @@ public final class WebSearchTool implements Tool {
             maxResults = Math.max(1, Math.min(input.get("max_results").asInt(DEFAULT_MAX_RESULTS), MAX_RESULTS_LIMIT));
         }
 
-        log.debug("Web search: query='{}', maxResults={}", query, maxResults);
+        log.debug("Web search: query='{}', maxResults={}, backend={}",
+                query, maxResults, apiKey != null ? "brave" : "ddg");
 
         try {
-            return performSearch(query, maxResults);
+            if (apiKey != null) {
+                return performBraveSearch(query, maxResults);
+            } else {
+                return performDdgSearch(query, maxResults);
+            }
         } catch (java.io.IOException e) {
             return new ToolResult("Search failed: " + e.getMessage(), true);
         } catch (InterruptedException e) {
@@ -89,7 +117,14 @@ public final class WebSearchTool implements Tool {
         }
     }
 
-    private ToolResult performSearch(String query, int maxResults) throws Exception {
+    /**
+     * Returns whether this tool is using Brave Search (true) or DDG fallback (false).
+     */
+    public boolean isBraveEnabled() {
+        return apiKey != null;
+    }
+
+    private ToolResult performBraveSearch(String query, int maxResults) throws Exception {
         var encodedQuery = URLEncoder.encode(query, StandardCharsets.UTF_8);
         var uri = URI.create(BRAVE_SEARCH_URL + "?q=" + encodedQuery + "&count=" + maxResults);
 
@@ -119,10 +154,102 @@ public final class WebSearchTool implements Tool {
             return new ToolResult("Empty response from Brave Search", true);
         }
 
-        return formatResults(body, maxResults);
+        return formatBraveResults(body, maxResults);
     }
 
-    private ToolResult formatResults(String jsonBody, int maxResults) {
+    private ToolResult performDdgSearch(String query, int maxResults) throws Exception {
+        var formBody = "q=" + URLEncoder.encode(query, StandardCharsets.UTF_8);
+
+        var request = HttpRequest.newBuilder()
+                .uri(URI.create(DDG_LITE_URL))
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .header("User-Agent", "AceClaw/1.0")
+                .timeout(Duration.ofSeconds(TIMEOUT_SECONDS))
+                .POST(HttpRequest.BodyPublishers.ofString(formBody))
+                .build();
+
+        var response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+        if (response.statusCode() >= 400) {
+            return new ToolResult("DuckDuckGo search failed (HTTP " + response.statusCode() + ")", true);
+        }
+
+        var body = response.body();
+        if (body == null || body.isEmpty()) {
+            return new ToolResult("Empty response from DuckDuckGo", true);
+        }
+
+        var results = parseDdgResults(body, maxResults);
+        if (results.isEmpty()) {
+            return new ToolResult("No results found", false);
+        }
+
+        return formatDdgResults(results);
+    }
+
+    /**
+     * Parses DuckDuckGo Lite HTML response into structured results.
+     * Package-private for testability.
+     */
+    List<DdgResult> parseDdgResults(String html, int maxResults) {
+        var results = new ArrayList<DdgResult>();
+        Document doc = Jsoup.parse(html);
+
+        // DDG Lite renders results as a table with specific structure:
+        // Each result has a link in a <a class="result-link"> and snippet in <td class="result-snippet">
+        var links = doc.select("a.result-link");
+        var snippets = doc.select("td.result-snippet");
+
+        for (int i = 0; i < links.size() && results.size() < maxResults; i++) {
+            Element link = links.get(i);
+            String title = link.text().strip();
+            String url = link.attr("href").strip();
+
+            if (title.isEmpty() || url.isEmpty()) continue;
+
+            String snippet = "";
+            if (i < snippets.size()) {
+                snippet = snippets.get(i).text().strip();
+            }
+
+            results.add(new DdgResult(title, url, snippet));
+        }
+
+        // Fallback: if result-link class is not found, try generic link extraction
+        // DDG Lite HTML can vary; some versions use different class names
+        if (results.isEmpty()) {
+            var allLinks = doc.select("a[href^=http]");
+            for (Element link : allLinks) {
+                if (results.size() >= maxResults) break;
+                String url = link.attr("href");
+                String title = link.text().strip();
+
+                // Skip DDG navigation/internal links
+                if (url.contains("duckduckgo.com") || title.isEmpty()) continue;
+
+                results.add(new DdgResult(title, url, ""));
+            }
+        }
+
+        return results;
+    }
+
+    private ToolResult formatDdgResults(List<DdgResult> results) {
+        var sb = new StringBuilder();
+        int count = 0;
+        for (var result : results) {
+            count++;
+            sb.append(count).append(". ").append(result.title()).append('\n');
+            sb.append("   URL: ").append(result.url()).append('\n');
+            if (!result.snippet().isEmpty()) {
+                sb.append("   ").append(result.snippet()).append('\n');
+            }
+            sb.append('\n');
+        }
+        return new ToolResult(sb.toString().strip(), false);
+    }
+
+    private ToolResult formatBraveResults(String jsonBody, int maxResults) {
         try {
             var root = MAPPER.readTree(jsonBody);
             var webResults = root.path("web").path("results");
@@ -156,4 +283,9 @@ public final class WebSearchTool implements Tool {
             return new ToolResult("Failed to parse search results: " + e.getMessage(), true);
         }
     }
+
+    /**
+     * A single DuckDuckGo search result.
+     */
+    record DdgResult(String title, String url, String snippet) {}
 }

--- a/aceclaw-tools/src/main/resources/tool-descriptions/web_search.md
+++ b/aceclaw-tools/src/main/resources/tool-descriptions/web_search.md
@@ -1,7 +1,8 @@
-Searches the web using Brave Search and returns results with title, URL, and snippet.
+Searches the web and returns results with title, URL, and snippet.
 
-Use this for finding up-to-date information, documentation, solutions, and resources
-from the internet. Returns real-time search results.
+Uses Brave Search API when BRAVE_SEARCH_API_KEY is configured, or DuckDuckGo
+Lite as a free fallback when no API key is set. Both backends return real-time
+search results.
 
 When to use:
 - Finding documentation or API references for a library or tool

--- a/aceclaw-tools/src/test/java/dev/aceclaw/tools/WebSearchToolTest.java
+++ b/aceclaw-tools/src/test/java/dev/aceclaw/tools/WebSearchToolTest.java
@@ -1,0 +1,147 @@
+package dev.aceclaw.tools;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WebSearchToolTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @TempDir
+    Path workDir;
+
+    private WebSearchTool ddgTool;
+    private WebSearchTool braveTool;
+
+    @BeforeEach
+    void setUp() {
+        ddgTool = new WebSearchTool(workDir);
+        braveTool = new WebSearchTool(workDir, "test-api-key");
+    }
+
+    @Test
+    void nameIsWebSearch() {
+        assertThat(ddgTool.name()).isEqualTo("web_search");
+    }
+
+    @Test
+    void descriptionIsNotEmpty() {
+        assertThat(ddgTool.description()).isNotBlank();
+    }
+
+    @Test
+    void ddgToolIsNotBraveEnabled() {
+        assertThat(ddgTool.isBraveEnabled()).isFalse();
+    }
+
+    @Test
+    void braveToolIsBraveEnabled() {
+        assertThat(braveTool.isBraveEnabled()).isTrue();
+    }
+
+    @Test
+    void missingQueryReturnsError() throws Exception {
+        var input = MAPPER.writeValueAsString(MAPPER.createObjectNode());
+
+        var result = ddgTool.execute(input);
+
+        assertThat(result.isError()).isTrue();
+        assertThat(result.output()).contains("Missing required parameter: query");
+    }
+
+    @Test
+    void blankQueryReturnsError() throws Exception {
+        var input = MAPPER.writeValueAsString(
+                MAPPER.createObjectNode().put("query", "   "));
+
+        var result = ddgTool.execute(input);
+
+        assertThat(result.isError()).isTrue();
+        assertThat(result.output()).contains("Missing required parameter: query");
+    }
+
+    @Test
+    void inputSchemaHasRequiredQuery() {
+        var schema = ddgTool.inputSchema();
+
+        assertThat(schema.has("required")).isTrue();
+        assertThat(schema.get("required").toString()).contains("query");
+    }
+
+    @Test
+    void parseDdgResultsFromSampleHtml() throws IOException {
+        String html = loadResource("ddg-lite-sample.html");
+
+        var results = ddgTool.parseDdgResults(html, 5);
+
+        assertThat(results).isNotEmpty();
+        assertThat(results.size()).isLessThanOrEqualTo(5);
+
+        var first = results.get(0);
+        assertThat(first.title()).isNotBlank();
+        assertThat(first.url()).startsWith("http");
+    }
+
+    @Test
+    void parseDdgResultsRespectsMaxResults() throws IOException {
+        String html = loadResource("ddg-lite-sample.html");
+
+        var results = ddgTool.parseDdgResults(html, 2);
+
+        assertThat(results.size()).isLessThanOrEqualTo(2);
+    }
+
+    @Test
+    void parseDdgResultsEmptyHtml() {
+        var results = ddgTool.parseDdgResults("<html><body></body></html>", 5);
+
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    void parseDdgResultsNoResultLinks() {
+        // HTML with links but not result-link class, and all links are DDG internal
+        String html = """
+                <html><body>
+                <a href="https://duckduckgo.com/about">About</a>
+                </body></html>
+                """;
+
+        var results = ddgTool.parseDdgResults(html, 5);
+
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    void parseDdgResultsFallbackToGenericLinks() {
+        // HTML with no result-link class but external links
+        String html = """
+                <html><body>
+                <a href="https://example.com/page1">Example Page 1</a>
+                <a href="https://example.com/page2">Example Page 2</a>
+                </body></html>
+                """;
+
+        var results = ddgTool.parseDdgResults(html, 5);
+
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0).url()).isEqualTo("https://example.com/page1");
+        assertThat(results.get(0).title()).isEqualTo("Example Page 1");
+    }
+
+    private static String loadResource(String name) throws IOException {
+        try (InputStream is = WebSearchToolTest.class.getClassLoader().getResourceAsStream(name)) {
+            if (is == null) throw new IOException("Resource not found: " + name);
+            return new String(is.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/aceclaw-tools/src/test/resources/ddg-lite-sample.html
+++ b/aceclaw-tools/src/test/resources/ddg-lite-sample.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head><title>DuckDuckGo Lite</title></head>
+<body>
+<form>
+<table>
+<tr>
+<td>
+<a class="result-link" href="https://en.wikipedia.org/wiki/Java_(programming_language)">Java (programming language) - Wikipedia</a>
+</td>
+</tr>
+<tr>
+<td class="result-snippet">Java is a high-level, class-based, object-oriented programming language that is designed to have as few implementation dependencies as possible.</td>
+</tr>
+<tr>
+<td>
+<a class="result-link" href="https://www.oracle.com/java/">Oracle Java</a>
+</td>
+</tr>
+<tr>
+<td class="result-snippet">Java is the #1 programming language and development platform. Download Java today for free.</td>
+</tr>
+<tr>
+<td>
+<a class="result-link" href="https://docs.oracle.com/en/java/">Java Documentation - Oracle</a>
+</td>
+</tr>
+<tr>
+<td class="result-snippet">Official Java documentation including tutorials, API references, and guides for Java SE.</td>
+</tr>
+<tr>
+<td>
+<a class="result-link" href="https://www.java.com/en/">java.com</a>
+</td>
+</tr>
+<tr>
+<td class="result-snippet">Java technology allows you to work and play in a secure computing environment.</td>
+</tr>
+<tr>
+<td>
+<a class="result-link" href="https://dev.java/">dev.java - The Destination for Java Developers</a>
+</td>
+</tr>
+<tr>
+<td class="result-snippet">The official site for Java developers. Find tutorials, news, and documentation for all things Java.</td>
+</tr>
+<tr>
+<td>
+<a class="result-link" href="https://openjdk.org/">OpenJDK</a>
+</td>
+</tr>
+<tr>
+<td class="result-snippet">OpenJDK is the open-source implementation of the Java Platform, Standard Edition.</td>
+</tr>
+</table>
+</form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- **WebSearchTool DDG fallback**: `web_search` tool is now always available. Uses Brave Search API when `BRAVE_SEARCH_API_KEY` is configured, falls back to DuckDuckGo Lite (free, no API key) otherwise.
- **Dynamic tool guidance**: New `ToolGuidanceGenerator` produces system prompt sections (tool priority, tool-specific guidelines, fallback chain) based on which tools are actually registered, eliminating stale references to unavailable tools.
- **Tool composition guidance**: New `tool-guidance-composition.md` teaches the agent to creatively compose existing tools (bash+curl, write_file+bash scripts) when dedicated tools are unavailable.
- **System prompt cleanup**: Removed static tool priority and fallback chain sections from `system-prompt.md`, replaced with dynamic injection via placeholder.

Closes #42

## Test plan
- [ ] `./gradlew :aceclaw-tools:test --tests WebSearchToolTest` — 8 tests for DDG parsing, routing, error handling
- [ ] `./gradlew :aceclaw-daemon:test --tests ToolGuidanceGeneratorTest` — 8 tests for dynamic guidance generation
- [ ] `./gradlew clean build -x :aceclaw-core:test` — full build passes (SkillRegistryTest failures are pre-existing on main)
- [ ] Manual: start daemon without BRAVE_SEARCH_API_KEY, verify web_search tool is registered and uses DDG
- [ ] Manual: start daemon with BRAVE_SEARCH_API_KEY, verify web_search uses Brave

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Web search now functions without a Brave Search API key, using DuckDuckGo Lite as a free fallback option.
  * System prompts now include dynamic, tool-specific guidance that automatically adapts based on available tools.

* **Documentation**
  * Added guidance for creatively composing existing tools to construct workflows when a dedicated tool is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->