### PR TITLE
fix: strip trailing blanks at printAbove consumer (#194)

### DIFF
--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
@@ -438,15 +438,9 @@ public final class TerminalRepl {
                         boolean didPrintAbove = false;
                         if (!pendingPrintAbove.isEmpty() && readingPrompt && !isPermissionModalActive()) {
                             for (String text : pendingPrintAbove) {
-                                // Split multi-line content into individual printAbove calls.
-                                // JLine's AttributedString is single-line oriented; passing
-                                // large multi-line ANSI strings to fromAnsi() can lose content.
-                                // Use split with -1 to preserve all lines faithfully.
-                                // Trailing blank lines are stripped at each producer site
-                                // (renderSchedulerEventNote, renderDeferredEventNote, etc.)
-                                // rather than here, to avoid silently swallowing intentional
-                                // trailing newlines from other producers.
-                                String[] lines = text.split("\n", -1);
+                                // Strip trailing blank lines before splitting to avoid
+                                // empty printAbove() calls that produce visible blank lines.
+                                String[] lines = text.stripTrailing().split("\n", -1);
                                 for (String line : lines) {
                                     try {
                                         reader.printAbove(AttributedString.fromAnsi(line));


### PR DESCRIPTION
## Summary
- Adds `text.stripTrailing()` at the `pendingPrintAbove` consumer loop before `split("\n", -1)`
- This eliminates trailing blank lines that appear after cron/deferred/background-task output

## Why PR #186 wasn't enough
PR #186 added `stripTrailing()` at each producer site, but:
1. `split("\n", -1)` preserves trailing empty strings from any residual `\n`
2. Each empty string becomes a `printAbove("")` → visible blank line
3. Relying on every producer to strip is fragile — one miss and blanks return

The correct fix is a single defensive strip at the consumer boundary.

## Change
```java
// Before
String[] lines = text.split("\n", -1);

// After  
String[] lines = text.stripTrailing().split("\n", -1);
```

One line, covers all producers.

Closes #194

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unnecessary blank lines appearing above the prompt in terminal output, resulting in cleaner and more polished display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->