### PR TITLE
feat(issue-61): automated skill promotion/rollback controller

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
@@ -77,7 +77,10 @@ public final class AceClawConfig {
     private static final double DEFAULT_SKILL_AUTO_RELEASE_CANARY_MAX_FAILURE_RATE = 0.35;
     private static final double DEFAULT_SKILL_AUTO_RELEASE_CANARY_MAX_TIMEOUT_RATE = 0.20;
     private static final double DEFAULT_SKILL_AUTO_RELEASE_CANARY_MAX_PERMISSION_BLOCK_RATE = 0.20;
-    private static final double DEFAULT_SKILL_AUTO_RELEASE_ACTIVE_MAX_FAILURE_RATE = 0.45;
+    private static final double DEFAULT_SKILL_AUTO_RELEASE_ACTIVE_MAX_FAILURE_RATE = 0.45; // legacy alias
+    private static final double DEFAULT_SKILL_AUTO_RELEASE_ROLLBACK_MAX_FAILURE_RATE = 0.45;
+    private static final double DEFAULT_SKILL_AUTO_RELEASE_ROLLBACK_MAX_TIMEOUT_RATE = 0.20;
+    private static final double DEFAULT_SKILL_AUTO_RELEASE_ROLLBACK_MAX_PERMISSION_BLOCK_RATE = 0.20;
     private static final int DEFAULT_SKILL_AUTO_RELEASE_HEALTH_LOOKBACK_HOURS = 168;
 
     /** Claude CLI credentials directory. */
@@ -127,6 +130,9 @@ public final class AceClawConfig {
     private double skillAutoReleaseCanaryMaxTimeoutRate;
     private double skillAutoReleaseCanaryMaxPermissionBlockRate;
     private double skillAutoReleaseActiveMaxFailureRate;
+    private double skillAutoReleaseRollbackMaxFailureRate;
+    private double skillAutoReleaseRollbackMaxTimeoutRate;
+    private double skillAutoReleaseRollbackMaxPermissionBlockRate;
     private int skillAutoReleaseHealthLookbackHours;
     private Map<String, List<HookMatcherFormat>> hooks;
 
@@ -166,6 +172,10 @@ public final class AceClawConfig {
         this.skillAutoReleaseCanaryMaxTimeoutRate = DEFAULT_SKILL_AUTO_RELEASE_CANARY_MAX_TIMEOUT_RATE;
         this.skillAutoReleaseCanaryMaxPermissionBlockRate = DEFAULT_SKILL_AUTO_RELEASE_CANARY_MAX_PERMISSION_BLOCK_RATE;
         this.skillAutoReleaseActiveMaxFailureRate = DEFAULT_SKILL_AUTO_RELEASE_ACTIVE_MAX_FAILURE_RATE;
+        this.skillAutoReleaseRollbackMaxFailureRate = DEFAULT_SKILL_AUTO_RELEASE_ROLLBACK_MAX_FAILURE_RATE;
+        this.skillAutoReleaseRollbackMaxTimeoutRate = DEFAULT_SKILL_AUTO_RELEASE_ROLLBACK_MAX_TIMEOUT_RATE;
+        this.skillAutoReleaseRollbackMaxPermissionBlockRate =
+                DEFAULT_SKILL_AUTO_RELEASE_ROLLBACK_MAX_PERMISSION_BLOCK_RATE;
         this.skillAutoReleaseHealthLookbackHours = DEFAULT_SKILL_AUTO_RELEASE_HEALTH_LOOKBACK_HOURS;
         this.providerModels = new java.util.HashMap<>();
     }
@@ -356,9 +366,45 @@ public final class AceClawConfig {
             try {
                 config.skillAutoReleaseActiveMaxFailureRate =
                         clampRate(Double.parseDouble(envSkillAutoReleaseActiveMaxFailureRate));
+                // Legacy env alias maps to rollback failure threshold.
+                config.skillAutoReleaseRollbackMaxFailureRate = config.skillAutoReleaseActiveMaxFailureRate;
             } catch (NumberFormatException e) {
                 log.warn("Invalid ACECLAW_SKILL_AUTO_RELEASE_ACTIVE_MAX_FAILURE_RATE: {}",
                         envSkillAutoReleaseActiveMaxFailureRate);
+            }
+        }
+        var envSkillAutoReleaseRollbackMaxFailureRate =
+                System.getenv("ACECLAW_SKILL_AUTO_RELEASE_ROLLBACK_MAX_FAILURE_RATE");
+        if (envSkillAutoReleaseRollbackMaxFailureRate != null && !envSkillAutoReleaseRollbackMaxFailureRate.isBlank()) {
+            try {
+                config.skillAutoReleaseRollbackMaxFailureRate =
+                        clampRate(Double.parseDouble(envSkillAutoReleaseRollbackMaxFailureRate));
+            } catch (NumberFormatException e) {
+                log.warn("Invalid ACECLAW_SKILL_AUTO_RELEASE_ROLLBACK_MAX_FAILURE_RATE: {}",
+                        envSkillAutoReleaseRollbackMaxFailureRate);
+            }
+        }
+        var envSkillAutoReleaseRollbackMaxTimeoutRate =
+                System.getenv("ACECLAW_SKILL_AUTO_RELEASE_ROLLBACK_MAX_TIMEOUT_RATE");
+        if (envSkillAutoReleaseRollbackMaxTimeoutRate != null && !envSkillAutoReleaseRollbackMaxTimeoutRate.isBlank()) {
+            try {
+                config.skillAutoReleaseRollbackMaxTimeoutRate =
+                        clampRate(Double.parseDouble(envSkillAutoReleaseRollbackMaxTimeoutRate));
+            } catch (NumberFormatException e) {
+                log.warn("Invalid ACECLAW_SKILL_AUTO_RELEASE_ROLLBACK_MAX_TIMEOUT_RATE: {}",
+                        envSkillAutoReleaseRollbackMaxTimeoutRate);
+            }
+        }
+        var envSkillAutoReleaseRollbackMaxPermissionRate =
+                System.getenv("ACECLAW_SKILL_AUTO_RELEASE_ROLLBACK_MAX_PERMISSION_BLOCK_RATE");
+        if (envSkillAutoReleaseRollbackMaxPermissionRate != null
+                && !envSkillAutoReleaseRollbackMaxPermissionRate.isBlank()) {
+            try {
+                config.skillAutoReleaseRollbackMaxPermissionBlockRate =
+                        clampRate(Double.parseDouble(envSkillAutoReleaseRollbackMaxPermissionRate));
+            } catch (NumberFormatException e) {
+                log.warn("Invalid ACECLAW_SKILL_AUTO_RELEASE_ROLLBACK_MAX_PERMISSION_BLOCK_RATE: {}",
+                        envSkillAutoReleaseRollbackMaxPermissionRate);
             }
         }
         var envSkillAutoReleaseLookbackHours = System.getenv("ACECLAW_SKILL_AUTO_RELEASE_HEALTH_LOOKBACK_HOURS");
@@ -730,6 +776,18 @@ public final class AceClawConfig {
         return skillAutoReleaseActiveMaxFailureRate;
     }
 
+    public double skillAutoReleaseRollbackMaxFailureRate() {
+        return skillAutoReleaseRollbackMaxFailureRate;
+    }
+
+    public double skillAutoReleaseRollbackMaxTimeoutRate() {
+        return skillAutoReleaseRollbackMaxTimeoutRate;
+    }
+
+    public double skillAutoReleaseRollbackMaxPermissionBlockRate() {
+        return skillAutoReleaseRollbackMaxPermissionBlockRate;
+    }
+
     public int skillAutoReleaseHealthLookbackHours() {
         return skillAutoReleaseHealthLookbackHours;
     }
@@ -1028,6 +1086,21 @@ public final class AceClawConfig {
         if (fileConfig.skillAutoReleaseActiveMaxFailureRate != null
                 && fileConfig.skillAutoReleaseActiveMaxFailureRate >= 0) {
             this.skillAutoReleaseActiveMaxFailureRate = clampRate(fileConfig.skillAutoReleaseActiveMaxFailureRate);
+            // Legacy config key maps to rollback failure threshold.
+            this.skillAutoReleaseRollbackMaxFailureRate = this.skillAutoReleaseActiveMaxFailureRate;
+        }
+        if (fileConfig.skillAutoReleaseRollbackMaxFailureRate != null
+                && fileConfig.skillAutoReleaseRollbackMaxFailureRate >= 0) {
+            this.skillAutoReleaseRollbackMaxFailureRate = clampRate(fileConfig.skillAutoReleaseRollbackMaxFailureRate);
+        }
+        if (fileConfig.skillAutoReleaseRollbackMaxTimeoutRate != null
+                && fileConfig.skillAutoReleaseRollbackMaxTimeoutRate >= 0) {
+            this.skillAutoReleaseRollbackMaxTimeoutRate = clampRate(fileConfig.skillAutoReleaseRollbackMaxTimeoutRate);
+        }
+        if (fileConfig.skillAutoReleaseRollbackMaxPermissionBlockRate != null
+                && fileConfig.skillAutoReleaseRollbackMaxPermissionBlockRate >= 0) {
+            this.skillAutoReleaseRollbackMaxPermissionBlockRate =
+                    clampRate(fileConfig.skillAutoReleaseRollbackMaxPermissionBlockRate);
         }
         if (fileConfig.skillAutoReleaseHealthLookbackHours != null
                 && fileConfig.skillAutoReleaseHealthLookbackHours > 0) {
@@ -1080,6 +1153,9 @@ public final class AceClawConfig {
         public Double skillAutoReleaseCanaryMaxTimeoutRate;
         public Double skillAutoReleaseCanaryMaxPermissionBlockRate;
         public Double skillAutoReleaseActiveMaxFailureRate;
+        public Double skillAutoReleaseRollbackMaxFailureRate;
+        public Double skillAutoReleaseRollbackMaxTimeoutRate;
+        public Double skillAutoReleaseRollbackMaxPermissionBlockRate;
         public Integer skillAutoReleaseHealthLookbackHours;
         public String defaultProfile;
         public Map<String, ConfigFileFormat> profiles;

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -386,7 +386,9 @@ public final class AceClawDaemon {
                                 config.skillAutoReleaseCanaryMaxFailureRate(),
                                 config.skillAutoReleaseCanaryMaxTimeoutRate(),
                                 config.skillAutoReleaseCanaryMaxPermissionBlockRate(),
-                                config.skillAutoReleaseActiveMaxFailureRate(),
+                                config.skillAutoReleaseRollbackMaxFailureRate(),
+                                config.skillAutoReleaseRollbackMaxTimeoutRate(),
+                                config.skillAutoReleaseRollbackMaxPermissionBlockRate(),
                                 Duration.ofHours(Math.max(1, config.skillAutoReleaseHealthLookbackHours()))
                         ),
                         validationGateForAuto

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AutoReleaseController.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AutoReleaseController.java
@@ -307,9 +307,9 @@ public final class AutoReleaseController {
 
     private boolean shouldRollback(HealthMetrics metrics) {
         return metrics.attempts() > 0 && (
-                metrics.failureRate() > config.activeMaxFailureRate()
-                        || metrics.timeoutRate() > config.canaryMaxTimeoutRate()
-                        || metrics.permissionRate() > config.canaryMaxPermissionRate()
+                metrics.failureRate() > config.rollbackMaxFailureRate()
+                        || metrics.timeoutRate() > config.rollbackMaxTimeoutRate()
+                        || metrics.permissionRate() > config.rollbackMaxPermissionRate()
         );
     }
 
@@ -452,7 +452,9 @@ public final class AutoReleaseController {
             double canaryMaxFailureRate,
             double canaryMaxTimeoutRate,
             double canaryMaxPermissionRate,
-            double activeMaxFailureRate,
+            double rollbackMaxFailureRate,
+            double rollbackMaxTimeoutRate,
+            double rollbackMaxPermissionRate,
             Duration healthLookback
     ) {
         public Config {
@@ -460,7 +462,7 @@ public final class AutoReleaseController {
         }
 
         public static Config defaults() {
-            return new Config(0.80, 3, 5, 0.35, 0.20, 0.20, 0.45, Duration.ofDays(7));
+            return new Config(0.80, 3, 5, 0.35, 0.20, 0.20, 0.45, 0.20, 0.20, Duration.ofDays(7));
         }
     }
 

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/AutoReleaseControllerTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/AutoReleaseControllerTest.java
@@ -37,7 +37,7 @@ class AutoReleaseControllerTest {
                 Path.of(".aceclaw/metrics/continuous-learning/replay-latest.json"), 0.65);
         var controller = new AutoReleaseController(
                 Clock.fixed(t0.plusSeconds(10), ZoneOffset.UTC),
-                new AutoReleaseController.Config(0.2, 1, 1, 0.5, 0.5, 0.5, 0.6, Duration.ofDays(7)),
+                new AutoReleaseController.Config(0.2, 1, 1, 0.5, 0.5, 0.5, 0.6, 0.6, 0.6, Duration.ofDays(7)),
                 validation);
 
         var first = controller.evaluateAll(tempDir, store, "test-1");
@@ -62,7 +62,7 @@ class AutoReleaseControllerTest {
                 Path.of(".aceclaw/metrics/continuous-learning/replay-latest.json"), 0.65);
         var controller = new AutoReleaseController(
                 Clock.fixed(t0.plusSeconds(10), ZoneOffset.UTC),
-                new AutoReleaseController.Config(0.2, 1, 1, 0.8, 0.8, 0.8, 0.2, Duration.ofDays(7)),
+                new AutoReleaseController.Config(0.2, 1, 1, 0.8, 0.8, 0.8, 0.2, 0.8, 0.8, Duration.ofDays(7)),
                 validation);
 
         controller.evaluateAll(tempDir, store, "bootstrap");

--- a/docs/continuous-learning-operations.md
+++ b/docs/continuous-learning-operations.md
@@ -34,7 +34,10 @@ Config keys in `.aceclaw/config.json`:
 - `skillAutoReleaseCanaryMaxFailureRate` (`double`, default `0.35`)
 - `skillAutoReleaseCanaryMaxTimeoutRate` (`double`, default `0.20`)
 - `skillAutoReleaseCanaryMaxPermissionBlockRate` (`double`, default `0.20`)
-- `skillAutoReleaseActiveMaxFailureRate` (`double`, default `0.45`)
+- `skillAutoReleaseRollbackMaxFailureRate` (`double`, default `0.45`)
+- `skillAutoReleaseRollbackMaxTimeoutRate` (`double`, default `0.20`)
+- `skillAutoReleaseRollbackMaxPermissionBlockRate` (`double`, default `0.20`)
+- `skillAutoReleaseActiveMaxFailureRate` (`double`, legacy alias for rollback failure threshold)
 - `skillAutoReleaseHealthLookbackHours` (`int`, default `168`)
 
 Environment overrides:
@@ -54,6 +57,9 @@ Environment overrides:
 - `ACECLAW_SKILL_AUTO_RELEASE_CANARY_MAX_FAILURE_RATE`
 - `ACECLAW_SKILL_AUTO_RELEASE_CANARY_MAX_TIMEOUT_RATE`
 - `ACECLAW_SKILL_AUTO_RELEASE_CANARY_MAX_PERMISSION_BLOCK_RATE`
+- `ACECLAW_SKILL_AUTO_RELEASE_ROLLBACK_MAX_FAILURE_RATE`
+- `ACECLAW_SKILL_AUTO_RELEASE_ROLLBACK_MAX_TIMEOUT_RATE`
+- `ACECLAW_SKILL_AUTO_RELEASE_ROLLBACK_MAX_PERMISSION_BLOCK_RATE`
 - `ACECLAW_SKILL_AUTO_RELEASE_ACTIVE_MAX_FAILURE_RATE`
 - `ACECLAW_SKILL_AUTO_RELEASE_HEALTH_LOOKBACK_HOURS`
 


### PR DESCRIPTION
## Summary
- implement `AutoReleaseController` for automation-first draft rollout lifecycle (`shadow -> canary -> active`)
- add auto-rollback logic on validation failure or health guardrail breach
- persist release state and machine-readable transition audit:
  - `.aceclaw/metrics/continuous-learning/skill-release-state.json`
  - `.aceclaw/metrics/continuous-learning/skill-release-audit.jsonl`
- wire controller into daemon runtime:
  - auto evaluation after `skill.draft.generate`
  - auto re-evaluation on evidence updates
  - new emergency/manual RPCs:
    - `skill.release.evaluate`
    - `skill.release.pause`
    - `skill.release.forceRollback`
    - `skill.release.forcePromote`
- add configurable release policy thresholds in config + env overrides
- update operations runbook with release workflow and commands

## Tests
- `./gradlew :aceclaw-daemon:test --tests dev.aceclaw.daemon.AutoReleaseControllerTest --tests dev.aceclaw.daemon.ValidationGateEngineTest --no-daemon`
- `./gradlew :aceclaw-daemon:test --tests dev.aceclaw.daemon.AutoReleaseControllerTest --tests dev.aceclaw.daemon.SkillDraftGeneratorTest --no-daemon`
- `./gradlew :aceclaw-daemon:continuousLearningSmokeTest --no-daemon`

Closes #61


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated skill release workflow (Shadow → Canary → Active) with configurable thresholds, health lookback, guardrail-based auto-rollback, persisted release state and audit events; runtime RPC controls to evaluate, pause, force-rollback, and force-promote.
* **Documentation**
  * Operational guides updated with auto-release config keys, environment overrides, RPC examples, audit/state paths, and playbook steps.
* **Tests**
  * Added end-to-end tests covering canary→active promotion and guardrail-triggered rollback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->