### PR TITLE
fix(cli): reset Status widget scroll region after Ctrl+L clear screen

### DIFF
--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
@@ -379,9 +379,17 @@ public final class TerminalRepl {
             // Render startup banner
             renderBanner(out, terminal.getWidth());
 
-            // Override Ctrl+L: clear screen + redraw status bar below prompt
+            // Override Ctrl+L: clear screen + reset status widget + redraw
             reader.getWidgets().put("aceclaw-clear-screen", () -> {
                 reader.callWidget(LineReader.CLEAR_SCREEN);
+                // Reset JLine's Status widget so it recalculates its scroll
+                // region from the cleared screen state. Without this, the
+                // widget writes to stale positions after clear.
+                synchronized (uiRenderLock) {
+                    if (promptStatus != null) {
+                        promptStatus.reset();
+                    }
+                }
                 requestUiRender();
                 return true;
             });


### PR DESCRIPTION
## Summary
- After Ctrl+L clear screen, the prompt cursor appeared at wrong position and status panel rendered garbled
- Root cause: JLine's Status widget retained stale scroll region state after `CLEAR_SCREEN`
- Fix: call `promptStatus.reset()` after clear so the widget recalculates from fresh screen state

## Test plan
- [x] All CLI tests pass
- [ ] Manual: press Ctrl+L, verify prompt and status panel render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)