### PR TITLE
fix: short write on non-blocking channel corrupts JSON-RPC stream

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/ConnectionBridge.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/ConnectionBridge.java
@@ -110,11 +110,29 @@ public final class ConnectionBridge implements UdsListener.ConnectionHandler {
      * to non-blocking mode), {@code channel.write()} may return fewer bytes than
      * the buffer contains. This method loops until the entire message is written,
      * preventing JSON corruption on the wire.
+     *
+     * <p>If the channel is under backpressure and {@code write()} returns 0,
+     * uses exponential backoff (1ms to 64ms) to avoid busy-spinning. Gives up
+     * after {@value #WRITE_TIMEOUT_MS}ms total wall-clock time.
      */
+    private static final long WRITE_TIMEOUT_MS = 30_000;
+
     private static void writeAll(SocketChannel channel, String json) throws IOException {
         var buf = ByteBuffer.wrap(json.getBytes(StandardCharsets.UTF_8));
+        long deadline = System.currentTimeMillis() + WRITE_TIMEOUT_MS;
+        long backoffNanos = 1_000_000L; // 1ms initial backoff
         while (buf.hasRemaining()) {
-            channel.write(buf);
+            int written = channel.write(buf);
+            if (written == 0) {
+                if (System.currentTimeMillis() >= deadline) {
+                    throw new IOException("Write timed out after " + WRITE_TIMEOUT_MS
+                            + "ms, " + buf.remaining() + " bytes remaining");
+                }
+                java.util.concurrent.locks.LockSupport.parkNanos(backoffNanos);
+                backoffNanos = Math.min(backoffNanos * 2, 64_000_000L); // cap at 64ms
+            } else {
+                backoffNanos = 1_000_000L; // reset on progress
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Extract `writeAll()` helper in `ConnectionBridge` that loops `while(buf.hasRemaining())` to handle short writes on non-blocking channels
- Replace all 3 raw `channel.write()` calls with `writeAll()`: final response, error response, and streaming notifications

Closes #181

## Test plan
- [x] `./gradlew :aceclaw-daemon:test` all green
- [ ] Manual: run a long-running task with large tool output (e.g. bash with Confluence post), verify stream completes without JsonParseException

🤖 Generated with [Claude Code](https://claude.com/claude-code)