### PR TITLE
Measure context effectiveness and injection cost

### DIFF
--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/ContextMonitor.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/ContextMonitor.java
@@ -52,6 +52,10 @@ public final class ContextMonitor {
     private long lastCompactionOriginalTokens;
     /** Most recent compaction post-compaction token estimate. */
     private long lastCompactionCompactedTokens;
+    /** Tokens reclaimed by the most recent compaction event. */
+    private long lastCompactionTokensSaved;
+    /** Cumulative tokens reclaimed across all compaction events. */
+    private long totalCompactionTokensSaved;
     /** Most recent compaction phase. */
     private String lastCompactionPhase;
     /** When the most recent compaction occurred. */
@@ -155,6 +159,8 @@ public final class ContextMonitor {
         }
         this.lastCompactionOriginalTokens = normalizedOriginal;
         this.lastCompactionCompactedTokens = normalizedCompacted;
+        this.lastCompactionTokensSaved = Math.max(0L, normalizedOriginal - normalizedCompacted);
+        this.totalCompactionTokensSaved += lastCompactionTokensSaved;
         this.lastCompactionPhase = normalizedPhase;
         this.lastCompactionAt = Instant.now();
         this.lastRealInputTokens = normalizedCompacted;
@@ -222,6 +228,18 @@ public final class ContextMonitor {
 
     public synchronized long lastCompactionCompactedTokens() {
         return lastCompactionCompactedTokens;
+    }
+
+    public synchronized long lastCompactionTokensSaved() {
+        return lastCompactionTokensSaved;
+    }
+
+    public synchronized long totalCompactionTokensSaved() {
+        return totalCompactionTokensSaved;
+    }
+
+    public synchronized long averageCompactionTokensSaved() {
+        return compactionCount == 0 ? 0L : totalCompactionTokensSaved / compactionCount;
     }
 
     public synchronized String lastCompactionPhase() {

--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
@@ -2658,6 +2658,10 @@ public final class TerminalRepl {
     }
 
     private void renderContextList(PrintWriter out, JsonNode root) {
+        ContextCostSummary summary = summarizeContextSections(
+                root.path("sections"),
+                root.path("estimatedTokens").asLong(0));
+
         out.println(BOLD + "Context Overview" + RESET);
         out.printf("  %sSystem prompt:%s %s chars (~%s tokens)%n",
                 MUTED, RESET,
@@ -2689,6 +2693,11 @@ public final class TerminalRepl {
                     contextMonitor.lastCompactionPhase(),
                     formatTokenCount(contextMonitor.lastCompactionOriginalTokens()),
                     formatTokenCount(contextMonitor.lastCompactionCompactedTokens()));
+            out.printf("  %sSaved:%s         total=%s | avg=%s | last=%s%n",
+                    MUTED, RESET,
+                    formatTokenCount(contextMonitor.totalCompactionTokensSaved()),
+                    formatTokenCount(contextMonitor.averageCompactionTokensSaved()),
+                    formatTokenCount(contextMonitor.lastCompactionTokensSaved()));
         }
 
         JsonNode activePaths = root.path("activeFilePaths");
@@ -2702,6 +2711,28 @@ public final class TerminalRepl {
             out.printf("  %sTruncated:%s    %s%n",
                     MUTED, RESET, joinArrayValues(truncated, 6));
         }
+
+        out.println();
+        out.println(BOLD + "Injection Cost" + RESET);
+        renderContextBucket(out, "Rules", summary.rules());
+        renderContextBucket(out, "Candidates", summary.candidates());
+        renderContextBucket(out, "Skills", summary.skills());
+        renderContextBucket(out, "Learned", summary.learnedSignals());
+        renderContextBucket(out, "Memory", summary.memoryOther());
+        renderContextBucket(out, "Core", summary.coreRuntime());
+
+        out.println();
+        out.println(BOLD + "Effectiveness" + RESET);
+        out.printf("  %sMemory reuse:%s  ~%s tokens across %d sections | retained=%.1f%%%n",
+                MUTED, RESET,
+                formatTokenCount(summary.memoryReuseTokens()),
+                summary.memoryReuseSections(),
+                summary.memoryRetentionPct());
+        out.printf("  %sLearned fit:%s   ~%s tokens | retained=%.1f%% | truncated=%d%n",
+                MUTED, RESET,
+                formatTokenCount(summary.learnedSignals().tokens()),
+                summary.learnedRetentionPct(),
+                summary.learnedSignals().truncatedSections());
 
         out.println();
         out.println(BOLD + "Sections" + RESET);
@@ -2722,7 +2753,10 @@ public final class TerminalRepl {
                     formatTokenCount(original),
                     formatTokenCount(finalChars),
                     section.path("priority").asInt(0),
-                    flags.isEmpty() ? "" : MUTED + " [" + flags + "]" + RESET);
+                    (flags.isEmpty() ? "" : MUTED + " [" + flags + "]" + RESET)
+                            + MUTED + " {" + sanitizeContextField(section.path("sourceType").asText("other"))
+                            + ", ~" + formatTokenCount(section.path("estimatedTokens").asLong(0))
+                            + " tok}" + RESET);
         }
         out.println();
         out.println(MUTED + "Use /context detail <key> for full section content." + RESET);
@@ -2743,6 +2777,9 @@ public final class TerminalRepl {
         out.printf("  %sSize:%s         %s -> %s%n", MUTED, RESET,
                 formatTokenCount(detail.path("originalChars").asLong(0)),
                 formatTokenCount(detail.path("finalChars").asLong(0)));
+        out.printf("  %sSource:%s       %s (~%s tokens)%n", MUTED, RESET,
+                sanitizeContextField(detail.path("sourceType").asText("other")),
+                formatTokenCount(detail.path("estimatedTokens").asLong(0)));
         out.printf("  %sProtected:%s    %s%n", MUTED, RESET, detail.path("protected").asBoolean(false));
         out.printf("  %sTruncated:%s    %s%n", MUTED, RESET, detail.path("truncated").asBoolean(false));
         out.println();
@@ -2758,6 +2795,116 @@ public final class TerminalRepl {
             rendered.add("+" + (values.size() - limit) + " more");
         }
         return String.join(", ", rendered);
+    }
+
+    private void renderContextBucket(PrintWriter out, String label, ContextBucketCost bucket) {
+        out.printf("  %s%-12s%s ~%s tokens | %.1f%% | retained=%.1f%%%n",
+                MUTED, fitWidth(label, 12), RESET,
+                formatTokenCount(bucket.tokens()),
+                bucket.sharePct(),
+                bucket.retainedPct());
+    }
+
+    private static ContextCostSummary summarizeContextSections(JsonNode sections, long totalEstimatedTokens) {
+        ContextBucketAccumulator rules = new ContextBucketAccumulator();
+        ContextBucketAccumulator candidates = new ContextBucketAccumulator();
+        ContextBucketAccumulator skills = new ContextBucketAccumulator();
+        ContextBucketAccumulator learnedSignals = new ContextBucketAccumulator();
+        ContextBucketAccumulator memoryOther = new ContextBucketAccumulator();
+        ContextBucketAccumulator coreRuntime = new ContextBucketAccumulator();
+
+        for (JsonNode section : sections) {
+            String sourceType = section.path("sourceType").asText("other");
+            ContextBucketAccumulator bucket = switch (sourceType) {
+                case "rules" -> rules;
+                case "candidates" -> candidates;
+                case "skills" -> skills;
+                case "learned-signals" -> learnedSignals;
+                case "memory" -> memoryOther;
+                default -> coreRuntime;
+            };
+            bucket.add(section);
+        }
+
+        return new ContextCostSummary(
+                rules.build(totalEstimatedTokens),
+                candidates.build(totalEstimatedTokens),
+                skills.build(totalEstimatedTokens),
+                learnedSignals.build(totalEstimatedTokens),
+                memoryOther.build(totalEstimatedTokens),
+                coreRuntime.build(totalEstimatedTokens));
+    }
+
+    private static final class ContextBucketAccumulator {
+        private long originalChars;
+        private long finalChars;
+        private long tokens;
+        private int sections;
+        private int includedSections;
+        private int truncatedSections;
+
+        private void add(JsonNode section) {
+            originalChars += Math.max(0L, section.path("originalChars").asLong(0));
+            finalChars += Math.max(0L, section.path("finalChars").asLong(0));
+            tokens += Math.max(0L, section.path("estimatedTokens").asLong(0));
+            sections++;
+            if (section.path("included").asBoolean(false) && section.path("finalChars").asLong(0) > 0) {
+                includedSections++;
+            }
+            if (section.path("truncated").asBoolean(false)) {
+                truncatedSections++;
+            }
+        }
+
+        private ContextBucketCost build(long totalEstimatedTokens) {
+            double sharePct = totalEstimatedTokens <= 0
+                    ? 0.0
+                    : (double) tokens / totalEstimatedTokens * 100.0;
+            double retainedPct = originalChars <= 0
+                    ? 0.0
+                    : (double) finalChars / originalChars * 100.0;
+            return new ContextBucketCost(tokens, sharePct, retainedPct, sections, includedSections, truncatedSections);
+        }
+    }
+
+    private record ContextBucketCost(
+            long tokens,
+            double sharePct,
+            double retainedPct,
+            int sections,
+            int includedSections,
+            int truncatedSections
+    ) {}
+
+    private record ContextCostSummary(
+            ContextBucketCost rules,
+            ContextBucketCost candidates,
+            ContextBucketCost skills,
+            ContextBucketCost learnedSignals,
+            ContextBucketCost memoryOther,
+            ContextBucketCost coreRuntime
+    ) {
+        private long memoryReuseTokens() {
+            return learnedSignals.tokens() + memoryOther.tokens();
+        }
+
+        private int memoryReuseSections() {
+            return learnedSignals.includedSections() + memoryOther.includedSections();
+        }
+
+        private double memoryRetentionPct() {
+            long totalTokens = learnedSignals.tokens() + memoryOther.tokens();
+            if (totalTokens == 0) {
+                return 0.0;
+            }
+            double weighted = learnedSignals.retainedPct() * learnedSignals.tokens()
+                    + memoryOther.retainedPct() * memoryOther.tokens();
+            return weighted / totalTokens;
+        }
+
+        private double learnedRetentionPct() {
+            return learnedSignals.retainedPct();
+        }
     }
 
     private void handleContinueCommand(PrintWriter out, LineReader reader, String arg) {

--- a/aceclaw-cli/src/test/java/dev/aceclaw/cli/ContextMonitorTest.java
+++ b/aceclaw-cli/src/test/java/dev/aceclaw/cli/ContextMonitorTest.java
@@ -47,6 +47,9 @@ class ContextMonitorTest {
         assertThat(monitor.compactionCount()).isEqualTo(1);
         assertThat(monitor.lastCompactionOriginalTokens()).isEqualTo(150_000);
         assertThat(monitor.lastCompactionCompactedTokens()).isEqualTo(62_000);
+        assertThat(monitor.lastCompactionTokensSaved()).isEqualTo(88_000);
+        assertThat(monitor.totalCompactionTokensSaved()).isEqualTo(88_000);
+        assertThat(monitor.averageCompactionTokensSaved()).isEqualTo(88_000);
         assertThat(monitor.lastCompactionPhase()).isEqualTo("SUMMARIZED");
         assertThat(monitor.pressureLevel()).isEqualTo(ContextMonitor.PressureLevel.NORMAL);
     }
@@ -86,5 +89,7 @@ class ContextMonitorTest {
         assertThat(monitor.lastCompactionPhase()).isEqualTo("PRUNED");
         assertThat(monitor.summarizedCount()).isEqualTo(1);
         assertThat(monitor.prunedCount()).isEqualTo(1);
+        assertThat(monitor.totalCompactionTokensSaved()).isEqualTo(70_000);
+        assertThat(monitor.averageCompactionTokensSaved()).isEqualTo(35_000);
     }
 }

--- a/aceclaw-cli/src/test/java/dev/aceclaw/cli/TerminalReplTest.java
+++ b/aceclaw-cli/src/test/java/dev/aceclaw/cli/TerminalReplTest.java
@@ -211,18 +211,32 @@ class TerminalReplTest {
         var sections = mapper.createArrayNode();
         sections.add(mapper.createObjectNode()
                 .put("key", "\u001B[31mbase\u001B[0m")
+                .put("sourceType", "base")
                 .put("priority", 95)
                 .put("protected", true)
                 .put("originalChars", 12000)
                 .put("finalChars", 12000)
+                .put("estimatedTokens", 3000)
                 .put("included", true)
                 .put("truncated", false));
         sections.add(mapper.createObjectNode()
                 .put("key", "skills")
+                .put("sourceType", "skills")
                 .put("priority", 58)
                 .put("protected", false)
                 .put("originalChars", 10000)
                 .put("finalChars", 4000)
+                .put("estimatedTokens", 1000)
+                .put("included", true)
+                .put("truncated", true));
+        sections.add(mapper.createObjectNode()
+                .put("key", "memory:Auto-Memory")
+                .put("sourceType", "learned-signals")
+                .put("priority", 60)
+                .put("protected", false)
+                .put("originalChars", 2000)
+                .put("finalChars", 1500)
+                .put("estimatedTokens", 375)
                 .put("included", true)
                 .put("truncated", true));
         root.set("sections", sections);
@@ -245,9 +259,15 @@ class TerminalReplTest {
         assertThat(plain).contains("Active paths:");
         assertThat(plain).contains("Truncated:");
         assertThat(plain).contains("Last compact:");
+        assertThat(plain).contains("Saved:");
+        assertThat(plain).contains("Injection Cost");
+        assertThat(plain).contains("Effectiveness");
+        assertThat(plain).contains("Memory reuse:");
+        assertThat(plain).contains("Learned fit:");
         assertThat(plain).contains("src/main/App.java");
         assertThat(plain).contains("base");
         assertThat(plain).contains("skills");
+        assertThat(plain).contains("learned-signals");
         assertThat(plain).contains("truncated");
         assertThat(plain).contains("protected");
         assertThat(plain).contains("Use /context detail <key>");
@@ -260,10 +280,12 @@ class TerminalReplTest {
         var root = mapper.createObjectNode();
         var detail = mapper.createObjectNode();
         detail.put("key", "rules\u001B]2;pwnd\u0007");
+        detail.put("sourceType", "rules");
         detail.put("priority", 88);
         detail.put("protected", false);
         detail.put("originalChars", 1200);
         detail.put("finalChars", 900);
+        detail.put("estimatedTokens", 225);
         detail.put("truncated", true);
         detail.put("content", ("Prefer AssertJ assertions.\u001B]2;pwnd\u0007\n" + "line\n").repeat(2_000));
         root.set("detail", detail);
@@ -278,6 +300,7 @@ class TerminalReplTest {
         assertThat(output).doesNotContain("\u0007");
         assertThat(plain).contains("Context Detail");
         assertThat(plain).contains("rules");
+        assertThat(plain).contains("Source:");
         assertThat(plain).contains("Prefer AssertJ assertions.");
         assertThat(plain).contains("true");
         assertThat(plain).contains("...[truncated]");

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/ContextRpcHelper.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/ContextRpcHelper.java
@@ -68,10 +68,12 @@ public final class ContextRpcHelper {
             for (var section : inspection.sections()) {
                 var node = mapper.createObjectNode();
                 node.put("key", section.key());
+                node.put("sourceType", section.sourceType());
                 node.put("priority", section.priority());
                 node.put("protected", section.protectedSection());
                 node.put("originalChars", section.originalChars());
                 node.put("finalChars", section.finalChars());
+                node.put("estimatedTokens", section.estimatedTokens());
                 node.put("included", section.included());
                 node.put("truncated", section.truncated());
                 sections.add(node);
@@ -88,6 +90,8 @@ public final class ContextRpcHelper {
                 detail.put("protected", selected.protectedSection());
                 detail.put("originalChars", selected.originalChars());
                 detail.put("finalChars", selected.finalChars());
+                detail.put("sourceType", selected.sourceType());
+                detail.put("estimatedTokens", selected.estimatedTokens());
                 detail.put("included", selected.included());
                 detail.put("truncated", selected.truncated());
                 detail.put("content", selected.content());

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/SystemPromptLoader.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/SystemPromptLoader.java
@@ -299,10 +299,12 @@ public final class SystemPromptLoader {
         var sections = result.sections().stream()
                 .map(section -> new ContextSection(
                         section.key(),
+                        classifySectionSource(section.key()),
                         section.priority(),
                         section.protectedSection(),
                         section.originalChars(),
                         section.finalChars(),
+                        ContextEstimator.estimateTokens(section.content()),
                         section.included(),
                         section.truncated(),
                         section.content()))
@@ -443,18 +445,40 @@ public final class SystemPromptLoader {
 
     public record ContextSection(
             String key,
+            String sourceType,
             int priority,
             boolean protectedSection,
             int originalChars,
             int finalChars,
+            int estimatedTokens,
             boolean included,
             boolean truncated,
             String content
     ) {
         public ContextSection {
             key = key != null ? key : "unknown";
+            sourceType = sourceType != null ? sourceType : "unknown";
             content = content != null ? content : "";
         }
+    }
+
+    private static String classifySectionSource(String key) {
+        if (key == null || key.isBlank()) {
+            return "unknown";
+        }
+        if (key.startsWith("memory:")) {
+            return "memory:Auto-Memory".equals(key) ? "learned-signals" : "memory";
+        }
+        return switch (key) {
+            case "base" -> "base";
+            case "rules" -> "rules";
+            case "tool-guidance" -> "tool-guidance";
+            case "environment" -> "environment";
+            case "git" -> "git";
+            case "skills" -> "skills";
+            case "candidates" -> "candidates";
+            default -> "other";
+        };
     }
 
     /**

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/SystemPromptLoaderTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/SystemPromptLoaderTest.java
@@ -316,17 +316,21 @@ class SystemPromptLoaderTest {
                 .filteredOn(section -> section.key().equals("rules"))
                 .singleElement()
                 .satisfies(section -> {
+                    assertThat(section.sourceType()).isEqualTo("rules");
                     assertThat(section.included()).isTrue();
                     assertThat(section.content()).contains("Prefer AssertJ assertions");
                     assertThat(section.finalChars()).isLessThanOrEqualTo(section.originalChars());
+                    assertThat(section.estimatedTokens()).isPositive();
                 });
         assertThat(inspection.sections())
                 .filteredOn(section -> section.key().equals("skills"))
                 .singleElement()
                 .satisfies(section -> {
+                    assertThat(section.sourceType()).isEqualTo("skills");
                     assertThat(section.originalChars()).isGreaterThan(8_000);
                     assertThat(section.truncated()).isTrue();
                     assertThat(section.finalChars()).isLessThan(section.originalChars());
+                    assertThat(section.estimatedTokens()).isPositive();
                 });
         assertThat(inspection.truncatedSectionKeys()).contains("skills");
     }


### PR DESCRIPTION
## Summary
- add per-section source and token-cost metadata to context inspection
- extend /context list with injection-cost and effectiveness summaries
- track total/average compaction token savings in the CLI monitor

## Testing
- ./gradlew :aceclaw-cli:test --tests dev.aceclaw.cli.ContextMonitorTest --tests dev.aceclaw.cli.TerminalReplTest :aceclaw-daemon:test --tests dev.aceclaw.daemon.SystemPromptLoaderTest
- ./gradlew :aceclaw-cli:test :aceclaw-daemon:test

Closes #266

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Token savings metrics for compaction operations, including per-operation and cumulative averages
  * Enhanced context inspection with detailed cost analysis broken down by source type (Rules, Candidates, Skills, Learned, Memory, Core)
  * Added effectiveness reporting including memory reuse metrics, learned fit analysis, and context retention insights

<!-- end of auto-generated comment: release notes by coderabbit.ai -->