### PR TITLE
feat(cli): surface generated skill drafts in repl

### DIFF
--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
@@ -139,8 +139,6 @@ public final class TerminalRepl {
     private volatile Instant cachedLearningStatusAt = Instant.EPOCH;
     private volatile SkillDraftSnapshot cachedSkillDraftSnapshot;
     private volatile Instant cachedSkillDraftSnapshotAt = Instant.EPOCH;
-    private volatile SkillDraftSnapshot lastNotifiedSkillDraftSnapshot;
-    private volatile boolean skillDraftNotificationPrimed;
     /** Cached cron status snapshot from daemon RPC. */
     private volatile CronStatusSnapshot cachedCronStatus;
     private volatile Instant cachedCronStatusAt = Instant.EPOCH;
@@ -158,6 +156,8 @@ public final class TerminalRepl {
     private volatile long schedulerEventSeq;
     /** Last consumed deferred event sequence from daemon. */
     private volatile long deferEventSeq;
+    /** Last consumed skill draft event sequence from daemon. */
+    private volatile long skillDraftEventSeq;
 
     private sealed interface UiEvent permits UiNoticeEvent, UiPrintAboveEvent {}
 
@@ -219,7 +219,8 @@ public final class TerminalRepl {
             String validationVerdict,
             List<String> validationReasons,
             String releaseStage,
-            boolean paused
+            boolean paused,
+            boolean manualReviewNeeded
     ) {
         private SkillDraftRecord {
             skillName = skillName == null ? "" : skillName;
@@ -231,6 +232,29 @@ public final class TerminalRepl {
                     ? "pending" : validationVerdict;
             validationReasons = validationReasons != null ? List.copyOf(validationReasons) : List.of();
             releaseStage = releaseStage == null || releaseStage.isBlank() ? "draft" : releaseStage;
+        }
+    }
+
+    private record SkillDraftEvent(
+            String type,
+            String trigger,
+            String skillName,
+            String draftPath,
+            String candidateId,
+            String verdict,
+            String releaseStage,
+            boolean paused,
+            List<String> reasons
+    ) {
+        private SkillDraftEvent {
+            type = type == null ? "" : type;
+            trigger = trigger == null ? "manual" : trigger;
+            skillName = skillName == null ? "" : skillName;
+            draftPath = draftPath == null ? "" : draftPath;
+            candidateId = candidateId == null ? "" : candidateId;
+            verdict = verdict == null ? "" : verdict;
+            releaseStage = releaseStage == null ? "" : releaseStage;
+            reasons = reasons != null ? List.copyOf(reasons) : List.of();
         }
     }
 
@@ -331,6 +355,7 @@ public final class TerminalRepl {
                 schedulerEventConnection = client.openTaskConnection();
                 schedulerEventSeq = bootstrapSchedulerEventSeq(schedulerEventConnection);
                 deferEventSeq = bootstrapDeferEventSeq(schedulerEventConnection);
+                skillDraftEventSeq = bootstrapSkillDraftEventSeq(schedulerEventConnection);
             } catch (Exception e) {
                 schedulerEventConnection = null;
                 log.debug("Failed to initialize scheduler event polling: {}", e.getMessage());
@@ -472,8 +497,8 @@ public final class TerminalRepl {
 
                         pollAndRenderSchedulerEvents(schedulerEventConn, reader);
                         pollAndRenderDeferredEvents(schedulerEventConn, reader);
+                        pollAndRenderSkillDraftEvents(schedulerEventConn);
                         pollCronStatus(schedulerEventConn);
-                        pollSkillDraftNotifications();
                     }
                 });
     }
@@ -684,6 +709,20 @@ public final class TerminalRepl {
         }
     }
 
