### PR TITLE
fix(tools): BashExecTool hangs on interactive commands, cancel can't kill process

### DIFF
--- a/aceclaw-tools/src/main/java/dev/aceclaw/tools/BashExecTool.java
+++ b/aceclaw-tools/src/main/java/dev/aceclaw/tools/BashExecTool.java
@@ -61,7 +61,6 @@ public final class BashExecTool implements Tool, CancellationAware {
 
     private final Path workingDir;
     private volatile CancellationToken cancellationToken;
-    private volatile Process activeProcess;
 
     public BashExecTool(Path workingDir) {
         this.workingDir = workingDir;
@@ -134,7 +133,6 @@ public final class BashExecTool implements Tool, CancellationAware {
                 .redirectInput(ProcessBuilder.Redirect.from(DEV_NULL));
 
         var process = processBuilder.start();
-        activeProcess = process;
 
         // Read stdout in a virtual thread so it doesn't block the timeout
         var outputHolder = new AtomicReference<>("");
@@ -217,7 +215,6 @@ public final class BashExecTool implements Tool, CancellationAware {
             destroyProcessTree(process);
             return new ToolResult("Command interrupted", true);
         } finally {
-            activeProcess = null;
             if (cancelWatcher != null) {
                 cancelWatcher.interrupt();
             }

--- a/aceclaw-tools/src/test/java/dev/aceclaw/tools/BashExecToolTest.java
+++ b/aceclaw-tools/src/test/java/dev/aceclaw/tools/BashExecToolTest.java
@@ -238,13 +238,12 @@ class BashExecToolTest {
         assertThat(elapsed).isLessThan(10_000);
 
         // Verify the child process is actually dead
-        if (Files.exists(pidFile)) {
-            long pid = Long.parseLong(Files.readString(pidFile).strip());
-            Thread.sleep(500); // brief grace period for OS cleanup
-            assertThat(ProcessHandle.of(pid).map(ProcessHandle::isAlive).orElse(false))
-                    .as("child process (PID %d) should be dead after timeout", pid)
-                    .isFalse();
-        }
+        assertThat(Files.exists(pidFile)).as("PID file should have been written").isTrue();
+        long pid = Long.parseLong(Files.readString(pidFile).strip());
+        Thread.sleep(500); // brief grace period for OS cleanup
+        assertThat(ProcessHandle.of(pid).map(ProcessHandle::isAlive).orElse(false))
+                .as("child process (PID %d) should be dead after timeout", pid)
+                .isFalse();
     }
 
     @Test
@@ -279,12 +278,11 @@ class BashExecToolTest {
         assertThat(resultHolder[0].output()).contains("cancelled");
 
         // Verify the child process is actually dead
-        if (Files.exists(pidFile)) {
-            long pid = Long.parseLong(Files.readString(pidFile).strip());
-            Thread.sleep(500); // brief grace period for OS cleanup
-            assertThat(ProcessHandle.of(pid).map(ProcessHandle::isAlive).orElse(false))
-                    .as("child process (PID %d) should be dead after cancellation", pid)
-                    .isFalse();
-        }
+        assertThat(Files.exists(pidFile)).as("PID file should have been written").isTrue();
+        long pid = Long.parseLong(Files.readString(pidFile).strip());
+        Thread.sleep(500); // brief grace period for OS cleanup
+        assertThat(ProcessHandle.of(pid).map(ProcessHandle::isAlive).orElse(false))
+                .as("child process (PID %d) should be dead after cancellation", pid)
+                .isFalse();
     }
 }


### PR DESCRIPTION
## Summary

Fixes #260 — three interrelated bugs in `BashExecTool.runCommand()`:

- **Stdin redirected to `/dev/null`**: Interactive commands (`git add -p`, `vim`, `read line`) now get EOF immediately instead of hanging forever
- **Read/wait reordering**: `readAllBytes()` moved to a virtual thread so `waitFor(timeout)` actually fires — previously the blocking read prevented the timeout from ever triggering
- **`CancellationAware` implemented**: A cancel-watcher virtual thread polls the token every 200ms and calls `destroyForcibly()` — `/cancel` now kills stuck processes

## Test plan

- [x] `./gradlew clean build` — all 13 modules compile, all tests pass
- [x] New test: `stdinRedirectedSoReadingStdinReturnsEof` — `head -1` returns immediately with EOF
- [x] New test: `timeoutActuallyFiresForLongRunningCommand` — `sleep 300` with 1s timeout finishes in <10s
- [x] New test: `cancellationKillsRunningProcess` — `sleep 300` cancelled after 500ms, process killed
- [ ] Manual: run AceClaw, execute `read line` — should return immediately
- [ ] Manual: execute `sleep 300`, then `/cancel` — process killed within 200ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cooperative cancellation for bash command execution with safer process-tree shutdown, non-blocking stdout capture, and stdin redirected to avoid blocking.
  * Improved timeout behavior: forcible termination, cleanup, and clearer timeout hints; internal output truncation to keep results concise.

* **Bug Fixes**
  * More accurate exit-code handling: common benign exits treated as non-errors with contextual hints.

* **Tests**
  * Added tests covering stdin EOF, timeout termination, and cancellation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->