### PR TITLE
feat(issue-59): generate skill drafts from promoted candidates

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -512,7 +512,7 @@ public final class AceClawDaemon {
             result.put("createdDrafts", summary.createdDrafts());
             result.put("updatedDrafts", summary.updatedDrafts());
             var paths = objectMapper.createArrayNode();
-            summary.draftPaths().forEach(paths::add);
+            summary.draftPaths().forEach(path -> paths.add(path.replace('\\', '/')));
             result.set("draftPaths", paths);
             result.put("auditFile", workingDir.relativize(summary.auditFile()).toString().replace('\\', '/'));
             return result;

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/SkillDraftGenerator.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/SkillDraftGenerator.java
@@ -5,8 +5,6 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import dev.aceclaw.memory.CandidateState;
 import dev.aceclaw.memory.CandidateStore;
 import dev.aceclaw.memory.LearningCandidate;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -29,9 +27,8 @@ import java.util.Objects;
  */
 public final class SkillDraftGenerator {
 
-    private static final Logger log = LoggerFactory.getLogger(SkillDraftGenerator.class);
-
     private static final int MAX_SKILL_NAME = 48;
+    private static final int MAX_SUFFIX_ATTEMPTS = 500;
     private static final int DEFAULT_MAX_TURNS = 8;
 
     private static final String DRAFTS_DIR = ".aceclaw/skills-drafts";
@@ -83,8 +80,10 @@ public final class SkillDraftGenerator {
             } else {
                 created++;
             }
-            draftPaths.add(projectRoot.relativize(skillFile).toString());
-            appendAudit(auditPath, candidate, resolvedName, projectRoot.relativize(skillFile), existed ? "updated" : "created");
+            Path relativePath = projectRoot.relativize(skillFile);
+            String normalizedPath = relativePath.toString().replace('\\', '/');
+            draftPaths.add(normalizedPath);
+            appendAudit(auditPath, candidate, resolvedName, relativePath, existed ? "updated" : "created");
         }
 
         return new GenerationSummary(promoted.size(), created, updated, List.copyOf(draftPaths), auditPath);
@@ -94,30 +93,27 @@ public final class SkillDraftGenerator {
                              LearningCandidate candidate,
                              String skillName,
                              Path relativeSkillPath,
-                             String action) {
-        try {
-            var node = mapper.createObjectNode();
-            node.put("timestamp", Instant.now(clock).toString());
-            node.put("action", action);
-            node.put("candidateId", candidate.id());
-            node.put("candidateKind", candidate.kind().name());
-            node.put("skillName", skillName);
-            node.put("path", relativeSkillPath.toString().replace('\\', '/'));
-            Files.writeString(
-                    auditPath,
-                    mapper.writeValueAsString(node) + "\n",
-                    StandardOpenOption.CREATE,
-                    StandardOpenOption.APPEND
-            );
-        } catch (Exception e) {
-            log.warn("Failed to append skill draft audit entry: {}", e.getMessage());
-        }
+                             String action) throws IOException {
+        var node = mapper.createObjectNode();
+        node.put("timestamp", Instant.now(clock).toString());
+        node.put("action", action);
+        node.put("candidateId", candidate.id());
+        node.put("candidateKind", candidate.kind().name());
+        node.put("skillName", skillName);
+        node.put("path", relativeSkillPath.toString().replace('\\', '/'));
+        Files.writeString(
+                auditPath,
+                mapper.writeValueAsString(node) + "\n",
+                StandardOpenOption.CREATE,
+                StandardOpenOption.APPEND
+        );
     }
 
     private static String resolveSkillName(Path draftsRoot, String baseName, String candidateId) throws IOException {
         String current = baseName;
         int suffix = 2;
-        while (true) {
+        int attempts = 0;
+        while (attempts < MAX_SUFFIX_ATTEMPTS) {
             Path skillFile = draftsRoot.resolve(current).resolve("SKILL.md");
             if (!Files.exists(skillFile)) {
                 return current;
@@ -129,7 +125,10 @@ public final class SkillDraftGenerator {
             }
             current = truncateName(baseName + "-" + suffix, MAX_SKILL_NAME);
             suffix++;
+            attempts++;
         }
+        throw new IOException("Failed to resolve unique skill draft name for base '" + baseName
+                + "' after " + MAX_SUFFIX_ATTEMPTS + " attempts");
     }
 
     private static String renderSkillMarkdown(String skillName, LearningCandidate candidate) {
@@ -209,7 +208,16 @@ public final class SkillDraftGenerator {
     }
 
     private static String quoted(String s) {
-        return "\"" + (s == null ? "" : s.replace("\"", "\\\"")) + "\"";
+        if (s == null) {
+            return "\"\"";
+        }
+        String escaped = s
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\r\n", "\n")
+                .replace("\r", "\n")
+                .replace("\n", "\\n");
+        return "\"" + escaped + "\"";
     }
 
     private static String truncate(String s, int max) {
@@ -224,5 +232,9 @@ public final class SkillDraftGenerator {
             int updatedDrafts,
             List<String> draftPaths,
             Path auditFile
-    ) {}
+    ) {
+        public GenerationSummary {
+            draftPaths = draftPaths != null ? List.copyOf(draftPaths) : List.of();
+        }
+    }
 }

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/SkillDraftGeneratorTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/SkillDraftGeneratorTest.java
@@ -81,6 +81,28 @@ class SkillDraftGeneratorTest {
     }
 
     @Test
+    void regeneratingExistingDraftIncrementsUpdatedCount() throws Exception {
+        var project = tempDir.resolve("project-regen");
+        var store = newStore(project);
+        var t0 = Instant.parse("2026-02-24T00:00:00Z");
+
+        store.upsert(obs("Prefer concise command output summaries", "bash", t0));
+        store.upsert(obs("Prefer concise command output summaries", "read_file", t0.plusSeconds(30)));
+        store.evaluateAll();
+        assertThat(store.byState(CandidateState.PROMOTED)).hasSize(2);
+
+        var generator = new SkillDraftGenerator();
+        var first = generator.generateFromPromoted(store, project);
+        var second = generator.generateFromPromoted(store, project);
+
+        assertThat(first.createdDrafts()).isEqualTo(2);
+        assertThat(first.updatedDrafts()).isZero();
+        assertThat(second.createdDrafts()).isZero();
+        assertThat(second.updatedDrafts()).isEqualTo(2);
+        assertThat(second.draftPaths()).containsExactlyElementsOf(first.draftPaths());
+    }
+
+    @Test
     void onlyPromotedCandidatesGenerateDrafts() throws Exception {
         var project = tempDir.resolve("project-c");
         var store = newStore(project);
@@ -91,18 +113,7 @@ class SkillDraftGeneratorTest {
         store.evaluateAll();
 
         // Shadow candidate (insufficient score/evidence) should not produce draft.
-        store.upsert(new CandidateStore.CandidateObservation(
-                MemoryEntry.Category.WORKFLOW,
-                CandidateKind.WORKFLOW,
-                "Experimental rough strategy",
-                "glob",
-                List.of("glob"),
-                0.01,
-                0,
-                1,
-                "src:shadow",
-                t0.plusSeconds(120)
-        ));
+        store.upsert(obsLow("Experimental rough strategy", "glob", t0.plusSeconds(120)));
 
         var generator = new SkillDraftGenerator();
         var summary = generator.generateFromPromoted(store, project);
@@ -135,6 +146,21 @@ class SkillDraftGeneratorTest {
                 1,
                 0,
                 "src:" + toolTag,
+                at
+        );
+    }
+
+    private static CandidateStore.CandidateObservation obsLow(String content, String toolTag, Instant at) {
+        return new CandidateStore.CandidateObservation(
+                MemoryEntry.Category.WORKFLOW,
+                CandidateKind.WORKFLOW,
+                content,
+                toolTag,
+                List.of(toolTag),
+                0.01,
+                0,
+                1,
+                "src:shadow",
                 at
         );
     }

--- a/docs/continuous-learning-operations.md
+++ b/docs/continuous-learning-operations.md
@@ -113,8 +113,6 @@ Parameters:
 
 ```json
 {
-  "jsonrpc": "2.0",
-  "id": 5,
   "method": "skill.draft.generate",
   "params": {}
 }
@@ -152,6 +150,7 @@ Smoke checks:
 1. `candidate.injection.set(enabled=false)` should remove injected section in next turn.
 2. `candidate.injection.set(enabled=true,maxTokens=...)` should apply within one turn.
 3. `candidate.rollback` should transition `PROMOTED -> DEMOTED` and append transition log.
+4. `skill.draft.generate` should create at least one `.aceclaw/skills-drafts/<skill-name>/SKILL.md` with `disable-model-invocation: true` and append one line to `.aceclaw/metrics/continuous-learning/skill-draft-audit.jsonl`.
 
 CI guardrail job:
 


### PR DESCRIPTION
## Summary
- implement `SkillDraftGenerator` to emit draft skills from promoted candidates
- add manual RPC `skill.draft.generate` for controlled draft generation
- add deterministic collision handling for draft skill names
- add generation audit log at `.aceclaw/metrics/continuous-learning/skill-draft-audit.jsonl`
- update continuous-learning operations doc with draft generation workflow

## Acceptance Criteria Mapping (#59)
- [x] promoted strategy can generate valid draft skill file
- [x] generated drafts are non-auto-invokable by default (`disable-model-invocation: true`)
- [x] naming collisions handled deterministically

## Tests
- `./gradlew :aceclaw-daemon:clean :aceclaw-daemon:test --tests dev.aceclaw.daemon.SkillDraftGeneratorTest --no-daemon`

## Notes
- this PR intentionally does not auto-promote drafts into `.aceclaw/skills`
- this PR keeps generation as explicit/manual trigger (`skill.draft.generate`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "skill.draft.generate" RPC endpoint that automatically creates skill draft files from promoted learning candidates, with standardized formatting and audit tracking to .aceclaw/metrics/continuous-learning/.

* **Documentation**
  * Updated documentation to describe the new skill generation capability and verification procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->