### PR TITLE
feat(planner): add DAG-based parallel plan executor (#122)

### DIFF
--- a/aceclaw-core/src/main/java/dev/aceclaw/core/planner/AgentLoopFactory.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/planner/AgentLoopFactory.java
@@ -1,0 +1,14 @@
+package dev.aceclaw.core.planner;
+
+import dev.aceclaw.core.agent.StreamingAgentLoop;
+
+/**
+ * Factory for creating new {@link StreamingAgentLoop} instances.
+ *
+ * <p>Used by {@link DagPlanExecutor} to create per-step loop instances for parallel execution.
+ * Each parallel step needs its own loop because {@code runTurn} is stateful.
+ */
+@FunctionalInterface
+public interface AgentLoopFactory {
+    StreamingAgentLoop create();
+}

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/planner/DagPlanExecutor.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/planner/DagPlanExecutor.java
@@ -1,0 +1,411 @@
+package dev.aceclaw.core.planner;
+
+import dev.aceclaw.core.agent.CancellationToken;
+import dev.aceclaw.core.agent.StreamingAgentLoop;
+import dev.aceclaw.core.llm.LlmException;
+import dev.aceclaw.core.llm.Message;
+import dev.aceclaw.core.llm.StreamEventHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.StructuredTaskScope;
+
+/**
+ * DAG-based parallel plan executor.
+ *
+ * <p>Steps declare dependencies via {@link PlannedStep#dependsOn()}. Independent steps
+ * run concurrently via {@link StructuredTaskScope}, while dependent steps wait for
+ * prerequisites to complete.
+ *
+ * <p>Algorithm:
+ * <ol>
+ *   <li>Find "ready" steps: status PENDING and all dependencies COMPLETED/SKIPPED</li>
+ *   <li>If 1 ready step: execute on the primary loop (conversation continuity)</li>
+ *   <li>If 2+ ready steps: fork each with {@code loopFactory.create()}</li>
+ *   <li>Collect results, update plan state, repeat</li>
+ *   <li>On failure: mark dependent steps SKIPPED, continue independent branches</li>
+ * </ol>
+ */
+public final class DagPlanExecutor implements PlanExecutor {
+
+    private static final Logger log = LoggerFactory.getLogger(DagPlanExecutor.class);
+
+    private final PlanEventListener listener;
+    private final AgentLoopFactory loopFactory;
+
+    public DagPlanExecutor(PlanEventListener listener, AgentLoopFactory loopFactory) {
+        this.listener = listener;
+        this.loopFactory = Objects.requireNonNull(loopFactory, "loopFactory");
+    }
+
+    @Override
+    public PlanExecutionResult execute(
+            TaskPlan plan,
+            StreamingAgentLoop primaryLoop,
+            List<Message> conversationHistory,
+            StreamEventHandler handler,
+            CancellationToken cancellationToken) throws LlmException {
+
+        long planStart = System.currentTimeMillis();
+        var allMessages = new ArrayList<>(
+                conversationHistory != null ? conversationHistory : Collections.<Message>emptyList());
+        var stepResults = new ConcurrentHashMap<String, StepResult>();
+        var mutablePlan = plan.withStatus(new PlanStatus.Executing(0, plan.steps().size()));
+        boolean allSuccess = true;
+        boolean wasCancelled = false;
+
+        while (true) {
+            // Check cancellation
+            if (cancellationToken != null && cancellationToken.isCancelled()) {
+                log.info("DAG plan execution cancelled");
+                wasCancelled = true;
+                break;
+            }
+
+            var readySteps = mutablePlan.readySteps();
+            if (readySteps.isEmpty()) {
+                // No more ready steps — either all done or all remaining are blocked
+                break;
+            }
+
+            if (readySteps.size() == 1) {
+                // Single ready step — execute on primary loop for conversation continuity
+                var step = readySteps.getFirst();
+                var stepIndex = indexOfStep(mutablePlan, step.stepId());
+
+                var result = executeSingleStep(
+                        step, stepIndex, mutablePlan, stepResults, primaryLoop,
+                        allMessages, handler, cancellationToken);
+                stepResults.put(step.stepId(), result);
+
+                if (result.success()) {
+                    mutablePlan = mutablePlan.withStepStatus(step.stepId(), StepStatus.COMPLETED)
+                            .withStatus(new PlanStatus.Executing(countCompleted(stepResults), plan.steps().size()));
+                } else {
+                    mutablePlan = markStepFailed(mutablePlan, step, result, stepResults);
+                    if (!hasRemainingWork(mutablePlan)) {
+                        allSuccess = false;
+                        break;
+                    }
+                    allSuccess = false;
+                }
+            } else {
+                // Multiple ready steps — execute in parallel
+                var batchResults = executeParallelBatch(
+                        readySteps, mutablePlan, stepResults, handler, cancellationToken);
+
+                for (var entry : batchResults.entrySet()) {
+                    var stepId = entry.getKey();
+                    var result = entry.getValue();
+                    stepResults.put(stepId, result);
+
+                    if (result.success()) {
+                        mutablePlan = mutablePlan.withStepStatus(stepId, StepStatus.COMPLETED);
+                    } else {
+                        var step = findStep(mutablePlan, stepId);
+                        mutablePlan = markStepFailed(mutablePlan, step, result, stepResults);
+                        allSuccess = false;
+                    }
+                }
+                mutablePlan = mutablePlan.withStatus(
+                        new PlanStatus.Executing(countCompleted(stepResults), plan.steps().size()));
+
+                if (!allSuccess && !hasRemainingWork(mutablePlan)) {
+                    break;
+                }
+            }
+        }
+
+        long totalDuration = System.currentTimeMillis() - planStart;
+        int totalTokens = stepResults.values().stream().mapToInt(StepResult::tokensUsed).sum();
+
+        // Build ordered result list aligned with plan step order
+        var orderedResults = new ArrayList<StepResult>();
+        for (var step : plan.steps()) {
+            var result = stepResults.get(step.stepId());
+            if (result != null) {
+                orderedResults.add(result);
+            }
+        }
+
+        if (wasCancelled) {
+            mutablePlan = mutablePlan.withStatus(
+                    new PlanStatus.Failed("Cancelled by user", null));
+            allSuccess = false;
+        } else if (allSuccess && !orderedResults.isEmpty()) {
+            mutablePlan = mutablePlan.withStatus(
+                    new PlanStatus.Completed(Duration.ofMillis(totalDuration)));
+        } else if (!allSuccess) {
+            // Find first failed step for the error message
+            var failedStep = mutablePlan.steps().stream()
+                    .filter(s -> s.status() == StepStatus.FAILED)
+                    .findFirst();
+            var failedId = failedStep.map(PlannedStep::stepId).orElse(null);
+            var failedResult = failedStep.map(s -> stepResults.get(s.stepId())).orElse(null);
+            var reason = failedResult != null && failedResult.error() != null
+                    ? failedResult.error() : "Step failed";
+            mutablePlan = mutablePlan.withStatus(new PlanStatus.Failed(reason, failedId));
+        }
+
+        if (listener != null) {
+            listener.onPlanCompleted(mutablePlan, allSuccess, totalDuration);
+        }
+
+        log.info("DAG plan execution finished: success={}, steps={}/{}, duration={}ms, tokens={}",
+                allSuccess, orderedResults.size(), plan.steps().size(), totalDuration, totalTokens);
+
+        return new PlanExecutionResult(mutablePlan, orderedResults, totalDuration, allSuccess, totalTokens);
+    }
+
+    private StepResult executeSingleStep(
+            PlannedStep step, int stepIndex, TaskPlan plan,
+            Map<String, StepResult> previousResults,
+            StreamingAgentLoop loop, List<Message> messages,
+            StreamEventHandler handler, CancellationToken cancellationToken) throws LlmException {
+
+        log.info("Executing plan step {}/{}: {}", stepIndex + 1, plan.steps().size(), step.name());
+
+        if (listener != null) {
+            listener.onStepStarted(step, stepIndex, plan.steps().size());
+        }
+
+        long stepStart = System.currentTimeMillis();
+        String stepPrompt = buildStepPrompt(step, stepIndex, plan, previousResults);
+
+        try {
+            var turn = loop.runTurn(stepPrompt, messages, handler, cancellationToken);
+            messages.addAll(turn.newMessages());
+
+            var usage = turn.totalUsage();
+            var result = new StepResult(
+                    true, turn.text(), null,
+                    System.currentTimeMillis() - stepStart,
+                    usage.inputTokens(), usage.outputTokens());
+
+            if (listener != null) {
+                listener.onStepCompleted(step, stepIndex, result);
+            }
+
+            log.info("Step {}/{} completed: {} ({}ms, {} tokens)",
+                    stepIndex + 1, plan.steps().size(), step.name(),
+                    result.durationMs(), result.tokensUsed());
+            return result;
+
+        } catch (LlmException e) {
+            log.warn("Step {}/{} failed: {} - {}", stepIndex + 1, plan.steps().size(),
+                    step.name(), e.getMessage());
+
+            // Attempt fallback
+            if (step.fallbackApproach() != null) {
+                log.info("Attempting fallback for step {}: {}", stepIndex + 1, step.fallbackApproach());
+                try {
+                    String fallbackPrompt = buildFallbackPrompt(step, e.getMessage());
+                    var fallbackTurn = loop.runTurn(fallbackPrompt, messages, handler, cancellationToken);
+                    messages.addAll(fallbackTurn.newMessages());
+
+                    var fbUsage = fallbackTurn.totalUsage();
+                    var fallbackResult = new StepResult(
+                            true, fallbackTurn.text(), null,
+                            System.currentTimeMillis() - stepStart,
+                            fbUsage.inputTokens(), fbUsage.outputTokens());
+
+                    if (listener != null) {
+                        listener.onStepCompleted(step, stepIndex, fallbackResult);
+                    }
+
+                    log.info("Fallback succeeded for step {}/{}", stepIndex + 1, plan.steps().size());
+                    return fallbackResult;
+
+                } catch (LlmException fallbackEx) {
+                    log.warn("Fallback also failed for step {}: {}", stepIndex + 1, fallbackEx.getMessage());
+                }
+            }
+
+            var failResult = new StepResult(
+                    false, null, e.getMessage(),
+                    System.currentTimeMillis() - stepStart, 0, 0);
+
+            if (listener != null) {
+                listener.onStepCompleted(step, stepIndex, failResult);
+            }
+            return failResult;
+        }
+    }
+
+    /**
+     * Executes multiple steps in parallel using StructuredTaskScope.
+     */
+    private Map<String, StepResult> executeParallelBatch(
+            List<PlannedStep> readySteps,
+            TaskPlan plan,
+            Map<String, StepResult> previousResults,
+            StreamEventHandler handler,
+            CancellationToken cancellationToken) throws LlmException {
+
+        log.info("Executing {} steps in parallel: {}",
+                readySteps.size(),
+                readySteps.stream().map(PlannedStep::name).toList());
+
+        var batchResults = new ConcurrentHashMap<String, StepResult>();
+
+        try (var scope = new StructuredTaskScope.ShutdownOnFailure()) {
+            for (var step : readySteps) {
+                var stepLoop = loopFactory.create();
+                int stepIndex = indexOfStep(plan, step.stepId());
+
+                scope.fork(() -> {
+                    var result = executeSingleStep(
+                            step, stepIndex, plan, previousResults,
+                            stepLoop, new ArrayList<>(), handler, cancellationToken);
+                    batchResults.put(step.stepId(), result);
+                    return result;
+                });
+            }
+
+            scope.join();
+            // Don't call throwIfFailed — we handle failures individually per step
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new LlmException("Parallel execution interrupted", 0, e);
+        }
+
+        return batchResults;
+    }
+
+    /**
+     * Marks a step as failed and all transitive dependents as SKIPPED.
+     */
+    private TaskPlan markStepFailed(
+            TaskPlan plan, PlannedStep failedStep, StepResult failResult,
+            Map<String, StepResult> stepResults) {
+
+        var updated = plan.withStepStatus(failedStep.stepId(), StepStatus.FAILED);
+
+        // Skip all transitive dependents
+        var toSkip = findTransitiveDependents(plan, failedStep.stepId());
+        for (var depId : toSkip) {
+            updated = updated.withStepStatus(depId, StepStatus.SKIPPED);
+            var depStep = findStep(updated, depId);
+            var depIndex = indexOfStep(updated, depId);
+            var skipResult = new StepResult(false, null,
+                    "Skipped: dependency '" + failedStep.name() + "' failed",
+                    0, 0, 0);
+            stepResults.put(depId, skipResult);
+
+            if (listener != null && depStep != null) {
+                listener.onStepCompleted(depStep, depIndex, skipResult);
+            }
+
+            log.info("Skipping step '{}' because dependency '{}' failed",
+                    depStep != null ? depStep.name() : depId, failedStep.name());
+        }
+
+        return updated;
+    }
+
+    /**
+     * Finds all transitive dependents of a given step.
+     */
+    private static List<String> findTransitiveDependents(TaskPlan plan, String stepId) {
+        var dependents = new ArrayList<String>();
+        var toProcess = new ArrayList<String>();
+        toProcess.add(stepId);
+
+        while (!toProcess.isEmpty()) {
+            var current = toProcess.removeFirst();
+            for (var step : plan.steps()) {
+                if (step.dependsOn().contains(current)
+                        && !dependents.contains(step.stepId())
+                        && !step.stepId().equals(stepId)) {
+                    dependents.add(step.stepId());
+                    toProcess.add(step.stepId());
+                }
+            }
+        }
+        return dependents;
+    }
+
+    private static boolean hasRemainingWork(TaskPlan plan) {
+        return plan.steps().stream().anyMatch(s -> s.status() == StepStatus.PENDING);
+    }
+
+    private static int countCompleted(Map<String, StepResult> results) {
+        return (int) results.values().stream().filter(StepResult::success).count();
+    }
+
+    private static int indexOfStep(TaskPlan plan, String stepId) {
+        for (int i = 0; i < plan.steps().size(); i++) {
+            if (plan.steps().get(i).stepId().equals(stepId)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static PlannedStep findStep(TaskPlan plan, String stepId) {
+        return plan.steps().stream()
+                .filter(s -> s.stepId().equals(stepId))
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * Builds the prompt for a step, including only its direct dependency results.
+     */
+    static String buildStepPrompt(PlannedStep step, int stepIndex, TaskPlan plan,
+                                   Map<String, StepResult> previousResults) {
+        var sb = new StringBuilder();
+        sb.append("You are executing step ").append(stepIndex + 1)
+                .append(" of ").append(plan.steps().size())
+                .append(" in a plan to: ").append(plan.originalGoal()).append("\n\n");
+
+        sb.append("## Current Step: ").append(step.name()).append("\n");
+        sb.append(step.description()).append("\n\n");
+
+        // Include only direct dependency results
+        if (!step.dependsOn().isEmpty()) {
+            sb.append("## Dependency Results:\n");
+            for (var depId : step.dependsOn()) {
+                var depStep = findStep(plan, depId);
+                var depResult = previousResults.get(depId);
+                if (depStep != null && depResult != null) {
+                    sb.append("- ").append(depStep.name());
+                    if (depResult.success()) {
+                        String output = depResult.output();
+                        String summary = output != null && output.length() > 200
+                                ? output.substring(0, 200) + "..."
+                                : (output != null ? output : "done");
+                        sb.append(" - ").append(summary);
+                    } else {
+                        sb.append(" - FAILED: ").append(
+                                depResult.error() != null ? depResult.error() : "Unknown error");
+                    }
+                    sb.append("\n");
+                }
+            }
+            sb.append("\n");
+        }
+
+        sb.append("Focus on this step only. When done, summarize what you accomplished.");
+        return sb.toString();
+    }
+
+    private static String buildFallbackPrompt(PlannedStep step, String error) {
+        return """
+                The previous attempt at step "%s" failed with: %s
+
+                Please try an alternative approach: %s
+
+                Focus on completing this step. When done, summarize what you accomplished.
+                """.formatted(step.name(), error,
+                step.fallbackApproach() != null ? step.fallbackApproach() : "try a different method");
+    }
+}

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/planner/DagPlanExecutor.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/planner/DagPlanExecutor.java
@@ -262,16 +262,28 @@ public final class DagPlanExecutor implements PlanExecutor {
                 int stepIndex = indexOfStep(plan, step.stepId());
 
                 scope.fork(() -> {
-                    var result = executeSingleStep(
-                            step, stepIndex, plan, previousResults,
-                            stepLoop, new ArrayList<>(), handler, cancellationToken);
-                    batchResults.put(step.stepId(), result);
-                    return result;
+                    try {
+                        var result = executeSingleStep(
+                                step, stepIndex, plan, previousResults,
+                                stepLoop, new ArrayList<>(), handler, cancellationToken);
+                        batchResults.put(step.stepId(), result);
+                        return result;
+                    } catch (Exception e) {
+                        log.warn("Parallel step '{}' threw unexpected exception: {}",
+                                step.name(), e.getMessage());
+                        var failResult = new StepResult(
+                                false, null, e.getMessage(), 0, 0, 0);
+                        batchResults.put(step.stepId(), failResult);
+                        if (listener != null) {
+                            listener.onStepCompleted(step, stepIndex, failResult);
+                        }
+                        return failResult;
+                    }
                 });
             }
 
             scope.join();
-            // Don't call throwIfFailed — we handle failures individually per step
+            scope.throwIfFailed(e -> new LlmException("Parallel step execution failed", 0, e));
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new LlmException("Parallel execution interrupted", 0, e);

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/planner/PlanEventListener.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/planner/PlanEventListener.java
@@ -1,0 +1,12 @@
+package dev.aceclaw.core.planner;
+
+/**
+ * Callback for plan execution events (step started, step completed, etc.).
+ *
+ * <p>Shared by both {@link SequentialPlanExecutor} and DAG-based parallel executors.
+ */
+public interface PlanEventListener {
+    void onStepStarted(PlannedStep step, int stepIndex, int totalSteps);
+    void onStepCompleted(PlannedStep step, int stepIndex, StepResult result);
+    void onPlanCompleted(TaskPlan plan, boolean success, long totalDurationMs);
+}

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/planner/PlannedStep.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/planner/PlannedStep.java
@@ -1,6 +1,7 @@
 package dev.aceclaw.core.planner;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * A single step in a task plan.
@@ -10,6 +11,7 @@ import java.util.List;
  * @param description      detailed description of what this step should accomplish
  * @param requiredTools    list of tool names this step is expected to use
  * @param fallbackApproach alternative approach if the primary approach fails (may be null)
+ * @param dependsOn        step IDs this step depends on (must complete before this step can start)
  * @param status           current execution status
  */
 public record PlannedStep(
@@ -18,11 +20,13 @@ public record PlannedStep(
         String description,
         List<String> requiredTools,
         String fallbackApproach,
+        Set<String> dependsOn,
         StepStatus status
 ) {
 
     public PlannedStep {
         requiredTools = requiredTools != null ? List.copyOf(requiredTools) : List.of();
+        dependsOn = dependsOn != null ? Set.copyOf(dependsOn) : Set.of();
         if (status == null) {
             status = StepStatus.PENDING;
         }
@@ -32,6 +36,13 @@ public record PlannedStep(
      * Returns a copy with the given status.
      */
     public PlannedStep withStatus(StepStatus newStatus) {
-        return new PlannedStep(stepId, name, description, requiredTools, fallbackApproach, newStatus);
+        return new PlannedStep(stepId, name, description, requiredTools, fallbackApproach, dependsOn, newStatus);
+    }
+
+    /**
+     * Returns true if this step has no dependencies (root step).
+     */
+    public boolean isRoot() {
+        return dependsOn.isEmpty();
     }
 }

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/planner/PlanningPromptBuilder.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/planner/PlanningPromptBuilder.java
@@ -21,6 +21,12 @@ public final class PlanningPromptBuilder {
             - Return a JSON object with a single key "steps" containing an array.
             - Each step must have: "name" (short title), "description" (what to do), \
               "requiredTools" (list of tool names), "fallbackApproach" (alternative if primary fails, or null).
+            - Each step may include "dependsOn": a list of step names that must complete first.
+            - Steps without dependsOn can run in parallel. Only add dependencies when a step \
+              truly needs the output or side effects of another step.
+            - Example: {"name": "Write tests", "dependsOn": ["Implement feature"], \
+              "description": "Write unit tests for the new feature", "requiredTools": ["write_file"], \
+              "fallbackApproach": null}
             - Order steps logically: research first, then implement, then verify.
             - Keep steps focused: one logical unit of work per step.
             - Use 2-15 steps. Fewer for simpler tasks, more for complex ones.

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/planner/PlanningPromptBuilder.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/planner/PlanningPromptBuilder.java
@@ -27,6 +27,7 @@ public final class PlanningPromptBuilder {
             - Example: {"name": "Write tests", "dependsOn": ["Implement feature"], \
               "description": "Write unit tests for the new feature", "requiredTools": ["write_file"], \
               "fallbackApproach": null}
+            - Each step name MUST be unique — names are used for dependency resolution.
             - Order steps logically: research first, then implement, then verify.
             - Keep steps focused: one logical unit of work per step.
             - Use 2-15 steps. Fewer for simpler tasks, more for complex ones.

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/planner/SequentialPlanExecutor.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/planner/SequentialPlanExecutor.java
@@ -31,15 +31,6 @@ public final class SequentialPlanExecutor implements PlanExecutor {
 
     private static final Logger log = LoggerFactory.getLogger(SequentialPlanExecutor.class);
 
-    /**
-     * Callback for plan execution events (step started, step completed, etc.).
-     */
-    public interface PlanEventListener {
-        void onStepStarted(PlannedStep step, int stepIndex, int totalSteps);
-        void onStepCompleted(PlannedStep step, int stepIndex, StepResult result);
-        void onPlanCompleted(TaskPlan plan, boolean success, long totalDurationMs);
-    }
-
     private final PlanEventListener listener;
 
     public SequentialPlanExecutor() {

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/planner/TaskPlan.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/planner/TaskPlan.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * An immutable task plan consisting of sequential steps to achieve a goal.
@@ -64,5 +65,30 @@ public record TaskPlan(
     public boolean isComplete() {
         return steps.stream().allMatch(s -> s.status() == StepStatus.COMPLETED
                 || s.status() == StepStatus.SKIPPED);
+    }
+
+    /**
+     * Returns all steps whose dependencies are satisfied and status is PENDING.
+     * These steps are ready to execute (either sequentially or in parallel).
+     */
+    public List<PlannedStep> readySteps() {
+        var completedIds = steps.stream()
+                .filter(s -> s.status() == StepStatus.COMPLETED || s.status() == StepStatus.SKIPPED)
+                .map(PlannedStep::stepId)
+                .collect(Collectors.toSet());
+        return steps.stream()
+                .filter(s -> s.status() == StepStatus.PENDING)
+                .filter(s -> completedIds.containsAll(s.dependsOn()))
+                .toList();
+    }
+
+    /**
+     * Returns true if the plan has steps that can benefit from parallel execution.
+     * This is the case when any step has explicit dependencies or multiple root steps exist.
+     */
+    public boolean hasParallelizableSteps() {
+        boolean hasDeps = steps.stream().anyMatch(s -> !s.dependsOn().isEmpty());
+        long rootCount = steps.stream().filter(PlannedStep::isRoot).count();
+        return hasDeps || rootCount > 1;
     }
 }

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/planner/TaskPlan.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/planner/TaskPlan.java
@@ -84,11 +84,28 @@ public record TaskPlan(
 
     /**
      * Returns true if the plan has steps that can benefit from parallel execution.
-     * This is the case when any step has explicit dependencies or multiple root steps exist.
+     * Simulates topological execution layers and checks if any layer has 2+ steps.
      */
     public boolean hasParallelizableSteps() {
-        boolean hasDeps = steps.stream().anyMatch(s -> !s.dependsOn().isEmpty());
-        long rootCount = steps.stream().filter(PlannedStep::isRoot).count();
-        return hasDeps || rootCount > 1;
+        if (steps.size() <= 1) return false;
+
+        // Simulate layer-by-layer execution to check for any parallel frontier
+        var completedIds = new java.util.HashSet<String>();
+        var remaining = new java.util.HashSet<String>();
+        for (var s : steps) remaining.add(s.stepId());
+
+        while (!remaining.isEmpty()) {
+            var ready = steps.stream()
+                    .filter(s -> remaining.contains(s.stepId()))
+                    .filter(s -> completedIds.containsAll(s.dependsOn()))
+                    .toList();
+            if (ready.isEmpty()) break; // all remaining are blocked (cycle)
+            if (ready.size() >= 2) return true;
+            for (var s : ready) {
+                completedIds.add(s.stepId());
+                remaining.remove(s.stepId());
+            }
+        }
+        return false;
     }
 }

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/planner/TaskPlanParser.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/planner/TaskPlanParser.java
@@ -9,6 +9,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -86,7 +87,10 @@ public final class TaskPlanParser {
             // Second pass: resolve name-based deps to stepIds
             var nameToId = new HashMap<String, String>();
             for (var raw : rawSteps) {
-                nameToId.put(raw.name, raw.stepId);
+                var existing = nameToId.putIfAbsent(raw.name, raw.stepId);
+                if (existing != null) {
+                    log.warn("Duplicate step name '{}', only the first occurrence will be used for dependency resolution", raw.name);
+                }
             }
 
             var steps = new ArrayList<PlannedStep>();
@@ -211,7 +215,15 @@ public final class TaskPlanParser {
             List<String> requiredTools,
             String fallbackApproach,
             Set<String> dependsOnNames
-    ) {}
+    ) {
+        RawStep {
+            Objects.requireNonNull(stepId, "stepId");
+            name = name != null ? name : "Unnamed step";
+            description = description != null ? description : "";
+            requiredTools = requiredTools != null ? List.copyOf(requiredTools) : List.of();
+            dependsOnNames = dependsOnNames != null ? Set.copyOf(dependsOnNames) : Set.of();
+        }
+    }
 
     private static RawStep parseRawStep(JsonNode stepNode) {
         String name = getTextOrDefault(stepNode, "name", "Unnamed step");

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/planner/TaskPlanParser.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/planner/TaskPlanParser.java
@@ -7,7 +7,12 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
@@ -19,6 +24,8 @@ import java.util.regex.Pattern;
  *   <li>JSON wrapped in markdown code fences ({@code ```json ... ```})</li>
  *   <li>Missing or extra fields in step objects</li>
  *   <li>Too many or too few steps (clamped to 1-20)</li>
+ *   <li>dependsOn name resolution (step names → stepIds)</li>
+ *   <li>Cycle detection with fallback to sequential execution</li>
  * </ul>
  */
 public final class TaskPlanParser {
@@ -61,18 +68,55 @@ public final class TaskPlanParser {
                 throw new IllegalArgumentException("Plan response has no 'steps' array");
             }
 
-            var steps = new ArrayList<PlannedStep>();
+            // First pass: parse steps with raw dependsOn names
+            var rawSteps = new ArrayList<RawStep>();
             for (var stepNode : stepsNode) {
-                if (steps.size() >= MAX_STEPS) {
+                if (rawSteps.size() >= MAX_STEPS) {
                     log.warn("Plan exceeds {} steps, truncating", MAX_STEPS);
                     break;
                 }
-                steps.add(parseStep(stepNode));
+                rawSteps.add(parseRawStep(stepNode));
             }
 
-            if (steps.size() < MIN_STEPS) {
+            if (rawSteps.size() < MIN_STEPS) {
                 throw new IllegalArgumentException(
                         "Plan has fewer than " + MIN_STEPS + " steps");
+            }
+
+            // Second pass: resolve name-based deps to stepIds
+            var nameToId = new HashMap<String, String>();
+            for (var raw : rawSteps) {
+                nameToId.put(raw.name, raw.stepId);
+            }
+
+            var steps = new ArrayList<PlannedStep>();
+            for (var raw : rawSteps) {
+                var resolvedDeps = new HashSet<String>();
+                for (var depName : raw.dependsOnNames) {
+                    var depId = nameToId.get(depName);
+                    if (depId != null) {
+                        resolvedDeps.add(depId);
+                    } else {
+                        log.warn("Unknown dependency '{}' in step '{}', ignoring", depName, raw.name);
+                    }
+                }
+                steps.add(new PlannedStep(
+                        raw.stepId, raw.name, raw.description,
+                        raw.requiredTools, raw.fallbackApproach,
+                        resolvedDeps, StepStatus.PENDING));
+            }
+
+            // Third pass: cycle detection — if cycle found, clear all deps
+            if (hasCycle(steps)) {
+                log.warn("Cycle detected in plan dependencies, falling back to sequential execution");
+                var sequential = new ArrayList<PlannedStep>();
+                for (var step : steps) {
+                    sequential.add(new PlannedStep(
+                            step.stepId(), step.name(), step.description(),
+                            step.requiredTools(), step.fallbackApproach(),
+                            Set.of(), step.status()));
+                }
+                steps = sequential;
             }
 
             return new TaskPlan(
@@ -110,7 +154,66 @@ public final class TaskPlanParser {
         return text;
     }
 
-    private static PlannedStep parseStep(JsonNode stepNode) {
+    /**
+     * Detects cycles in the step dependency graph using DFS.
+     */
+    static boolean hasCycle(List<PlannedStep> steps) {
+        var idToStep = new HashMap<String, PlannedStep>();
+        for (var step : steps) {
+            idToStep.put(step.stepId(), step);
+        }
+
+        var visited = new HashSet<String>();
+        var inStack = new HashSet<String>();
+
+        for (var step : steps) {
+            if (hasCycleDfs(step.stepId(), idToStep, visited, inStack)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasCycleDfs(
+            String nodeId,
+            Map<String, PlannedStep> idToStep,
+            Set<String> visited,
+            Set<String> inStack) {
+        if (inStack.contains(nodeId)) {
+            return true;
+        }
+        if (visited.contains(nodeId)) {
+            return false;
+        }
+        visited.add(nodeId);
+        inStack.add(nodeId);
+
+        var step = idToStep.get(nodeId);
+        if (step != null) {
+            for (var dep : step.dependsOn()) {
+                if (hasCycleDfs(dep, idToStep, visited, inStack)) {
+                    return true;
+                }
+            }
+        }
+
+        inStack.remove(nodeId);
+        return false;
+    }
+
+    /**
+     * Intermediate representation for a parsed step before dependency resolution.
+     */
+    private record RawStep(
+            String stepId,
+            String name,
+            String description,
+            List<String> requiredTools,
+            String fallbackApproach,
+            Set<String> dependsOnNames
+    ) {}
+
+    private static RawStep parseRawStep(JsonNode stepNode) {
         String name = getTextOrDefault(stepNode, "name", "Unnamed step");
         String description = getTextOrDefault(stepNode, "description", "");
 
@@ -128,13 +231,20 @@ public final class TaskPlanParser {
             fallback = fallbackNode.asText();
         }
 
-        return new PlannedStep(
+        var dependsOnNames = new LinkedHashSet<String>();
+        var depsNode = stepNode.get("dependsOn");
+        if (depsNode != null && depsNode.isArray()) {
+            for (var depNode : depsNode) {
+                var depText = depNode.asText();
+                if (depText != null && !depText.isBlank()) {
+                    dependsOnNames.add(depText);
+                }
+            }
+        }
+
+        return new RawStep(
                 UUID.randomUUID().toString(),
-                name,
-                description,
-                requiredTools,
-                fallback,
-                StepStatus.PENDING);
+                name, description, requiredTools, fallback, dependsOnNames);
     }
 
     private static String getTextOrDefault(JsonNode node, String field, String defaultValue) {

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/planner/DagPlanExecutorTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/planner/DagPlanExecutorTest.java
@@ -1,0 +1,379 @@
+package dev.aceclaw.core.planner;
+
+import dev.aceclaw.core.agent.CancellationToken;
+import dev.aceclaw.core.agent.StreamingAgentLoop;
+import dev.aceclaw.core.agent.ToolRegistry;
+import dev.aceclaw.core.llm.*;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DagPlanExecutorTest {
+
+    /**
+     * Thread-safe mock LlmClient for parallel execution tests.
+     */
+    static class SimpleMockLlmClient implements LlmClient {
+        private final ConcurrentLinkedQueue<Object> responses = new ConcurrentLinkedQueue<>();
+
+        void enqueueTextResponse(String text) {
+            responses.add(List.of(
+                    new StreamEvent.MessageStart("msg-mock", "mock-model"),
+                    new StreamEvent.ContentBlockStart(0, new ContentBlock.Text("")),
+                    new StreamEvent.TextDelta(text),
+                    new StreamEvent.ContentBlockStop(0),
+                    new StreamEvent.MessageDelta(StopReason.END_TURN, new Usage(100, 50)),
+                    new StreamEvent.StreamComplete()));
+        }
+
+        void enqueueError() {
+            responses.add(List.of(
+                    new StreamEvent.MessageStart("msg-mock", "mock-model"),
+                    new StreamEvent.StreamError(new LlmException("Step failed", 500))));
+        }
+
+        @Override
+        public LlmResponse sendMessage(LlmRequest request) {
+            return new LlmResponse("id", "model", List.of(new ContentBlock.Text("ok")),
+                    StopReason.END_TURN, new Usage(10, 5));
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public StreamSession streamMessage(LlmRequest request) throws LlmException {
+            var next = responses.poll();
+            if (next == null) throw new LlmException("No mock responses", 500);
+            var events = (List<StreamEvent>) next;
+            return new SimpleStreamSession(events);
+        }
+
+        @Override
+        public String provider() { return "mock"; }
+
+        @Override
+        public String defaultModel() { return "mock-model"; }
+    }
+
+    static class SimpleStreamSession implements StreamSession {
+        private final List<StreamEvent> events;
+        private final AtomicBoolean cancelled = new AtomicBoolean(false);
+
+        SimpleStreamSession(List<StreamEvent> events) { this.events = events; }
+
+        @Override
+        public void onEvent(StreamEventHandler handler) {
+            for (var event : events) {
+                if (cancelled.get()) return;
+                switch (event) {
+                    case StreamEvent.MessageStart e -> handler.onMessageStart(e);
+                    case StreamEvent.ContentBlockStart e -> handler.onContentBlockStart(e);
+                    case StreamEvent.TextDelta e -> handler.onTextDelta(e);
+                    case StreamEvent.ThinkingDelta e -> handler.onThinkingDelta(e);
+                    case StreamEvent.ToolUseDelta e -> handler.onToolUseDelta(e);
+                    case StreamEvent.ContentBlockStop e -> handler.onContentBlockStop(e);
+                    case StreamEvent.MessageDelta e -> handler.onMessageDelta(e);
+                    case StreamEvent.StreamComplete e -> handler.onComplete(e);
+                    case StreamEvent.StreamError e -> handler.onError(e);
+                    case StreamEvent.Heartbeat e -> handler.onHeartbeat(e);
+                }
+            }
+        }
+
+        @Override
+        public void cancel() { cancelled.set(true); }
+    }
+
+    private StreamingAgentLoop createLoop(SimpleMockLlmClient client) {
+        return new StreamingAgentLoop(client, new ToolRegistry(), "mock-model", null);
+    }
+
+    private AgentLoopFactory createFactory(SimpleMockLlmClient client) {
+        return () -> new StreamingAgentLoop(client, new ToolRegistry(), "mock-model", null);
+    }
+
+    private final StreamEventHandler noOpHandler = new StreamEventHandler() {};
+
+    // --- Diamond DAG: A → {B, C} → D ---
+
+    @Test
+    void diamondDag_executesInCorrectOrder() throws LlmException {
+        var client = new SimpleMockLlmClient();
+        // A, B, C, D all need responses
+        client.enqueueTextResponse("A done");
+        client.enqueueTextResponse("B done");
+        client.enqueueTextResponse("C done");
+        client.enqueueTextResponse("D done");
+
+        var stepA = new PlannedStep("a", "Step A", "Root step", List.of(), null, Set.of(), StepStatus.PENDING);
+        var stepB = new PlannedStep("b", "Step B", "Branch 1", List.of(), null, Set.of("a"), StepStatus.PENDING);
+        var stepC = new PlannedStep("c", "Step C", "Branch 2", List.of(), null, Set.of("a"), StepStatus.PENDING);
+        var stepD = new PlannedStep("d", "Step D", "Join step", List.of(), null, Set.of("b", "c"), StepStatus.PENDING);
+        var plan = new TaskPlan("plan-1", "Diamond test", List.of(stepA, stepB, stepC, stepD),
+                new PlanStatus.Draft(), Instant.now());
+
+        var startedSteps = new ConcurrentLinkedQueue<String>();
+        var completedSteps = new ConcurrentLinkedQueue<String>();
+
+        var listener = new PlanEventListener() {
+            @Override
+            public void onStepStarted(PlannedStep step, int stepIndex, int totalSteps) {
+                startedSteps.add(step.name());
+            }
+
+            @Override
+            public void onStepCompleted(PlannedStep step, int stepIndex, StepResult result) {
+                completedSteps.add(step.name());
+            }
+
+            @Override
+            public void onPlanCompleted(TaskPlan p, boolean success, long totalDurationMs) {}
+        };
+
+        var executor = new DagPlanExecutor(listener, createFactory(client));
+        var result = executor.execute(plan, createLoop(client), new ArrayList<>(), noOpHandler, null);
+
+        assertTrue(result.success());
+        assertEquals(4, result.stepResults().size());
+        assertTrue(result.stepResults().stream().allMatch(StepResult::success));
+        assertInstanceOf(PlanStatus.Completed.class, result.plan().status());
+
+        // A must complete before B and C; B and C must complete before D
+        var completedList = new ArrayList<>(completedSteps);
+        assertTrue(completedList.indexOf("Step A") < completedList.indexOf("Step B"));
+        assertTrue(completedList.indexOf("Step A") < completedList.indexOf("Step C"));
+        assertTrue(completedList.indexOf("Step B") < completedList.indexOf("Step D"));
+        assertTrue(completedList.indexOf("Step C") < completedList.indexOf("Step D"));
+    }
+
+    // --- Fully independent steps ---
+
+    @Test
+    void fullyIndependentSteps_allRunInParallel() throws LlmException {
+        var client = new SimpleMockLlmClient();
+        client.enqueueTextResponse("X done");
+        client.enqueueTextResponse("Y done");
+        client.enqueueTextResponse("Z done");
+
+        var stepX = new PlannedStep("x", "Step X", "Independent 1", List.of(), null, Set.of(), StepStatus.PENDING);
+        var stepY = new PlannedStep("y", "Step Y", "Independent 2", List.of(), null, Set.of(), StepStatus.PENDING);
+        var stepZ = new PlannedStep("z", "Step Z", "Independent 3", List.of(), null, Set.of(), StepStatus.PENDING);
+        var plan = new TaskPlan("plan-2", "Parallel test", List.of(stepX, stepY, stepZ),
+                new PlanStatus.Draft(), Instant.now());
+
+        var executor = new DagPlanExecutor(null, createFactory(client));
+        var result = executor.execute(plan, createLoop(client), new ArrayList<>(), noOpHandler, null);
+
+        assertTrue(result.success());
+        assertEquals(3, result.stepResults().size());
+    }
+
+    // --- Purely sequential fallback (single linear chain) ---
+
+    @Test
+    void purelySequential_executesInOrder() throws LlmException {
+        var client = new SimpleMockLlmClient();
+        client.enqueueTextResponse("first");
+        client.enqueueTextResponse("second");
+        client.enqueueTextResponse("third");
+
+        var s1 = new PlannedStep("s1", "Step 1", "First", List.of(), null, Set.of(), StepStatus.PENDING);
+        var s2 = new PlannedStep("s2", "Step 2", "Second", List.of(), null, Set.of("s1"), StepStatus.PENDING);
+        var s3 = new PlannedStep("s3", "Step 3", "Third", List.of(), null, Set.of("s2"), StepStatus.PENDING);
+        var plan = new TaskPlan("plan-3", "Sequential test", List.of(s1, s2, s3),
+                new PlanStatus.Draft(), Instant.now());
+
+        var completedSteps = new ConcurrentLinkedQueue<String>();
+        var listener = new PlanEventListener() {
+            @Override
+            public void onStepStarted(PlannedStep step, int stepIndex, int totalSteps) {}
+
+            @Override
+            public void onStepCompleted(PlannedStep step, int stepIndex, StepResult result) {
+                completedSteps.add(step.name());
+            }
+
+            @Override
+            public void onPlanCompleted(TaskPlan p, boolean success, long totalDurationMs) {}
+        };
+
+        var executor = new DagPlanExecutor(listener, createFactory(client));
+        var result = executor.execute(plan, createLoop(client), new ArrayList<>(), noOpHandler, null);
+
+        assertTrue(result.success());
+        assertEquals(3, result.stepResults().size());
+
+        var ordered = new ArrayList<>(completedSteps);
+        assertEquals(List.of("Step 1", "Step 2", "Step 3"), ordered);
+    }
+
+    // --- Branch failure + skip ---
+
+    @Test
+    void branchFailure_skipsDependents_continuesIndependent() throws LlmException {
+        var client = new SimpleMockLlmClient();
+        // A and C are both roots — run in parallel, both succeed (order doesn't matter)
+        client.enqueueTextResponse("A done");
+        client.enqueueTextResponse("C done");
+        // B depends on A — runs alone after A completes, fails
+        client.enqueueError();
+
+        // C is an independent root (no deps on A), so it runs in parallel with A
+        // B depends on A, D depends on B
+        var stepA = new PlannedStep("a", "Step A", "Root 1", List.of(), null, Set.of(), StepStatus.PENDING);
+        var stepC = new PlannedStep("c", "Step C", "Root 2 (independent)", List.of(), null, Set.of(), StepStatus.PENDING);
+        var stepB = new PlannedStep("b", "Step B", "Will fail", List.of(), null, Set.of("a"), StepStatus.PENDING);
+        var stepD = new PlannedStep("d", "Step D", "Depends on B", List.of(), null, Set.of("b"), StepStatus.PENDING);
+        var plan = new TaskPlan("plan-4", "Failure test", List.of(stepA, stepC, stepB, stepD),
+                new PlanStatus.Draft(), Instant.now());
+
+        var executor = new DagPlanExecutor(null, createFactory(client));
+        var result = executor.execute(plan, createLoop(client), new ArrayList<>(), noOpHandler, null);
+
+        assertFalse(result.success());
+
+        // D should be SKIPPED because B failed
+        var finalPlan = result.plan();
+        assertEquals(StepStatus.COMPLETED, findStepStatus(finalPlan, "a"));
+        assertEquals(StepStatus.COMPLETED, findStepStatus(finalPlan, "c"));
+        assertEquals(StepStatus.FAILED, findStepStatus(finalPlan, "b"));
+        assertEquals(StepStatus.SKIPPED, findStepStatus(finalPlan, "d"));
+    }
+
+    // --- Cancellation ---
+
+    @Test
+    void cancellation_stopsExecution() throws LlmException {
+        var client = new SimpleMockLlmClient();
+        client.enqueueTextResponse("first");
+        client.enqueueTextResponse("second");
+
+        var s1 = new PlannedStep("s1", "Step 1", "First", List.of(), null, Set.of(), StepStatus.PENDING);
+        var s2 = new PlannedStep("s2", "Step 2", "Second", List.of(), null, Set.of("s1"), StepStatus.PENDING);
+        var plan = new TaskPlan("plan-5", "Cancel test", List.of(s1, s2),
+                new PlanStatus.Draft(), Instant.now());
+
+        var token = new CancellationToken();
+
+        var cancellingListener = new PlanEventListener() {
+            @Override
+            public void onStepStarted(PlannedStep step, int stepIndex, int totalSteps) {}
+
+            @Override
+            public void onStepCompleted(PlannedStep step, int stepIndex, StepResult result) {
+                if (stepIndex == 0) token.cancel();
+            }
+
+            @Override
+            public void onPlanCompleted(TaskPlan p, boolean success, long totalDurationMs) {}
+        };
+
+        var executor = new DagPlanExecutor(cancellingListener, createFactory(client));
+        var result = executor.execute(plan, createLoop(client), new ArrayList<>(), noOpHandler, token);
+
+        assertFalse(result.success());
+        assertEquals(1, result.stepResults().size());
+        assertInstanceOf(PlanStatus.Failed.class, result.plan().status());
+    }
+
+    // --- hasParallelizableSteps ---
+
+    @Test
+    void hasParallelizableSteps_trueForDiamondDag() {
+        var plan = new TaskPlan("p", "goal", List.of(
+                new PlannedStep("a", "A", "a", List.of(), null, Set.of(), StepStatus.PENDING),
+                new PlannedStep("b", "B", "b", List.of(), null, Set.of("a"), StepStatus.PENDING),
+                new PlannedStep("c", "C", "c", List.of(), null, Set.of("a"), StepStatus.PENDING)
+        ), new PlanStatus.Draft(), Instant.now());
+        assertTrue(plan.hasParallelizableSteps());
+    }
+
+    @Test
+    void hasParallelizableSteps_trueForMultipleRoots() {
+        var plan = new TaskPlan("p", "goal", List.of(
+                new PlannedStep("a", "A", "a", List.of(), null, Set.of(), StepStatus.PENDING),
+                new PlannedStep("b", "B", "b", List.of(), null, Set.of(), StepStatus.PENDING)
+        ), new PlanStatus.Draft(), Instant.now());
+        assertTrue(plan.hasParallelizableSteps());
+    }
+
+    @Test
+    void hasParallelizableSteps_falseForSingleLinearChain() {
+        var plan = new TaskPlan("p", "goal", List.of(
+                new PlannedStep("a", "A", "a", List.of(), null, Set.of(), StepStatus.PENDING)
+        ), new PlanStatus.Draft(), Instant.now());
+        assertFalse(plan.hasParallelizableSteps());
+    }
+
+    // --- readySteps ---
+
+    @Test
+    void readySteps_returnsRootsInitially() {
+        var plan = new TaskPlan("p", "goal", List.of(
+                new PlannedStep("a", "A", "a", List.of(), null, Set.of(), StepStatus.PENDING),
+                new PlannedStep("b", "B", "b", List.of(), null, Set.of("a"), StepStatus.PENDING)
+        ), new PlanStatus.Draft(), Instant.now());
+
+        var ready = plan.readySteps();
+        assertEquals(1, ready.size());
+        assertEquals("a", ready.getFirst().stepId());
+    }
+
+    @Test
+    void readySteps_afterCompletion() {
+        var plan = new TaskPlan("p", "goal", List.of(
+                new PlannedStep("a", "A", "a", List.of(), null, Set.of(), StepStatus.COMPLETED),
+                new PlannedStep("b", "B", "b", List.of(), null, Set.of("a"), StepStatus.PENDING),
+                new PlannedStep("c", "C", "c", List.of(), null, Set.of("a"), StepStatus.PENDING)
+        ), new PlanStatus.Draft(), Instant.now());
+
+        var ready = plan.readySteps();
+        assertEquals(2, ready.size());
+    }
+
+    // --- buildStepPrompt ---
+
+    @Test
+    void buildStepPrompt_includesDependencyResults() {
+        var stepA = new PlannedStep("a", "Step A", "Root", List.of(), null, Set.of(), StepStatus.COMPLETED);
+        var stepB = new PlannedStep("b", "Step B", "Depends on A", List.of(), null, Set.of("a"), StepStatus.PENDING);
+        var plan = new TaskPlan("p", "Test goal", List.of(stepA, stepB),
+                new PlanStatus.Draft(), Instant.now());
+
+        var results = java.util.Map.of("a", new StepResult(true, "Found 5 files", null, 1000, 60, 40));
+
+        var prompt = DagPlanExecutor.buildStepPrompt(stepB, 1, plan, results);
+
+        assertTrue(prompt.contains("Step B"));
+        assertTrue(prompt.contains("Dependency Results"));
+        assertTrue(prompt.contains("Step A"));
+        assertTrue(prompt.contains("Found 5 files"));
+    }
+
+    @Test
+    void buildStepPrompt_noDependencies_noSection() {
+        var stepA = new PlannedStep("a", "Step A", "Root", List.of(), null, Set.of(), StepStatus.PENDING);
+        var plan = new TaskPlan("p", "Test goal", List.of(stepA),
+                new PlanStatus.Draft(), Instant.now());
+
+        var prompt = DagPlanExecutor.buildStepPrompt(stepA, 0, plan, java.util.Map.of());
+
+        assertTrue(prompt.contains("Step A"));
+        assertFalse(prompt.contains("Dependency Results"));
+    }
+
+    private static StepStatus findStepStatus(TaskPlan plan, String stepId) {
+        return plan.steps().stream()
+                .filter(s -> s.stepId().equals(stepId))
+                .findFirst()
+                .map(PlannedStep::status)
+                .orElseThrow();
+    }
+}

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/planner/DagPlanExecutorTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/planner/DagPlanExecutorTest.java
@@ -305,9 +305,19 @@ class DagPlanExecutorTest {
     }
 
     @Test
-    void hasParallelizableSteps_falseForSingleLinearChain() {
+    void hasParallelizableSteps_falseForSingleStep() {
         var plan = new TaskPlan("p", "goal", List.of(
                 new PlannedStep("a", "A", "a", List.of(), null, Set.of(), StepStatus.PENDING)
+        ), new PlanStatus.Draft(), Instant.now());
+        assertFalse(plan.hasParallelizableSteps());
+    }
+
+    @Test
+    void hasParallelizableSteps_falseForLinearChain() {
+        var plan = new TaskPlan("p", "goal", List.of(
+                new PlannedStep("a", "A", "a", List.of(), null, Set.of(), StepStatus.PENDING),
+                new PlannedStep("b", "B", "b", List.of(), null, Set.of("a"), StepStatus.PENDING),
+                new PlannedStep("c", "C", "c", List.of(), null, Set.of("b"), StepStatus.PENDING)
         ), new PlanStatus.Draft(), Instant.now());
         assertFalse(plan.hasParallelizableSteps());
     }

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/planner/PlanCheckpointTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/planner/PlanCheckpointTest.java
@@ -14,7 +14,7 @@ class PlanCheckpointTest {
         for (int i = 0; i < stepCount; i++) {
             steps.add(new PlannedStep(
                     "step-" + i, "Step " + (i + 1), "Do step " + (i + 1),
-                    List.of("bash"), null, StepStatus.PENDING));
+                    List.of("bash"), null, java.util.Set.of(), StepStatus.PENDING));
         }
         return new TaskPlan("plan-1", "Build feature X", steps,
                 new PlanStatus.Draft(), Instant.now());

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/planner/SequentialPlanExecutorTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/planner/SequentialPlanExecutorTest.java
@@ -103,6 +103,7 @@ class SequentialPlanExecutorTest {
                     "Do step " + (i + 1),
                     List.of("read_file"),
                     i == 0 ? "Try alternative approach" : null,
+                    java.util.Set.of(),
                     StepStatus.PENDING));
         }
         return new TaskPlan("plan-1", "Test goal", steps, new PlanStatus.Draft(), Instant.now());
@@ -154,8 +155,8 @@ class SequentialPlanExecutorTest {
         client.enqueueError(); // step 1 fails
 
         var steps = List.of(
-                new PlannedStep("s1", "Step 1", "Do it", List.of(), null, StepStatus.PENDING),
-                new PlannedStep("s2", "Step 2", "Do more", List.of(), null, StepStatus.PENDING));
+                new PlannedStep("s1", "Step 1", "Do it", List.of(), null, java.util.Set.of(), StepStatus.PENDING),
+                new PlannedStep("s2", "Step 2", "Do more", List.of(), null, java.util.Set.of(), StepStatus.PENDING));
         var plan = new TaskPlan("plan-1", "Goal", steps, new PlanStatus.Draft(), Instant.now());
 
         var loop = createLoop(client);
@@ -182,7 +183,7 @@ class SequentialPlanExecutorTest {
 
         // Execute step 1, then cancel before step 2
         // We use a listener to cancel after step 1 completes
-        var cancellingListener = new SequentialPlanExecutor.PlanEventListener() {
+        var cancellingListener = new PlanEventListener() {
             @Override
             public void onStepStarted(PlannedStep step, int stepIndex, int totalSteps) {}
 
@@ -259,7 +260,7 @@ class SequentialPlanExecutorTest {
         var startedSteps = new ArrayList<String>();
         var completedSteps = new ArrayList<String>();
 
-        var listener = new SequentialPlanExecutor.PlanEventListener() {
+        var listener = new PlanEventListener() {
             @Override
             public void onStepStarted(PlannedStep step, int stepIndex, int totalSteps) {
                 startedSteps.add(step.name());

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/planner/TaskPlanParserTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/planner/TaskPlanParserTest.java
@@ -122,4 +122,105 @@ class TaskPlanParserTest {
         var text = "Some text {\"key\": \"value\"} more text";
         assertEquals("{\"key\": \"value\"}", TaskPlanParser.extractJson(text));
     }
+
+    @Test
+    void dependsOn_parsedAndResolved() {
+        var json = """
+                {
+                  "steps": [
+                    {"name": "Research", "description": "Find files"},
+                    {"name": "Implement", "description": "Write code", "dependsOn": ["Research"]},
+                    {"name": "Test", "description": "Run tests", "dependsOn": ["Implement"]}
+                  ]
+                }
+                """;
+
+        var plan = TaskPlanParser.parse(json, "Build feature");
+
+        assertEquals(3, plan.steps().size());
+        assertTrue(plan.steps().get(0).dependsOn().isEmpty());
+
+        // "Implement" depends on "Research" — resolved to Research's stepId
+        var implementStep = plan.steps().get(1);
+        assertEquals(1, implementStep.dependsOn().size());
+        assertTrue(implementStep.dependsOn().contains(plan.steps().get(0).stepId()));
+
+        // "Test" depends on "Implement" — resolved to Implement's stepId
+        var testStep = plan.steps().get(2);
+        assertEquals(1, testStep.dependsOn().size());
+        assertTrue(testStep.dependsOn().contains(implementStep.stepId()));
+    }
+
+    @Test
+    void dependsOn_unknownDepsIgnored() {
+        var json = """
+                {
+                  "steps": [
+                    {"name": "Step A", "description": "do A", "dependsOn": ["NonExistent"]},
+                    {"name": "Step B", "description": "do B"}
+                  ]
+                }
+                """;
+
+        var plan = TaskPlanParser.parse(json, "test");
+        // Unknown dep "NonExistent" should be silently ignored
+        assertTrue(plan.steps().get(0).dependsOn().isEmpty());
+    }
+
+    @Test
+    void dependsOn_cycleDetection_fallsBackToSequential() {
+        var json = """
+                {
+                  "steps": [
+                    {"name": "A", "description": "step A", "dependsOn": ["B"]},
+                    {"name": "B", "description": "step B", "dependsOn": ["A"]}
+                  ]
+                }
+                """;
+
+        var plan = TaskPlanParser.parse(json, "cycle test");
+        // All deps should be cleared because of cycle
+        assertTrue(plan.steps().get(0).dependsOn().isEmpty());
+        assertTrue(plan.steps().get(1).dependsOn().isEmpty());
+    }
+
+    @Test
+    void dependsOn_noDeps_noChange() {
+        var json = """
+                {
+                  "steps": [
+                    {"name": "Solo", "description": "independent step"}
+                  ]
+                }
+                """;
+
+        var plan = TaskPlanParser.parse(json, "test");
+        assertTrue(plan.steps().get(0).dependsOn().isEmpty());
+    }
+
+    @Test
+    void hasCycle_noCycle() {
+        var steps = java.util.List.of(
+                new PlannedStep("a", "A", "a", java.util.List.of(), null, java.util.Set.of(), StepStatus.PENDING),
+                new PlannedStep("b", "B", "b", java.util.List.of(), null, java.util.Set.of("a"), StepStatus.PENDING)
+        );
+        assertFalse(TaskPlanParser.hasCycle(steps));
+    }
+
+    @Test
+    void hasCycle_withCycle() {
+        var steps = java.util.List.of(
+                new PlannedStep("a", "A", "a", java.util.List.of(), null, java.util.Set.of("b"), StepStatus.PENDING),
+                new PlannedStep("b", "B", "b", java.util.List.of(), null, java.util.Set.of("a"), StepStatus.PENDING)
+        );
+        assertTrue(TaskPlanParser.hasCycle(steps));
+    }
+
+    @Test
+    void hasCycle_selfCycle() {
+        var steps = java.util.List.of(
+                new PlannedStep("a", "A", "a", java.util.List.of(), null, java.util.Set.of("a"), StepStatus.PENDING)
+        );
+        assertTrue(TaskPlanParser.hasCycle(steps));
+    }
 }

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/FilePlanCheckpointStore.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/FilePlanCheckpointStore.java
@@ -394,16 +394,19 @@ public final class FilePlanCheckpointStore implements PlanCheckpointStore {
             String description,
             List<String> requiredTools,
             String fallbackApproach,
+            List<String> dependsOn,
             String status
     ) {
         StepDto {
             requiredTools = requiredTools != null ? List.copyOf(requiredTools) : List.of();
+            dependsOn = dependsOn != null ? List.copyOf(dependsOn) : List.of();
         }
 
         static StepDto from(PlannedStep step) {
             return new StepDto(
                     step.stepId(), step.name(), step.description(),
                     step.requiredTools(), step.fallbackApproach(),
+                    step.dependsOn() != null ? List.copyOf(step.dependsOn()) : List.of(),
                     step.status().name()
             );
         }
@@ -415,8 +418,9 @@ public final class FilePlanCheckpointStore implements PlanCheckpointStore {
             } catch (IllegalArgumentException e) {
                 domainStatus = StepStatus.PENDING;
             }
+            var depSet = dependsOn != null ? new java.util.HashSet<>(dependsOn) : java.util.Set.<String>of();
             return new PlannedStep(stepId, name, description, requiredTools,
-                    fallbackApproach, domainStatus);
+                    fallbackApproach, depSet, domainStatus);
         }
     }
 

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -28,6 +28,10 @@ import dev.aceclaw.core.planner.PlanCheckpointStore;
 import dev.aceclaw.core.planner.PlanExecutionResult;
 import dev.aceclaw.core.planner.PlanStatus;
 import dev.aceclaw.core.planner.PlannedStep;
+import dev.aceclaw.core.planner.AgentLoopFactory;
+import dev.aceclaw.core.planner.DagPlanExecutor;
+import dev.aceclaw.core.planner.PlanEventListener;
+import dev.aceclaw.core.planner.PlanExecutor;
 import dev.aceclaw.core.planner.SequentialPlanExecutor;
 import dev.aceclaw.core.planner.StepResult;
 import dev.aceclaw.core.planner.StepStatus;
@@ -359,7 +363,7 @@ public final class StreamingAgentHandler {
 
         // 3. Execute the plan
         var conversationHistory = toMessages(session.messages());
-        var listener = new SequentialPlanExecutor.PlanEventListener() {
+        var listener = new PlanEventListener() {
             @Override
             public void onStepStarted(PlannedStep step, int stepIndex, int totalSteps) {
                 try {
@@ -409,7 +413,7 @@ public final class StreamingAgentHandler {
         };
 
         // Wrap listener with checkpointing if store is available
-        SequentialPlanExecutor.PlanEventListener effectiveListener = listener;
+        PlanEventListener effectiveListener = listener;
         if (planCheckpointStore != null) {
             var wsHash = ResumeRouter.hashWorkspace(session.projectPath());
             var initialCheckpoint = new PlanCheckpoint(
@@ -426,7 +430,17 @@ public final class StreamingAgentHandler {
                     listener, planCheckpointStore, initialCheckpoint, session, 0);
         }
 
-        var executor = new SequentialPlanExecutor(effectiveListener);
+        PlanExecutor executor;
+        if (plan.hasParallelizableSteps()) {
+            AgentLoopFactory factory = () -> new StreamingAgentLoop(
+                    getLlmClient(), createPermissionAwareRegistry(cancelContext, sessionId),
+                    getModelForSession(sessionId), getSystemPrompt(sessionId),
+                    maxTokens, thinkingBudget, null, AgentLoopConfig.EMPTY);
+            executor = new DagPlanExecutor(effectiveListener, factory);
+            log.info("Using DAG parallel executor for plan with {} steps", plan.steps().size());
+        } else {
+            executor = new SequentialPlanExecutor(effectiveListener);
+        }
         var planResult = executor.execute(plan, permissionAwareLoop, conversationHistory,
                 eventHandler, cancellationToken);
 
@@ -1573,7 +1587,7 @@ public final class StreamingAgentHandler {
         }
 
         // 8. Create notification listener for the resumed plan
-        var notificationListener = new SequentialPlanExecutor.PlanEventListener() {
+        var notificationListener = new PlanEventListener() {
             @Override
             public void onStepStarted(PlannedStep step, int stepIndex, int totalSteps) {
                 try {
@@ -1748,16 +1762,16 @@ public final class StreamingAgentHandler {
      * Writes a checkpoint after each step completion and marks final status.
      */
     private static final class CheckpointingPlanEventListener
-            implements SequentialPlanExecutor.PlanEventListener {
+            implements PlanEventListener {
 
-        private final SequentialPlanExecutor.PlanEventListener delegate;
+        private final PlanEventListener delegate;
         private final PlanCheckpointStore store;
         private volatile PlanCheckpoint currentCheckpoint;
         private final AgentSession session;
         private final int stepIndexOffset;
 
         CheckpointingPlanEventListener(
-                SequentialPlanExecutor.PlanEventListener delegate,
+                PlanEventListener delegate,
                 PlanCheckpointStore store,
                 PlanCheckpoint initialCheckpoint,
                 AgentSession session,

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -432,10 +432,18 @@ public final class StreamingAgentHandler {
 
         PlanExecutor executor;
         if (plan.hasParallelizableSteps()) {
+            // Each parallel step gets its own loop instance (runTurn is stateful).
+            // CancellationToken is shared intentionally — cancelling one cancels all
+            // parallel branches (global cancel semantics).
             AgentLoopFactory factory = () -> new StreamingAgentLoop(
                     getLlmClient(), createPermissionAwareRegistry(cancelContext, sessionId),
                     getModelForSession(sessionId), getSystemPrompt(sessionId),
-                    maxTokens, thinkingBudget, null, AgentLoopConfig.EMPTY);
+                    maxTokens, thinkingBudget, null,
+                    AgentLoopConfig.builder()
+                            .sessionId(sessionId)
+                            .metricsCollector(metricsCollector)
+                            .maxIterations(maxIterations)
+                            .build());
             executor = new DagPlanExecutor(effectiveListener, factory);
             log.info("Using DAG parallel executor for plan with {} steps", plan.steps().size());
         } else {
@@ -1769,6 +1777,7 @@ public final class StreamingAgentHandler {
         private volatile PlanCheckpoint currentCheckpoint;
         private final AgentSession session;
         private final int stepIndexOffset;
+        private final Object checkpointLock = new Object();
 
         CheckpointingPlanEventListener(
                 PlanEventListener delegate,
@@ -1792,32 +1801,35 @@ public final class StreamingAgentHandler {
         public void onStepCompleted(PlannedStep step, int stepIndex, StepResult result) {
             delegate.onStepCompleted(step, stepIndex, result);
 
-            // Apply offset: stepIndex from executor is 0-based relative to the
-            // (possibly partial) plan. For resumed plans, offset maps it back to
-            // the absolute index in the original full plan.
-            int absoluteIndex = stepIndex + stepIndexOffset;
+            // Synchronized: DAG executor may call from parallel threads
+            synchronized (checkpointLock) {
+                // Apply offset: stepIndex from executor is 0-based relative to the
+                // (possibly partial) plan. For resumed plans, offset maps it back to
+                // the absolute index in the original full plan.
+                int absoluteIndex = stepIndex + stepIndexOffset;
 
-            // Update and persist checkpoint
-            var updatedPlan = currentCheckpoint.plan()
-                    .withStepStatus(step.stepId(),
-                            result.success() ? StepStatus.COMPLETED : StepStatus.FAILED);
+                // Update and persist checkpoint
+                var updatedPlan = currentCheckpoint.plan()
+                        .withStepStatus(step.stepId(),
+                                result.success() ? StepStatus.COMPLETED : StepStatus.FAILED);
 
-            // Serialize current conversation state
-            var conversationJson = serializeSessionMessages(session);
+                // Serialize current conversation state
+                var conversationJson = serializeSessionMessages(session);
 
-            String hint = result.success()
-                    ? "Step " + (absoluteIndex + 1) + " completed successfully"
-                    : "Step " + (absoluteIndex + 1) + " failed: "
-                            + (result.error() != null ? result.error() : "unknown");
+                String hint = result.success()
+                        ? "Step " + (absoluteIndex + 1) + " completed successfully"
+                        : "Step " + (absoluteIndex + 1) + " failed: "
+                                + (result.error() != null ? result.error() : "unknown");
 
-            currentCheckpoint = currentCheckpoint.withStepCompleted(
-                    absoluteIndex, result, updatedPlan, conversationJson, hint, List.of());
+                currentCheckpoint = currentCheckpoint.withStepCompleted(
+                        absoluteIndex, result, updatedPlan, conversationJson, hint, List.of());
 
-            try {
-                store.save(currentCheckpoint);
-            } catch (Exception e) {
-                log.warn("Failed to persist plan checkpoint after step {}: {}",
-                        stepIndex + 1, e.getMessage());
+                try {
+                    store.save(currentCheckpoint);
+                } catch (Exception e) {
+                    log.warn("Failed to persist plan checkpoint after step {}: {}",
+                            stepIndex + 1, e.getMessage());
+                }
             }
         }
 
@@ -1825,13 +1837,15 @@ public final class StreamingAgentHandler {
         public void onPlanCompleted(TaskPlan plan, boolean success, long totalDurationMs) {
             delegate.onPlanCompleted(plan, success, totalDurationMs);
 
-            currentCheckpoint = currentCheckpoint.withStatus(
-                    success ? PlanCheckpoint.CheckpointStatus.COMPLETED
-                            : PlanCheckpoint.CheckpointStatus.FAILED);
-            try {
-                store.save(currentCheckpoint);
-            } catch (Exception e) {
-                log.warn("Failed to persist final plan checkpoint: {}", e.getMessage());
+            synchronized (checkpointLock) {
+                currentCheckpoint = currentCheckpoint.withStatus(
+                        success ? PlanCheckpoint.CheckpointStatus.COMPLETED
+                                : PlanCheckpoint.CheckpointStatus.FAILED);
+                try {
+                    store.save(currentCheckpoint);
+                } catch (Exception e) {
+                    log.warn("Failed to persist final plan checkpoint: {}", e.getMessage());
+                }
             }
         }
 

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/DaemonIntegrationTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/DaemonIntegrationTest.java
@@ -37,6 +37,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -1083,9 +1084,9 @@ class DaemonIntegrationTest {
             // Build and save a checkpoint that matches this session
             var wsHash = ResumeRouter.hashWorkspace(projectDir);
             var plan = new TaskPlan("plan-resume-test", "Build feature X", List.of(
-                    new PlannedStep("s1", "Research", "Find APIs", List.of("read_file"), null, StepStatus.COMPLETED),
-                    new PlannedStep("s2", "Implement", "Write code", List.of("write_file"), null, StepStatus.PENDING),
-                    new PlannedStep("s3", "Test", "Run tests", List.of("bash"), null, StepStatus.PENDING)
+                    new PlannedStep("s1", "Research", "Find APIs", List.of("read_file"), null, Set.of(), StepStatus.COMPLETED),
+                    new PlannedStep("s2", "Implement", "Write code", List.of("write_file"), null, Set.of(), StepStatus.PENDING),
+                    new PlannedStep("s3", "Test", "Run tests", List.of("bash"), null, Set.of(), StepStatus.PENDING)
             ), new PlanStatus.Executing(1, 3), Instant.now());
 
             var checkpoint = new PlanCheckpoint(
@@ -1149,8 +1150,8 @@ class DaemonIntegrationTest {
 
             var wsHash = ResumeRouter.hashWorkspace(projectDir);
             var plan = new TaskPlan("plan-resume-accept", "Implement login", List.of(
-                    new PlannedStep("s1", "Research", "Find auth libs", List.of("read_file"), null, StepStatus.COMPLETED),
-                    new PlannedStep("s2", "Implement", "Write auth code", List.of("write_file"), null, StepStatus.PENDING)
+                    new PlannedStep("s1", "Research", "Find auth libs", List.of("read_file"), null, Set.of(), StepStatus.COMPLETED),
+                    new PlannedStep("s2", "Implement", "Write auth code", List.of("write_file"), null, Set.of(), StepStatus.PENDING)
             ), new PlanStatus.Executing(1, 2), Instant.now());
 
             var checkpoint = new PlanCheckpoint(
@@ -1218,8 +1219,8 @@ class DaemonIntegrationTest {
             // Seed a checkpoint for projectB (different workspace)
             var wsHashB = ResumeRouter.hashWorkspace(projectB);
             var plan = new TaskPlan("plan-wrong-ws", "Other project task", List.of(
-                    new PlannedStep("s1", "Done", "Done", List.of(), null, StepStatus.COMPLETED),
-                    new PlannedStep("s2", "Pending", "Pending", List.of(), null, StepStatus.PENDING)
+                    new PlannedStep("s1", "Done", "Done", List.of(), null, Set.of(), StepStatus.COMPLETED),
+                    new PlannedStep("s2", "Pending", "Pending", List.of(), null, Set.of(), StepStatus.PENDING)
             ), new PlanStatus.Executing(1, 2), Instant.now());
 
             var checkpoint = new PlanCheckpoint(

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/FilePlanCheckpointStoreTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/FilePlanCheckpointStoreTest.java
@@ -30,7 +30,7 @@ class FilePlanCheckpointStoreTest {
         for (int i = 0; i < stepCount; i++) {
             steps.add(new PlannedStep(
                     "step-" + i, "Step " + (i + 1), "Do step " + (i + 1),
-                    List.of("bash"), null, StepStatus.PENDING));
+                    List.of("bash"), null, java.util.Set.of(), StepStatus.PENDING));
         }
         return new TaskPlan(planId, "Build feature X", steps,
                 new PlanStatus.Draft(), Instant.now());
@@ -157,8 +157,8 @@ class FilePlanCheckpointStoreTest {
     @Test
     void planStatusSerialization_executingStatus() {
         var plan = new TaskPlan("plan-ex", "goal", List.of(
-                new PlannedStep("s1", "Step 1", "desc", List.of(), null, StepStatus.COMPLETED),
-                new PlannedStep("s2", "Step 2", "desc", List.of(), null, StepStatus.PENDING)
+                new PlannedStep("s1", "Step 1", "desc", List.of(), null, java.util.Set.of(), StepStatus.COMPLETED),
+                new PlannedStep("s2", "Step 2", "desc", List.of(), null, java.util.Set.of(), StepStatus.PENDING)
         ), new PlanStatus.Executing(1, 2), Instant.now());
 
         var cp = new PlanCheckpoint("plan-ex", "s1", "ws", "goal", plan,
@@ -178,7 +178,7 @@ class FilePlanCheckpointStoreTest {
     @Test
     void planStatusSerialization_completedStatus() {
         var plan = new TaskPlan("plan-c", "goal", List.of(
-                new PlannedStep("s1", "Step 1", "desc", List.of(), null, StepStatus.COMPLETED)
+                new PlannedStep("s1", "Step 1", "desc", List.of(), null, java.util.Set.of(), StepStatus.COMPLETED)
         ), new PlanStatus.Completed(java.time.Duration.ofMillis(5000)), Instant.now());
 
         var cp = new PlanCheckpoint("plan-c", "s1", "ws", "goal", plan,
@@ -195,7 +195,7 @@ class FilePlanCheckpointStoreTest {
     @Test
     void planStatusSerialization_failedStatus() {
         var plan = new TaskPlan("plan-f", "goal", List.of(
-                new PlannedStep("s1", "Step 1", "desc", List.of(), null, StepStatus.FAILED)
+                new PlannedStep("s1", "Step 1", "desc", List.of(), null, java.util.Set.of(), StepStatus.FAILED)
         ), new PlanStatus.Failed("timeout", "s1"), Instant.now());
 
         var cp = new PlanCheckpoint("plan-f", "s1", "ws", "goal", plan,
@@ -214,9 +214,9 @@ class FilePlanCheckpointStoreTest {
     void stepDetailsPreserved_afterRoundTrip() {
         var plan = new TaskPlan("plan-steps", "goal", List.of(
                 new PlannedStep("s1", "Research", "Find APIs",
-                        List.of("bash", "grep"), "manual search", StepStatus.COMPLETED),
+                        List.of("bash", "grep"), "manual search", java.util.Set.of(), StepStatus.COMPLETED),
                 new PlannedStep("s2", "Implement", "Write code",
-                        List.of("edit_file"), null, StepStatus.PENDING)
+                        List.of("edit_file"), null, java.util.Set.of(), StepStatus.PENDING)
         ), new PlanStatus.Executing(1, 2), Instant.now());
 
         var cp = new PlanCheckpoint("plan-steps", "s1", "ws", "goal", plan,

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/ResumeRouterTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/ResumeRouterTest.java
@@ -18,7 +18,7 @@ class ResumeRouterTest {
         for (int i = 0; i < stepCount; i++) {
             steps.add(new PlannedStep(
                     "step-" + i, "Step " + (i + 1), "Do step " + (i + 1),
-                    List.of("bash"), null, StepStatus.PENDING));
+                    List.of("bash"), null, java.util.Set.of(), StepStatus.PENDING));
         }
         return new TaskPlan("plan-1", "Build feature X", steps,
                 new PlanStatus.Draft(), Instant.now());


### PR DESCRIPTION
## Summary
- Add `DagPlanExecutor` that runs independent plan steps concurrently via `StructuredTaskScope`, while dependent steps wait for prerequisites — targeting >1.5x speedup for plans with 2+ independent branches
- Steps now declare dependencies via `dependsOn` (step names resolved to IDs post-parse), with DFS cycle detection falling back to sequential execution
- Extract `PlanEventListener` to a shared top-level interface; `StreamingAgentHandler` auto-selects DAG vs sequential executor based on `plan.hasParallelizableSteps()`

## Changes
- **New**: `DagPlanExecutor`, `PlanEventListener`, `AgentLoopFactory`, `DagPlanExecutorTest`
- **Modified**: `PlannedStep` (+dependsOn), `TaskPlan` (+readySteps/hasParallelizableSteps), `TaskPlanParser` (+dep parsing/resolution/cycle detection), `PlanningPromptBuilder` (+dep instructions), `SequentialPlanExecutor` (uses top-level listener), `StreamingAgentHandler` (executor selection), `FilePlanCheckpointStore` (+dependsOn persistence)
- **17 files changed**, +1130/-49 lines

## Test plan
- [x] `./gradlew clean build` — 65 tasks, BUILD SUCCESSFUL, 237+ tests pass
- [x] `DagPlanExecutorTest` — diamond DAG ordering, fully independent parallel, sequential chain, branch failure + skip, cancellation
- [x] `TaskPlanParserTest` — dependsOn parsing, name→ID resolution, unknown deps ignored, cycle detection (self-cycle, mutual cycle)
- [x] `SequentialPlanExecutorTest` — backward-compatible with `Set.of()` dependsOn
- [x] `PlanCheckpointTest` — backward-compatible with `Set.of()` dependsOn
- [x] `FilePlanCheckpointStoreTest` — dependsOn round-trip persistence
- [x] `ResumeRouterTest` — backward-compatible

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Steps can declare dependencies, enabling prerequisite-driven plans and improved parallelism for independent steps.
  * Plans may now execute independent steps in parallel with aggregated results and progress events.

* **Bug Fixes / Reliability**
  * Detects dependency cycles and falls back to safe sequential execution.
  * Robust handling of failed steps: transitive dependents are skipped and execution continues where possible.

* **Events & Visibility**
  * Unified plan execution events for step start/completion and overall plan completion.

* **Tests**
  * Extensive new tests covering DAG scenarios, cycle detection, readiness, and cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->