### PR TITLE
feat: support Claude Sonnet 4.5 via Copilot provider

### DIFF
--- a/aceclaw-core/src/main/java/dev/aceclaw/core/llm/ProviderCapabilities.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/llm/ProviderCapabilities.java
@@ -35,4 +35,19 @@ public record ProviderCapabilities(
     /** GitHub Copilot Codex models (Responses API): no extended thinking, no caching, no images, 400K context. */
     public static final ProviderCapabilities CODEX =
             new ProviderCapabilities(false, false, false, 0, 400_000);
+
+    /** Claude models on Copilot/OpenAI: extended thinking enabled, 200K context. */
+    public static final ProviderCapabilities COPILOT_CLAUDE =
+            new ProviderCapabilities(true, false, true, 0, 200_000);
+
+    /** Returns capabilities appropriate for a given model on Copilot. */
+    public static ProviderCapabilities forCopilotModel(String model) {
+        if (model != null && model.toLowerCase().contains("claude")) {
+            return COPILOT_CLAUDE;
+        }
+        if (model != null && model.toLowerCase().contains("codex")) {
+            return CODEX;
+        }
+        return OPENAI;
+    }
 }

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/llm/ProviderCapabilitiesTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/llm/ProviderCapabilitiesTest.java
@@ -34,6 +34,37 @@ class ProviderCapabilitiesTest {
     }
 
     @Test
