### PR TITLE
fix(cli): always show context usage bar in status panel

### DIFF
--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
@@ -1509,9 +1509,9 @@ public final class TerminalRepl {
         }
 
         int ctxWindow = sessionInfo.contextWindowTokens();
-        if (ctxWindow > 0 && latestInputTokens > 0) {
+        if (ctxWindow > 0) {
             sb.append(MUTED).append(" | ").append(RESET);
-            long pct = latestInputTokens * 100 / ctxWindow;
+            long pct = ctxWindow > 0 ? latestInputTokens * 100 / ctxWindow : 0;
             sb.append(WARNING).append(formatTokenCount(latestInputTokens))
               .append("/").append(formatTokenCount(ctxWindow))
               .append(" (").append(pct).append("%)").append(RESET);


### PR DESCRIPTION
## Summary
- Context usage bar (`14/200K (0%)`) disappeared from status panel because the condition required `latestInputTokens > 0`
- Before first turn or when tokens are 0, the bar was hidden — user loses visibility into context window capacity
- Removed the `latestInputTokens > 0` guard so the bar always shows when context window size is known

One-line fix: `ctxWindow > 0 && latestInputTokens > 0` → `ctxWindow > 0`

## Test plan
- [x] All CLI tests pass
- [ ] Manual: start fresh session, verify `0/200K (0%)` shows immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced terminal REPL status display to reliably show token usage information whenever a context window is available, with more robust percentage calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->