### PR TITLE
feat(learning): add explainability for learned actions

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -81,6 +81,8 @@ public final class AceClawDaemon {
     private final SessionHistoryStore historyStore;
     private final AutoMemoryStore memoryStore;
     private final HistoricalLogIndex historicalLogIndex;
+    private final LearningExplanationStore learningExplanationStore;
+    private final LearningExplanationRecorder learningExplanationRecorder;
     private final MarkdownMemoryStore markdownStore;
     private final JobStore cronJobStore;
     private final EventBus eventBus;
@@ -152,6 +154,8 @@ public final class AceClawDaemon {
             log.warn("Failed to initialize historical log index: {}", e.getMessage());
         }
         this.historicalLogIndex = hli;
+        this.learningExplanationStore = new LearningExplanationStore();
+        this.learningExplanationRecorder = new LearningExplanationRecorder(learningExplanationStore);
 
         // Markdown memory store (persistent MEMORY.md + topic files)
         MarkdownMemoryStore mds = null;
@@ -546,6 +550,7 @@ public final class AceClawDaemon {
                             draftPipelineLock.unlock();
                         }
                     } : null);
+            selfImprovementEngine.setLearningExplanationRecorder(learningExplanationRecorder);
             agentHandler.setSelfImprovementEngine(selfImprovementEngine);
             candidateStoreRef = cs;
 
@@ -598,6 +603,8 @@ public final class AceClawDaemon {
                 llmClient,
                 agentHandler::getModelForSession,
                 skillRegistry);
+        dynamicSkillGenerator.setLearningExplanationRecorder(learningExplanationRecorder);
+        agentHandler.setLearningExplanationRecorder(learningExplanationRecorder);
         agentHandler.setDynamicSkillGenerator(dynamicSkillGenerator);
 
         // Wire deferred action scheduler (no turn lock dependency — uses isolated context)
@@ -692,6 +699,17 @@ public final class AceClawDaemon {
                                 "session-analysis:" + session.id(),
                                 false,
                                 sessionWorkingDir);
+                        learningExplanationRecorder.recordMemoryWrite(
+                                sessionWorkingDir,
+                                session.id(),
+                                "session-analysis",
+                                insight.category(),
+                                insight.content(),
+                                insight.tags(),
+                                List.of(new LearningExplanation.EvidenceRef(
+                                        "session-summary",
+                                        session.id(),
+                                        learnings.sessionSummary())));
                     } catch (Exception e) {
                         log.warn("Failed to save session analysis memory: {}", e.getMessage());
                     }
@@ -1234,6 +1252,47 @@ public final class AceClawDaemon {
             return result;
         });
 
