### PR TITLE
fix(cli): remove status line refresh on every token delta

### DIFF
--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/ForegroundOutputSink.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/ForegroundOutputSink.java
@@ -62,7 +62,6 @@ public final class ForegroundOutputSink implements OutputSink {
             out.print(THINKING + delta + RESET);
             out.flush();
             wasThinking = true;
-            statusRenderer.refresh();
         }
     }
 
@@ -104,7 +103,6 @@ public final class ForegroundOutputSink implements OutputSink {
                     out.flush();
                 }
             }
-            statusRenderer.refresh();
         }
     }
 


### PR DESCRIPTION
## Summary

- Remove `statusRenderer.refresh()` from `onTextDelta()` and `onThinkingDelta()` in `ForegroundOutputSink` to fix status line flickering during streaming
- At 50-100+ tokens/sec, the `hide() → print(δ) → refresh()` cycle per token caused ANSI corruption and duplicated status lines
- Status lines now stay hidden during text streaming and reappear naturally on the next lifecycle event (tool/plan step/turn complete)

Closes #155

## Test plan

- [ ] `./gradlew :aceclaw-cli:build` passes
- [ ] Manual: trigger plan execution, verify text streams smoothly without duplicated status lines
- [ ] Manual: verify status line appears on plan step start and updates on step complete
- [ ] Manual: verify no ANSI artifacts or flickering

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized output rendering in the CLI by streamlining refresh logic for status indicators and text display, reducing redundant refresh cycles during processing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->