### PR TITLE
[Continuous Learning 5/14] Candidate merge and deduplication

### DIFF
--- a/aceclaw-memory/src/main/java/dev/aceclaw/memory/CandidateKind.java
+++ b/aceclaw-memory/src/main/java/dev/aceclaw/memory/CandidateKind.java
@@ -1,0 +1,12 @@
+package dev.aceclaw.memory;
+
+/**
+ * Candidate categories for the continuous-learning layer.
+ */
+public enum CandidateKind {
+    ERROR_RECOVERY,
+    PREFERENCE,
+    WORKFLOW,
+    ANTI_PATTERN,
+    SKILL_SEED
+}

--- a/aceclaw-memory/src/main/java/dev/aceclaw/memory/CandidateSimilarity.java
+++ b/aceclaw-memory/src/main/java/dev/aceclaw/memory/CandidateSimilarity.java
@@ -1,0 +1,47 @@
+package dev.aceclaw.memory;
+
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Similarity helper for candidate merge/dedup decisions.
+ */
+public final class CandidateSimilarity {
+
+    private CandidateSimilarity() {}
+
+    /**
+     * Blended similarity over text and tags with category/tool hard constraints.
+     */
+    public static double score(LearningCandidate a, LearningCandidate b) {
+        if (a.category() != b.category()) return 0.0;
+        if (!a.toolTag().equalsIgnoreCase(b.toolTag())) return 0.0;
+        double content = jaccard(a.content(), b.content());
+        double tags = jaccard(String.join(" ", a.tags()), String.join(" ", b.tags()));
+        return (0.7 * content) + (0.3 * tags);
+    }
+
+    static double jaccard(String left, String right) {
+        if (left == null || right == null || left.isBlank() || right.isBlank()) return 0.0;
+        Set<String> leftTokens = tokenize(left);
+        Set<String> rightTokens = tokenize(right);
+        if (leftTokens.isEmpty() && rightTokens.isEmpty()) return 1.0;
+        if (leftTokens.isEmpty() || rightTokens.isEmpty()) return 0.0;
+        var intersection = new HashSet<>(leftTokens);
+        intersection.retainAll(rightTokens);
+        var union = new HashSet<>(leftTokens);
+        union.addAll(rightTokens);
+        return (double) intersection.size() / union.size();
+    }
+
+    private static Set<String> tokenize(String text) {
+        var out = new HashSet<String>();
+        for (String token : text.toLowerCase(Locale.ROOT).split("\\W+")) {
+            if (!token.isBlank()) {
+                out.add(token);
+            }
+        }
+        return out;
+    }
+}

--- a/aceclaw-memory/src/main/java/dev/aceclaw/memory/CandidateState.java
+++ b/aceclaw-memory/src/main/java/dev/aceclaw/memory/CandidateState.java
@@ -1,0 +1,10 @@
+package dev.aceclaw.memory;
+
+/**
+ * Lifecycle state of a learning candidate.
+ */
+public enum CandidateState {
+    SHADOW,
+    PROMOTED,
+    REJECTED
+}

