### PR TITLE
feat(learning): add validation semantics for learned behaviors

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -83,6 +83,8 @@ public final class AceClawDaemon {
     private final HistoricalLogIndex historicalLogIndex;
     private final LearningExplanationStore learningExplanationStore;
     private final LearningExplanationRecorder learningExplanationRecorder;
+    private final LearningValidationStore learningValidationStore;
+    private final LearningValidationRecorder learningValidationRecorder;
     private final MarkdownMemoryStore markdownStore;
     private final JobStore cronJobStore;
     private final EventBus eventBus;
@@ -156,6 +158,8 @@ public final class AceClawDaemon {
         this.historicalLogIndex = hli;
         this.learningExplanationStore = new LearningExplanationStore();
         this.learningExplanationRecorder = new LearningExplanationRecorder(learningExplanationStore);
+        this.learningValidationStore = new LearningValidationStore();
+        this.learningValidationRecorder = new LearningValidationRecorder(learningValidationStore);
 
         // Markdown memory store (persistent MEMORY.md + topic files)
         MarkdownMemoryStore mds = null;
@@ -538,10 +542,10 @@ public final class AceClawDaemon {
                             // Validate drafts and evaluate for auto-release
                             if (validationGateForAuto != null) {
                                 var validation = validationGateForAuto.validateAll(projectPath, "auto-promotion");
-                                publishSkillDraftValidationEvents(validation, "auto-promotion");
+                                publishSkillDraftValidationEvents(validation, workingDir, "auto-promotion");
                                 if (autoReleaseForAuto != null && candidateStoreForAuto != null) {
                                     var release = autoReleaseForAuto.evaluateAll(projectPath, candidateStoreForAuto, "auto-promotion");
-                                    publishSkillDraftReleaseEvents(release, "auto-promotion");
+                                    publishSkillDraftReleaseEvents(release, workingDir, "auto-promotion");
                                 }
                             }
                         } catch (Exception e) {
@@ -584,10 +588,10 @@ public final class AceClawDaemon {
                         }
                         if (catchupValidation != null && summary.createdDrafts() > 0) {
                             var validation = catchupValidation.validateAll(workingDir, "startup-catchup");
-                            publishSkillDraftValidationEvents(validation, "startup-catchup");
+                            publishSkillDraftValidationEvents(validation, workingDir, "startup-catchup");
                             if (catchupAutoRelease != null) {
                                 var release = catchupAutoRelease.evaluateAll(workingDir, catchupCs, "startup-catchup");
-                                publishSkillDraftReleaseEvents(release, "startup-catchup");
+                                publishSkillDraftReleaseEvents(release, workingDir, "startup-catchup");
                             }
                         }
                     } catch (Exception e) {
@@ -604,7 +608,9 @@ public final class AceClawDaemon {
                 agentHandler::getModelForSession,
                 skillRegistry);
         dynamicSkillGenerator.setLearningExplanationRecorder(learningExplanationRecorder);
+        dynamicSkillGenerator.setLearningValidationRecorder(learningValidationRecorder);
         agentHandler.setLearningExplanationRecorder(learningExplanationRecorder);
+        agentHandler.setLearningValidationRecorder(learningValidationRecorder);
         agentHandler.setDynamicSkillGenerator(dynamicSkillGenerator);
 
         // Wire deferred action scheduler (no turn lock dependency — uses isolated context)
@@ -919,11 +925,11 @@ public final class AceClawDaemon {
                 result.put("auditFile", workingDir.relativize(summary.auditFile()).toString().replace('\\', '/'));
                 if (validationGateForRpc != null) {
                     var validation = validationGateForRpc.validateAll(workingDir, "draft-generated");
-                    publishSkillDraftValidationEvents(validation, "draft-generated");
+                    publishSkillDraftValidationEvents(validation, workingDir, "draft-generated");
                     result.set("validation", toValidationJson(validation, workingDir));
                     if (autoReleaseForRpc != null && candidateStoreForRpc != null) {
                         var release = autoReleaseForRpc.evaluateAll(workingDir, candidateStoreForRpc, "draft-generated");
-                        publishSkillDraftReleaseEvents(release, "draft-generated");
+                        publishSkillDraftReleaseEvents(release, workingDir, "draft-generated");
                         result.set("release", toReleaseJson(release));
                     }
                 }
@@ -943,11 +949,11 @@ public final class AceClawDaemon {
                 if (params != null && params.has("draftPath")) {
                     Path draftPath = workingDir.resolve(params.get("draftPath").asText()).normalize();
                     var summary = validationGateForRpc.validateSingleDraft(workingDir, draftPath, trigger);
-                    publishSkillDraftValidationEvents(summary, trigger);
+                    publishSkillDraftValidationEvents(summary, workingDir, trigger);
                     return toValidationJson(summary, workingDir);
                 }
                 var summary = validationGateForRpc.validateAll(workingDir, trigger);
-                publishSkillDraftValidationEvents(summary, trigger);
+                publishSkillDraftValidationEvents(summary, workingDir, trigger);
                 return toValidationJson(summary, workingDir);
             } finally {
                 draftPipelineLock.unlock();
@@ -962,7 +968,7 @@ public final class AceClawDaemon {
                 String trigger = params != null && params.has("trigger")
                         ? params.get("trigger").asText() : "manual";
                 var summary = autoReleaseForRpc.evaluateAll(workingDir, candidateStoreForRpc, trigger);
-                publishSkillDraftReleaseEvents(summary, trigger);
+                publishSkillDraftReleaseEvents(summary, workingDir, trigger);
                 return toReleaseJson(summary);
             } finally {
                 draftPipelineLock.unlock();
@@ -979,7 +985,7 @@ public final class AceClawDaemon {
             String reason = params.has("reason") ? params.get("reason").asText() : "manual pause";
             String trigger = params.has("trigger") ? params.get("trigger").asText() : "manual";
             var summary = autoReleaseForRpc.pause(workingDir, skillName, reason, trigger);
-            publishSkillDraftReleaseEvents(summary, trigger);
+            publishSkillDraftReleaseEvents(summary, workingDir, trigger);
             return toReleaseJson(summary);
         });
         router.register("skill.release.forceRollback", params -> {
@@ -993,7 +999,7 @@ public final class AceClawDaemon {
             String reason = params.has("reason") ? params.get("reason").asText() : "manual force rollback";
             String trigger = params.has("trigger") ? params.get("trigger").asText() : "manual";
             var summary = autoReleaseForRpc.forceRollback(workingDir, skillName, reason, trigger);
-            publishSkillDraftReleaseEvents(summary, trigger);
+            publishSkillDraftReleaseEvents(summary, workingDir, trigger);
             return toReleaseJson(summary);
         });
         router.register("skill.release.forcePromote", params -> {
@@ -1015,7 +1021,7 @@ public final class AceClawDaemon {
             String reason = params.has("reason") ? params.get("reason").asText() : "manual force promote";
             String trigger = params.has("trigger") ? params.get("trigger").asText() : "manual";
             var summary = autoReleaseForRpc.forcePromote(workingDir, skillName, stage, reason, trigger);
-            publishSkillDraftReleaseEvents(summary, trigger);
+            publishSkillDraftReleaseEvents(summary, workingDir, trigger);
             return toReleaseJson(summary);
         });
 
@@ -1483,12 +1489,14 @@ public final class AceClawDaemon {
 
     private void publishSkillDraftValidationEvents(
             ValidationGateEngine.ValidationSummary summary,
+            Path projectRoot,
             String trigger
     ) {
         if (summary == null || summary.changedDecisions().isEmpty()) {
             return;
         }
         for (var decision : summary.changedDecisions()) {
+            learningValidationRecorder.recordDraftValidation(projectRoot, trigger, decision);
             String skillName = skillNameFromDraftPath(decision.draftPath());
             var reasons = decision.reasons().stream()
                     .map(reason -> reason.code() + ": " + reason.message())
@@ -1510,12 +1518,14 @@ public final class AceClawDaemon {
 
     private void publishSkillDraftReleaseEvents(
             AutoReleaseController.EvaluationSummary summary,
+            Path projectRoot,
             String trigger
     ) {
         if (summary == null || summary.events().isEmpty()) {
             return;
         }
         for (var event : summary.events()) {
+            learningValidationRecorder.recordReleaseValidation(projectRoot, trigger, event);
             var release = summary.releases().stream()
                     .filter(candidate -> candidate.skillName().equals(event.skillName()))
                     .findFirst()
@@ -2023,10 +2033,10 @@ public final class AceClawDaemon {
                 publishSkillDraftCreatedEvents(summary, workingDir, trigger);
                 if (validationGateEngine != null && summary.createdDrafts() > 0) {
                     var validation = validationGateEngine.validateAll(workingDir, trigger);
-                    publishSkillDraftValidationEvents(validation, trigger);
+                    publishSkillDraftValidationEvents(validation, workingDir, trigger);
                     if (autoReleaseController != null) {
                         var release = autoReleaseController.evaluateAll(workingDir, candidateStore, trigger);
-                        publishSkillDraftReleaseEvents(release, trigger);
+                        publishSkillDraftReleaseEvents(release, workingDir, trigger);
                     }
                 }
             } catch (Exception e) {

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/DynamicSkillGenerator.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/DynamicSkillGenerator.java
@@ -59,6 +59,7 @@ public final class DynamicSkillGenerator {
     private final ConcurrentHashMap<String, SessionRuntimeState> sessionStates = new ConcurrentHashMap<>();
     private final Set<String> closedSessions = ConcurrentHashMap.newKeySet();
     private LearningExplanationRecorder learningExplanationRecorder;
+    private LearningValidationRecorder learningValidationRecorder;
 
     public DynamicSkillGenerator(LlmClient llmClient,
                                  Function<String, String> modelResolver,
@@ -70,6 +71,10 @@ public final class DynamicSkillGenerator {
 
     public void setLearningExplanationRecorder(LearningExplanationRecorder learningExplanationRecorder) {
         this.learningExplanationRecorder = learningExplanationRecorder;
+    }
+
+    public void setLearningValidationRecorder(LearningValidationRecorder learningValidationRecorder) {
+        this.learningValidationRecorder = learningValidationRecorder;
     }
 
     public java.util.Optional<SkillConfig> maybeGenerate(String sessionId,
@@ -147,6 +152,14 @@ public final class DynamicSkillGenerator {
                         sequenceSignature,
                         allowedTools);
             }
+            if (learningValidationRecorder != null) {
+                learningValidationRecorder.recordRuntimeSkillObserved(
+                        projectPath,
+                        sessionId,
+                        skillName,
+                        sequenceSignature,
+                        allowedTools);
+            }
             log.info("Registered runtime skill '{}' for session {}", skillName, sessionId);
             return java.util.Optional.of(config);
         }
@@ -185,6 +198,13 @@ public final class DynamicSkillGenerator {
                                 StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
                         if (learningExplanationRecorder != null) {
                             learningExplanationRecorder.recordRuntimeSkillDraftPersisted(
+                                    projectPath,
+                                    sessionId,
+                                    resolvedName,
+                                    projectPath.relativize(skillFile).toString().replace('\\', '/'));
+                        }
+                        if (learningValidationRecorder != null) {
+                            learningValidationRecorder.recordRuntimeSkillAwaitingDurableValidation(
                                     projectPath,
                                     sessionId,
                                     resolvedName,

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/LearningValidation.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/LearningValidation.java
@@ -1,0 +1,65 @@
+package dev.aceclaw.daemon;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Compact validation payload for learned behaviors and adaptive actions.
+ */
+public record LearningValidation(
+        Instant timestamp,
+        String targetType,
+        String targetId,
+        String sessionId,
+        String trigger,
+        String policy,
+        Verdict verdict,
+        String summary,
+        List<Reason> reasons,
+        List<EvidenceRef> evidence
+) {
+    public LearningValidation {
+        Objects.requireNonNull(timestamp, "timestamp");
+        Objects.requireNonNull(targetType, "targetType");
+        targetId = targetId != null ? targetId : "";
+        sessionId = sessionId != null ? sessionId : "";
+        trigger = trigger != null ? trigger : "";
+        policy = Objects.requireNonNull(policy, "policy");
+        verdict = Objects.requireNonNull(verdict, "verdict");
+        summary = summary != null ? summary : "";
+        reasons = reasons != null ? List.copyOf(reasons) : List.of();
+        evidence = evidence != null ? List.copyOf(evidence) : List.of();
+    }
+
+    public enum Verdict {
+        OBSERVED_USEFUL,
+        PROVISIONAL,
+        PASS,
+        HOLD,
+        REJECT,
+        ROLLBACK
+    }
+
+    public record Reason(
+            String code,
+            String message
+    ) {
+        public Reason {
+            code = Objects.requireNonNull(code, "code");
+            message = message != null ? message : "";
+        }
+    }
+
+    public record EvidenceRef(
+            String type,
+            String ref,
+            String detail
+    ) {
+        public EvidenceRef {
+            type = Objects.requireNonNull(type, "type");
+            ref = ref != null ? ref : "";
+            detail = detail != null ? detail : "";
+        }
+    }
+}

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/LearningValidationRecorder.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/LearningValidationRecorder.java
@@ -1,0 +1,168 @@
+package dev.aceclaw.daemon;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Best-effort recorder for learned-behavior validation decisions.
+ */
+public final class LearningValidationRecorder {
+
+    private final LearningValidationStore store;
+
+    public LearningValidationRecorder(LearningValidationStore store) {
+        this.store = Objects.requireNonNull(store, "store");
+    }
+
+    public void recordRuntimeSkillObserved(Path projectRoot,
+                                           String sessionId,
+                                           String skillName,
+                                           String sequenceSignature,
+                                           List<String> allowedTools) {
+        append(projectRoot, new LearningValidation(
+                java.time.Instant.now(),
+                "runtime-skill",
+                skillName,
+                sessionId,
+                "runtime-generation",
+                "runtime-skill-policy",
+                LearningValidation.Verdict.OBSERVED_USEFUL,
+                "Observed a useful repeated tool sequence and created a session-scoped runtime skill.",
+                List.of(
+                        new LearningValidation.Reason("REPEATED_SEQUENCE_OBSERVED",
+                                "Repeated non-bash tool sequence reached the runtime generation threshold."),
+                        new LearningValidation.Reason("SESSION_SCOPED_ONLY",
+                                "Runtime skills are session-scoped and not yet validated for durable reuse.")
+                ),
+                List.of(
+                        new LearningValidation.EvidenceRef("sequence", sequenceSignature, ""),
+                        new LearningValidation.EvidenceRef("allowed-tools", String.join(",", allowedTools), "")
+                )));
+    }
+
+    public void recordRuntimeSkillAwaitingDurableValidation(Path projectRoot,
+                                                            String sessionId,
+                                                            String skillName,
+                                                            String draftPath) {
+        append(projectRoot, new LearningValidation(
+                java.time.Instant.now(),
+                "skill-draft",
+                draftPath,
+                sessionId,
+                "session-end",
+                "runtime-skill-policy",
+                LearningValidation.Verdict.HOLD,
+                "Runtime skill persisted as draft and is awaiting durable validation.",
+                List.of(new LearningValidation.Reason(
+                        "AWAITING_DURABLE_VALIDATION",
+                        "Observed useful in-session behavior must still pass draft validation and release gates.")),
+                List.of(new LearningValidation.EvidenceRef("runtime-skill", skillName, draftPath))));
+    }
+
+    public void recordDraftValidation(Path projectRoot,
+                                      String trigger,
+                                      ValidationGateEngine.DraftDecision decision) {
+        append(projectRoot, new LearningValidation(
+                decision.evaluatedAt(),
+                "skill-draft",
+                decision.draftPath(),
+                "",
+                trigger,
+                "draft-validation-gate",
+                mapDraftVerdict(decision.verdict()),
+                "Draft validation " + decision.verdict().name().toLowerCase() + " for " + decision.draftPath(),
+                decision.reasons().stream()
+                        .map(reason -> new LearningValidation.Reason(reason.code(), reason.message()))
+                        .toList(),
+                List.of(new LearningValidation.EvidenceRef("draft-path", decision.draftPath(), trigger))));
+    }
+
+    public void recordReleaseValidation(Path projectRoot,
+                                        String trigger,
+                                        AutoReleaseController.ReleaseEvent event) {
+        append(projectRoot, new LearningValidation(
+                event.timestamp(),
+                "skill",
+                event.skillName(),
+                "",
+                trigger,
+                "auto-release-controller",
+                mapReleaseVerdict(event),
+                "Release stage moved from " + stageName(event.fromStage()) + " to "
+                        + event.toStage().name().toLowerCase() + " for " + event.skillName(),
+                List.of(new LearningValidation.Reason(event.reasonCode(), event.reason())),
+                List.of(new LearningValidation.EvidenceRef(
+                        "stage-transition",
+                        stageName(event.fromStage()) + "->" + event.toStage().name().toLowerCase(),
+                        event.trigger()))));
+    }
+
+    public void recordRefinementValidation(Path projectRoot,
+                                           String skillName,
+                                           SkillRefinementEngine.RefinementAction action,
+                                           String reason) {
+        if (action == null || action == SkillRefinementEngine.RefinementAction.NONE) {
+            return;
+        }
+        append(projectRoot, new LearningValidation(
+                java.time.Instant.now(),
+                "skill",
+                skillName,
+                "",
+                "skill-refinement",
+                "refinement-policy",
+                mapRefinementVerdict(action),
+                action.name().toLowerCase() + " for " + skillName,
+                List.of(new LearningValidation.Reason(action.name(), reason)),
+                List.of(new LearningValidation.EvidenceRef("skill", skillName, reason))));
+    }
+
+    private static LearningValidation.Verdict mapDraftVerdict(ValidationGateEngine.Verdict verdict) {
+        return switch (verdict) {
+            case PASS -> LearningValidation.Verdict.PASS;
+            case HOLD -> LearningValidation.Verdict.HOLD;
+            case BLOCK -> LearningValidation.Verdict.REJECT;
+        };
+    }
+
+    private static LearningValidation.Verdict mapReleaseVerdict(AutoReleaseController.ReleaseEvent event) {
+        if (event.toStage() == AutoReleaseController.Stage.ACTIVE) {
+            return LearningValidation.Verdict.PASS;
+        }
+        if (event.toStage() == AutoReleaseController.Stage.CANARY) {
+            return LearningValidation.Verdict.PROVISIONAL;
+        }
+        if (event.toStage() == AutoReleaseController.Stage.SHADOW
+                && event.fromStage() != null
+                && event.fromStage() != AutoReleaseController.Stage.SHADOW) {
+            return LearningValidation.Verdict.ROLLBACK;
+        }
+        return LearningValidation.Verdict.HOLD;
+    }
+
+    private static LearningValidation.Verdict mapRefinementVerdict(SkillRefinementEngine.RefinementAction action) {
+        return switch (action) {
+            case REFINED -> LearningValidation.Verdict.PROVISIONAL;
+            case STABILIZED -> LearningValidation.Verdict.PASS;
+            case DEPRECATED -> LearningValidation.Verdict.REJECT;
+            case ROLLED_BACK -> LearningValidation.Verdict.ROLLBACK;
+            case NONE -> LearningValidation.Verdict.HOLD;
+        };
+    }
+
+    private static String stageName(AutoReleaseController.Stage stage) {
+        return stage == null ? "none" : stage.name().toLowerCase();
+    }
+
+    private void append(Path projectRoot, LearningValidation validation) {
+        if (projectRoot == null || validation == null) {
+            return;
+        }
+        try {
+            store.append(projectRoot, validation);
+        } catch (Exception ignored) {
+            // Validation logging must never break the learning pipeline.
+        }
+    }
+}

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/LearningValidationStore.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/LearningValidationStore.java
@@ -1,0 +1,71 @@
+package dev.aceclaw.daemon;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Persistent JSONL store for learned-behavior validation records.
+ */
+public final class LearningValidationStore {
+
+    private static final String METRICS_DIR = ".aceclaw/metrics";
+    private static final String FILE_NAME = "learning-validations.jsonl";
+
+    private final ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    public void append(Path projectRoot, LearningValidation validation) throws java.io.IOException {
+        Objects.requireNonNull(projectRoot, "projectRoot");
+        Objects.requireNonNull(validation, "validation");
+        Path file = validationsFile(projectRoot);
+        Files.createDirectories(file.getParent());
+        try (var channel = FileChannel.open(file,
+                StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.APPEND);
+             var ignored = channel.lock()) {
+            Files.writeString(file,
+                    mapper.writeValueAsString(validation) + "\n",
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.APPEND);
+        }
+    }
+
+    public List<LearningValidation> recent(Path projectRoot, int limit) {
+        Objects.requireNonNull(projectRoot, "projectRoot");
+        int safeLimit = Math.max(1, limit);
+        Path file = validationsFile(projectRoot);
+        if (!Files.isRegularFile(file)) {
+            return List.of();
+        }
+        try {
+            var rows = new ArrayList<LearningValidation>();
+            for (var line : Files.readAllLines(file)) {
+                if (line == null || line.isBlank()) {
+                    continue;
+                }
+                try {
+                    rows.add(mapper.readValue(line, LearningValidation.class));
+                } catch (Exception ignored) {
+                    // Skip malformed rows; validation history is best-effort.
+                }
+            }
+            return rows.stream()
+                    .sorted(Comparator.comparing(LearningValidation::timestamp).reversed())
+                    .limit(safeLimit)
+                    .toList();
+        } catch (Exception ignored) {
+            return List.of();
+        }
+    }
+
+    Path validationsFile(Path projectRoot) {
+        return projectRoot.resolve(METRICS_DIR).resolve(FILE_NAME);
+    }
+}

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -838,6 +838,13 @@ public final class StreamingAgentHandler {
                             outcome.action().name(),
                             outcome.reason());
                 }
+                if (learningValidationRecorder != null) {
+                    learningValidationRecorder.recordRefinementValidation(
+                            projectPath,
+                            skillName,
+                            outcome.action(),
+                            outcome.reason());
+                }
                 log.info("Skill refinement action={} skill={} reason={}",
                         outcome.action(), skillName, outcome.reason());
             }
@@ -1285,6 +1292,7 @@ public final class StreamingAgentHandler {
     private SkillRefinementEngine skillRefinementEngine;
     private DynamicSkillGenerator dynamicSkillGenerator;
     private LearningExplanationRecorder learningExplanationRecorder;
+    private LearningValidationRecorder learningValidationRecorder;
 
     /**
      * Sets the LLM configuration for permission-aware agent loop creation.
@@ -1351,6 +1359,10 @@ public final class StreamingAgentHandler {
         this.skillMemoryFeedback = memoryStore != null
                 ? new SkillMemoryFeedback(memoryStore, learningExplanationRecorder)
                 : null;
+    }
+
+    public void setLearningValidationRecorder(LearningValidationRecorder learningValidationRecorder) {
+        this.learningValidationRecorder = learningValidationRecorder;
     }
 
     /**

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/DynamicSkillGeneratorTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/DynamicSkillGeneratorTest.java
@@ -42,6 +42,8 @@ class DynamicSkillGeneratorTest {
     void recordsRuntimeSkillExplainabilityAndDraftPersistence() throws Exception {
         var explanationStore = new LearningExplanationStore();
         generator.setLearningExplanationRecorder(new LearningExplanationRecorder(explanationStore));
+        var validationStore = new LearningValidationStore();
+        generator.setLearningValidationRecorder(new LearningValidationRecorder(validationStore));
         mockLlm.enqueueSendMessageResponse(MockLlmClient.sendMessageTextResponse("""
                 {
                   "name": "review-file-workflow",
@@ -65,6 +67,9 @@ class DynamicSkillGeneratorTest {
         var explanations = explanationStore.recent(workDir, 10);
         assertThat(explanations).anyMatch(explanation -> explanation.actionType().equals("runtime_skill_created"));
         assertThat(explanations).anyMatch(explanation -> explanation.actionType().equals("runtime_skill_persisted"));
+        var validations = validationStore.recent(workDir, 10);
+        assertThat(validations).anyMatch(validation -> validation.verdict() == LearningValidation.Verdict.OBSERVED_USEFUL);
+        assertThat(validations).anyMatch(validation -> validation.verdict() == LearningValidation.Verdict.HOLD);
     }
 
     @Test

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/LearningValidationRecorderTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/LearningValidationRecorderTest.java
@@ -1,0 +1,55 @@
+package dev.aceclaw.daemon;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LearningValidationRecorderTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void mapsDraftReleaseAndRefinementValidationStates() {
+        var store = new LearningValidationStore();
+        var recorder = new LearningValidationRecorder(store);
+
+        recorder.recordDraftValidation(tempDir, "manual", new ValidationGateEngine.DraftDecision(
+                ".aceclaw/skills-drafts/review/SKILL.md",
+                ValidationGateEngine.Verdict.HOLD,
+                List.of(new ValidationGateEngine.ReasonCode(
+                        "replay",
+                        "REPLAY_GATE_FAILED",
+                        ValidationGateEngine.Verdict.HOLD,
+                        "Replay metrics not good enough")),
+                Instant.parse("2026-03-13T10:15:30Z"),
+                "manual"));
+
+        recorder.recordReleaseValidation(tempDir, "release-eval", new AutoReleaseController.ReleaseEvent(
+                Instant.parse("2026-03-13T10:16:30Z"),
+                "release-eval",
+                "review",
+                AutoReleaseController.Stage.CANARY,
+                AutoReleaseController.Stage.SHADOW,
+                "AUTO_ROLLBACK_GUARDRAIL_BREACH",
+                "Guardrail breach"));
+
+        recorder.recordRefinementValidation(
+                tempDir,
+                "review",
+                SkillRefinementEngine.RefinementAction.STABILIZED,
+                "Observation window met baseline");
+
+        var recent = store.recent(tempDir, 10);
+
+        assertThat(recent).extracting(LearningValidation::verdict)
+                .contains(LearningValidation.Verdict.HOLD,
+                        LearningValidation.Verdict.ROLLBACK,
+                        LearningValidation.Verdict.PASS);
+    }
+}

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/LearningValidationStoreTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/LearningValidationStoreTest.java
@@ -1,0 +1,55 @@
+package dev.aceclaw.daemon;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LearningValidationStoreTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void appendAndReadRecentValidations() throws Exception {
+        var store = new LearningValidationStore();
+        store.append(tempDir, new LearningValidation(
+                Instant.parse("2026-03-13T10:15:30Z"),
+                "skill-draft",
+                ".aceclaw/skills-drafts/review/SKILL.md",
+                "session-1",
+                "manual",
+                "draft-validation-gate",
+                LearningValidation.Verdict.HOLD,
+                "Draft awaiting durable validation.",
+                List.of(new LearningValidation.Reason("AWAITING_DURABLE_VALIDATION", "Waiting for draft validation.")),
+                List.of(new LearningValidation.EvidenceRef("draft-path", "review", "SKILL.md"))));
+
+        var recent = store.recent(tempDir, 10);
+
+        assertThat(recent).hasSize(1);
+        assertThat(recent.getFirst().policy()).isEqualTo("draft-validation-gate");
+        assertThat(recent.getFirst().verdict()).isEqualTo(LearningValidation.Verdict.HOLD);
+    }
+
+    @Test
+    void recentSkipsMalformedJsonlRows() throws Exception {
+        var store = new LearningValidationStore();
+        var file = store.validationsFile(tempDir);
+        Files.createDirectories(file.getParent());
+        Files.writeString(file, """
+                {"timestamp":"2026-03-13T10:15:30Z","targetType":"skill","targetId":"ok","sessionId":"","trigger":"x","policy":"p","verdict":"PASS","summary":"ok","reasons":[],"evidence":[]}
+                not-json
+                """);
+
+        var recent = store.recent(tempDir, 10);
+
+        assertThat(recent).hasSize(1);
+        assertThat(recent.getFirst().targetId()).isEqualTo("ok");
+    }
+}


### PR DESCRIPTION
## Summary
- add a persisted learning validation model for learned behaviors
- record uniform validation semantics for runtime skills, draft validation, release transitions, and refinement outcomes
- add focused tests for validation storage and runtime/refinement validation paths

## Testing
- ./gradlew :aceclaw-daemon:test --tests dev.aceclaw.daemon.LearningValidationStoreTest --tests dev.aceclaw.daemon.LearningValidationRecorderTest --tests dev.aceclaw.daemon.DynamicSkillGeneratorTest --tests dev.aceclaw.daemon.SkillIntegrationTest --no-daemon
- ./gradlew :aceclaw-daemon:test --no-daemon

Closes #227