### PR TITLE
feat(issue-102): config-first max-turns runtime control (phase 1)

### DIFF
--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/AgentLoop.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/AgentLoop.java
@@ -31,9 +31,6 @@ public final class AgentLoop {
 
     private static final Logger log = LoggerFactory.getLogger(AgentLoop.class);
 
-    /** Maximum number of tool-use iterations before forcing a stop. */
-    private static final int MAX_ITERATIONS = 25;
-
     private final LlmClient llmClient;
     private final ToolRegistry toolRegistry;
     private final String model;
@@ -97,9 +94,10 @@ public final class AgentLoop {
         int totalOutputTokens = 0;
         int totalCacheCreationTokens = 0;
         int totalCacheReadTokens = 0;
+        int maxIterations = config.effectiveMaxIterations();
 
         try {
-            for (int iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
+            for (int iteration = 0; iteration < maxIterations; iteration++) {
                 log.debug("ReAct iteration {} (messages: {})", iteration + 1, allMessages.size());
 
                 // Build and send the LLM request
@@ -145,7 +143,7 @@ public final class AgentLoop {
             }
 
             // Exceeded max iterations — return what we have
-            log.warn("ReAct loop exceeded max iterations ({})", MAX_ITERATIONS);
+            log.warn("ReAct loop exceeded max iterations ({})", maxIterations);
             var totalUsage = new Usage(
                     totalInputTokens, totalOutputTokens,
                     totalCacheCreationTokens, totalCacheReadTokens);

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/AgentLoopConfig.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/AgentLoopConfig.java
@@ -13,17 +13,32 @@ import dev.aceclaw.infra.event.EventBus;
  * @param permissionChecker  permission checker for tool execution authorization
  * @param memoryHandler      handler for persisting context extracted during compaction
  * @param metricsCollector   collector for per-tool execution statistics (null = disabled)
+ * @param maxIterations      maximum ReAct iterations per turn (null/<=0 uses default)
  */
 public record AgentLoopConfig(
         String sessionId,
         EventBus eventBus,
         ToolPermissionChecker permissionChecker,
         CompactionMemoryHandler memoryHandler,
-        ToolMetricsCollector metricsCollector
+        ToolMetricsCollector metricsCollector,
+        Integer maxIterations
 ) {
 
+    /** Default maximum ReAct iterations per turn when no override is provided. */
+    public static final int DEFAULT_MAX_ITERATIONS = 25;
+
     /** Empty config with all integrations disabled. */
-    public static final AgentLoopConfig EMPTY = new AgentLoopConfig(null, null, null, null, null);
+    public static final AgentLoopConfig EMPTY = new AgentLoopConfig(null, null, null, null, null, null);
+
+    /**
+     * Resolves the effective max iterations for this loop config.
+     */
+    public int effectiveMaxIterations() {
+        if (maxIterations == null || maxIterations <= 0) {
+            return DEFAULT_MAX_ITERATIONS;
+        }
+        return maxIterations;
+    }
 
     public static Builder builder() {
         return new Builder();
@@ -35,6 +50,7 @@ public record AgentLoopConfig(
         private ToolPermissionChecker permissionChecker;
         private CompactionMemoryHandler memoryHandler;
         private ToolMetricsCollector metricsCollector;
+        private Integer maxIterations;
 
         private Builder() {}
 
@@ -63,8 +79,14 @@ public record AgentLoopConfig(
             return this;
         }
 
+        public Builder maxIterations(int maxIterations) {
+            this.maxIterations = maxIterations;
+            return this;
+        }
+
         public AgentLoopConfig build() {
-            return new AgentLoopConfig(sessionId, eventBus, permissionChecker, memoryHandler, metricsCollector);
+            return new AgentLoopConfig(
+                    sessionId, eventBus, permissionChecker, memoryHandler, metricsCollector, maxIterations);
         }
     }
 }

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/SkillConfig.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/SkillConfig.java
@@ -45,7 +45,7 @@ public record SkillConfig(
 ) {
 
     /** Default maximum turns for fork-mode skill execution. */
-    public static final int DEFAULT_MAX_TURNS = 25;
+    public static final int DEFAULT_MAX_TURNS = AgentLoopConfig.DEFAULT_MAX_ITERATIONS;
 
     /** Execution context for a skill. */
     public enum ExecutionContext {

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/StreamingAgentLoop.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/StreamingAgentLoop.java
@@ -33,9 +33,6 @@ public final class StreamingAgentLoop {
 
     private static final Logger log = LoggerFactory.getLogger(StreamingAgentLoop.class);
 
-    /** Maximum number of tool-use iterations before forcing a stop. */
-    private static final int MAX_ITERATIONS = 25;
-
     /** Maximum characters allowed in a single tool result before truncation. */
     private static final int MAX_TOOL_RESULT_CHARS = 30_000;
 
@@ -145,9 +142,10 @@ public final class StreamingAgentLoop {
         CompactionResult compactionResult = null;
         // Tracks repeated tool failures within this turn to emit generic fallback guidance.
         var toolFailureAdvisor = new ToolFailureAdvisor();
+        int maxIterations = config.effectiveMaxIterations();
 
         try {
-            for (int iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
+            for (int iteration = 0; iteration < maxIterations; iteration++) {
 
                 // Checkpoint 1: before LLM call
                 if (cancellationToken != null && cancellationToken.isCancelled()) {
@@ -273,7 +271,7 @@ public final class StreamingAgentLoop {
             }
 
             // Exceeded max iterations
-            log.warn("Streaming ReAct loop exceeded max iterations ({})", MAX_ITERATIONS);
+            log.warn("Streaming ReAct loop exceeded max iterations ({})", maxIterations);
             var totalUsage = new Usage(
                     totalInputTokens, totalOutputTokens,
                     totalCacheCreationTokens, totalCacheReadTokens);

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/SubAgentConfig.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/SubAgentConfig.java
@@ -15,7 +15,7 @@ import java.util.List;
  * @param model               model to use (null = inherit parent model)
  * @param allowedTools        explicit list of allowed tools (empty = all minus disallowed)
  * @param disallowedTools     tools to exclude (always includes "task" for no-nesting)
- * @param maxTurns            maximum ReAct iterations (default 25)
+ * @param maxTurns            maximum ReAct iterations (default from {@link AgentLoopConfig})
  * @param systemPromptTemplate system prompt markdown body for the sub-agent
  */
 public record SubAgentConfig(
@@ -29,7 +29,7 @@ public record SubAgentConfig(
 ) {
 
     /** Default maximum turns for sub-agents. */
-    public static final int DEFAULT_MAX_TURNS = 25;
+    public static final int DEFAULT_MAX_TURNS = AgentLoopConfig.DEFAULT_MAX_ITERATIONS;
 
     public SubAgentConfig {
         if (name == null || name.isBlank()) {

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/SubAgentRunner.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/SubAgentRunner.java
@@ -164,6 +164,7 @@ public final class SubAgentRunner {
         if (permissionChecker != null) {
             loopConfigBuilder.permissionChecker(permissionChecker);
         }
+        loopConfigBuilder.maxIterations(config.maxTurns());
         var loopConfig = loopConfigBuilder.build();
 
         // Sub-agents use no compaction (short-lived, fresh context)

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/agent/AgentLoopIntegrationTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/agent/AgentLoopIntegrationTest.java
@@ -12,11 +12,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -225,6 +223,44 @@ class AgentLoopIntegrationTest {
         var loop = new AgentLoop(llm, registry, "model", null);
         var turn = loop.runTurn("hi", List.of());
         assertThat(turn.text()).isEqualTo("Hello");
+    }
+
+    @Test
+    void maxIterationsFromConfigCapsLoop() throws Exception {
+        var llmCalls = new AtomicInteger();
+        var llm = new LlmClient() {
+            @Override
+            public String provider() {
+                return "test";
+            }
+
+            @Override
+            public String defaultModel() {
+                return "test-model";
+            }
+
+            @Override
+            public LlmResponse sendMessage(LlmRequest request) {
+                int seq = llmCalls.incrementAndGet();
+                var toolUse = new ContentBlock.ToolUse("t" + seq, "missing_tool", "{}");
+                return new LlmResponse(
+                        "id-" + seq, "model", List.of(toolUse), StopReason.TOOL_USE, new Usage(1, 1, 0, 0));
+            }
+
+            @Override
+            public StreamSession streamMessage(LlmRequest request) {
+                throw new UnsupportedOperationException();
+            }
+        };
+
+        var config = AgentLoopConfig.builder()
+                .maxIterations(3)
+                .build();
+        var loop = new AgentLoop(llm, new ToolRegistry(), "model", null, config);
+
+        var turn = loop.runTurn("loop", List.of());
+        assertThat(llmCalls.get()).isEqualTo(3);
+        assertThat(turn.finalStopReason()).isEqualTo(StopReason.END_TURN);
     }
 
     // -- Test helpers --

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/agent/SubAgentRunnerTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/agent/SubAgentRunnerTest.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -115,6 +116,52 @@ class SubAgentRunnerTest {
 
         assertThat(result).isEqualTo("Result from haiku");
         assertThat(mockClient.lastRequest.model()).isEqualTo("haiku-model");
+    }
+
+    @Test
+    void runRespectsConfigMaxTurns() throws Exception {
+        var calls = new AtomicInteger();
+        var loopingClient = new LlmClient() {
+            @Override
+            public LlmResponse sendMessage(LlmRequest request) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public StreamSession streamMessage(LlmRequest request) {
+                calls.incrementAndGet();
+                return new StreamSession() {
+                    @Override
+                    public void onEvent(StreamEventHandler handler) {
+                        handler.onMessageStart(new StreamEvent.MessageStart("msg", "mock"));
+                        handler.onContentBlockStart(
+                                new StreamEvent.ContentBlockStart(0, new ContentBlock.ToolUse("t", "nope", "{}")));
+                        handler.onContentBlockStop(new StreamEvent.ContentBlockStop(0));
+                        handler.onMessageDelta(new StreamEvent.MessageDelta(StopReason.TOOL_USE, new Usage(1, 1)));
+                        handler.onComplete(new StreamEvent.StreamComplete());
+                    }
+
+                    @Override
+                    public void cancel() {}
+                };
+            }
+
+            @Override
+            public String provider() {
+                return "mock";
+            }
+
+            @Override
+            public String defaultModel() {
+                return "mock-model";
+            }
+        };
+
+        var runner = new SubAgentRunner(loopingClient, new ToolRegistry(), "model", tempDir, 4096, 0);
+        var config = new SubAgentConfig("test", "", null, List.of(), List.of(), 2, "prompt");
+
+        runner.run(config, "do stuff", null);
+        assertThat(calls.get()).isEqualTo(2);
     }
 
     @Test

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
@@ -3,6 +3,7 @@ package dev.aceclaw.daemon;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.aceclaw.core.agent.AgentLoopConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +34,7 @@ import java.util.Map;
  *   <li>{@code ANTHROPIC_API_KEY} → apiKey</li>
  *   <li>{@code OPENAI_API_KEY} → apiKey (fallback for non-Anthropic providers)</li>
  *   <li>{@code ACECLAW_MODEL} → model</li>
+ *   <li>{@code ACECLAW_MAX_TURNS} → maxTurns</li>
  *   <li>{@code ACECLAW_LOG_LEVEL} → logLevel</li>
  *   <li>{@code BRAVE_SEARCH_API_KEY} → braveSearchApiKey</li>
  * </ul>
@@ -48,6 +50,7 @@ public final class AceClawConfig {
     private static final String DEFAULT_MODEL = "claude-sonnet-4-5-20250929";
     private static final int DEFAULT_MAX_TOKENS = 16384;
     private static final int DEFAULT_THINKING_BUDGET = 10240;
+    private static final int DEFAULT_MAX_TURNS = AgentLoopConfig.DEFAULT_MAX_ITERATIONS;
     private static final int DEFAULT_CONTEXT_WINDOW = 0;
     private static final String DEFAULT_LOG_LEVEL = "INFO";
     private static final boolean DEFAULT_BOOT_ENABLED = true;
@@ -97,6 +100,7 @@ public final class AceClawConfig {
     private String model;
     private int maxTokens;
     private int thinkingBudget;
+    private int maxTurns;
     private int contextWindowTokens;
     private String logLevel;
     private String braveSearchApiKey;
@@ -145,6 +149,7 @@ public final class AceClawConfig {
         this.model = null; // resolved dynamically via providerModels or LlmClientFactory defaults
         this.maxTokens = DEFAULT_MAX_TOKENS;
         this.thinkingBudget = DEFAULT_THINKING_BUDGET;
+        this.maxTurns = DEFAULT_MAX_TURNS;
         this.contextWindowTokens = DEFAULT_CONTEXT_WINDOW;
         this.logLevel = DEFAULT_LOG_LEVEL;
         this.permissionMode = "normal";
@@ -243,6 +248,14 @@ public final class AceClawConfig {
         var envModel = System.getenv("ACECLAW_MODEL");
         if (envModel != null && !envModel.isBlank()) {
             config.model = envModel;
+        }
+        var envMaxTurns = System.getenv("ACECLAW_MAX_TURNS");
+        if (envMaxTurns != null && !envMaxTurns.isBlank()) {
+            try {
+                config.maxTurns = Math.max(1, Integer.parseInt(envMaxTurns));
+            } catch (NumberFormatException e) {
+                log.warn("Invalid ACECLAW_MAX_TURNS: {}", envMaxTurns);
+            }
         }
         var envLogLevel = System.getenv("ACECLAW_LOG_LEVEL");
         if (envLogLevel != null && !envLogLevel.isBlank()) {
@@ -453,8 +466,8 @@ public final class AceClawConfig {
             config.loadClaudeCliCredentials();
         }
 
-        log.info("Config loaded: provider={}, model={}, maxTokens={}, thinkingBudget={}, contextWindow={}, logLevel={}, baseUrl={}, apiKey={}, refreshToken={}",
-                config.provider, config.model, config.maxTokens, config.thinkingBudget, config.contextWindowTokens, config.logLevel,
+        log.info("Config loaded: provider={}, model={}, maxTokens={}, thinkingBudget={}, maxTurns={}, contextWindow={}, logLevel={}, baseUrl={}, apiKey={}, refreshToken={}",
+                config.provider, config.model, config.maxTokens, config.thinkingBudget, config.maxTurns, config.contextWindowTokens, config.logLevel,
                 config.baseUrl != null ? config.baseUrl : "(default)",
                 config.apiKey != null ? config.apiKey.substring(0, Math.min(15, config.apiKey.length())) + "***" : "(not set)",
                 config.refreshToken != null ? "***" : "(not set)");
@@ -521,6 +534,13 @@ public final class AceClawConfig {
      */
     public int thinkingBudget() {
         return thinkingBudget;
+    }
+
+    /**
+     * Returns the max ReAct iterations per turn.
+     */
+    public int maxTurns() {
+        return maxTurns;
     }
 
     /**
@@ -1006,6 +1026,9 @@ public final class AceClawConfig {
         if (fileConfig.thinkingBudget > 0) {
             this.thinkingBudget = fileConfig.thinkingBudget;
         }
+        if (fileConfig.maxTurns > 0) {
+            this.maxTurns = fileConfig.maxTurns;
+        }
         if (fileConfig.contextWindowTokens > 0) {
             this.contextWindowTokens = fileConfig.contextWindowTokens;
         }
@@ -1158,6 +1181,7 @@ public final class AceClawConfig {
         public String model;
         public int maxTokens;
         public int thinkingBudget;
+        public int maxTurns;
         public int contextWindowTokens;
         public String logLevel;
         public String braveSearchApiKey;

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -323,15 +323,18 @@ public final class AceClawDaemon {
                 systemPrompt.length(), systemPromptTokens, compactionConfig.effectiveWindowTokens());
 
         // 7. Streaming agent loop (with compaction support)
+        var loopConfig = dev.aceclaw.core.agent.AgentLoopConfig.builder()
+                .maxIterations(config.maxTurns())
+                .build();
         var agentLoop = new StreamingAgentLoop(
                 llmClient, toolRegistry, model, systemPrompt,
-                config.maxTokens(), config.thinkingBudget(), compactor);
+                config.maxTokens(), config.thinkingBudget(), compactor, loopConfig);
 
         // 8. Streaming agent handler
         var agentHandler = new StreamingAgentHandler(
                 sessionManager, agentLoop, toolRegistry, permissionManager, objectMapper);
         agentHandler.setLlmConfig(llmClient, model, systemPrompt);
-        agentHandler.setTokenConfig(config.maxTokens(), config.thinkingBudget());
+        agentHandler.setTokenConfig(config.maxTokens(), config.thinkingBudget(), config.maxTurns());
         agentHandler.setPlannerConfig(config.plannerEnabled(), config.plannerThreshold());
         agentHandler.setCompactor(compactor);
         agentHandler.setMemoryStore(memoryStore, workingDir);
@@ -881,6 +884,7 @@ public final class AceClawDaemon {
                         bootLlmClient, bootToolRegistry,
                         bootModel, bootSystemPrompt,
                         config.maxTokens(), config.thinkingBudget(),
+                        config.maxTurns(),
                         config.bootTimeoutSeconds());
                 if (bootResult.executed()) {
                     log.info("Boot completed: {}", bootResult.summary());

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/BootExecutor.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/BootExecutor.java
@@ -77,6 +77,7 @@ public final class BootExecutor {
      * @param systemPrompt   system prompt for the LLM
      * @param maxTokens      max tokens per LLM request
      * @param thinkingBudget thinking budget tokens (0 = disabled)
+     * @param maxTurns       max ReAct iterations per BOOT execution
      * @param timeoutSeconds max seconds for all boot execution
      * @return the boot result (never null)
      */
@@ -84,6 +85,7 @@ public final class BootExecutor {
                                      LlmClient llmClient, ToolRegistry toolRegistry,
                                      String model, String systemPrompt,
                                      int maxTokens, int thinkingBudget,
+                                     int maxTurns,
                                      int timeoutSeconds) {
         long startNanos = System.nanoTime();
 
@@ -102,6 +104,7 @@ public final class BootExecutor {
         var bootConfig = AgentLoopConfig.builder()
                 .sessionId("boot")
                 .permissionChecker(bootPermChecker)
+                .maxIterations(maxTurns)
                 .build();
         var agentLoop = new StreamingAgentLoop(
                 llmClient, toolRegistry, model, systemPrompt,

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -179,6 +179,7 @@ public final class StreamingAgentHandler {
         var agentConfig = AgentLoopConfig.builder()
                 .sessionId(sessionId)
                 .metricsCollector(metricsCollector)
+                .maxIterations(maxIterations)
                 .build();
         var permissionAwareLoop = new StreamingAgentLoop(
                 getLlmClient(), permissionAwareRegistry,
@@ -618,6 +619,7 @@ public final class StreamingAgentHandler {
     private String systemPrompt;
     private int maxTokens = 16384;
     private int thinkingBudget = 10240;
+    private int maxIterations = AgentLoopConfig.DEFAULT_MAX_ITERATIONS;
     private MessageCompactor compactor;
     private AutoMemoryStore memoryStore;
     private DailyJournal dailyJournal;
@@ -645,9 +647,10 @@ public final class StreamingAgentHandler {
     /**
      * Sets the token configuration for permission-aware agent loop creation.
      */
-    public void setTokenConfig(int maxTokens, int thinkingBudget) {
+    public void setTokenConfig(int maxTokens, int thinkingBudget, int maxIterations) {
         this.maxTokens = maxTokens;
         this.thinkingBudget = thinkingBudget;
+        this.maxIterations = Math.max(1, maxIterations);
     }
 
     /**

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/cron/CronScheduler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/cron/CronScheduler.java
@@ -277,6 +277,7 @@ public final class CronScheduler {
         var loopConfig = AgentLoopConfig.builder()
                 .sessionId("cron-" + job.id())
                 .permissionChecker(permChecker)
+                .maxIterations(job.maxIterations())
                 .build();
         var agentLoop = new StreamingAgentLoop(
                 llmClient, toolRegistry, model, systemPrompt,

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/BootExecutorTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/BootExecutorTest.java
@@ -1,6 +1,7 @@
 package dev.aceclaw.daemon;
 
 import dev.aceclaw.core.agent.ToolRegistry;
+import dev.aceclaw.core.agent.AgentLoopConfig;
 import dev.aceclaw.core.llm.*;
 import dev.aceclaw.tools.GlobSearchTool;
 import dev.aceclaw.tools.GrepSearchTool;
@@ -54,7 +55,7 @@ class BootExecutorTest {
     void noBootMd_returnsNotExecuted() {
         var result = BootExecutor.execute(
                 homeDir, workDir, mockLlm, toolRegistry,
-                "mock-model", "system prompt", 4096, 0, 30);
+                "mock-model", "system prompt", 4096, 0, AgentLoopConfig.DEFAULT_MAX_ITERATIONS, 30);
 
         assertThat(result.executed()).isFalse();
         assertThat(result.filesFound()).isZero();
@@ -75,7 +76,7 @@ class BootExecutorTest {
 
         var result = BootExecutor.execute(
                 homeDir, workDir, mockLlm, toolRegistry,
-                "mock-model", "system prompt", 4096, 0, 30);
+                "mock-model", "system prompt", 4096, 0, AgentLoopConfig.DEFAULT_MAX_ITERATIONS, 30);
 
         assertThat(result.executed()).isTrue();
         assertThat(result.filesFound()).isEqualTo(1);
@@ -99,7 +100,7 @@ class BootExecutorTest {
 
         var result = BootExecutor.execute(
                 homeDir, workDir, mockLlm, toolRegistry,
-                "mock-model", "system prompt", 4096, 0, 30);
+                "mock-model", "system prompt", 4096, 0, AgentLoopConfig.DEFAULT_MAX_ITERATIONS, 30);
 
         assertThat(result.executed()).isTrue();
         assertThat(result.filesFound()).isEqualTo(1);
@@ -121,7 +122,7 @@ class BootExecutorTest {
 
         var result = BootExecutor.execute(
                 homeDir, workDir, mockLlm, toolRegistry,
-                "mock-model", "system prompt", 4096, 0, 30);
+                "mock-model", "system prompt", 4096, 0, AgentLoopConfig.DEFAULT_MAX_ITERATIONS, 30);
 
         assertThat(result.executed()).isTrue();
         assertThat(result.filesFound()).isEqualTo(2);
@@ -152,7 +153,7 @@ class BootExecutorTest {
 
         var result = BootExecutor.execute(
                 homeDir, workDir, mockLlm, toolRegistry,
-                "mock-model", "system prompt", 4096, 0, 30);
+                "mock-model", "system prompt", 4096, 0, AgentLoopConfig.DEFAULT_MAX_ITERATIONS, 30);
 
         assertThat(result.executed()).isTrue();
         assertThat(result.filesFound()).isEqualTo(1);
@@ -172,7 +173,7 @@ class BootExecutorTest {
 
         var result = BootExecutor.execute(
                 homeDir, workDir, mockLlm, toolRegistry,
-                "mock-model", "system prompt", 4096, 0, 30);
+                "mock-model", "system prompt", 4096, 0, AgentLoopConfig.DEFAULT_MAX_ITERATIONS, 30);
 
         // Boot should fail gracefully, not crash
         assertThat(result.filesFound()).isEqualTo(1);
@@ -188,7 +189,7 @@ class BootExecutorTest {
 
         var result = BootExecutor.execute(
                 homeDir, workDir, mockLlm, toolRegistry,
-                "mock-model", "system prompt", 4096, 0, 30);
+                "mock-model", "system prompt", 4096, 0, AgentLoopConfig.DEFAULT_MAX_ITERATIONS, 30);
 
         // Empty file found but not executed
         assertThat(result.filesFound()).isEqualTo(1);


### PR DESCRIPTION
## Summary
Implements issue #102 phase 1 (config-first) by removing hardcoded runtime loop caps and routing max-turn limits through configuration.

## What changed
- Replaced hardcoded ReAct loop cap in `AgentLoop` and `StreamingAgentLoop` with `AgentLoopConfig.maxIterations` (default remains 25).
- Added `maxIterations` support to `AgentLoopConfig` with `effectiveMaxIterations()`.
- Added daemon config `maxTurns` with env override `ACECLAW_MAX_TURNS`, and passed it into primary session loops.
- Updated `StreamingAgentHandler` to propagate configured max turns to per-request loops.
- Updated `BootExecutor` to accept max-turn configuration and wired from daemon config.
- Updated `CronScheduler` to enforce each cron job's `maxIterations` via loop config.
- Fixed sub-agent execution so `SubAgentConfig.maxTurns` is actually enforced (previously logged but not applied).
- Unified `SkillConfig`/`SubAgentConfig` default max turns to `AgentLoopConfig.DEFAULT_MAX_ITERATIONS`.

## Tests
- `./gradlew :aceclaw-core:test --tests dev.aceclaw.core.agent.AgentLoopIntegrationTest --tests dev.aceclaw.core.agent.SubAgentRunnerTest`
- `./gradlew :aceclaw-daemon:test --tests dev.aceclaw.daemon.BootExecutorTest --tests dev.aceclaw.daemon.cron.CronSchedulerTest`

## Scope note
This PR is intentionally limited to phase 1 (config-first). Adaptive continuation segments, no-progress guardrails, and continuation metrics from issue #102 are not included yet.

Closes #102


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Agent iteration limits are now configurable. Users can set the maximum number of turns via environment variables or configuration files. The limit applies consistently across all agent execution modes, including standard operations, streaming execution, boot sequences, and scheduled jobs. Default maximum remains 25 iterations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->