### PR TITLE
Add ADR: harness session concurrency and learning-loop integration

### DIFF
--- a/aceclaw-cli/docs/adr/ADR-0001-harness-session-concurrency-and-learning-loop.md
+++ b/aceclaw-cli/docs/adr/ADR-0001-harness-session-concurrency-and-learning-loop.md
@@ -38,8 +38,7 @@ Adopt a **Dual-Channel Session Model**:
 
 2. **Worker Sessions (isolated, optional)**
 - Harness may create additional sessions only for explicitly decomposed sub-tasks (research/verification/isolated execution).
-- Worker sessions do not mutate lead-session transcript directly.
-- Worker outputs are returned as structured artifacts/evidence and merged by lead session.
+- Worker sessions do not mutate the lead-session transcript directly; they return structured artifacts/evidence which the lead session merges.
 
 3. **Session Spawning Policy (default conservative)**
 - Do not spawn worker sessions for simple or tightly stateful flows.
@@ -310,9 +309,6 @@ Phase 1 exit criterion:
 
 ## References
 
-- `research/openclaw-agent-orchestration.md`
-- `research/architecture-agent-teams.md`
-- `research/security-review.md`
 - `docs/continuous-learning-plan.md`
 - `docs/continuous-learning-governance.md`
 - `docs/continuous-learning-operations.md`


### PR DESCRIPTION
## Summary
- Add ADR-0001 for agent harness architecture direction
- Define dual-channel session model: lead session + optional worker sessions
- Codify non-conflict constraints with existing PRD resume/session semantics
- Document OpenClaw/Claude Code orchestration lessons to adopt and pitfalls to avoid

## Why
Current multi-task behavior can appear blocked under single-session execution semantics. This ADR clarifies the intended harness evolution path while preserving deterministic resume and governance constraints.

## Scope
- Documentation only (no runtime behavior changes)

## Key Decisions
- Lead session remains authoritative user-facing truth
- Worker sessions are isolated and merge via artifacts/evidence
- Learning outcomes must flow through existing continuous-learning gates

## Validation
- Reviewed against:
  - PRD session/resume/planner sections
  - Continuous-learning governance/operations docs
  - OpenClaw orchestration and security research notes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added architectural documentation detailing a Dual-Channel Session Model for enhanced task decomposition and concurrent execution. Introduces Lead and Worker session structures with planned artifact-merge protocols and phased rollout strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->