### PR TITLE
fix(cli): truncate status panel fields by display width, not char count

### DIFF
--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
@@ -106,8 +106,8 @@ public final class TerminalRepl {
     private final Deque<String> pendingPrintAbove = new ArrayDeque<>();
     /** Fixed status panel height so JLine's Status widget never resizes its scroll region. */
     private static final int FIXED_STATUS_LINE_COUNT = 8;
-    /** Soft cap for daemon-provided fields rendered inside the status panel. */
-    private static final int STATUS_PANEL_FIELD_MAX_CHARS = 160;
+    /** Soft cap (in display columns) for daemon-provided fields rendered inside the status panel. */
+    private static final int STATUS_PANEL_FIELD_MAX_COLS = 80;
     private final Object uiRenderLock = new Object();
     private final AtomicBoolean permissionInterruptRequested = new AtomicBoolean(false);
     private final AtomicBoolean uiRenderRequested = new AtomicBoolean(true);
@@ -3067,10 +3067,7 @@ public final class TerminalRepl {
                 .replace('\t', ' ')
                 .replaceAll("\\s+", " ")
                 .trim();
-        if (singleLine.length() <= STATUS_PANEL_FIELD_MAX_CHARS) {
-            return singleLine;
-        }
-        return singleLine.substring(0, STATUS_PANEL_FIELD_MAX_CHARS - 3) + "...";
+        return fitWidth(singleLine, STATUS_PANEL_FIELD_MAX_COLS);
     }
 
     private static Instant parseInstant(String raw) {

--- a/aceclaw-cli/src/test/java/dev/aceclaw/cli/TerminalReplTest.java
+++ b/aceclaw-cli/src/test/java/dev/aceclaw/cli/TerminalReplTest.java
@@ -370,7 +370,27 @@ class TerminalReplTest {
 
         assertThat(normalized).doesNotContain("\n").doesNotContain("\r").doesNotContain("\t");
         assertThat(normalized).startsWith("line1 line2 line3 ");
-        assertThat(normalized.length()).isLessThanOrEqualTo(160);
+        // Truncated by display width (80 columns), not char count
+        assertThat(TerminalTheme.displayWidth(normalized)).isLessThanOrEqualTo(80);
+        assertThat(normalized).endsWith("...");
+    }
+
+    @Test
+    void normalizeStatusPanelField_cjkTruncatedByDisplayWidth() throws Exception {
+        // 50 CJK chars = 100 display columns, should be truncated to 80
+        String raw = "\u4e2d\u6587".repeat(50);
+
+        String normalized = (String) invokePrivate(
+                repl,
+                "normalizeStatusPanelField",
+                new Class<?>[]{String.class},
+                raw);
+
+        assertThat(TerminalTheme.displayWidth(normalized)).isLessThanOrEqualTo(80);
+        assertThat(normalized).endsWith("...");
+        // char count should be less than 50 CJK chars since we truncated by display width
+        int contentLen = normalized.length() - 3; // minus "..."
+        assertThat(contentLen).isLessThan(50);
     }
 
     /**


### PR DESCRIPTION
## Summary
- `normalizeStatusPanelField()` used `String.length()` (UTF-16 code units) to cap fields at 160 chars — CJK characters are 1 Java char but 2 terminal columns, so lines with CJK text could be 320+ columns wide
- Switched to `fitWidth()` with an 80-display-column cap, which correctly counts CJK/emoji as 2 columns
- Added CJK-specific truncation test

Closes #220

## Test plan
- [x] Existing `normalizeStatusPanelField_collapsesMultilineAndCapsLength` updated and passing
- [x] New `normalizeStatusPanelField_cjkTruncatedByDisplayWidth` test added and passing
- [x] All CLI tests pass (`./gradlew :aceclaw-cli:test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status panel field truncation to use display width (80 columns) instead of character count, ensuring proper rendering of wide characters.

* **Tests**
  * Added test coverage for CJK character truncation behavior to verify display-width based handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->