### PR TITLE
fix(cli): restore status panel after /fg command (#224)

### DIFF
--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
@@ -2798,27 +2798,28 @@ public final class TerminalRepl {
         // Suspend JLine's Status widget so its scroll region doesn't go
         // stale while ForegroundOutputSink writes directly to the terminal.
         suspendStatusPanel();
+        try {
+            // Create new foreground sink and swap it in atomically
+            var fgSink = new ForegroundOutputSink(out, markdownRenderer);
+            var oldSink = target.swapOutputSink(fgSink);
+            activeForegroundSink = fgSink;
+            taskManager.setForeground(target.taskId());
+            resumeCheckpointStore.markForeground(sessionId, target.taskId(), true);
 
-        // Create new foreground sink and swap it in atomically
-        var fgSink = new ForegroundOutputSink(out, markdownRenderer);
-        var oldSink = target.swapOutputSink(fgSink);
-        activeForegroundSink = fgSink;
-        taskManager.setForeground(target.taskId());
-        resumeCheckpointStore.markForeground(sessionId, target.taskId(), true);
+            // Replay buffered events if the task was backgrounded
+            if (oldSink instanceof BackgroundOutputBuffer bgBuffer) {
+                bgBuffer.replay(fgSink);
+            }
 
-        // Replay buffered events if the task was backgrounded
-        if (oldSink instanceof BackgroundOutputBuffer bgBuffer) {
-            bgBuffer.replay(fgSink);
+            waitForForeground(out, reader);
+            renderTaskCompletion(out, target);
+            taskManager.clearForeground();
+            activeForegroundSink = null;
+        } finally {
+            // Restore JLine's Status widget so it recalculates scroll region
+            // based on the terminal's current state after task output.
+            restoreStatusPanel();
         }
-
-        waitForForeground(out, reader);
-        renderTaskCompletion(out, target);
-        taskManager.clearForeground();
-        activeForegroundSink = null;
-
-        // Restore JLine's Status widget so it recalculates scroll region
-        // based on the terminal's current state after task output.
-        restoreStatusPanel();
     }
 
     // -- /cancel command -----------------------------------------------------


### PR DESCRIPTION
## Summary
- Add missing `suspendStatusPanel()` / `restoreStatusPanel()` calls in `/fg` command handler
- Matches the lifecycle already used in the normal submit -> foreground path

## Root Cause
The `/fg` command handler was missing the JLine Status widget suspend/restore lifecycle that the normal task submission path includes. Without these calls, the status panel's scroll region gets corrupted when `ForegroundOutputSink` writes directly to the terminal, and never recovers.

## Test plan
- [ ] Start a task, Ctrl+Z to background, /fg to foreground — status panel should reappear after completion
- [ ] Normal task flow unchanged (regression check)

Closes #224

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Added a visual separator above the status panel and slightly increased its height for clearer layout.

* **Bug Fixes**
  * Preserve and restore terminal scroll regions during direct terminal output and mode transitions.
  * Ensure buffered background events are replayed correctly when switching foreground/background modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->