### PR TITLE
fix(cli): context bar shows wrong usage — message_start input_tokens was dropped

### DIFF
--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/StreamingAgentLoop.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/StreamingAgentLoop.java
@@ -897,7 +897,10 @@ public final class StreamingAgentLoop {
         private boolean inThinking;
 
         StopReason stopReason;
+        /** Final merged usage: input_tokens from message_start + output_tokens from message_delta. */
         Usage usage;
+        /** Usage from message_start (carries accurate input_tokens for Anthropic). */
+        private Usage startUsage;
         LlmException error;
 
         StreamAccumulator(StreamEventHandler delegate) {
@@ -906,6 +909,9 @@ public final class StreamingAgentLoop {
 
         @Override
         public void onMessageStart(StreamEvent.MessageStart event) {
+            if (event.usage() != null) {
+                this.startUsage = event.usage();
+            }
             delegate.onMessageStart(event);
         }
 
@@ -970,8 +976,25 @@ public final class StreamingAgentLoop {
         @Override
         public void onMessageDelta(StreamEvent.MessageDelta event) {
             this.stopReason = event.stopReason();
-            this.usage = event.usage();
+            // Merge: input_tokens from message_start + output_tokens from message_delta.
+            // Anthropic sends input_tokens only in message_start, and output_tokens only in message_delta.
+            this.usage = mergeUsage(startUsage, event.usage());
             delegate.onMessageDelta(event);
+        }
+
+        /**
+         * Merges usage from {@code message_start} (which carries {@code input_tokens})
+         * with usage from {@code message_delta} (which carries {@code output_tokens}).
+         * If either is null, returns the other. Cache tokens are summed from both.
+         */
+        private static Usage mergeUsage(Usage start, Usage delta) {
+            if (start == null) return delta;
+            if (delta == null) return start;
+            return new Usage(
+                    Math.max(start.inputTokens(), delta.inputTokens()),
+                    Math.max(start.outputTokens(), delta.outputTokens()),
+                    start.cacheCreationInputTokens() + delta.cacheCreationInputTokens(),
+                    start.cacheReadInputTokens() + delta.cacheReadInputTokens());
         }
 
         @Override

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/llm/StreamEvent.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/llm/StreamEvent.java
@@ -11,8 +11,18 @@ public sealed interface StreamEvent {
 
     /**
      * The stream has started and the message metadata is available.
+     *
+     * @param id    message identifier
+     * @param model model name
+     * @param usage initial usage stats (contains {@code input_tokens} from Anthropic {@code message_start});
+     *              may be {@code null} for providers that don't report usage at stream start
      */
-    record MessageStart(String id, String model) implements StreamEvent {}
+    record MessageStart(String id, String model, Usage usage) implements StreamEvent {
+        /** Convenience constructor for providers/tests that don't supply start-of-stream usage. */
+        public MessageStart(String id, String model) {
+            this(id, model, null);
+        }
+    }
 
     /**
      * A new content block has started at the given index.

--- a/aceclaw-llm/src/main/java/dev/aceclaw/llm/anthropic/AnthropicStreamSession.java
+++ b/aceclaw-llm/src/main/java/dev/aceclaw/llm/anthropic/AnthropicStreamSession.java
@@ -169,7 +169,8 @@ final class AnthropicStreamSession implements StreamSession {
         JsonNode message = root.path("message");
         String id = message.path("id").asText("");
         String model = message.path("model").asText("");
-        handler.onMessageStart(new StreamEvent.MessageStart(id, model));
+        Usage usage = mapper.parseUsage(message.path("usage"));
+        handler.onMessageStart(new StreamEvent.MessageStart(id, model, usage));
     }
 
     private void handleContentBlockStart(String data, StreamEventHandler handler) throws Exception {


### PR DESCRIPTION
## Summary

Fixes the erratic context usage bar that jumps between values like 10% to 1%.

### Root Cause

Anthropic streaming API sends usage data in two separate SSE events:

| SSE event | Contains |
|---|---|
| `message_start` | `usage.input_tokens` = **real context occupation** |
| `message_delta` | `usage.output_tokens` = final output count, `input_tokens` = 0 |

Our code only captured usage from `message_delta` (which has `input_tokens=0`), completely ignoring the accurate `input_tokens` from `message_start`. This caused the context bar to display near-zero or erratic percentages.

### Changes (3 files, 37 lines added)

1. **`StreamEvent.MessageStart`** — Added optional `Usage` field. Backward-compatible two-arg constructor preserved for tests and providers that don't send start-of-stream usage.

2. **`AnthropicStreamSession.handleMessageStart()`** — Now parses `usage` from the `message_start` SSE event and passes it through.

3. **`StreamAccumulator`** — Captures `input_tokens` from `onMessageStart`, merges with `output_tokens` from `onMessageDelta` via new `mergeUsage()` method.

## Test plan

- `./gradlew test` — all tests pass
- Existing tests use the two-arg `MessageStart(id, model)` constructor which still works via backward-compatible overload

Fixes #249
Part of Epic #248


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token usage tracking for streaming operations. Usage metrics are now properly captured and aggregated from both message initiation and message delta events, then correctly merged to ensure accurate and comprehensive accounting of all input tokens, output tokens, and cache tokens for streaming-based operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->