### PR TITLE
fix: correct openai-codex factory endpoint paths

### DIFF
--- a/aceclaw-llm/src/main/java/dev/aceclaw/llm/LlmClientFactory.java
+++ b/aceclaw-llm/src/main/java/dev/aceclaw/llm/LlmClientFactory.java
@@ -161,10 +161,10 @@ public final class LlmClientFactory {
         String resolvedModel = model != null ? model : DEFAULT_MODELS.getOrDefault("openai-codex", "gpt-5-codex");
 
         var chatClient = new OpenAICompatClient(
-                tokenProvider, resolvedBaseUrl, "/v1/chat/completions",
+                tokenProvider, resolvedBaseUrl, "/chat/completions",
                 "openai-codex", resolvedModel, ProviderCapabilities.OPENAI, Map.of());
         var responsesClient = new OpenAIResponsesClient(
-                tokenProvider, resolvedBaseUrl, "/v1/responses",
+                tokenProvider, resolvedBaseUrl, "/responses",
                 "openai-codex", resolvedModel, ProviderCapabilities.CODEX, Map.of());
 
         return new OpenAIRoutingClient(chatClient, responsesClient, resolvedModel, "openai-codex");


### PR DESCRIPTION
## Summary
- fix missed `openai-codex` factory paths for ChatGPT Codex backend
- use `/chat/completions` instead of `/v1/chat/completions`
- use `/responses` instead of `/v1/responses`

## Scope
- only touches `LlmClientFactory#createOpenAiCodexClient`
- no behavior change for `copilot` provider

Follow-up to #72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated API endpoint configurations to align with current service specifications, ensuring continued compatibility with model operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->