### PR TITLE
CLI: learning status clarity + cleaner tool logs

### DIFF
--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/ForegroundOutputSink.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/ForegroundOutputSink.java
@@ -18,6 +18,12 @@ import static dev.aceclaw.cli.TerminalTheme.*;
  * status area under the active streaming line for tools, sub-agents, and plan steps.
  */
 public final class ForegroundOutputSink implements OutputSink {
+    /**
+     * Tool panel lines (⏳/✅) are noisy on some terminals because cursor restore behavior
+     * differs across environments. Keep it opt-in; default to trace-only tool logs.
+     */
+    private static final boolean TOOL_STATUS_PANEL_ENABLED =
+            Boolean.parseBoolean(System.getenv().getOrDefault("ACECLAW_TOOL_STATUS_PANEL", "false"));
 
     private final PrintWriter out;
     private final TerminalMarkdownRenderer markdownRenderer;
@@ -123,7 +129,9 @@ public final class ForegroundOutputSink implements OutputSink {
             }
             stopSpinner();
             emitToolTraceStart(toolName, summary);
-            statusRenderer.onToolStarted(toolId, toolName, summary);
+            if (TOOL_STATUS_PANEL_ENABLED) {
+                statusRenderer.onToolStarted(toolId, toolName, summary);
+            }
         }
     }
 
@@ -132,7 +140,9 @@ public final class ForegroundOutputSink implements OutputSink {
                                 long durationMs, boolean isError, String error) {
         synchronized (lock) {
             emitToolTraceCompleted(toolName, durationMs, isError, error);
-            statusRenderer.onToolCompleted(toolId, toolName, durationMs, isError, error);
+            if (TOOL_STATUS_PANEL_ENABLED) {
+                statusRenderer.onToolCompleted(toolId, toolName, durationMs, isError, error);
+            }
         }
     }
 

--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
@@ -1008,6 +1008,7 @@ public final class TerminalRepl {
         if (!Files.isRegularFile(candidatesPath)) return null;
         int total = 0;
         int promoted = 0;
+        int shadow = 0;
         int demoted = 0;
         try (var lines = Files.lines(candidatesPath)) {
             var it = lines.iterator();
@@ -1019,13 +1020,14 @@ public final class TerminalRepl {
                 if (node == null) continue;
                 String state = node.path("state").asText("");
                 if ("PROMOTED".equals(state)) promoted++;
+                if ("SHADOW".equals(state)) shadow++;
                 if ("DEMOTED".equals(state)) demoted++;
             }
         } catch (Exception e) {
             log.debug("Failed to parse candidates.jsonl: {}", e.getMessage());
             return "read-error";
         }
-        return total + "(p:" + promoted + ",d:" + demoted + ")";
+        return total + "(p:" + promoted + ",s:" + shadow + ",d:" + demoted + ")";
     }
 
     private String releaseStatusSummary(Path releaseStatePath) {

--- a/aceclaw-cli/src/test/java/dev/aceclaw/cli/ForegroundOutputSinkTest.java
+++ b/aceclaw-cli/src/test/java/dev/aceclaw/cli/ForegroundOutputSinkTest.java
@@ -21,8 +21,8 @@ class ForegroundOutputSinkTest {
         sink.onToolCompleted("toolu_1", "bash", 820, false, "");
 
         String output = buffer.toString();
-        assertThat(output).contains("bash: git diff --stat");
-        assertThat(output).contains("\u2705");
+        assertThat(output).contains("[tool:start] bash - git diff --stat");
+        assertThat(output).contains("[tool:done] bash (0.8s)");
     }
 
     @Test
@@ -50,7 +50,7 @@ class ForegroundOutputSinkTest {
     }
 
     @Test
-    void repeatedSameTool_reusesSingleStatusEntry() throws Exception {
+    void repeatedSameTool_traceModeDoesNotCreatePanelEntries() throws Exception {
         var buffer = new StringWriter();
         var sink = new ForegroundOutputSink(new PrintWriter(buffer), new TerminalMarkdownRenderer());
 
@@ -67,6 +67,6 @@ class ForegroundOutputSinkTest {
 
         @SuppressWarnings("unchecked")
         Map<String, Object> entries = (Map<String, Object>) entriesField.get(renderer);
-        assertThat(entries).hasSize(1);
+        assertThat(entries).isEmpty();
     }
 }

--- a/aceclaw-cli/src/test/java/dev/aceclaw/cli/TerminalReplTest.java
+++ b/aceclaw-cli/src/test/java/dev/aceclaw/cli/TerminalReplTest.java
@@ -178,6 +178,22 @@ class TerminalReplTest {
     }
 
     @Test
+    void candidateStatusSummary_includesShadowCount() throws Exception {
+        var statusRepl = newReplForProject(tempDir);
+        Path candidates = tempDir.resolve(".aceclaw/memory/candidates.jsonl");
+        Files.createDirectories(candidates.getParent());
+        Files.writeString(candidates, """
+                {"id":"1","state":"PROMOTED"}
+                {"id":"2","state":"DEMOTED"}
+                {"id":"3","state":"SHADOW"}
+                """);
+
+        String summary = (String) invokePrivate(statusRepl, "candidateStatusSummary",
+                new Class<?>[]{Path.class}, candidates);
+        assertThat(summary).isEqualTo("3(p:1,s:1,d:1)");
+    }
+
+    @Test
     void buildContinuousLearningStatusLine_concurrentAccess_isStable() throws Exception {
         var statusRepl = newReplForProject(tempDir);
         writeLearningArtifacts(tempDir);


### PR DESCRIPTION
Summary:\n- show shadow count in learning candidates status as p/s/d\n- reduce tool output noise by defaulting to trace-only tool logs\n- keep tool status panel opt-in via ACECLAW_TOOL_STATUS_PANEL=true\n- update/add tests for new status formatting and tool rendering behavior\n\nValidation:\n- ./gradlew :aceclaw-cli:test --tests dev.aceclaw.cli.ForegroundOutputSinkTest --tests dev.aceclaw.cli.TerminalReplTest --no-daemon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool status panel can now be disabled via environment variable configuration.
  * Candidate status summary now tracks and displays shadow state counts in addition to promoted and demoted candidates.

* **Tests**
  * Updated test expectations and assertions to align with new output format and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->