--- a/aceclaw-memory/src/main/java/dev/aceclaw/memory/CandidateStore.java
+++ b/aceclaw-memory/src/main/java/dev/aceclaw/memory/CandidateStore.java
@@ -1,0 +1,273 @@
+package dev.aceclaw.memory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Persistent store for learning candidates with merge/dedup behavior.
+ */
+public final class CandidateStore {
+
+    private static final Logger log = LoggerFactory.getLogger(CandidateStore.class);
+
+    private static final String MEMORY_DIR = "memory";
+    private static final String KEY_FILE = "memory.key";
+    private static final String CANDIDATES_FILE = "candidates.jsonl";
+    private static final int KEY_SIZE_BYTES = 32;
+    private static final Duration DEFAULT_RECENT_WINDOW = Duration.ofDays(30);
+    private static final double DEFAULT_MERGE_THRESHOLD = 0.50;
+
+    private final Path memoryDir;
+    private final Path candidatesFile;
+    private final ObjectMapper mapper;
+    private final MemorySigner signer;
+    private final CopyOnWriteArrayList<LearningCandidate> candidates;
+    private final ReentrantLock fileLock = new ReentrantLock();
+    private final Duration recentWindow;
+    private final double mergeThreshold;
+
+    public CandidateStore(Path aceclawHome) throws IOException {
+        this(aceclawHome, DEFAULT_RECENT_WINDOW, DEFAULT_MERGE_THRESHOLD);
+    }
+
+    CandidateStore(Path aceclawHome, Duration recentWindow, double mergeThreshold) throws IOException {
+        this.memoryDir = aceclawHome.resolve(MEMORY_DIR);
+        this.candidatesFile = memoryDir.resolve(CANDIDATES_FILE);
+        this.recentWindow = Objects.requireNonNull(recentWindow, "recentWindow");
+        this.mergeThreshold = mergeThreshold;
+        Files.createDirectories(memoryDir);
+
+        this.mapper = new ObjectMapper();
+        this.mapper.registerModule(new JavaTimeModule());
+        this.signer = new MemorySigner(loadOrCreateKey());
+        this.candidates = new CopyOnWriteArrayList<>();
+    }
+
+    public void load() {
+        fileLock.lock();
+        try {
+            candidates.clear();
+            loadFile();
+        } finally {
+            fileLock.unlock();
+        }
+    }
+
+    public List<LearningCandidate> all() {
+        return List.copyOf(candidates);
+    }
+
+    /**
+     * Upserts an observation into the candidate store.
+     * Matching key is category + toolTag + similarity(content/tags) in a recent window.
+     */
+    public LearningCandidate upsert(CandidateObservation observation) {
+        Objects.requireNonNull(observation, "observation");
+        fileLock.lock();
+        try {
+            var incoming = createUnsignedCandidate(observation);
+            int mergeIdx = findMergeIndex(incoming);
+            LearningCandidate stored;
+            if (mergeIdx >= 0) {
+                var merged = candidates.get(mergeIdx).mergeWith(incoming);
+                stored = sign(merged);
+                candidates.set(mergeIdx, stored);
+                rewriteFile();
+            } else {
+                stored = sign(incoming);
+                candidates.add(stored);
+                append(stored);
+            }
+            return stored;
+        } finally {
+            fileLock.unlock();
+        }
+    }
+
+    private int findMergeIndex(LearningCandidate incoming) {
+        Instant cutoff = incoming.lastSeenAt().minus(recentWindow);
+        int bestIdx = -1;
+        double bestScore = -1.0;
+        for (int i = 0; i < candidates.size(); i++) {
+            var existing = candidates.get(i);
+            if (existing.lastSeenAt().isBefore(cutoff)) {
+                continue;
+            }
+            double score = CandidateSimilarity.score(existing, incoming);
+            if (score >= mergeThreshold && score > bestScore) {
+                bestScore = score;
+                bestIdx = i;
+            }
+        }
+        return bestIdx;
+    }
+
+    private LearningCandidate createUnsignedCandidate(CandidateObservation observation) {
+        var now = observation.occurredAt() == null ? Instant.now() : observation.occurredAt();
+        return new LearningCandidate(
+                UUID.randomUUID().toString(),
+                observation.category(),
+                observation.kind(),
+                CandidateState.SHADOW,
+                observation.content(),
+                normalizeToolTag(observation.toolTag()),
+                List.copyOf(observation.tags()),
+                observation.score(),
+                1,
+                Math.max(0, observation.successDelta()),
+                Math.max(0, observation.failureDelta()),
+                now,
+                now,
+                observation.sourceRef() == null || observation.sourceRef().isBlank()
+                        ? List.of()
+                        : List.of(observation.sourceRef()),
+                null
+        );
+    }
+
+    private LearningCandidate sign(LearningCandidate candidate) {
+        return new LearningCandidate(
+                candidate.id(),
+                candidate.category(),
+                candidate.kind(),
+                candidate.state(),
+                candidate.content(),
+                candidate.toolTag(),
+                candidate.tags(),
+                candidate.score(),
+                candidate.evidenceCount(),
+                candidate.successCount(),
+                candidate.failureCount(),
+                candidate.firstSeenAt(),
+                candidate.lastSeenAt(),
+                candidate.sourceRefs(),
+                signer.sign(candidate.signablePayload()));
+    }
+
+    private void loadFile() {
+        if (!Files.isRegularFile(candidatesFile)) return;
+        try {
+            var lines = Files.readAllLines(candidatesFile);
+            int loaded = 0;
+            int skipped = 0;
+            for (var line : lines) {
+                if (line.isBlank()) continue;
+                try {
+                    var candidate = mapper.readValue(line, LearningCandidate.class);
+                    if (candidate.hmac() != null && signer.verify(candidate.signablePayload(), candidate.hmac())) {
+                        candidates.add(candidate);
+                        loaded++;
+                    } else {
+                        skipped++;
+                        log.warn("Skipped tampered candidate: id={}", candidate.id());
+                    }
+                } catch (Exception e) {
+                    skipped++;
+                    log.warn("Skipped malformed candidate entry: {}", e.getMessage());
+                }
+            }
+            candidates.sort(Comparator.comparing(LearningCandidate::lastSeenAt).reversed());
+            log.debug("Loaded {} candidates ({} skipped)", loaded, skipped);
+        } catch (IOException e) {
+            log.warn("Failed to read candidate file {}: {}", candidatesFile, e.getMessage());
+        }
+    }
+
+    private void rewriteFile() {
+        try {
+            var lines = new ArrayList<String>(candidates.size());
+            for (var candidate : candidates) {
+                lines.add(mapper.writeValueAsString(candidate));
+            }
+            Path tmp = candidatesFile.resolveSibling(candidatesFile.getFileName() + ".tmp");
+            Files.write(tmp, lines, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+            Files.move(tmp, candidatesFile, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+        } catch (IOException e) {
+            log.error("Failed to persist candidate store: {}", e.getMessage());
+        }
+    }
+
+    private void append(LearningCandidate candidate) {
+        try {
+            Files.writeString(
+                    candidatesFile,
+                    mapper.writeValueAsString(candidate) + "\n",
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.APPEND
+            );
+        } catch (IOException e) {
+            log.error("Failed to append candidate to store: {}", e.getMessage());
+        }
+    }
+
+    private byte[] loadOrCreateKey() throws IOException {
+        Path keyFile = memoryDir.resolve(KEY_FILE);
+        if (Files.isRegularFile(keyFile)) {
+            byte[] key = Files.readAllBytes(keyFile);
+            if (key.length >= KEY_SIZE_BYTES) {
+                return key;
+            }
+            log.warn("Candidate signing key file too short ({}B), regenerating", key.length);
+        }
+        byte[] key = new byte[KEY_SIZE_BYTES];
+        new SecureRandom().nextBytes(key);
+        Files.write(keyFile, key, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+        try {
+            Files.setPosixFilePermissions(keyFile, java.util.Set.of(
+                    PosixFilePermission.OWNER_READ,
+                    PosixFilePermission.OWNER_WRITE));
+        } catch (UnsupportedOperationException e) {
+            log.debug("POSIX permissions not supported on this filesystem");
+        }
+        return key;
+    }
+
+    private static String normalizeToolTag(String toolTag) {
+        if (toolTag == null || toolTag.isBlank()) {
+            return "general";
+        }
+        return toolTag.toLowerCase();
+    }
+
+    public record CandidateObservation(
+            MemoryEntry.Category category,
+            CandidateKind kind,
+            String content,
+            String toolTag,
+            List<String> tags,
+            double score,
+            int successDelta,
+            int failureDelta,
+            String sourceRef,
+            Instant occurredAt
+    ) {
+        public CandidateObservation {
+            Objects.requireNonNull(category, "category");
+            Objects.requireNonNull(kind, "kind");
+            Objects.requireNonNull(content, "content");
+            Objects.requireNonNull(tags, "tags");
+            if (score < 0.0 || score > 1.0) {
+                throw new IllegalArgumentException("score must be in [0.0, 1.0], got: " + score);
+            }
+        }
+    }
+}

--- a/aceclaw-memory/src/main/java/dev/aceclaw/memory/LearningCandidate.java
+++ b/aceclaw-memory/src/main/java/dev/aceclaw/memory/LearningCandidate.java
@@ -1,0 +1,88 @@
+package dev.aceclaw.memory;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.time.Instant;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Persisted continuous-learning candidate record.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record LearningCandidate(
+        String id,
+        MemoryEntry.Category category,
+        CandidateKind kind,
+        CandidateState state,
+        String content,
+        String toolTag,
+        List<String> tags,
+        double score,
+        int evidenceCount,
+        int successCount,
+        int failureCount,
+        Instant firstSeenAt,
+        Instant lastSeenAt,
+        List<String> sourceRefs,
+        String hmac
+) {
+
+    private static final int MAX_SOURCE_REFS = 50;
+
+    public LearningCandidate {
+        Objects.requireNonNull(id, "id");
+        Objects.requireNonNull(category, "category");
+        Objects.requireNonNull(kind, "kind");
+        Objects.requireNonNull(state, "state");
+        Objects.requireNonNull(content, "content");
+        Objects.requireNonNull(toolTag, "toolTag");
+        Objects.requireNonNull(tags, "tags");
+        Objects.requireNonNull(firstSeenAt, "firstSeenAt");
+        Objects.requireNonNull(lastSeenAt, "lastSeenAt");
+        Objects.requireNonNull(sourceRefs, "sourceRefs");
+        tags = List.copyOf(tags);
+        sourceRefs = List.copyOf(sourceRefs);
+        if (score < 0.0 || score > 1.0) {
+            throw new IllegalArgumentException("score must be in [0.0, 1.0], got: " + score);
+        }
+        if (evidenceCount < 0 || successCount < 0 || failureCount < 0) {
+            throw new IllegalArgumentException("counts must be non-negative");
+        }
+    }
+
+    public String signablePayload() {
+        return id + "|" + category + "|" + kind + "|" + state + "|" + content + "|" + toolTag + "|"
+                + String.join(",", tags) + "|" + score + "|" + evidenceCount + "|" + successCount + "|"
+                + failureCount + "|" + firstSeenAt + "|" + lastSeenAt + "|" + String.join(",", sourceRefs);
+    }
+
+    public LearningCandidate mergeWith(LearningCandidate incoming) {
+        int mergedEvidence = evidenceCount + incoming.evidenceCount;
+        double mergedScore = ((score * evidenceCount) + (incoming.score * incoming.evidenceCount))
+                / Math.max(1, mergedEvidence);
+        var mergedSources = new LinkedHashSet<>(sourceRefs);
+        mergedSources.addAll(incoming.sourceRefs);
+        while (mergedSources.size() > MAX_SOURCE_REFS) {
+            mergedSources.remove(mergedSources.iterator().next());
+        }
+        return new LearningCandidate(
+                id,
+                category,
+                kind,
+                state,
+                content,
+                toolTag,
+                tags,
+                mergedScore,
+                mergedEvidence,
+                successCount + incoming.successCount,
+                failureCount + incoming.failureCount,
+                firstSeenAt.isBefore(incoming.firstSeenAt) ? firstSeenAt : incoming.firstSeenAt,
+                lastSeenAt.isAfter(incoming.lastSeenAt) ? lastSeenAt : incoming.lastSeenAt,
+                List.copyOf(mergedSources),
+                hmac
+        );
+    }
+}

--- a/aceclaw-memory/src/test/java/dev/aceclaw/memory/CandidateSimilarityTest.java
+++ b/aceclaw-memory/src/test/java/dev/aceclaw/memory/CandidateSimilarityTest.java
@@ -1,0 +1,53 @@
+package dev.aceclaw.memory;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CandidateSimilarityTest {
+
+    @Test
+    void scoreReturnsZeroWhenCategoryDiffers() {
+        var a = candidate(MemoryEntry.Category.ERROR_RECOVERY, "bash", "timeout command");
+        var b = candidate(MemoryEntry.Category.PREFERENCE, "bash", "timeout command");
+        assertThat(CandidateSimilarity.score(a, b)).isEqualTo(0.0);
+    }
+
+    @Test
+    void scoreReturnsZeroWhenToolTagDiffers() {
+        var a = candidate(MemoryEntry.Category.ERROR_RECOVERY, "bash", "timeout command");
+        var b = candidate(MemoryEntry.Category.ERROR_RECOVERY, "read_file", "timeout command");
+        assertThat(CandidateSimilarity.score(a, b)).isEqualTo(0.0);
+    }
+
+    @Test
+    void scoreIsHighForCloseContentAndTags() {
+        var a = candidate(MemoryEntry.Category.ERROR_RECOVERY, "bash",
+                "command timeout after 120 seconds");
+        var b = candidate(MemoryEntry.Category.ERROR_RECOVERY, "bash",
+                "bash command timed out after 120 sec");
+        assertThat(CandidateSimilarity.score(a, b)).isGreaterThan(0.5);
+    }
+
+    private static LearningCandidate candidate(MemoryEntry.Category category, String toolTag, String content) {
+        return new LearningCandidate(
+                "id-" + toolTag + "-" + category.name(),
+                category,
+                CandidateKind.ERROR_RECOVERY,
+                CandidateState.SHADOW,
+                content,
+                toolTag,
+                List.of(toolTag, "failure"),
+                0.8,
+                1,
+                1,
+                0,
+                Instant.parse("2026-02-22T00:00:00Z"),
+                Instant.parse("2026-02-22T00:00:00Z"),
+                List.of("session:a"),
+                "hmac");
+    }
+}

--- a/aceclaw-memory/src/test/java/dev/aceclaw/memory/CandidateStoreTest.java
+++ b/aceclaw-memory/src/test/java/dev/aceclaw/memory/CandidateStoreTest.java
@@ -1,0 +1,130 @@
+package dev.aceclaw.memory;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CandidateStoreTest {
+
+    @TempDir
+    Path tempDir;
+
+    private CandidateStore store;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        store = new CandidateStore(tempDir);
+        store.load();
+    }
+
+    @Test
+    void upsertMergesSimilarObservations() {
+        var t0 = Instant.parse("2026-02-22T00:00:00Z");
+        var t1 = t0.plusSeconds(60);
+
+        store.upsert(observation("command timeout after 120 seconds", "session:a", t0));
+        store.upsert(observation("bash command timed out after 120 sec", "session:b", t1));
+
+        var all = store.all();
+        assertThat(all).hasSize(1);
+        var c = all.getFirst();
+        assertThat(c.evidenceCount()).isEqualTo(2);
+        assertThat(c.successCount()).isEqualTo(2);
+        assertThat(c.sourceRefs()).containsExactly("session:a", "session:b");
+        assertThat(c.lastSeenAt()).isEqualTo(t1);
+    }
+
+    @Test
+    void upsertKeepsDistinctCandidatesWhenBelowThreshold() {
+        store.upsert(observation("permission denied on chmod", "session:a",
+                Instant.parse("2026-02-22T00:00:00Z")));
+        store.upsert(observation("network timeout while downloading", "session:b",
+                Instant.parse("2026-02-22T00:01:00Z")));
+        assertThat(store.all()).hasSize(2);
+    }
+
+    @Test
+    void loadSkipsTamperedAndMalformedEntries() throws Exception {
+        store.upsert(observation("command timeout after 120 seconds", "session:a",
+                Instant.parse("2026-02-22T00:00:00Z")));
+        Path file = tempDir.resolve("memory").resolve("candidates.jsonl");
+        String content = Files.readString(file);
+        String tampered = content.replace("timeout", "tampered-timeout");
+        Files.writeString(file, tampered + "{\"bad-json\":\n");
+
+        var reloaded = new CandidateStore(tempDir);
+        reloaded.load();
+        assertThat(reloaded.all()).isEmpty();
+    }
+
+    @Test
+    void recentWindowLimitsMergeLookupRange() throws Exception {
+        var narrowWindowStore = new CandidateStore(tempDir, Duration.ofDays(1), 0.72);
+        narrowWindowStore.load();
+        narrowWindowStore.upsert(observation("command timeout after 120 seconds", "session:a",
+                Instant.parse("2026-01-01T00:00:00Z")));
+        narrowWindowStore.upsert(observation("bash command timed out after 120 sec", "session:b",
+                Instant.parse("2026-02-22T00:00:00Z")));
+        assertThat(narrowWindowStore.all()).hasSize(2);
+    }
+
+    @Test
+    void mergeBaselineAtTenThousandCandidates() throws IOException {
+        var largeStore = new CandidateStore(tempDir.resolve("perf"));
+        largeStore.load();
+        Instant base = Instant.parse("2026-02-22T00:00:00Z");
+        for (int i = 0; i < 10_000; i++) {
+            largeStore.upsert(new CandidateStore.CandidateObservation(
+                    MemoryEntry.Category.ERROR_RECOVERY,
+                    CandidateKind.ERROR_RECOVERY,
+                    "timeout error signature " + i,
+                    "bash",
+                    List.of("bash", "timeout", "sig-" + i),
+                    0.8,
+                    1,
+                    0,
+                    "seed:" + i,
+                    base.minusSeconds(i)));
+        }
+
+        long start = System.nanoTime();
+        largeStore.upsert(new CandidateStore.CandidateObservation(
+                MemoryEntry.Category.ERROR_RECOVERY,
+                CandidateKind.ERROR_RECOVERY,
+                "timeout error signature 9999",
+                "bash",
+                List.of("bash", "timeout", "sig-9999"),
+                0.9,
+                1,
+                0,
+                "measure",
+                base.plusSeconds(5)));
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+        assertThat(elapsedMs).isLessThan(10_000);
+    }
+
+    private static CandidateStore.CandidateObservation observation(String content, String source, Instant at) {
+        return new CandidateStore.CandidateObservation(
+                MemoryEntry.Category.ERROR_RECOVERY,
+                CandidateKind.ERROR_RECOVERY,
+                content,
+                "bash",
+                List.of("bash", "timeout"),
+                0.8,
+                1,
+                0,
+                source,
+                at
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add a new LearningCandidate model and enums for candidate lifecycle
- add CandidateStore with JSONL+HMAC persistence, upsert-merge path, and write-time dedup guard
- add CandidateSimilarity and tests for similarity boundaries, dedup behavior, corruption tolerance, and 10k-scale merge baseline

## Issue
Closes #56


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New observation storage system with multi-category support, lifecycle state management, and intelligent similarity-based deduplication.
  * Persistent storage with automatic merging of similar observations and configurable matching thresholds.
  * Validation and integrity support for stored observations.

* **Tests**
  * Comprehensive test coverage for storage operations, deduplication logic, and similarity scoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->