### PR TITLE
feat(issue-102): phase3 default adaptive continuation rollout

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
@@ -56,7 +56,7 @@ public final class AceClawConfig {
     private static final int DEFAULT_MAX_TOKENS = 16384;
     private static final int DEFAULT_THINKING_BUDGET = 10240;
     private static final int DEFAULT_MAX_TURNS = AgentLoopConfig.DEFAULT_MAX_ITERATIONS;
-    private static final boolean DEFAULT_ADAPTIVE_CONTINUATION_ENABLED = false;
+    private static final boolean DEFAULT_ADAPTIVE_CONTINUATION_ENABLED = true;
     private static final int DEFAULT_ADAPTIVE_CONTINUATION_MAX_SEGMENTS = 3;
     private static final int DEFAULT_ADAPTIVE_CONTINUATION_NO_PROGRESS_THRESHOLD = 2;
     private static final int DEFAULT_ADAPTIVE_CONTINUATION_MAX_TOTAL_TOKENS = 0;

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -479,6 +479,12 @@ public final class StreamingAgentHandler {
             continuationNode.put("reason", adaptive.reason());
             continuationNode.put("stopped_by_budget", adaptive.stoppedByBudget());
             result.set("continuation", continuationNode);
+
+            var metricsNode = objectMapper.createObjectNode();
+            metricsNode.put("turns_used", adaptive.segmentIndex());
+            metricsNode.put("continuation_count", adaptive.continuationCount());
+            metricsNode.put("no_progress_stops", "no_progress_stop".equals(adaptive.reason()) ? 1 : 0);
+            result.set("metrics", metricsNode);
         }
 
         log.info("Streaming turn complete: sessionId={}, stopReason={}, tokens={}, cancelled={}, compacted={}",
@@ -755,7 +761,7 @@ public final class StreamingAgentHandler {
     private int maxTokens = 16384;
     private int thinkingBudget = 10240;
     private int maxIterations = AgentLoopConfig.DEFAULT_MAX_ITERATIONS;
-    private boolean adaptiveContinuationEnabled = false;
+    private boolean adaptiveContinuationEnabled = true;
     private int adaptiveContinuationMaxSegments = 3;
     private int adaptiveContinuationNoProgressThreshold = 2;
     private int adaptiveContinuationMaxTotalTokens = 0;


### PR DESCRIPTION
## Summary
Implements issue #102 phase 3 rollout defaults and ops-facing continuation metrics.

## What changed
- Switched adaptive continuation to default-on in daemon config:
  - `DEFAULT_ADAPTIVE_CONTINUATION_ENABLED = true`
  - Can still be disabled explicitly via config/env (`ACECLAW_ADAPTIVE_CONTINUATION=false`).
- Aligned `StreamingAgentHandler` runtime default to adaptive-enabled.
- Exposed operations metrics on `agent.prompt` response when continuation metadata is present:
  - `metrics.turns_used`
  - `metrics.continuation_count`
  - `metrics.no_progress_stops`

## Tests
- `./gradlew :aceclaw-daemon:compileJava :aceclaw-daemon:test --tests dev.aceclaw.daemon.BootExecutorTest :aceclaw-core:test --tests dev.aceclaw.core.agent.AgentLoopIntegrationTest`

## Scope note
This PR focuses on phase-3 default rollout + metrics exposure. It does not alter phase-2 continuation guardrail logic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metrics reporting for adaptive continuation results, including turns used, continuation count, and progress tracking information.
  * Adaptive continuation is now enabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->