+        router.register("learning.explanations.list", params -> {
+            Path projectPath = workingDir;
+            int limit = 30;
+            if (params != null) {
+                if (params.has("project") && !params.get("project").asText("").isBlank()) {
+                    projectPath = Path.of(params.get("project").asText()).toAbsolutePath().normalize();
+                }
+                if (params.has("limit")) {
+                    limit = Math.max(1, Math.min(200, params.get("limit").asInt(30)));
+                }
+            }
+
+            var result = objectMapper.createObjectNode();
+            var explanations = objectMapper.createArrayNode();
+            for (var explanation : learningExplanationStore.recent(projectPath, limit)) {
+                var node = objectMapper.createObjectNode();
+                node.put("timestamp", explanation.timestamp().toString());
+                node.put("actionType", explanation.actionType());
+                node.put("targetType", explanation.targetType());
+                node.put("targetId", explanation.targetId());
+                node.put("sessionId", explanation.sessionId());
+                node.put("trigger", explanation.trigger());
+                node.put("summary", explanation.summary());
+                var tags = objectMapper.createArrayNode();
+                explanation.tags().forEach(tags::add);
+                node.set("tags", tags);
+                var evidence = objectMapper.createArrayNode();
+                for (var ref : explanation.evidence()) {
+                    var en = objectMapper.createObjectNode();
+                    en.put("type", ref.type());
+                    en.put("ref", ref.ref());
+                    en.put("detail", ref.detail());
+                    evidence.add(en);
+                }
+                node.set("evidence", evidence);
+                explanations.add(node);
+            }
+            result.set("explanations", explanations);
+            return result;
+        });
+
         // Deferred action RPC routes
         router.register("deferred.status", params -> {
             var result = objectMapper.createObjectNode();
@@ -1401,6 +1460,12 @@ public final class AceClawDaemon {
                 candidateId = parseDraftFrontmatter(draftFile).getOrDefault("source-candidate-id", "");
             } catch (Exception ignored) {
             }
+            learningExplanationRecorder.recordSkillDraft(
+                    workingDir,
+                    trigger,
+                    skillName,
+                    draftPath.replace('\\', '/'),
+                    candidateId);
             skillDraftEventFeed.append(new SkillDraftEvent(
                     Instant.now(),
                     "draft_created",
@@ -1904,6 +1969,25 @@ public final class AceClawDaemon {
                             + bridgeResult.upserts() + " observations, "
                             + bridgeResult.transitions() + " transitions, "
                             + bridgeResult.promoted() + " promoted");
+                }
+                for (var candidate : bridgeResult.observedCandidates()) {
+                    learningExplanationRecorder.recordCandidateObservation(
+                            workingDir,
+                            "",
+                            "maintenance-" + trigger,
+                            candidate,
+                            candidate.content(),
+                            List.of(new LearningExplanation.EvidenceRef(
+                                    "maintenance-trigger",
+                                    trigger,
+                                    candidate.toolTag())));
+                }
+                for (var transition : bridgeResult.stateTransitions()) {
+                    learningExplanationRecorder.recordCandidateTransition(
+                            workingDir,
+                            "",
+                            "maintenance-" + trigger,
+                            transition);
                 }
                 if (bridgeResult.promoted() > 0) {
                     triggerMaintenanceDraftLifecycle(

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/DynamicSkillGenerator.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/DynamicSkillGenerator.java
@@ -58,6 +58,7 @@ public final class DynamicSkillGenerator {
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final ConcurrentHashMap<String, SessionRuntimeState> sessionStates = new ConcurrentHashMap<>();
     private final Set<String> closedSessions = ConcurrentHashMap.newKeySet();
+    private LearningExplanationRecorder learningExplanationRecorder;
 
     public DynamicSkillGenerator(LlmClient llmClient,
                                  Function<String, String> modelResolver,
@@ -65,6 +66,10 @@ public final class DynamicSkillGenerator {
         this.llmClient = Objects.requireNonNull(llmClient, "llmClient");
         this.modelResolver = Objects.requireNonNull(modelResolver, "modelResolver");
         this.skillRegistry = Objects.requireNonNull(skillRegistry, "skillRegistry");
+    }
+
+    public void setLearningExplanationRecorder(LearningExplanationRecorder learningExplanationRecorder) {
+        this.learningExplanationRecorder = learningExplanationRecorder;
     }
 
     public java.util.Optional<SkillConfig> maybeGenerate(String sessionId,
@@ -134,6 +139,14 @@ public final class DynamicSkillGenerator {
             state.signatures.add(sequenceSignature);
             state.skillsByName.put(skillName,
                     new RuntimeSkillRecord(config, Instant.now(), List.copyOf(allowedTools), sequenceSignature));
+            if (learningExplanationRecorder != null) {
+                learningExplanationRecorder.recordRuntimeSkill(
+                        projectPath,
+                        sessionId,
+                        skillName,
+                        sequenceSignature,
+                        allowedTools);
+            }
             log.info("Registered runtime skill '{}' for session {}", skillName, sessionId);
             return java.util.Optional.of(config);
         }
@@ -170,6 +183,13 @@ public final class DynamicSkillGenerator {
                         Files.writeString(temp, renderDraftMarkdown(resolvedName, record, sessionId));
                         Files.move(temp, skillFile,
                                 StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+                        if (learningExplanationRecorder != null) {
+                            learningExplanationRecorder.recordRuntimeSkillDraftPersisted(
+                                    projectPath,
+                                    sessionId,
+                                    resolvedName,
+                                    projectPath.relativize(skillFile).toString().replace('\\', '/'));
+                        }
                         persisted++;
                     }
                 }

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/LearningExplanation.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/LearningExplanation.java
@@ -1,0 +1,44 @@
+package dev.aceclaw.daemon;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Compact explanation payload for learned artifacts and adaptive actions.
+ */
+public record LearningExplanation(
+        Instant timestamp,
+        String actionType,
+        String targetType,
+        String targetId,
+        String sessionId,
+        String trigger,
+        String summary,
+        List<String> tags,
+        List<EvidenceRef> evidence
+) {
+    public LearningExplanation {
+        Objects.requireNonNull(timestamp, "timestamp");
+        Objects.requireNonNull(actionType, "actionType");
+        Objects.requireNonNull(targetType, "targetType");
+        targetId = targetId != null ? targetId : "";
+        sessionId = sessionId != null ? sessionId : "";
+        trigger = trigger != null ? trigger : "";
+        summary = summary != null ? summary : "";
+        tags = tags != null ? List.copyOf(tags) : List.of();
+        evidence = evidence != null ? List.copyOf(evidence) : List.of();
+    }
+
+    public record EvidenceRef(
+            String type,
+            String ref,
+            String detail
+    ) {
+        public EvidenceRef {
+            type = Objects.requireNonNull(type, "type");
+            ref = ref != null ? ref : "";
+            detail = detail != null ? detail : "";
+        }
+    }
+}

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/LearningExplanationRecorder.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/LearningExplanationRecorder.java
@@ -1,0 +1,155 @@
+package dev.aceclaw.daemon;
+
+import dev.aceclaw.memory.CandidateTransition;
+import dev.aceclaw.memory.LearningCandidate;
+import dev.aceclaw.memory.MemoryEntry;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Best-effort recorder that turns adaptive actions into explanation records.
+ */
+public final class LearningExplanationRecorder {
+
+    private final LearningExplanationStore store;
+
+    public LearningExplanationRecorder(LearningExplanationStore store) {
+        this.store = Objects.requireNonNull(store, "store");
+    }
+
+    public void recordMemoryWrite(Path projectRoot,
+                                  String sessionId,
+                                  String trigger,
+                                  MemoryEntry.Category category,
+                                  String content,
+                                  List<String> tags,
+                                  List<LearningExplanation.EvidenceRef> evidence) {
+        append(projectRoot, new LearningExplanation(
+                Instant.now(),
+                "memory_write",
+                "memory",
+                category.name().toLowerCase() + ":" + Integer.toHexString(Objects.hash(category, content)),
+                sessionId,
+                trigger,
+                content,
+                tags,
+                evidence));
+    }
+
+    public void recordCandidateObservation(Path projectRoot,
+                                           String sessionId,
+                                           String trigger,
+                                           LearningCandidate candidate,
+                                           String summary,
+                                           List<LearningExplanation.EvidenceRef> evidence) {
+        append(projectRoot, new LearningExplanation(
+                Instant.now(),
+                "candidate_observed",
+                "candidate",
+                candidate.id(),
+                sessionId,
+                trigger,
+                summary,
+                candidate.tags(),
+                evidence));
+    }
+
+    public void recordCandidateTransition(Path projectRoot,
+                                          String sessionId,
+                                          String trigger,
+                                          CandidateTransition transition) {
+        append(projectRoot, new LearningExplanation(
+                transition.timestamp(),
+                "candidate_transition",
+                "candidate",
+                transition.candidateId(),
+                sessionId,
+                trigger,
+                transition.fromState().name().toLowerCase() + " -> "
+                        + transition.toState().name().toLowerCase() + ": " + transition.reason(),
+                List.of("candidate-transition", transition.toState().name().toLowerCase()),
+                List.of(new LearningExplanation.EvidenceRef("reason-code", transition.reasonCode(), transition.triggeredBy()))));
+    }
+
+    public void recordSkillDraft(Path projectRoot,
+                                 String trigger,
+                                 String skillName,
+                                 String draftPath,
+                                 String sourceCandidateId) {
+        append(projectRoot, new LearningExplanation(
+                Instant.now(),
+                "skill_draft_created",
+                "skill-draft",
+                draftPath,
+                "",
+                trigger,
+                "Created skill draft '" + skillName + "'.",
+                List.of("skill-draft", skillName),
+                List.of(new LearningExplanation.EvidenceRef("candidate", sourceCandidateId, draftPath))));
+    }
+
+    public void recordRuntimeSkill(Path projectRoot,
+                                   String sessionId,
+                                   String skillName,
+                                   String sequenceSignature,
+                                   List<String> allowedTools) {
+        append(projectRoot, new LearningExplanation(
+                Instant.now(),
+                "runtime_skill_created",
+                "runtime-skill",
+                skillName,
+                sessionId,
+                "runtime-generation",
+                "Created runtime skill '" + skillName + "' for repeated tool sequence.",
+                List.of("runtime-skill", skillName),
+                List.of(
+                        new LearningExplanation.EvidenceRef("sequence", sequenceSignature, ""),
+                        new LearningExplanation.EvidenceRef("allowed-tools", String.join(",", allowedTools), ""))));
+    }
+
+    public void recordRuntimeSkillDraftPersisted(Path projectRoot,
+                                                 String sessionId,
+                                                 String skillName,
+                                                 String draftPath) {
+        append(projectRoot, new LearningExplanation(
+                Instant.now(),
+                "runtime_skill_persisted",
+                "skill-draft",
+                draftPath,
+                sessionId,
+                "session-end",
+                "Persisted runtime skill '" + skillName + "' as draft.",
+                List.of("runtime-skill", "skill-draft", skillName),
+                List.of(new LearningExplanation.EvidenceRef("draft-path", draftPath, skillName))));
+    }
+
+    public void recordRefinement(Path projectRoot,
+                                 String skillName,
+                                 String action,
+                                 String reason) {
+        append(projectRoot, new LearningExplanation(
+                Instant.now(),
+                "skill_refinement",
+                "skill",
+                skillName,
+                "",
+                "skill-refinement",
+                action + " for '" + skillName + "': " + reason,
+                List.of("skill-refinement", action.toLowerCase(), skillName),
+                List.of(new LearningExplanation.EvidenceRef("reason", action, reason))));
+    }
+
+    private void append(Path projectRoot, LearningExplanation explanation) {
+        if (projectRoot == null || explanation == null) {
+            return;
+        }
+        try {
+            store.append(projectRoot, explanation);
+        } catch (Exception ignored) {
+            // Explainability must never break the learning pipeline.
+        }
+    }
+}

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/LearningExplanationStore.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/LearningExplanationStore.java
@@ -1,0 +1,67 @@
+package dev.aceclaw.daemon;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Stores learning explanations as project-local JSONL.
+ */
+public final class LearningExplanationStore {
+
+    private static final String EXPLANATIONS_FILE = ".aceclaw/metrics/learning-explanations.jsonl";
+
+    private final ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    public void append(Path projectRoot, LearningExplanation explanation) throws IOException {
+        Objects.requireNonNull(projectRoot, "projectRoot");
+        Objects.requireNonNull(explanation, "explanation");
+        Path file = explanationsFile(projectRoot);
+        Files.createDirectories(file.getParent());
+        try (var channel = FileChannel.open(file,
+                StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.APPEND);
+             FileLock ignored = channel.lock()) {
+            channel.write(java.nio.charset.StandardCharsets.UTF_8.encode(
+                    mapper.writeValueAsString(explanation) + "\n"));
+        }
+    }
+
+    public List<LearningExplanation> recent(Path projectRoot, int limit) throws IOException {
+        Objects.requireNonNull(projectRoot, "projectRoot");
+        int bounded = Math.max(1, limit);
+        Path file = explanationsFile(projectRoot);
+        if (!Files.exists(file)) {
+            return List.of();
+        }
+        var explanations = new ArrayList<LearningExplanation>();
+        for (var line : Files.readAllLines(file)) {
+            if (line == null || line.isBlank()) {
+                continue;
+            }
+            try {
+                explanations.add(mapper.readValue(line, LearningExplanation.class));
+            } catch (Exception ignored) {
+                // Skip malformed rows; explainability should be best-effort.
+            }
+        }
+        explanations.sort(Comparator.comparing(LearningExplanation::timestamp).reversed());
+        if (explanations.size() > bounded) {
+            return List.copyOf(explanations.subList(0, bounded));
+        }
+        return List.copyOf(explanations);
+    }
+
+    Path explanationsFile(Path projectRoot) {
+        return projectRoot.resolve(EXPLANATIONS_FILE);
+    }
+}

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/LearningMaintenanceCandidateBridge.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/LearningMaintenanceCandidateBridge.java
@@ -2,9 +2,11 @@ package dev.aceclaw.daemon;
 
 import dev.aceclaw.memory.CandidateKind;
 import dev.aceclaw.memory.CandidateState;
+import dev.aceclaw.memory.CandidateTransition;
 import dev.aceclaw.memory.CandidateStore;
 import dev.aceclaw.memory.CrossSessionPatternMiner;
 import dev.aceclaw.memory.ErrorClass;
+import dev.aceclaw.memory.LearningCandidate;
 import dev.aceclaw.memory.MemoryEntry;
 import dev.aceclaw.memory.TrendDetector;
 
@@ -33,15 +35,21 @@ public final class LearningMaintenanceCandidateBridge {
         Objects.requireNonNull(trends, "trends");
 
         int upserts = 0;
+        var observedCandidates = new ArrayList<LearningCandidate>();
         for (var observation : toObservations(trigger, miningResult, trends)) {
-            candidateStore.upsert(observation);
+            observedCandidates.add(candidateStore.upsert(observation));
             upserts++;
         }
         var transitions = candidateStore.evaluateAll();
         int promoted = (int) transitions.stream()
                 .filter(t -> t.toState() == CandidateState.PROMOTED)
                 .count();
-        return new BridgeResult(upserts, transitions.size(), promoted);
+        return new BridgeResult(
+                upserts,
+                transitions.size(),
+                promoted,
+                List.copyOf(observedCandidates),
+                List.copyOf(transitions));
     }
 
     private static List<CandidateStore.CandidateObservation> toObservations(
@@ -171,5 +179,16 @@ public final class LearningMaintenanceCandidateBridge {
         return metric.substring(0, dot).toLowerCase(Locale.ROOT);
     }
 
-    public record BridgeResult(int upserts, int transitions, int promoted) {}
+    public record BridgeResult(
+            int upserts,
+            int transitions,
+            int promoted,
+            List<LearningCandidate> observedCandidates,
+            List<CandidateTransition> stateTransitions
+    ) {
+        public BridgeResult {
+            observedCandidates = observedCandidates != null ? List.copyOf(observedCandidates) : List.of();
+            stateTransitions = stateTransitions != null ? List.copyOf(stateTransitions) : List.of();
+        }
+    }
 }

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/SelfImprovementEngine.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/SelfImprovementEngine.java
@@ -63,6 +63,7 @@ public final class SelfImprovementEngine {
     private final CandidateStore candidateStore;
     private final boolean candidateTransitionsEnabled;
     private final Consumer<Path> draftReevaluationTrigger;
+    private LearningExplanationRecorder learningExplanationRecorder;
 
     private final AtomicInteger turnsSinceRefinement = new AtomicInteger();
     private final AtomicInteger persistedSinceLastRefinement = new AtomicInteger();
@@ -160,6 +161,10 @@ public final class SelfImprovementEngine {
         this.draftReevaluationTrigger = draftReevaluationTrigger;
     }
 
+    public void setLearningExplanationRecorder(LearningExplanationRecorder learningExplanationRecorder) {
+        this.learningExplanationRecorder = learningExplanationRecorder;
+    }
+
     /**
      * Analyzes a completed turn and returns deduplicated insights from all detectors.
      *
@@ -229,6 +234,19 @@ public final class SelfImprovementEngine {
                         "self-improve:" + sessionId,
                         false,
                         projectPath);
+                if (learningExplanationRecorder != null) {
+                    learningExplanationRecorder.recordMemoryWrite(
+                            projectPath,
+                            sessionId,
+                            "self-improvement",
+                            insight.targetCategory(),
+                            content,
+                            insight.tags(),
+                            List.of(new LearningExplanation.EvidenceRef(
+                                    "insight",
+                                    insight.getClass().getSimpleName(),
+                                    truncate(insight.description(), 140))));
+                }
                 persisted++;
                 log.debug("Persisted insight: category={}, confidence={}, content={}",
                         insight.targetCategory(), insight.confidence(), truncate(content));
@@ -255,12 +273,30 @@ public final class SelfImprovementEngine {
                             isSuccess ? 1 : 0, isSuccess ? 0 : 1,
                             "self-improve:" + sessionId, null,
                             severeFailure, correctionConflict, insight.description(), null);
-                    candidateStore.upsert(observation);
+                    var stored = candidateStore.upsert(observation);
+                    if (learningExplanationRecorder != null) {
+                        learningExplanationRecorder.recordCandidateObservation(
+                                projectPath,
+                                sessionId,
+                                "self-improvement",
+                                stored,
+                                truncate(insight.description(), 160),
+                                List.of(new LearningExplanation.EvidenceRef(
+                                        "insight",
+                                        insight.getClass().getSimpleName(),
+                                        truncate(insight.description(), 140))));
+                    }
                 }
                 if (candidateTransitionsEnabled) {
                     var transitions = candidateStore.evaluateAll();
                     if (!transitions.isEmpty()) {
                         log.info("Candidate pipeline: {} transitions applied after turn", transitions.size());
+                        if (learningExplanationRecorder != null) {
+                            for (var transition : transitions) {
+                                learningExplanationRecorder.recordCandidateTransition(
+                                        projectPath, sessionId, "self-improvement", transition);
+                            }
+                        }
                     }
                 }
                 // Always fire draft re-evaluation trigger (not just on new promotions).

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/SkillMemoryFeedback.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/SkillMemoryFeedback.java
@@ -18,9 +18,16 @@ public final class SkillMemoryFeedback {
     private static final int MAX_CONTENT_LENGTH = 220;
 
     private final AutoMemoryStore memoryStore;
+    private final LearningExplanationRecorder learningExplanationRecorder;
 
     public SkillMemoryFeedback(AutoMemoryStore memoryStore) {
+        this(memoryStore, null);
+    }
+
+    public SkillMemoryFeedback(AutoMemoryStore memoryStore,
+                               LearningExplanationRecorder learningExplanationRecorder) {
         this.memoryStore = Objects.requireNonNull(memoryStore, "memoryStore");
+        this.learningExplanationRecorder = learningExplanationRecorder;
     }
 
     /**
@@ -40,6 +47,7 @@ public final class SkillMemoryFeedback {
                         List.of(skillName, "skill-feedback", "successful-strategy"),
                         projectPath,
                         "skill:" + skillName);
+                recordMemoryExplanation(projectPath, skillName, "skill-success", MemoryEntry.Category.SUCCESSFUL_STRATEGY, content);
             }
             case SkillOutcome.Failure failure -> {
                 var content = truncate("Avoid relying on skill '" + skillName
@@ -50,6 +58,7 @@ public final class SkillMemoryFeedback {
                         List.of(skillName, "skill-feedback", "anti-pattern"),
                         projectPath,
                         "skill:" + skillName);
+                recordMemoryExplanation(projectPath, skillName, "skill-failure", MemoryEntry.Category.ANTI_PATTERN, content);
                 if (metrics != null && metrics.failureCount() >= 3) {
                     var recovery = truncate("Before reusing skill '" + skillName
                             + "', review recent failures and apply the latest corrected workflow.");
@@ -59,22 +68,27 @@ public final class SkillMemoryFeedback {
                             List.of(skillName, "skill-feedback", "recovery-recipe"),
                             projectPath,
                             "skill:" + skillName);
+                    recordMemoryExplanation(projectPath, skillName, "skill-recovery", MemoryEntry.Category.RECOVERY_RECIPE, recovery);
                 }
             }
             case SkillOutcome.UserCorrected corrected -> {
                 String normalized = normalize(corrected.correction());
+                var correction = truncate("User corrected skill '" + skillName + "': " + normalized);
                 addIfAbsent(
                         MemoryEntry.Category.CORRECTION,
-                        truncate("User corrected skill '" + skillName + "': " + normalized),
+                        correction,
                         List.of(skillName, "skill-feedback", "user-correction"),
                         projectPath,
                         "skill:" + skillName);
+                recordMemoryExplanation(projectPath, skillName, "skill-correction", MemoryEntry.Category.CORRECTION, correction);
+                var preference = truncate("When using skill '" + skillName + "', prefer: " + normalized);
                 addIfAbsent(
                         MemoryEntry.Category.PREFERENCE,
-                        truncate("When using skill '" + skillName + "', prefer: " + normalized),
+                        preference,
                         List.of(skillName, "skill-feedback", "user-preference"),
                         projectPath,
                         "skill:" + skillName);
+                recordMemoryExplanation(projectPath, skillName, "skill-preference", MemoryEntry.Category.PREFERENCE, preference);
             }
         }
     }
@@ -92,6 +106,12 @@ public final class SkillMemoryFeedback {
                 List.of(skillName, "skill-feedback", "rollback", "anti-pattern"),
                 projectPath,
                 "skill-refinement:" + skillName);
+        recordMemoryExplanation(
+                projectPath,
+                skillName,
+                "skill-rollback",
+                MemoryEntry.Category.ANTI_PATTERN,
+                truncate("Avoid reusing the last refinement of skill '" + skillName + "': " + normalize(reason) + "."));
     }
 
     private String buildSuccessContent(String skillName, SkillOutcome.Success success) {
@@ -108,6 +128,24 @@ public final class SkillMemoryFeedback {
                              Path projectPath,
                              String source) {
         memoryStore.addIfAbsent(category, content, tags, source, false, projectPath);
+    }
+
+    private void recordMemoryExplanation(Path projectPath,
+                                         String skillName,
+                                         String trigger,
+                                         MemoryEntry.Category category,
+                                         String content) {
+        if (learningExplanationRecorder == null || projectPath == null) {
+            return;
+        }
+        learningExplanationRecorder.recordMemoryWrite(
+                projectPath,
+                "",
+                trigger,
+                category,
+                content,
+                List.of(skillName, "skill-feedback"),
+                List.of(new LearningExplanation.EvidenceRef("skill", skillName, trigger)));
     }
 
     private static String normalize(String text) {

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -831,6 +831,13 @@ public final class StreamingAgentHandler {
 
             if (outcome.action() != SkillRefinementEngine.RefinementAction.NONE) {
                 emitSkillRollbackFeedback(projectPath, skillName, outcome);
+                if (learningExplanationRecorder != null) {
+                    learningExplanationRecorder.recordRefinement(
+                            projectPath,
+                            skillName,
+                            outcome.action().name(),
+                            outcome.reason());
+                }
                 log.info("Skill refinement action={} skill={} reason={}",
                         outcome.action(), skillName, outcome.reason());
             }
@@ -1277,6 +1284,7 @@ public final class StreamingAgentHandler {
     private SkillMemoryFeedback skillMemoryFeedback;
     private SkillRefinementEngine skillRefinementEngine;
     private DynamicSkillGenerator dynamicSkillGenerator;
+    private LearningExplanationRecorder learningExplanationRecorder;
 
     /**
      * Sets the LLM configuration for permission-aware agent loop creation.
@@ -1330,10 +1338,19 @@ public final class StreamingAgentHandler {
     public void setMemoryStore(AutoMemoryStore memoryStore, Path workingDir) {
         this.memoryStore = memoryStore;
         this.workingDir = workingDir;
-        this.skillMemoryFeedback = memoryStore != null ? new SkillMemoryFeedback(memoryStore) : null;
+        this.skillMemoryFeedback = memoryStore != null
+                ? new SkillMemoryFeedback(memoryStore, learningExplanationRecorder)
+                : null;
         if (workingDir != null) {
             this.antiPatternGateFeedbackStore = new AntiPatternGateFeedbackStore(workingDir);
         }
+    }
+
+    public void setLearningExplanationRecorder(LearningExplanationRecorder learningExplanationRecorder) {
+        this.learningExplanationRecorder = learningExplanationRecorder;
+        this.skillMemoryFeedback = memoryStore != null
+                ? new SkillMemoryFeedback(memoryStore, learningExplanationRecorder)
+                : null;
     }
 
     /**

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/DynamicSkillGeneratorTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/DynamicSkillGeneratorTest.java
@@ -39,6 +39,35 @@ class DynamicSkillGeneratorTest {
     }
 
     @Test
+    void recordsRuntimeSkillExplainabilityAndDraftPersistence() throws Exception {
+        var explanationStore = new LearningExplanationStore();
+        generator.setLearningExplanationRecorder(new LearningExplanationRecorder(explanationStore));
+        mockLlm.enqueueSendMessageResponse(MockLlmClient.sendMessageTextResponse("""
+                {
+                  "name": "review-file-workflow",
+                  "description": "Review a file-oriented workflow.",
+                  "argument_hint": "<target>",
+                  "body": "# Runtime Workflow\\n\\nFollow the repeated workflow carefully."
+                }
+                """));
+
+        var generated = generator.maybeGenerate(
+                "session-1",
+                workDir,
+                repeatedSequenceTurn("read_file", "grep", "edit_file"),
+                sessionHistory("Please inspect the config files."),
+                repeatedSequenceInsight(),
+                Set.of("read_file", "grep", "edit_file", "skill"));
+
+        assertThat(generated).isPresent();
+        assertThat(generator.persistDrafts("session-1", workDir)).isEqualTo(1);
+
+        var explanations = explanationStore.recent(workDir, 10);
+        assertThat(explanations).anyMatch(explanation -> explanation.actionType().equals("runtime_skill_created"));
+        assertThat(explanations).anyMatch(explanation -> explanation.actionType().equals("runtime_skill_persisted"));
+    }
+
+    @Test
     void generatesRuntimeSkillAndPersistsDraftOnSessionEnd() throws Exception {
         mockLlm.enqueueSendMessageResponse(MockLlmClient.sendMessageTextResponse("""
                 {

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/LearningExplanationStoreTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/LearningExplanationStoreTest.java
@@ -1,0 +1,54 @@
+package dev.aceclaw.daemon;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LearningExplanationStoreTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void appendAndReadRecentExplanations() throws Exception {
+        var store = new LearningExplanationStore();
+        store.append(tempDir, new LearningExplanation(
+                Instant.parse("2026-03-13T10:15:30Z"),
+                "memory_write",
+                "memory",
+                "memory-1",
+                "session-1",
+                "self-improvement",
+                "Persisted a successful strategy.",
+                List.of("strategy"),
+                List.of(new LearningExplanation.EvidenceRef("insight", "SuccessInsight", "read -> edit"))));
+
+        var recent = store.recent(tempDir, 10);
+
+        assertThat(recent).hasSize(1);
+        assertThat(recent.getFirst().actionType()).isEqualTo("memory_write");
+        assertThat(recent.getFirst().evidence()).hasSize(1);
+    }
+
+    @Test
+    void recentSkipsMalformedJsonlRows() throws Exception {
+        var store = new LearningExplanationStore();
+        var file = store.explanationsFile(tempDir);
+        Files.createDirectories(file.getParent());
+        Files.writeString(file, """
+                {"timestamp":"2026-03-13T10:15:30Z","actionType":"memory_write","targetType":"memory","targetId":"ok","sessionId":"","trigger":"x","summary":"ok","tags":[],"evidence":[]}
+                not-json
+                """);
+
+        var recent = store.recent(tempDir, 10);
+
+        assertThat(recent).hasSize(1);
+        assertThat(recent.getFirst().targetId()).isEqualTo("ok");
+    }
+}

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/SelfImprovementEngineTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/SelfImprovementEngineTest.java
@@ -152,6 +152,24 @@ class SelfImprovementEngineTest {
     }
 
     @Test
+    void persistRecordsLearningExplanationWhenRecorderConfigured() throws Exception {
+        var explanationStore = new LearningExplanationStore();
+        engine.setLearningExplanationRecorder(new LearningExplanationRecorder(explanationStore));
+
+        var insights = List.<Insight>of(
+                ErrorInsight.of("read_file", "File not found", "Used correct path", 0.9)
+        );
+
+        int count = engine.persist(insights, "test-session", tempDir);
+
+        assertThat(count).isEqualTo(1);
+        var explanations = explanationStore.recent(tempDir, 10);
+        assertThat(explanations).anyMatch(explanation ->
+                explanation.actionType().equals("memory_write")
+                        && explanation.trigger().equals("self-improvement"));
+    }
+
+    @Test
     void persistSkipsLowConfidenceInsights() {
         var insights = List.<Insight>of(
                 ErrorInsight.of("read_file", "File not found", "Retry", 0.3), // below 0.7

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/SkillMemoryFeedbackTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/SkillMemoryFeedbackTest.java
@@ -109,4 +109,21 @@ class SkillMemoryFeedbackTest {
         assertThat(antiPatterns).hasSize(1);
         assertThat(antiPatterns.getFirst().content()).contains("last refinement").contains("review");
     }
+
+    @Test
+    void successRecordsLearningExplanationWhenRecorderConfigured() throws Exception {
+        var explanationStore = new LearningExplanationStore();
+        feedback = new SkillMemoryFeedback(store, new LearningExplanationRecorder(explanationStore));
+
+        feedback.onOutcome(
+                "review",
+                new SkillOutcome.Success(Instant.now(), 1),
+                new SkillMetrics("review", 1, 1, 0, 0, 1.0, Instant.now(), 1.0),
+                tempDir);
+
+        var explanations = explanationStore.recent(tempDir, 10);
+        assertThat(explanations).anyMatch(explanation ->
+                explanation.actionType().equals("memory_write")
+                        && explanation.trigger().equals("skill-success"));
+    }
 }


### PR DESCRIPTION
## Summary
- add a persistent learning explanation model and JSONL store
- record provenance for self-improvement memory writes, candidate observations/transitions, skill drafts, runtime skills, and refinement actions
- expose recent explanations through a daemon RPC and cover the new flow with daemon tests

## Testing
- ./gradlew :aceclaw-daemon:test --tests dev.aceclaw.daemon.LearningExplanationStoreTest --tests dev.aceclaw.daemon.SelfImprovementEngineTest --tests dev.aceclaw.daemon.DynamicSkillGeneratorTest --tests dev.aceclaw.daemon.SkillMemoryFeedbackTest --no-daemon
- ./gradlew :aceclaw-core:test :aceclaw-tools:test :aceclaw-daemon:test --no-daemon

Closes #226