### PR TITLE
fix(cli): refresh git branch in status bar instead of using startup value

### DIFF
--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
@@ -144,6 +144,10 @@ public final class TerminalRepl {
     /** Cached cron status snapshot from daemon RPC. */
     private volatile CronStatusSnapshot cachedCronStatus;
     private volatile Instant cachedCronStatusAt = Instant.EPOCH;
+    /** Cached git branch name, refreshed periodically. */
+    private volatile String cachedGitBranch;
+    private volatile Instant cachedGitBranchAt = Instant.EPOCH;
+    private static final Duration GIT_BRANCH_REFRESH = Duration.ofSeconds(5);
     /** Last non-trivial user task prompt, used by /continue fallback. */
     private volatile String lastTaskPrompt;
     private final ResumeCheckpointStore resumeCheckpointStore;
@@ -1449,13 +1453,46 @@ public final class TerminalRepl {
 
     // -- Status line ---------------------------------------------------------
 
+    /**
+     * Returns the current git branch, refreshing from disk at most every 5 seconds.
+     * Falls back to the startup value from {@code SessionInfo} if detection fails.
+     */
+    private String currentGitBranch() {
+        Instant now = Instant.now();
+        if (cachedGitBranch != null
+                && Duration.between(cachedGitBranchAt, now).compareTo(GIT_BRANCH_REFRESH) < 0) {
+            return cachedGitBranch;
+        }
+        String project = sessionInfo.project();
+        if (project == null || project.isBlank()) {
+            return sessionInfo.gitBranch();
+        }
+        try {
+            var pb = new ProcessBuilder("git", "rev-parse", "--abbrev-ref", "HEAD");
+            pb.directory(Path.of(project).toFile());
+            pb.redirectErrorStream(true);
+            var process = pb.start();
+            String output = new String(process.getInputStream().readAllBytes()).trim();
+            int exitCode = process.waitFor();
+            if (exitCode == 0 && !output.isBlank()) {
+                cachedGitBranch = output;
+            } else {
+                cachedGitBranch = sessionInfo.gitBranch();
+            }
+        } catch (Exception e) {
+            cachedGitBranch = sessionInfo.gitBranch();
+        }
+        cachedGitBranchAt = now;
+        return cachedGitBranch;
+    }
+
     private String buildStatusString() {
         var sb = new StringBuilder();
 
         sb.append(PURPLE).append(ICON_PRIMARY).append(RESET).append(" ");
         sb.append(INFO).append(BOLD).append(effectiveModel).append(RESET);
 
-        String branch = sessionInfo.gitBranch();
+        String branch = currentGitBranch();
         if (branch != null && !branch.isBlank()) {
             sb.append(MUTED).append(" | ").append(RESET);
             sb.append(SUCCESS).append("branch=")
@@ -2360,8 +2397,9 @@ public final class TerminalRepl {
                 out.println(BOLD + "Session Status" + RESET);
                 out.printf("  %sModel:%s       %s%n", MUTED, RESET, effectiveModel);
                 out.printf("  %sProject:%s     %s%n", MUTED, RESET, sessionInfo.project());
-                if (sessionInfo.gitBranch() != null) {
-                    out.printf("  %sGit branch:%s  %s%n", MUTED, RESET, sessionInfo.gitBranch());
+                String statusBranch = currentGitBranch();
+                if (statusBranch != null) {
+                    out.printf("  %sGit branch:%s  %s%n", MUTED, RESET, statusBranch);
                 }
                 out.printf("  %sContext:%s     %s / %s (%d%%)%n", MUTED, RESET,
                         formatTokenCount(latestInputTokens),


### PR DESCRIPTION
## Summary
- `SessionInfo.gitBranch()` is an immutable record field read once at startup — status bar showed stale branch after `git checkout`
- Added `currentGitBranch()` that re-reads via `git rev-parse --abbrev-ref HEAD` with a 5-second cache TTL (same pattern as cron/learning status refresh)
- Updated both the status bar header and `/status` command to use live branch

Closes #228

## Test plan
- [x] All CLI tests pass (`./gradlew :aceclaw-cli:test`)
- [ ] Manual: start AceClaw, run `git checkout -b test-branch`, verify status bar updates within 5 seconds
- [ ] Manual: verify context usage % updates after each turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Status now shows a periodically refreshed Git branch so branch display updates more responsively.

* **Bug Fixes**
  * Improved reliability and graceful fallback when Git is unavailable or project path is missing, ensuring consistent branch info in status output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->