+    void copilotClaudeConstantHasCorrectCapabilities() {
+        var caps = ProviderCapabilities.COPILOT_CLAUDE;
+        assertTrue(caps.supportsExtendedThinking());
+        assertFalse(caps.supportsPromptCaching());
+        assertTrue(caps.supportsImageInput());
+        assertEquals(200_000, caps.contextWindowTokens());
+    }
+
+    @Test
+    void forCopilotModel_returnsClaudeForClaudeModels() {
+        assertSame(ProviderCapabilities.COPILOT_CLAUDE,
+                ProviderCapabilities.forCopilotModel("claude-sonnet-4.5"));
+        assertSame(ProviderCapabilities.COPILOT_CLAUDE,
+                ProviderCapabilities.forCopilotModel("Claude-Opus-4"));
+    }
+
+    @Test
+    void forCopilotModel_returnsCodexForCodexModels() {
+        assertSame(ProviderCapabilities.CODEX,
+                ProviderCapabilities.forCopilotModel("gpt-5.2-codex"));
+    }
+
+    @Test
+    void forCopilotModel_returnsOpenAIForOtherModels() {
+        assertSame(ProviderCapabilities.OPENAI,
+                ProviderCapabilities.forCopilotModel("gpt-4o"));
+        assertSame(ProviderCapabilities.OPENAI,
+                ProviderCapabilities.forCopilotModel(null));
+    }
+
+    @Test
     void customConstructionWorks() {
         var custom = new ProviderCapabilities(false, false, true, 10, 64_000);
         assertEquals(64_000, custom.contextWindowTokens());

--- a/aceclaw-llm/src/main/java/dev/aceclaw/llm/LlmClientFactory.java
+++ b/aceclaw-llm/src/main/java/dev/aceclaw/llm/LlmClientFactory.java
@@ -129,9 +129,10 @@ public final class LlmClientFactory {
         // The routing client dispatches to the correct endpoint based on model name:
         // - Codex models (e.g. gpt-5.2-codex) → Responses API (/responses)
         // - All other models → Chat Completions API (/chat/completions)
+        var chatCaps = ProviderCapabilities.forCopilotModel(resolvedModel);
         var chatClient = new OpenAICompatClient(
                 tokenProvider, resolvedBaseUrl, "/chat/completions",
-                "copilot", resolvedModel, ProviderCapabilities.OPENAI,
+                "copilot", resolvedModel, chatCaps,
                 COPILOT_API_HEADERS);
         var responsesClient = new OpenAIResponsesClient(
                 tokenProvider, resolvedBaseUrl, "/responses",

--- a/aceclaw-llm/src/main/java/dev/aceclaw/llm/openai/CopilotRoutingClient.java
+++ b/aceclaw-llm/src/main/java/dev/aceclaw/llm/openai/CopilotRoutingClient.java
@@ -85,10 +85,7 @@ public final class CopilotRoutingClient implements LlmClient {
 
     @Override
     public ProviderCapabilities capabilities() {
-        // Return capabilities for the default model.
-        // Both OPENAI and CODEX disable extended thinking and prompt caching,
-        // so the difference is minimal (only supportsImageInput).
-        return isCodexModel(defaultModel) ? ProviderCapabilities.CODEX : ProviderCapabilities.OPENAI;
+        return ProviderCapabilities.forCopilotModel(defaultModel);
     }
 
     private LlmClient selectClient(String model) {

--- a/aceclaw-llm/src/main/java/dev/aceclaw/llm/openai/OpenAIMapper.java
+++ b/aceclaw-llm/src/main/java/dev/aceclaw/llm/openai/OpenAIMapper.java
@@ -87,7 +87,15 @@ final class OpenAIMapper {
             root.set("stream_options", streamOptions);
         }
 
-        // Extended thinking is silently ignored (not supported by OpenAI)
+        // Extended thinking for models that support it (e.g. Claude on Copilot)
+        if (request.thinkingBudget() > 0) {
+            ObjectNode thinking = objectMapper.createObjectNode();
+            thinking.put("type", "enabled");
+            thinking.put("budget_tokens", request.thinkingBudget());
+            root.set("thinking", thinking);
+            // When thinking is enabled, temperature must be 1.0 and cannot be explicitly set
+            root.remove("temperature");
+        }
 
         return root.toString();
     }

--- a/aceclaw-llm/src/test/java/dev/aceclaw/llm/openai/OpenAIMapperTest.java
+++ b/aceclaw-llm/src/test/java/dev/aceclaw/llm/openai/OpenAIMapperTest.java
@@ -124,6 +124,30 @@ class OpenAIMapperTest {
         assertThat(tool.get("function").get("description").asText()).isEqualTo("does stuff");
     }
 
+    @Test
+    void thinkingBudget_emitsThinkingBlock() throws Exception {
+        var request = baseRequest()
+                .thinkingBudget(10240)
+                .build();
+        JsonNode root = objectMapper.readTree(mapper.toRequestJson(request, false));
+
+        assertThat(root.has("thinking")).isTrue();
+        assertThat(root.get("thinking").get("type").asText()).isEqualTo("enabled");
+        assertThat(root.get("thinking").get("budget_tokens").asInt()).isEqualTo(10240);
+        // Temperature must be removed when thinking is enabled
+        assertThat(root.has("temperature")).isFalse();
+    }
+
+    @Test
+    void zeroThinkingBudget_omitsThinkingBlock() throws Exception {
+        var request = baseRequest()
+                .thinkingBudget(0)
+                .build();
+        JsonNode root = objectMapper.readTree(mapper.toRequestJson(request, false));
+
+        assertThat(root.has("thinking")).isFalse();
+    }
+
     // --- Response parsing ---
 
     @Test


### PR DESCRIPTION
## Summary
- Add model-aware `ProviderCapabilities.forCopilotModel()` that returns `COPILOT_CLAUDE` preset (thinking=true, 200K context) for Claude models on the Copilot provider
- `CopilotRoutingClient.capabilities()` and `LlmClientFactory.createCopilotClient()` now use model-aware capabilities instead of hardcoded `OPENAI` preset
- `OpenAIMapper` emits `{"thinking": {"type": "enabled", "budget_tokens": N}}` when `thinkingBudget > 0`, and removes `temperature` (required by API when thinking is enabled)

Closes #178

## Test plan
- [x] `ProviderCapabilities.forCopilotModel()` returns correct preset for "claude-sonnet-4.5", "gpt-5.2-codex", "gpt-4o", null
- [x] `OpenAIMapper.toRequestJson()` includes `thinking` block when `thinkingBudget > 0`
- [x] `OpenAIMapper.toRequestJson()` omits `thinking` block when `thinkingBudget == 0`
- [x] `./gradlew :aceclaw-core:test :aceclaw-llm:test` all green
- [ ] Manual: set `provider=copilot, model=claude-sonnet-4.5` and verify reasoning output appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Claude models with extended thinking capabilities.
  * Implemented dynamic provider detection to automatically map model types with appropriate capabilities.
  * Extended thinking budget is now supported for compatible models.

* **Tests**
  * Added comprehensive test coverage for model capability detection and extended thinking feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->