### PR TITLE
feat: auto-trigger skill draft generation on candidate promotion

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -485,14 +485,26 @@ public final class AceClawDaemon {
             var selfImprovementEngine = new SelfImprovementEngine(
                     errorDetector, patternDetector, failureSignalDetector, memoryStore, strategyRefiner, cs,
                     config.candidatePromotionEnabled(),
-                    validationGateForAuto != null ? projectPath -> {
+                    (validationGateForAuto != null || candidateStoreForAuto != null) ? projectPath -> {
                         try {
-                            validationGateForAuto.validateAll(projectPath, "evidence-update");
-                            if (autoReleaseForAuto != null && candidateStoreForAuto != null) {
-                                autoReleaseForAuto.evaluateAll(projectPath, candidateStoreForAuto, "evidence-update");
+                            // Auto-generate skill drafts from newly promoted candidates
+                            if (candidateStoreForAuto != null) {
+                                var generator = new SkillDraftGenerator();
+                                var summary = generator.generateFromPromoted(candidateStoreForAuto, projectPath);
+                                if (summary.createdDrafts() > 0 || summary.updatedDrafts() > 0) {
+                                    log.info("Auto skill draft generation: {} created, {} updated",
+                                            summary.createdDrafts(), summary.updatedDrafts());
+                                }
+                            }
+                            // Validate drafts and evaluate for auto-release
+                            if (validationGateForAuto != null) {
+                                validationGateForAuto.validateAll(projectPath, "auto-promotion");
+                                if (autoReleaseForAuto != null && candidateStoreForAuto != null) {
+                                    autoReleaseForAuto.evaluateAll(projectPath, candidateStoreForAuto, "auto-promotion");
+                                }
                             }
                         } catch (Exception e) {
-                            log.warn("Draft auto-revalidation failed: {}", e.getMessage());
+                            log.warn("Auto draft generation/validation failed: {}", e.getMessage());
                         }
                     } : null);
             agentHandler.setSelfImprovementEngine(selfImprovementEngine);

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/SelfImprovementEngine.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/SelfImprovementEngine.java
@@ -262,8 +262,19 @@ public final class SelfImprovementEngine {
                     if (!transitions.isEmpty()) {
                         log.info("Candidate pipeline: {} transitions applied after turn", transitions.size());
                     }
-                }
-                if (draftReevaluationTrigger != null) {
+                    // Auto-trigger draft generation + validation + release when candidates get promoted
+                    boolean hasNewPromotions = transitions.stream()
+                            .anyMatch(t -> t.toState() == dev.aceclaw.memory.CandidateState.PROMOTED);
+                    if (hasNewPromotions && draftReevaluationTrigger != null) {
+                        try {
+                            log.info("New promotions detected, triggering auto draft generation + validation");
+                            draftReevaluationTrigger.accept(projectPath);
+                        } catch (Exception e) {
+                            log.warn("Auto draft generation/validation failed: {}", e.getMessage());
+                        }
+                    }
+                } else if (draftReevaluationTrigger != null) {
+                    // Fallback: re-validate existing drafts even without transitions
                     try {
                         draftReevaluationTrigger.accept(projectPath);
                     } catch (Exception e) {

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/CandidatePipelineIntegrationTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/CandidatePipelineIntegrationTest.java
@@ -193,6 +193,82 @@ class CandidatePipelineIntegrationTest {
         assertThat(result).contains("retry");
     }
 
+    @Test
+    void autoPromotionTriggersSkillDraftGeneration() throws IOException {
+        var t0 = Instant.parse("2026-02-23T00:00:00Z");
+
+        // Track whether the trigger was called and capture the project path
+        var triggerCalled = new java.util.concurrent.atomic.AtomicBoolean(false);
+        var draftsCreated = new java.util.concurrent.atomic.AtomicInteger(0);
+
+        // Wire engine with candidate store + draft generation trigger
+        var errorDetector = new ErrorDetector(memoryStore);
+        var patternDetector = new PatternDetector(memoryStore);
+        var engineWithTrigger = new SelfImprovementEngine(
+                errorDetector, patternDetector, new FailureSignalDetector(),
+                memoryStore, null, candidateStore, true,
+                projectPath -> {
+                    triggerCalled.set(true);
+                    // Simulate what the daemon lambda does: generate drafts from promoted candidates
+                    var generator = new SkillDraftGenerator();
+                    try {
+                        var summary = generator.generateFromPromoted(candidateStore, projectPath);
+                        draftsCreated.set(summary.createdDrafts());
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+
+        // Feed enough observations to trigger promotion (evidence >= 2, score >= 0.5)
+        candidateStore.upsert(obs("timeout recovery via retry", "bash", 0.8, t0));
+        candidateStore.upsert(obs("bash timeout recovery via retry approach", "bash", 0.8,
+                t0.plusSeconds(60)));
+
+        // Persist insights to trigger evaluateAll() + draft generation
+        var insights = List.<Insight>of(
+                Insight.ErrorInsight.of("bash", "Command timed out", "Retry with shorter timeout", 0.9)
+        );
+        engineWithTrigger.persist(insights, "test-session", tempDir);
+
+        // Verify: trigger was called because new promotions occurred
+        assertThat(triggerCalled.get()).isTrue();
+
+        // Verify: skill drafts were generated for the promoted candidate
+        assertThat(draftsCreated.get()).isGreaterThanOrEqualTo(1);
+
+        // Verify: draft file exists on disk
+        Path draftsDir = tempDir.resolve(".aceclaw").resolve("skills-drafts");
+        assertThat(draftsDir).exists();
+        var draftFiles = Files.walk(draftsDir)
+                .filter(p -> p.getFileName().toString().equals("SKILL.md"))
+                .toList();
+        assertThat(draftFiles).isNotEmpty();
+    }
+
+    @Test
+    void noPromotionDoesNotTriggerDraftGeneration() {
+        // Wire engine with trigger that tracks calls
+        var triggerCalled = new java.util.concurrent.atomic.AtomicBoolean(false);
+        var errorDetector = new ErrorDetector(memoryStore);
+        var patternDetector = new PatternDetector(memoryStore);
+        var engineWithTrigger = new SelfImprovementEngine(
+                errorDetector, patternDetector, new FailureSignalDetector(),
+                memoryStore, null, candidateStore, true,
+                projectPath -> triggerCalled.set(true));
+
+        // Only one observation — not enough for promotion (needs evidence >= 2)
+        var t0 = Instant.parse("2026-02-23T00:00:00Z");
+        candidateStore.upsert(obs("single observation", "bash", 0.8, t0));
+
+        var insights = List.<Insight>of(
+                Insight.ErrorInsight.of("bash", "Command failed", "Retry", 0.9)
+        );
+        engineWithTrigger.persist(insights, "test-session", tempDir);
+
+        // No promotion happened, so trigger should NOT be called
+        assertThat(triggerCalled.get()).isFalse();
+    }
+
     private static CandidateStore.CandidateObservation obs(String content, String toolTag,
                                                             double score, Instant at) {
         return new CandidateStore.CandidateObservation(


### PR DESCRIPTION
## Summary

- Connect the missing link in the self-learning pipeline: auto-generate skill drafts when candidates get promoted
- `SelfImprovementEngine` now only fires the trigger when `evaluateAll()` produces new `PROMOTED` transitions
- `AceClawDaemon` trigger lambda now calls `SkillDraftGenerator.generateFromPromoted()` before validation + release
- Full pipeline now runs end-to-end without manual RPC intervention:
  `insight → candidate → promotion → draft → validate → release`

## Before / After

```
Before: insight → candidate → PROMOTED → ❌ (manual RPC needed) → draft → validate → release
After:  insight → candidate → PROMOTED → ✅ auto-draft → validate → release
```

## Test plan

- [x] `./gradlew clean build` passes (65 tasks, BUILD SUCCESSFUL)
- [x] New test: `autoPromotionTriggersSkillDraftGeneration` — verifies trigger fires and SKILL.md created
- [x] New test: `noPromotionDoesNotTriggerDraftGeneration` — verifies trigger skipped when no promotions
- [x] All existing pipeline integration tests still pass

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-promotion now generates drafts from newly promoted candidates.
  * Improved auto-improvement triggering logic to activate only when actual promotions occur.

* **Tests**
  * Added integration tests verifying draft generation behavior with promotion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->