+    private long bootstrapSkillDraftEventSeq(DaemonConnection conn)
+            throws IOException, DaemonClient.DaemonClientException {
+        var params = client.objectMapper().createObjectNode();
+        params.put("afterSeq", Long.MAX_VALUE);
+        params.put("limit", 1);
+        try {
+            JsonNode result = conn.sendRequest("skill.draft.events.poll", params);
+            return Math.max(0L, result.path("nextSeq").asLong(0L));
+        } catch (Exception e) {
+            log.debug("skill.draft.events.poll not available (daemon may not support it): {}", e.getMessage());
+            return 0L;
+        }
+    }
+
     private void pollAndRenderDeferredEvents(DaemonConnection conn, LineReader reader) {
         if (conn == null) return;
         try {
@@ -719,6 +758,27 @@ public final class TerminalRepl {
             requestUiRender();
         } catch (Exception e) {
             log.debug("Failed to poll deferred events: {}", e.getMessage());
+        }
+    }
+
+    private void pollAndRenderSkillDraftEvents(DaemonConnection conn) {
+        if (conn == null) return;
+        try {
+            var params = client.objectMapper().createObjectNode();
+            params.put("afterSeq", skillDraftEventSeq);
+            params.put("limit", 20);
+            JsonNode result = conn.sendRequest("skill.draft.events.poll", params);
+            skillDraftEventSeq = Math.max(skillDraftEventSeq, result.path("nextSeq").asLong(skillDraftEventSeq));
+            JsonNode events = result.path("events");
+            if (!events.isArray() || events.isEmpty()) {
+                return;
+            }
+            for (JsonNode event : events) {
+                renderSkillDraftEventNotice(parseSkillDraftEvent(event));
+            }
+            requestUiRender();
+        } catch (Exception e) {
+            log.debug("Failed to poll skill.draft.events: {}", e.getMessage());
         }
     }
 
@@ -1926,60 +1986,55 @@ public final class TerminalRepl {
                 + "(p:" + pass + ",h:" + hold + ",b:" + block + ",n:" + pending + ")";
     }
 
-    private void pollSkillDraftNotifications() {
-        if (sessionInfo.project() == null || sessionInfo.project().isBlank()) {
-            return;
-        }
-        final Path projectRoot;
-        try {
-            projectRoot = Path.of(sessionInfo.project());
-        } catch (Exception e) {
-            log.debug("Invalid project path for skill draft polling: {}", e.getMessage());
-            return;
-        }
-
-        var snapshot = getSkillDraftSnapshot(projectRoot);
-        if (snapshot == null) {
-            return;
-        }
-
-        if (!skillDraftNotificationPrimed) {
-            lastNotifiedSkillDraftSnapshot = snapshot;
-            skillDraftNotificationPrimed = true;
-            if (!snapshot.drafts().isEmpty()) {
-                enqueueUiNotice(INFO + "skill drafts pending" + RESET + ": "
-                        + snapshot.drafts().size() + " draft(s); use /skills drafts");
+    private SkillDraftEvent parseSkillDraftEvent(JsonNode node) {
+        var reasons = new ArrayList<String>();
+        JsonNode arr = node.path("reasons");
+        if (arr.isArray()) {
+            for (JsonNode reason : arr) {
+                String text = sanitizeTerminalText(reason.asText(""));
+                if (!text.isBlank()) {
+                    reasons.add(text);
+                }
             }
+        }
+        return new SkillDraftEvent(
+                node.path("type").asText(""),
+                node.path("trigger").asText("manual"),
+                sanitizeTerminalText(node.path("skillName").asText("")),
+                sanitizeTerminalText(node.path("draftPath").asText("")),
+                sanitizeTerminalText(node.path("candidateId").asText("")),
+                sanitizeTerminalText(node.path("verdict").asText("")),
+                sanitizeTerminalText(node.path("releaseStage").asText("")),
+                node.path("paused").asBoolean(false),
+                reasons
+        );
+    }
+
+    private void renderSkillDraftEventNotice(SkillDraftEvent event) {
+        if (event == null) {
             return;
         }
-
-        var previous = lastNotifiedSkillDraftSnapshot;
-        lastNotifiedSkillDraftSnapshot = snapshot;
-
-        for (var entry : snapshot.drafts().entrySet()) {
-            String key = entry.getKey();
-            var current = entry.getValue();
-            var prior = previous.drafts().get(key);
-            if (prior == null) {
+        switch (event.type()) {
+            case "draft_created" -> {
                 enqueueUiNotice(INFO + "skill draft created" + RESET + ": "
-                        + current.skillName() + " (" + current.validationVerdict() + ")");
-                continue;
+                        + fitWidth(event.skillName(), 36)
+                        + (event.candidateId().isBlank() ? "" : " [" + fitWidth(event.candidateId(), 24) + "]"));
             }
-            if (!Objects.equals(prior.validationVerdict(), current.validationVerdict())) {
-                String reason = current.validationReasons().isEmpty()
-                        ? current.validationVerdict()
-                        : current.validationReasons().get(0);
-                enqueueUiNotice(INFO + "skill draft " + current.validationVerdict() + RESET + ": "
-                        + current.skillName() + " - " + fitWidth(reason, 72));
+            case "validation_changed" -> {
+                String reason = event.reasons().isEmpty() ? event.verdict() : event.reasons().get(0);
+                enqueueUiNotice(INFO + "skill draft " + event.verdict() + RESET + ": "
+                        + fitWidth(event.skillName(), 32)
+                        + " - " + fitWidth(reason, 68));
             }
-            if (!Objects.equals(prior.releaseStage(), current.releaseStage())
-                    || prior.paused() != current.paused()) {
-                String suffix = current.paused() ? " (paused)" : "";
+            case "release_changed" -> {
+                String suffix = event.paused() ? " (paused)" : "";
                 enqueueUiNotice(INFO + "skill release" + RESET + ": "
-                        + current.skillName() + " -> " + current.releaseStage() + suffix);
+                        + fitWidth(event.skillName(), 32)
+                        + " -> " + fitWidth(event.releaseStage(), 16) + suffix);
+            }
+            default -> {
             }
         }
-        requestUiRender();
     }
 
     private SkillDraftSnapshot getSkillDraftSnapshot(Path projectRoot) {
@@ -2013,21 +2068,24 @@ public final class TerminalRepl {
                     .sorted()
                     .toList()) {
                 String draftPath = projectRoot.relativize(draftFile).toString().replace('\\', '/');
-                Map<String, String> frontmatter = parseSkillFrontmatter(Files.readString(draftFile));
-                String skillName = frontmatter.getOrDefault("name", draftFile.getParent().getFileName().toString());
+                Map<String, String> frontmatter = parseSkillFrontmatter(draftFile);
+                String skillName = sanitizeTerminalText(
+                        frontmatter.getOrDefault("name", draftFile.getParent().getFileName().toString()));
                 var validation = validations.getOrDefault(draftPath, new SkillValidationStatus("pending", List.of()));
                 var release = releases.getOrDefault(skillName.toLowerCase(), new SkillReleaseStatus("draft", false));
+                boolean manualReviewNeeded = !"active".equalsIgnoreCase(release.stage());
                 drafts.put(skillName.toLowerCase(), new SkillDraftRecord(
                         skillName,
-                        frontmatter.getOrDefault("description", ""),
+                        sanitizeTerminalText(frontmatter.getOrDefault("description", "")),
                         draftPath,
-                        frontmatter.getOrDefault("source-candidate-id", ""),
-                        frontmatter.getOrDefault("allowed-tools", ""),
+                        sanitizeTerminalText(frontmatter.getOrDefault("source-candidate-id", "")),
+                        sanitizeTerminalText(frontmatter.getOrDefault("allowed-tools", "")),
                         parseBoolean(frontmatter.get("disable-model-invocation")),
                         validation.verdict(),
                         validation.reasons(),
                         release.stage(),
-                        release.paused()
+                        release.paused(),
+                        manualReviewNeeded
                 ));
             }
         } catch (Exception e) {
@@ -2042,8 +2100,10 @@ public final class TerminalRepl {
         if (!Files.isRegularFile(auditPath)) {
             return statuses;
         }
-        try {
-            for (String line : Files.readAllLines(auditPath)) {
+        try (var lines = Files.lines(auditPath)) {
+            var iterator = lines.iterator();
+            while (iterator.hasNext()) {
+                String line = iterator.next();
                 if (line == null || line.isBlank()) continue;
                 JsonNode node = statusMapper.readTree(line);
                 if (node == null) continue;
@@ -2056,16 +2116,16 @@ public final class TerminalRepl {
                         String code = reason.path("code").asText("");
                         String message = reason.path("message").asText("");
                         if (!code.isBlank() && !message.isBlank()) {
-                            reasons.add(code + ": " + message);
+                            reasons.add(sanitizeTerminalText(code + ": " + message));
                         } else if (!code.isBlank()) {
-                            reasons.add(code);
+                            reasons.add(sanitizeTerminalText(code));
                         } else if (!message.isBlank()) {
-                            reasons.add(message);
+                            reasons.add(sanitizeTerminalText(message));
                         }
                     }
                 }
                 statuses.put(draftPath, new SkillValidationStatus(
-                        node.path("verdict").asText("pending"),
+                        sanitizeTerminalText(node.path("verdict").asText("pending")),
                         reasons
                 ));
             }
@@ -2100,34 +2160,23 @@ public final class TerminalRepl {
         return statuses;
     }
 
-    private static Map<String, String> parseSkillFrontmatter(String raw) {
+    private static Map<String, String> parseSkillFrontmatter(Path path) throws IOException {
         var map = new LinkedHashMap<String, String>();
-        if (raw == null || raw.isBlank()) {
-            return map;
-        }
-        String[] lines = raw.split("\n");
-        int first = -1;
-        int second = -1;
-        for (int i = 0; i < lines.length; i++) {
-            if ("---".equals(lines[i].trim())) {
-                if (first < 0) {
-                    first = i;
-                } else {
-                    second = i;
+        try (var reader = Files.newBufferedReader(path)) {
+            String line = reader.readLine();
+            if (line == null || !"---".equals(line.trim())) {
+                return map;
+            }
+            while ((line = reader.readLine()) != null) {
+                if ("---".equals(line.trim())) {
                     break;
                 }
+                int idx = line.indexOf(':');
+                if (idx <= 0) continue;
+                String key = line.substring(0, idx).trim().toLowerCase();
+                String value = line.substring(idx + 1).trim();
+                map.put(key, stripQuotes(value));
             }
-        }
-        if (first < 0 || second <= first) {
-            return map;
-        }
-        for (int i = first + 1; i < second; i++) {
-            String line = lines[i];
-            int idx = line.indexOf(':');
-            if (idx <= 0) continue;
-            String key = line.substring(0, idx).trim().toLowerCase();
-            String value = line.substring(idx + 1).trim();
-            map.put(key, stripQuotes(value));
         }
         return map;
     }
@@ -2151,6 +2200,10 @@ public final class TerminalRepl {
             return raw.substring(1, raw.length() - 1);
         }
         return raw;
+    }
+
+    private static String sanitizeTerminalText(String raw) {
+        return sanitizeCronSummary(raw);
     }
 
     private TaskRuntimeInfo deriveRuntimeInfo(TaskHandle task, Instant now) {
@@ -2478,7 +2531,11 @@ public final class TerminalRepl {
         }
 
         if (arg == null || arg.isBlank() || "drafts".equalsIgnoreCase(arg)) {
-            renderSkillDraftList(out, projectRoot);
+            renderSkillDraftList(out, projectRoot, false);
+            return;
+        }
+        if ("drafts pending".equalsIgnoreCase(arg) || "pending".equalsIgnoreCase(arg)) {
+            renderSkillDraftList(out, projectRoot, true);
             return;
         }
         if (arg.regionMatches(true, 0, "inspect ", 0, "inspect ".length())) {
@@ -2486,11 +2543,11 @@ public final class TerminalRepl {
             return;
         }
 
-        out.println(WARNING + "Usage: /skills drafts | /skills inspect <name>" + RESET);
+        out.println(WARNING + "Usage: /skills drafts | /skills drafts pending | /skills inspect <name>" + RESET);
         out.flush();
     }
 
-    private void renderSkillDraftList(PrintWriter out, Path projectRoot) {
+    private void renderSkillDraftList(PrintWriter out, Path projectRoot, boolean pendingOnly) {
         var snapshot = getSkillDraftSnapshot(projectRoot);
         if (snapshot == null || snapshot.drafts().isEmpty()) {
             out.println();
@@ -2501,15 +2558,26 @@ public final class TerminalRepl {
         }
 
         out.println();
-        out.println(BOLD + "Skill Drafts" + RESET);
-        for (var draft : snapshot.drafts().values().stream()
+        out.println(BOLD + (pendingOnly ? "Pending Skill Drafts" : "Skill Drafts") + RESET);
+        var visibleDrafts = snapshot.drafts().values().stream()
+                .filter(draft -> !pendingOnly || draft.manualReviewNeeded())
                 .sorted((left, right) -> left.skillName().compareToIgnoreCase(right.skillName()))
-                .toList()) {
+                .toList();
+        if (visibleDrafts.isEmpty()) {
+            out.println(MUTED + "No pending manual-review drafts." + RESET);
+            out.println();
+            out.flush();
+            return;
+        }
+        for (var draft : visibleDrafts) {
             String paused = draft.paused() ? " paused" : "";
-            out.printf("  %s%s%s  %sverdict=%s%s  %srelease=%s%s%s%n",
+            out.printf("  %s%s%s  %scandidate=%s%s  %sverdict=%s%s  %srelease=%s%s%s%n",
                     BOLD, draft.skillName(), RESET,
+                    MUTED, fitWidth(draft.candidateId(), 20), RESET,
                     MUTED, draft.validationVerdict(), RESET,
                     MUTED, draft.releaseStage(), paused, RESET);
+            out.printf("      %smanual-review=%s%s%n", MUTED,
+                    draft.manualReviewNeeded() ? "yes" : "no", RESET);
             if (!draft.description().isBlank()) {
                 out.printf("      %s%s%s%n", MUTED, fitWidth(draft.description(), 96), RESET);
             }
@@ -2546,14 +2614,14 @@ public final class TerminalRepl {
         out.println(BOLD + "Skill Draft" + RESET);
         out.printf("  %sName:%s        %s%n", MUTED, RESET, selected.skillName());
         out.printf("  %sDraft path:%s  %s%n", MUTED, RESET, selected.draftPath());
+        out.printf("  %sCandidate:%s   %s%n", MUTED, RESET, selected.candidateId());
         out.printf("  %sVerdict:%s     %s%n", MUTED, RESET, selected.validationVerdict());
         out.printf("  %sRelease:%s     %s%s%n", MUTED, RESET, selected.releaseStage(),
                 selected.paused() ? " (paused)" : "");
+        out.printf("  %sReview:%s      %s%n", MUTED, RESET,
+                selected.manualReviewNeeded() ? "manual review needed" : "no manual review needed");
         out.printf("  %sModel inv:%s   %s%n", MUTED, RESET,
                 selected.disableModelInvocation() ? "disabled" : "enabled");
-        if (!selected.candidateId().isBlank()) {
-            out.printf("  %sCandidate:%s   %s%n", MUTED, RESET, selected.candidateId());
-        }
         if (!selected.allowedTools().isBlank()) {
             out.printf("  %sTools:%s       %s%n", MUTED, RESET, selected.allowedTools());
         }

--- a/aceclaw-cli/src/test/java/dev/aceclaw/cli/TerminalReplTest.java
+++ b/aceclaw-cli/src/test/java/dev/aceclaw/cli/TerminalReplTest.java
@@ -153,8 +153,10 @@ class TerminalReplTest {
         String output = outputBuffer.toString();
         assertThat(output).contains("Skill Drafts");
         assertThat(output).contains("retry-safe");
+        assertThat(output).contains("candidate=cand-123");
         assertThat(output).contains("verdict=hold");
         assertThat(output).contains("release=shadow");
+        assertThat(output).contains("manual-review=yes");
     }
 
     @Test
@@ -169,7 +171,23 @@ class TerminalReplTest {
         assertThat(output).contains("Skill Draft");
         assertThat(output).contains("retry-safe");
         assertThat(output).contains("cand-123");
+        assertThat(output).contains("manual review needed");
         assertThat(output).contains("STATIC_ALLOWED_TOOLS_POLICY_VIOLATION");
+    }
+
+    @Test
+    void skillsDraftsPending_filtersToManualReviewItems() throws Exception {
+        var statusRepl = newReplForProject(tempDir);
+        writeSkillDraftArtifacts(tempDir);
+        writeActiveSkillDraftArtifacts(tempDir);
+
+        boolean shouldExit = statusRepl.handleSlashCommand(out, "/skills drafts pending", null);
+
+        assertThat(shouldExit).isFalse();
+        String output = outputBuffer.toString();
+        assertThat(output).contains("Pending Skill Drafts");
+        assertThat(output).contains("retry-safe");
+        assertThat(output).doesNotContain("fully-active");
     }
 
     @Test
@@ -267,6 +285,36 @@ class TerminalReplTest {
         String summary = (String) invokePrivate(statusRepl, "skillDraftStatusSummary",
                 new Class<?>[]{Path.class}, tempDir);
         assertThat(summary).isEqualTo("1(p:0,h:1,b:0,n:0)");
+    }
+
+    @Test
+    void renderSkillDraftEventNotice_enqueuesNotice() throws Exception {
+        var statusRepl = newReplForProject(tempDir);
+        var mapper = new ObjectMapper();
+        ObjectNode event = mapper.createObjectNode();
+        event.put("type", "validation_changed");
+        event.put("trigger", "draft-generated");
+        event.put("skillName", "retry-safe");
+        event.put("draftPath", ".aceclaw/skills-drafts/retry-safe/SKILL.md");
+        event.put("candidateId", "cand-123");
+        event.put("verdict", "hold");
+        event.put("releaseStage", "shadow");
+        event.put("paused", false);
+        var reasons = mapper.createArrayNode();
+        reasons.add("STATIC_ALLOWED_TOOLS_POLICY_VIOLATION: allowed-tools includes unsafe or malformed values");
+        event.set("reasons", reasons);
+
+        Object parsed = invokePrivate(statusRepl, "parseSkillDraftEvent",
+                new Class<?>[]{com.fasterxml.jackson.databind.JsonNode.class}, event);
+        invokePrivate(statusRepl, "renderSkillDraftEventNotice",
+                new Class<?>[]{parsed.getClass()}, parsed);
+        invokePrivate(statusRepl, "drainUiEventsIntoState", new Class<?>[]{});
+
+        @SuppressWarnings("unchecked")
+        var notices = (java.util.Deque<Object>) getPrivateField(statusRepl, "uiNoticeBuffer");
+        assertThat(notices).isNotEmpty();
+        assertThat(notices.getLast().toString()).contains("retry-safe");
+        assertThat(notices.getLast().toString()).contains("STATIC_ALLOWED_TOOLS_POLICY_VIOLATION");
     }
 
     @Test
@@ -477,6 +525,30 @@ class TerminalReplTest {
                 {
                   "releases": [
                     {"skillName":"retry-safe","stage":"shadow","paused":false}
+                  ]
+                }
+                """);
+    }
+
+    private static void writeActiveSkillDraftArtifacts(Path root) throws Exception {
+        Path draft = root.resolve(".aceclaw/skills-drafts/fully-active/SKILL.md");
+        Path release = root.resolve(".aceclaw/metrics/continuous-learning/skill-release-state.json");
+        Files.createDirectories(draft.getParent());
+        Files.writeString(draft, """
+                ---
+                name: "fully-active"
+                description: "Already active"
+                disable-model-invocation: true
+                source-candidate-id: "cand-999"
+                ---
+
+                # Draft Skill
+                """);
+        Files.writeString(release, """
+                {
+                  "releases": [
+                    {"skillName":"retry-safe","stage":"shadow","paused":false},
+                    {"skillName":"fully-active","stage":"active","paused":false}
                   ]
                 }
                 """);

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -36,10 +36,16 @@ import dev.aceclaw.tools.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 /**
  * The AceClaw daemon — a persistent system process that orchestrates all services.
@@ -74,6 +80,7 @@ public final class AceClawDaemon {
     private final EventBus eventBus;
     private final SchedulerEventFeed schedulerEventFeed;
     private final DeferredEventFeed deferredEventFeed;
+    private final SkillDraftEventFeed skillDraftEventFeed;
     private final HealthMonitor healthMonitor;
     private final RequestRouter router;
     private final ConnectionBridge connectionBridge;
@@ -111,6 +118,7 @@ public final class AceClawDaemon {
         eventBus.subscribe(SchedulerEvent.class, schedulerEventFeed::append);
         this.deferredEventFeed = new DeferredEventFeed();
         eventBus.subscribe(DeferEvent.class, deferredEventFeed::append);
+        this.skillDraftEventFeed = new SkillDraftEventFeed();
 
         // Health monitor (aggregates per-component health checks)
         this.healthMonitor = new HealthMonitor(eventBus);
@@ -500,6 +508,7 @@ public final class AceClawDaemon {
                             if (candidateStoreForAuto != null) {
                                 var generator = new SkillDraftGenerator();
                                 var summary = generator.generateFromPromoted(candidateStoreForAuto, projectPath);
+                                publishSkillDraftCreatedEvents(summary, projectPath, "auto-promotion");
                                 if (summary.createdDrafts() > 0) {
                                     log.info("Auto skill draft generation: {} created, {} skipped",
                                             summary.createdDrafts(), summary.skippedDrafts());
@@ -507,9 +516,11 @@ public final class AceClawDaemon {
                             }
                             // Validate drafts and evaluate for auto-release
                             if (validationGateForAuto != null) {
-                                validationGateForAuto.validateAll(projectPath, "auto-promotion");
+                                var validation = validationGateForAuto.validateAll(projectPath, "auto-promotion");
+                                publishSkillDraftValidationEvents(validation, "auto-promotion");
                                 if (autoReleaseForAuto != null && candidateStoreForAuto != null) {
-                                    autoReleaseForAuto.evaluateAll(projectPath, candidateStoreForAuto, "auto-promotion");
+                                    var release = autoReleaseForAuto.evaluateAll(projectPath, candidateStoreForAuto, "auto-promotion");
+                                    publishSkillDraftReleaseEvents(release, "auto-promotion");
                                 }
                             }
                         } catch (Exception e) {
@@ -544,14 +555,17 @@ public final class AceClawDaemon {
                     try {
                         var generator = new SkillDraftGenerator();
                         var summary = generator.generateFromPromoted(catchupCs, workingDir);
+                        publishSkillDraftCreatedEvents(summary, workingDir, "startup-catchup");
                         if (summary.createdDrafts() > 0) {
                             log.info("Draft catch-up: {} new drafts generated for existing promoted candidates",
                                     summary.createdDrafts());
                         }
                         if (catchupValidation != null && summary.createdDrafts() > 0) {
-                            catchupValidation.validateAll(workingDir, "startup-catchup");
+                            var validation = catchupValidation.validateAll(workingDir, "startup-catchup");
+                            publishSkillDraftValidationEvents(validation, "startup-catchup");
                             if (catchupAutoRelease != null) {
-                                catchupAutoRelease.evaluateAll(workingDir, catchupCs, "startup-catchup");
+                                var release = catchupAutoRelease.evaluateAll(workingDir, catchupCs, "startup-catchup");
+                                publishSkillDraftReleaseEvents(release, "startup-catchup");
                             }
                         }
                     } catch (Exception e) {
@@ -766,6 +780,7 @@ public final class AceClawDaemon {
             try {
                 var generator = new SkillDraftGenerator();
                 var summary = generator.generateFromPromoted(candidateStoreForRpc, workingDir);
+                publishSkillDraftCreatedEvents(summary, workingDir, "draft-generated");
                 var result = objectMapper.createObjectNode();
                 result.put("processedPromotedCandidates", summary.processedPromotedCandidates());
                 result.put("createdDrafts", summary.createdDrafts());
@@ -776,9 +791,11 @@ public final class AceClawDaemon {
                 result.put("auditFile", workingDir.relativize(summary.auditFile()).toString().replace('\\', '/'));
                 if (validationGateForRpc != null) {
                     var validation = validationGateForRpc.validateAll(workingDir, "draft-generated");
+                    publishSkillDraftValidationEvents(validation, "draft-generated");
                     result.set("validation", toValidationJson(validation, workingDir));
                     if (autoReleaseForRpc != null && candidateStoreForRpc != null) {
                         var release = autoReleaseForRpc.evaluateAll(workingDir, candidateStoreForRpc, "draft-generated");
+                        publishSkillDraftReleaseEvents(release, "draft-generated");
                         result.set("release", toReleaseJson(release));
                     }
                 }
@@ -798,9 +815,11 @@ public final class AceClawDaemon {
                 if (params != null && params.has("draftPath")) {
                     Path draftPath = workingDir.resolve(params.get("draftPath").asText()).normalize();
                     var summary = validationGateForRpc.validateSingleDraft(workingDir, draftPath, trigger);
+                    publishSkillDraftValidationEvents(summary, trigger);
                     return toValidationJson(summary, workingDir);
                 }
                 var summary = validationGateForRpc.validateAll(workingDir, trigger);
+                publishSkillDraftValidationEvents(summary, trigger);
                 return toValidationJson(summary, workingDir);
             } finally {
                 draftPipelineLock.unlock();
@@ -815,6 +834,7 @@ public final class AceClawDaemon {
                 String trigger = params != null && params.has("trigger")
                         ? params.get("trigger").asText() : "manual";
                 var summary = autoReleaseForRpc.evaluateAll(workingDir, candidateStoreForRpc, trigger);
+                publishSkillDraftReleaseEvents(summary, trigger);
                 return toReleaseJson(summary);
             } finally {
                 draftPipelineLock.unlock();
@@ -830,7 +850,9 @@ public final class AceClawDaemon {
             String skillName = params.get("skillName").asText();
             String reason = params.has("reason") ? params.get("reason").asText() : "manual pause";
             String trigger = params.has("trigger") ? params.get("trigger").asText() : "manual";
-            return toReleaseJson(autoReleaseForRpc.pause(workingDir, skillName, reason, trigger));
+            var summary = autoReleaseForRpc.pause(workingDir, skillName, reason, trigger);
+            publishSkillDraftReleaseEvents(summary, trigger);
+            return toReleaseJson(summary);
         });
         router.register("skill.release.forceRollback", params -> {
             if (autoReleaseForRpc == null) {
@@ -842,7 +864,9 @@ public final class AceClawDaemon {
             String skillName = params.get("skillName").asText();
             String reason = params.has("reason") ? params.get("reason").asText() : "manual force rollback";
             String trigger = params.has("trigger") ? params.get("trigger").asText() : "manual";
-            return toReleaseJson(autoReleaseForRpc.forceRollback(workingDir, skillName, reason, trigger));
+            var summary = autoReleaseForRpc.forceRollback(workingDir, skillName, reason, trigger);
+            publishSkillDraftReleaseEvents(summary, trigger);
+            return toReleaseJson(summary);
         });
         router.register("skill.release.forcePromote", params -> {
             if (autoReleaseForRpc == null) {
@@ -862,7 +886,9 @@ public final class AceClawDaemon {
             }
             String reason = params.has("reason") ? params.get("reason").asText() : "manual force promote";
             String trigger = params.has("trigger") ? params.get("trigger").asText() : "manual";
-            return toReleaseJson(autoReleaseForRpc.forcePromote(workingDir, skillName, stage, reason, trigger));
+            var summary = autoReleaseForRpc.forcePromote(workingDir, skillName, stage, reason, trigger);
+            publishSkillDraftReleaseEvents(summary, trigger);
+            return toReleaseJson(summary);
         });
 
         // Session skill packer (extract successful workflow from session into skill draft)
@@ -1056,6 +1082,48 @@ public final class AceClawDaemon {
             return result;
         });
 
+        router.register("skill.draft.events.poll", params -> {
+            long afterSeq = 0L;
+            int limit = 20;
+            if (params != null) {
+                if (params.has("afterSeq")) {
+                    afterSeq = Math.max(0L, params.get("afterSeq").asLong());
+                }
+                if (params.has("limit")) {
+                    limit = params.get("limit").asInt(20);
+                }
+            }
+
+            var polled = skillDraftEventFeed.poll(afterSeq, limit);
+            var result = objectMapper.createObjectNode();
+            result.put("nextSeq", polled.nextSequence());
+            var events = objectMapper.createArrayNode();
+            for (var entry : polled.entries()) {
+                var node = objectMapper.createObjectNode();
+                node.put("seq", entry.sequence());
+                var event = entry.event();
+                node.put("type", event.type());
+                node.put("timestamp", event.timestamp().toString());
+                node.put("trigger", event.trigger());
+                node.put("skillName", event.skillName());
+                node.put("draftPath", event.draftPath());
+                node.put("candidateId", event.candidateId());
+                if (!event.verdict().isBlank()) {
+                    node.put("verdict", event.verdict());
+                }
+                if (!event.releaseStage().isBlank()) {
+                    node.put("releaseStage", event.releaseStage());
+                }
+                node.put("paused", event.paused());
+                var reasons = objectMapper.createArrayNode();
+                event.reasons().forEach(reasons::add);
+                node.set("reasons", reasons);
+                events.add(node);
+            }
+            result.set("events", events);
+            return result;
+        });
+
         // Deferred action RPC routes
         router.register("deferred.status", params -> {
             var result = objectMapper.createObjectNode();
@@ -1205,6 +1273,137 @@ public final class AceClawDaemon {
         node.set("releases", releases);
         node.set("events", events);
         return node;
+    }
+
+    private void publishSkillDraftCreatedEvents(
+            SkillDraftGenerator.GenerationSummary summary,
+            Path workingDir,
+            String trigger
+    ) {
+        if (summary == null || summary.draftPaths().isEmpty()) {
+            return;
+        }
+        for (String draftPath : summary.draftPaths()) {
+            Path draftFile = workingDir.resolve(draftPath).normalize();
+            String skillName = draftFile.getParent() != null ? draftFile.getParent().getFileName().toString() : "";
+            String candidateId = "";
+            try {
+                candidateId = parseDraftFrontmatter(draftFile).getOrDefault("source-candidate-id", "");
+            } catch (Exception ignored) {
+            }
+            skillDraftEventFeed.append(new SkillDraftEvent(
+                    Instant.now(),
+                    "draft_created",
+                    trigger,
+                    skillName,
+                    draftPath.replace('\\', '/'),
+                    candidateId,
+                    "",
+                    "",
+                    false,
+                    List.of()
+            ));
+        }
+    }
+
+    private void publishSkillDraftValidationEvents(
+            ValidationGateEngine.ValidationSummary summary,
+            String trigger
+    ) {
+        if (summary == null || summary.changedDecisions().isEmpty()) {
+            return;
+        }
+        for (var decision : summary.changedDecisions()) {
+            String skillName = skillNameFromDraftPath(decision.draftPath());
+            var reasons = decision.reasons().stream()
+                    .map(reason -> reason.code() + ": " + reason.message())
+                    .toList();
+            skillDraftEventFeed.append(new SkillDraftEvent(
+                    decision.evaluatedAt(),
+                    "validation_changed",
+                    trigger,
+                    skillName,
+                    decision.draftPath(),
+                    "",
+                    decision.verdict().name().toLowerCase(),
+                    "",
+                    false,
+                    reasons
+            ));
+        }
+    }
+
+    private void publishSkillDraftReleaseEvents(
+            AutoReleaseController.EvaluationSummary summary,
+            String trigger
+    ) {
+        if (summary == null || summary.events().isEmpty()) {
+            return;
+        }
+        for (var event : summary.events()) {
+            var release = summary.releases().stream()
+                    .filter(candidate -> candidate.skillName().equals(event.skillName()))
+                    .findFirst()
+                    .orElse(null);
+            skillDraftEventFeed.append(new SkillDraftEvent(
+                    event.timestamp(),
+                    "release_changed",
+                    trigger,
+                    event.skillName(),
+                    release == null ? "" : release.draftPath(),
+                    release == null ? "" : release.candidateId(),
+                    "",
+                    event.toStage().name().toLowerCase(),
+                    release != null && release.paused(),
+                    List.of(event.reasonCode() + ": " + event.reason())
+            ));
+        }
+    }
+
+    private static String skillNameFromDraftPath(String draftPath) {
+        Path p = Path.of(draftPath.replace('\\', '/'));
+        if (p.getNameCount() < 2) {
+            return "";
+        }
+        return p.getName(p.getNameCount() - 2).toString();
+    }
+
+    private static Map<String, String> parseDraftFrontmatter(Path draftFile) throws IOException {
+        String raw = Files.readString(draftFile);
+        String[] lines = raw.split("\n");
+        int first = -1;
+        int second = -1;
+        for (int i = 0; i < lines.length; i++) {
+            if ("---".equals(lines[i].trim())) {
+                if (first < 0) {
+                    first = i;
+                } else {
+                    second = i;
+                    break;
+                }
+            }
+        }
+        var map = new LinkedHashMap<String, String>();
+        if (first < 0 || second <= first) {
+            return map;
+        }
+        for (int i = first + 1; i < second; i++) {
+            String line = lines[i];
+            int idx = line.indexOf(':');
+            if (idx <= 0) continue;
+            String key = line.substring(0, idx).trim().toLowerCase(Locale.ROOT);
+            String value = line.substring(idx + 1).trim();
+            map.put(key, stripQuotes(value));
+        }
+        return map;
+    }
+
+    private static String stripQuotes(String value) {
+        if (value == null || value.length() < 2) return value == null ? "" : value;
+        if ((value.startsWith("\"") && value.endsWith("\"")) || (value.startsWith("'") && value.endsWith("'"))) {
+            return value.substring(1, value.length() - 1);
+        }
+        return value;
     }
 
     /**

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/SkillDraftEvent.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/SkillDraftEvent.java
@@ -1,0 +1,32 @@
+package dev.aceclaw.daemon;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Event emitted by the daemon skill-draft pipeline for REPL notifications.
+ */
+public record SkillDraftEvent(
+        Instant timestamp,
+        String type,
+        String trigger,
+        String skillName,
+        String draftPath,
+        String candidateId,
+        String verdict,
+        String releaseStage,
+        boolean paused,
+        List<String> reasons
+) {
+    public SkillDraftEvent {
+        timestamp = timestamp != null ? timestamp : Instant.EPOCH;
+        type = type != null ? type : "";
+        trigger = trigger != null ? trigger : "manual";
+        skillName = skillName != null ? skillName : "";
+        draftPath = draftPath != null ? draftPath : "";
+        candidateId = candidateId != null ? candidateId : "";
+        verdict = verdict != null ? verdict : "";
+        releaseStage = releaseStage != null ? releaseStage : "";
+        reasons = reasons != null ? List.copyOf(reasons) : List.of();
+    }
+}

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/SkillDraftEventFeed.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/SkillDraftEventFeed.java
@@ -1,0 +1,72 @@
+package dev.aceclaw.daemon;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * In-memory ring buffer for skill draft lifecycle events, exposed via polling RPC.
+ */
+public final class SkillDraftEventFeed {
+
+    private static final int DEFAULT_MAX_EVENTS = 256;
+
+    private final int maxEvents;
+    private final AtomicLong sequence = new AtomicLong(0);
+    private final Object lock = new Object();
+    private final Deque<Entry> entries = new ArrayDeque<>();
+
+    public SkillDraftEventFeed() {
+        this(DEFAULT_MAX_EVENTS);
+    }
+
+    public SkillDraftEventFeed(int maxEvents) {
+        if (maxEvents <= 0) {
+            throw new IllegalArgumentException("maxEvents must be > 0, got: " + maxEvents);
+        }
+        this.maxEvents = maxEvents;
+    }
+
+    public void append(SkillDraftEvent event) {
+        Objects.requireNonNull(event, "event");
+        synchronized (lock) {
+            long seq = sequence.incrementAndGet();
+            entries.addLast(new Entry(seq, event));
+            while (entries.size() > maxEvents) {
+                entries.removeFirst();
+            }
+        }
+    }
+
+    public PollResult poll(long afterSeq, int limit) {
+        int safeLimit = Math.max(1, Math.min(limit, 100));
+        List<Entry> out = new ArrayList<>(safeLimit);
+        long nextSeq = sequence.get();
+        synchronized (lock) {
+            for (Entry entry : entries) {
+                if (entry.sequence() <= afterSeq) {
+                    continue;
+                }
+                out.add(entry);
+                if (out.size() >= safeLimit) {
+                    break;
+                }
+            }
+            if (!entries.isEmpty()) {
+                nextSeq = entries.getLast().sequence();
+            }
+        }
+        return new PollResult(nextSeq, out);
+    }
+
+    public record Entry(long sequence, SkillDraftEvent event) {}
+
+    public record PollResult(long nextSequence, List<Entry> entries) {
+        public PollResult {
+            entries = entries != null ? List.copyOf(entries) : List.of();
+        }
+    }
+}

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/ValidationGateEngine.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/ValidationGateEngine.java
@@ -70,7 +70,7 @@ public final class ValidationGateEngine {
         Path draftsRoot = projectRoot.resolve(DRAFTS_DIR);
         if (!Files.isDirectory(draftsRoot)) {
             return new ValidationSummary(
-                    0, 0, 0, 0, List.of(), projectRoot.resolve(AUDIT_DIR).resolve(AUDIT_FILE));
+                    0, 0, 0, 0, List.of(), List.of(), projectRoot.resolve(AUDIT_DIR).resolve(AUDIT_FILE));
         }
 
         var replay = evaluateReplay(projectRoot);
@@ -87,8 +87,8 @@ public final class ValidationGateEngine {
         for (var draftFile : draftFiles) {
             decisions.add(validateSingle(projectRoot, draftFile, normalizedTrigger, replay));
         }
-        writeAudit(projectRoot, decisions);
-        return summarize(projectRoot, decisions);
+        var changed = writeAudit(projectRoot, decisions);
+        return summarize(projectRoot, decisions, changed);
     }
 
     public ValidationSummary validateSingleDraft(Path projectRoot, Path draftPath, String trigger) throws IOException {
@@ -97,11 +97,11 @@ public final class ValidationGateEngine {
         String normalizedTrigger = normalizeTrigger(trigger);
         var replay = evaluateReplay(projectRoot);
         var decision = validateSingle(projectRoot, draftPath, normalizedTrigger, replay);
-        writeAudit(projectRoot, List.of(decision));
-        return summarize(projectRoot, List.of(decision));
+        var changed = writeAudit(projectRoot, List.of(decision));
+        return summarize(projectRoot, List.of(decision), changed);
     }
 
-    private ValidationSummary summarize(Path projectRoot, List<DraftDecision> decisions) {
+    private ValidationSummary summarize(Path projectRoot, List<DraftDecision> decisions, List<DraftDecision> changedDecisions) {
         int pass = 0;
         int hold = 0;
         int block = 0;
@@ -111,7 +111,7 @@ public final class ValidationGateEngine {
             if (d.verdict() == Verdict.BLOCK) block++;
         }
         return new ValidationSummary(
-                decisions.size(), pass, hold, block, List.copyOf(decisions),
+                decisions.size(), pass, hold, block, List.copyOf(decisions), List.copyOf(changedDecisions),
                 projectRoot.resolve(AUDIT_DIR).resolve(AUDIT_FILE));
     }
 
@@ -231,15 +231,16 @@ public final class ValidationGateEngine {
         }
     }
 
-    private void writeAudit(Path projectRoot, List<DraftDecision> decisions) throws IOException {
+    private List<DraftDecision> writeAudit(Path projectRoot, List<DraftDecision> decisions) throws IOException {
         if (decisions.isEmpty()) {
-            return;
+            return List.of();
         }
         Path auditPath = projectRoot.resolve(AUDIT_DIR).resolve(AUDIT_FILE);
         Files.createDirectories(auditPath.getParent());
 
         // Load last-known verdict per draft path to avoid duplicate entries
         var lastVerdicts = loadLastVerdicts(auditPath);
+        var changed = new ArrayList<DraftDecision>();
 
         for (var d : decisions) {
             String previousVerdict = lastVerdicts.get(d.draftPath());
@@ -270,7 +271,9 @@ public final class ValidationGateEngine {
                     StandardOpenOption.CREATE,
                     StandardOpenOption.APPEND
             );
+            changed.add(d);
         }
+        return List.copyOf(changed);
     }
 
     /**
@@ -425,10 +428,12 @@ public final class ValidationGateEngine {
             int holdCount,
             int blockCount,
             List<DraftDecision> decisions,
+            List<DraftDecision> changedDecisions,
             Path auditFile
     ) {
         public ValidationSummary {
             decisions = decisions != null ? List.copyOf(decisions) : List.of();
+            changedDecisions = changedDecisions != null ? List.copyOf(changedDecisions) : List.of();
         }
     }
 }


### PR DESCRIPTION
## Summary
- surface generated skill drafts in the REPL via `/skills drafts` and `/skills inspect <name>`
- poll local draft, validation, and release artifacts to show skill draft notifications in the main console
- add draft counts to the continuous-learning status line and cover the new behavior with CLI tests

## Testing
- ./gradlew :aceclaw-cli:test --tests dev.aceclaw.cli.TerminalReplTest

## Related
- closes #196

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added skill drafts management with `/skills` commands to list and inspect drafts, plus UI views for draft details.
  * Real-time notifications for draft creation, verdict changes, and release transitions.
  * Skill-drafts summary now appears in continuous learning status and is cached for performance.

* **Tests**
  * Added tests covering `/skills` commands, draft listing/inspection, and status summary counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->