### PR TITLE
fix(cli): suspend/restore JLine Status widget around foreground tasks

### DIFF
--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
@@ -891,6 +891,10 @@ public final class TerminalRepl {
                     true
             );
 
+            // Suspend JLine's Status widget so its scroll region doesn't go
+            // stale while ForegroundOutputSink writes directly to the terminal.
+            suspendStatusPanel();
+
             // Start thinking spinner
             fgSink.startThinkingSpinner();
 
@@ -906,6 +910,10 @@ public final class TerminalRepl {
 
             taskManager.clearForeground();
             activeForegroundSink = null;
+
+            // Restore JLine's Status widget so it recalculates scroll region
+            // based on the terminal's current state after task output.
+            restoreStatusPanel();
 
             // Connection is closed by TaskManager.handleTaskComplete() when the task ends
 
@@ -1587,16 +1595,44 @@ public final class TerminalRepl {
                     .map(as -> clampAttributedLine(as, safeWidth, terminalWidth))
                     .toList();
 
-            // Save cursor (CSI s) before status update, restore (CSI u) after.
-            // Uses SCP/RCP stack which is separate from JLine's internal DECSC/DECRC.
-            var writer = terminal.writer();
-            writer.print("\u001B[s");
-            writer.flush();
+            // Let JLine's Status.update() handle cursor positioning internally.
+            // Do NOT wrap with SCP/RCP (\u001B[s / \u001B[u) as that conflicts
+            // with JLine's own cursor management and corrupts cursor position.
             promptStatus.update(rendered);
-            writer.print("\u001B[u");
-            writer.flush();
         }
         ensureCursorVisible();
+    }
+
+    /**
+     * Suspends JLine's Status widget before a foreground task takes over the terminal.
+     * This tears down the scroll region so direct writes don't corrupt JLine's state.
+     */
+    private void suspendStatusPanel() {
+        synchronized (uiRenderLock) {
+            if (promptStatus != null) {
+                try {
+                    promptStatus.suspend();
+                } catch (Exception e) {
+                    log.debug("Failed to suspend status panel: {}", e.getMessage());
+                }
+            }
+        }
+    }
+
+    /**
+     * Restores JLine's Status widget after a foreground task completes.
+     * This re-establishes the scroll region based on the terminal's current state.
+     */
+    private void restoreStatusPanel() {
+        synchronized (uiRenderLock) {
+            if (promptStatus != null) {
+                try {
+                    promptStatus.restore();
+                } catch (Exception e) {
+                    log.debug("Failed to restore status panel: {}", e.getMessage());
+                }
+            }
+        }
     }
 
     private void ensureCursorVisible() {


### PR DESCRIPTION
## Summary
- After a long-running foreground task completes, the status panel produced massively garbled output — clock seconds printed as individual lines with blank gaps, fragments of status text scattered across the screen
- **Root cause**: JLine's `Status` widget maintained a stale scroll region while `ForegroundOutputSink` wrote directly to the terminal, so when `Status.update()` resumed, it wrote to wrong positions
- **Fix 1**: Call `Status.suspend()` before foreground task starts and `Status.restore()` after it completes — JLine recalculates scroll region from current terminal state
- **Fix 2**: Remove SCP/RCP (`\u001B[s`/`\u001B[u`) cursor save/restore wrapper around `Status.update()` — conflicted with JLine's internal cursor management, causing prompt cursor misplacement

Closes #221

## Test plan
- [x] All CLI tests pass (`./gradlew :aceclaw-cli:test`)
- [ ] Manual: run a long task (e.g., Whisper transcription), verify status panel renders cleanly after completion
- [ ] Manual: verify input cursor appears correctly after `aceclaw>` prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of terminal status panel display during foreground task execution.

* **Refactor**
  * Enhanced cursor management in terminal status rendering with improved error handling and thread synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->