### PR TITLE
feat(cli): compact tool status with subtle trace logs

### DIFF
--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/ForegroundOutputSink.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/ForegroundOutputSink.java
@@ -122,6 +122,7 @@ public final class ForegroundOutputSink implements OutputSink {
                 wasThinking = false;
             }
             stopSpinner();
+            emitToolTraceStart(toolName, summary);
             statusRenderer.onToolStarted(toolId, toolName, summary);
         }
     }
@@ -130,6 +131,7 @@ public final class ForegroundOutputSink implements OutputSink {
     public void onToolCompleted(String toolId, String toolName,
                                 long durationMs, boolean isError, String error) {
         synchronized (lock) {
+            emitToolTraceCompleted(toolName, durationMs, isError, error);
             statusRenderer.onToolCompleted(toolId, toolName, durationMs, isError, error);
         }
     }
@@ -290,6 +292,40 @@ public final class ForegroundOutputSink implements OutputSink {
         return normalized.substring(0, maxLen - 3) + "...";
     }
 
+    private void emitToolTraceStart(String toolName, String summary) {
+        statusRenderer.hide();
+        String label = safeName(toolName);
+        String detail = truncate(summary, 90);
+        if (detail.isBlank()) {
+            out.println(MUTED + "[tool:start] " + label + RESET);
+        } else {
+            out.println(MUTED + "[tool:start] " + label + " - " + detail + RESET);
+        }
+        out.flush();
+    }
+
+    private void emitToolTraceCompleted(String toolName, long durationMs, boolean isError, String error) {
+        statusRenderer.hide();
+        String label = safeName(toolName);
+        String elapsed = String.format(Locale.ROOT, "%.1fs", Math.max(0L, durationMs) / 1000.0);
+        if (isError) {
+            String reason = truncate(error, 90);
+            if (reason.isBlank()) {
+                out.println(MUTED + "[tool:error] " + label + " (" + elapsed + ")" + RESET);
+            } else {
+                out.println(MUTED + "[tool:error] " + label + " (" + elapsed + ") - " + reason + RESET);
+            }
+        } else {
+            out.println(MUTED + "[tool:done] " + label + " (" + elapsed + ")" + RESET);
+        }
+        out.flush();
+    }
+
+    private static String safeName(String toolName) {
+        if (toolName == null || toolName.isBlank()) return "unknown";
+        return toolName;
+    }
+
     /**
      * Lightweight status renderer for tool/sub-agent/plan progress lines.
      *
@@ -335,13 +371,31 @@ public final class ForegroundOutputSink implements OutputSink {
 
         void onToolStarted(String toolId, String toolName, String summary) {
             pruneExpired();
-            String key = (toolId != null && !toolId.isBlank())
-                    ? toolId : "tool-" + (++nextSyntheticId);
             String parent = firstActiveKey(Kind.SUBAGENT);
-            var entry = new StatusEntry(key, Kind.TOOL, safe(toolName, "unknown"),
-                    truncate(summary, 60), System.nanoTime());
+            String normalizedToolName = safe(toolName, "unknown");
+
+            StatusEntry entry = null;
+            if (toolId != null && !toolId.isBlank()) {
+                entry = entries.get(toolId);
+            }
+            if (entry == null) {
+                entry = firstReusableTool(normalizedToolName);
+            }
+
+            if (entry == null) {
+                String key = (toolId != null && !toolId.isBlank())
+                        ? toolId : "tool-" + (++nextSyntheticId);
+                entry = new StatusEntry(key, Kind.TOOL, normalizedToolName,
+                        truncate(summary, 60), System.nanoTime());
+                entries.put(key, entry);
+            } else {
+                entry.name = normalizedToolName;
+                entry.detail = truncate(summary, 60);
+                entry.state = State.ACTIVE;
+                entry.durationMs = 0L;
+                entry.expiresAtMs = 0L;
+            }
             entry.parentKey = parent;
-            entries.put(key, entry);
             redraw();
         }
 
@@ -564,6 +618,17 @@ public final class ForegroundOutputSink implements OutputSink {
                 if (entry.kind == Kind.TOOL
                         && entry.state == State.ACTIVE
                         && toolName.equals(entry.name)) {
+                    return entry;
+                }
+            }
+            return null;
+        }
+
+        private StatusEntry firstReusableTool(String toolName) {
+            StatusEntry active = firstActiveTool(toolName);
+            if (active != null) return active;
+            for (var entry : entries.values()) {
+                if (entry.kind == Kind.TOOL && toolName.equals(entry.name)) {
                     return entry;
                 }
             }

--- a/aceclaw-cli/src/test/java/dev/aceclaw/cli/ForegroundOutputSinkTest.java
+++ b/aceclaw-cli/src/test/java/dev/aceclaw/cli/ForegroundOutputSinkTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Test;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.lang.reflect.Field;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -45,5 +47,26 @@ class ForegroundOutputSinkTest {
         assertThat(output).contains("Sub-agent");
         assertThat(output).contains("step 2/4");
         assertThat(output).contains("Run tests");
+    }
+
+    @Test
+    void repeatedSameTool_reusesSingleStatusEntry() throws Exception {
+        var buffer = new StringWriter();
+        var sink = new ForegroundOutputSink(new PrintWriter(buffer), new TerminalMarkdownRenderer());
+
+        sink.onToolUse("toolu_1", "web_search", "q1");
+        sink.onToolCompleted("toolu_1", "web_search", 900, false, "");
+        sink.onToolUse("toolu_2", "web_search", "q2");
+        sink.onToolCompleted("toolu_2", "web_search", 1000, false, "");
+
+        Field rendererField = ForegroundOutputSink.class.getDeclaredField("statusRenderer");
+        rendererField.setAccessible(true);
+        Object renderer = rendererField.get(sink);
+        Field entriesField = renderer.getClass().getDeclaredField("entries");
+        entriesField.setAccessible(true);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> entries = (Map<String, Object>) entriesField.get(renderer);
+        assertThat(entries).hasSize(1);
     }
 }


### PR DESCRIPTION
## Summary\n- reuse a single status entry for repeated same-name tools instead of growing many lines\n- add subtle gray trace lines for tool lifecycle visibility:\n  - [tool:start] ...\n  - [tool:done] ...\n  - [tool:error] ...\n- keep status panel behavior and tests updated\n\n## Validation\n- ./gradlew :aceclaw-cli:test --no-daemon