### PR TITLE
feat: harden auto-release guardrails

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
@@ -93,12 +93,13 @@ public final class AceClawConfig {
     private static final boolean DEFAULT_SKILL_AUTO_RELEASE_ENABLED = true;
     private static final double DEFAULT_SKILL_AUTO_RELEASE_MIN_CANDIDATE_SCORE = 0.80;
     private static final int DEFAULT_SKILL_AUTO_RELEASE_MIN_EVIDENCE = 3;
-    private static final int DEFAULT_SKILL_AUTO_RELEASE_CANARY_MIN_ATTEMPTS = 5;
-    private static final double DEFAULT_SKILL_AUTO_RELEASE_CANARY_MAX_FAILURE_RATE = 0.35;
+    private static final int DEFAULT_SKILL_AUTO_RELEASE_CANARY_MIN_ATTEMPTS = 20;
+    private static final double DEFAULT_SKILL_AUTO_RELEASE_CANARY_MAX_FAILURE_RATE = 0.10;
     private static final double DEFAULT_SKILL_AUTO_RELEASE_CANARY_MAX_TIMEOUT_RATE = 0.20;
     private static final double DEFAULT_SKILL_AUTO_RELEASE_CANARY_MAX_PERMISSION_BLOCK_RATE = 0.20;
-    private static final double DEFAULT_SKILL_AUTO_RELEASE_ACTIVE_MAX_FAILURE_RATE = 0.45; // legacy alias
-    private static final double DEFAULT_SKILL_AUTO_RELEASE_ROLLBACK_MAX_FAILURE_RATE = 0.45;
+    private static final int DEFAULT_SKILL_AUTO_RELEASE_CANARY_DWELL_HOURS = 24;
+    private static final double DEFAULT_SKILL_AUTO_RELEASE_ACTIVE_MAX_FAILURE_RATE = 0.20; // legacy alias
+    private static final double DEFAULT_SKILL_AUTO_RELEASE_ROLLBACK_MAX_FAILURE_RATE = 0.20;
     private static final double DEFAULT_SKILL_AUTO_RELEASE_ROLLBACK_MAX_TIMEOUT_RATE = 0.20;
     private static final double DEFAULT_SKILL_AUTO_RELEASE_ROLLBACK_MAX_PERMISSION_BLOCK_RATE = 0.20;
     private static final int DEFAULT_SKILL_AUTO_RELEASE_HEALTH_LOOKBACK_HOURS = 168;
@@ -173,6 +174,7 @@ public final class AceClawConfig {
     private double skillAutoReleaseRollbackMaxTimeoutRate;
     private double skillAutoReleaseRollbackMaxPermissionBlockRate;
     private int skillAutoReleaseHealthLookbackHours;
+    private int skillAutoReleaseCanaryDwellHours;
     private int maxAgentTurns;
     private int maxAgentWallTimeSec;
     private int maxAgentHardTurns;
@@ -236,6 +238,7 @@ public final class AceClawConfig {
         this.skillAutoReleaseRollbackMaxPermissionBlockRate =
                 DEFAULT_SKILL_AUTO_RELEASE_ROLLBACK_MAX_PERMISSION_BLOCK_RATE;
         this.skillAutoReleaseHealthLookbackHours = DEFAULT_SKILL_AUTO_RELEASE_HEALTH_LOOKBACK_HOURS;
+        this.skillAutoReleaseCanaryDwellHours = DEFAULT_SKILL_AUTO_RELEASE_CANARY_DWELL_HOURS;
         this.maxAgentTurns = DEFAULT_MAX_AGENT_TURNS;
         this.maxAgentWallTimeSec = DEFAULT_MAX_AGENT_WALL_TIME_SEC;
         this.maxAgentHardTurns = DEFAULT_MAX_AGENT_HARD_TURNS;
@@ -1020,6 +1023,14 @@ public final class AceClawConfig {
     }
 
     /**
+     * Returns the minimum dwell time in hours at CANARY stage before promotion to ACTIVE.
+     * Defaults to 24.
+     */
+    public int skillAutoReleaseCanaryDwellHours() {
+        return skillAutoReleaseCanaryDwellHours;
+    }
+
+    /**
      * Returns whether the deferred action scheduler is enabled.
      * Defaults to true.
      */
@@ -1485,6 +1496,10 @@ public final class AceClawConfig {
                 && fileConfig.skillAutoReleaseHealthLookbackHours > 0) {
             this.skillAutoReleaseHealthLookbackHours = fileConfig.skillAutoReleaseHealthLookbackHours;
         }
+        if (fileConfig.skillAutoReleaseCanaryDwellHours != null
+                && fileConfig.skillAutoReleaseCanaryDwellHours >= 0) {
+            this.skillAutoReleaseCanaryDwellHours = fileConfig.skillAutoReleaseCanaryDwellHours;
+        }
         if (fileConfig.maxAgentTurns != null && fileConfig.maxAgentTurns >= 0) {
             this.maxAgentTurns = fileConfig.maxAgentTurns;
         }
@@ -1587,6 +1602,7 @@ public final class AceClawConfig {
         public Double skillAutoReleaseRollbackMaxTimeoutRate;
         public Double skillAutoReleaseRollbackMaxPermissionBlockRate;
         public Integer skillAutoReleaseHealthLookbackHours;
+        public Integer skillAutoReleaseCanaryDwellHours;
         public Integer maxAgentTurns;
         public Integer maxAgentWallTimeSec;
         public Integer maxAgentHardTurns;

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -533,7 +533,8 @@ public final class AceClawDaemon {
                                 config.skillAutoReleaseRollbackMaxFailureRate(),
                                 config.skillAutoReleaseRollbackMaxTimeoutRate(),
                                 config.skillAutoReleaseRollbackMaxPermissionBlockRate(),
-                                Duration.ofHours(Math.max(1, config.skillAutoReleaseHealthLookbackHours()))
+                                Duration.ofHours(Math.max(1, config.skillAutoReleaseHealthLookbackHours())),
+                                config.skillAutoReleaseCanaryDwellHours()
                         ),
                         validationGateForAuto
                 );

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AutoReleaseController.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AutoReleaseController.java
@@ -128,7 +128,7 @@ public final class AutoReleaseController {
                 continue;
             }
 
-            if (release.stage() == Stage.CANARY && !promotedToCanaryThisRun && canPromoteToActive(metrics)) {
+            if (release.stage() == Stage.CANARY && !promotedToCanaryThisRun && canPromoteToActive(metrics, release)) {
                 var active = transition(projectRoot, release, Stage.ACTIVE,
                         "AUTO_PROMOTE_ACTIVE", "canary guardrails pass", normalizedTrigger);
                 releasesByName.put(skillName, active.release());
@@ -298,11 +298,26 @@ public final class AutoReleaseController {
                 && candidate.evidenceCount() >= config.minEvidenceCount();
     }
 
-    private boolean canPromoteToActive(HealthMetrics metrics) {
-        return metrics.attempts() >= config.canaryMinAttempts()
+    private boolean canPromoteToActive(HealthMetrics metrics, SkillRelease release) {
+        // Minimum dwell time at CANARY stage before promotion
+        if (config.canaryDwellHours() > 0) {
+            Duration dwellTime = Duration.between(release.updatedAt(), Instant.now(clock));
+            if (dwellTime.toHours() < config.canaryDwellHours()) {
+                log.debug("Skill {} dwell time {}h < required {}h, deferring promotion",
+                        release.skillName(), dwellTime.toHours(), config.canaryDwellHours());
+                return false;
+            }
+        }
+        boolean passes = metrics.attempts() >= config.canaryMinAttempts()
                 && metrics.failureRate() <= config.canaryMaxFailureRate()
                 && metrics.timeoutRate() <= config.canaryMaxTimeoutRate()
                 && metrics.permissionRate() <= config.canaryMaxPermissionRate();
+
+        // Approach warning: log when metrics reach 80% of guardrail threshold
+        if (!passes) {
+            logApproachWarning(release.skillName(), metrics);
+        }
+        return passes;
     }
 
     private boolean shouldRollback(HealthMetrics metrics) {
@@ -311,6 +326,19 @@ public final class AutoReleaseController {
                         || metrics.timeoutRate() > config.rollbackMaxTimeoutRate()
                         || metrics.permissionRate() > config.rollbackMaxPermissionRate()
         );
+    }
+
+    private void logApproachWarning(String skillName, HealthMetrics metrics) {
+        if (config.canaryMaxFailureRate() > 0
+                && metrics.failureRate() >= config.canaryMaxFailureRate() * 0.8) {
+            log.warn("Skill {} failure rate {} approaching canary threshold {}",
+                    skillName, metrics.failureRate(), config.canaryMaxFailureRate());
+        }
+        if (config.canaryMaxTimeoutRate() > 0
+                && metrics.timeoutRate() >= config.canaryMaxTimeoutRate() * 0.8) {
+            log.warn("Skill {} timeout rate {} approaching canary threshold {}",
+                    skillName, metrics.timeoutRate(), config.canaryMaxTimeoutRate());
+        }
     }
 
     private String guardrailMessage(HealthMetrics metrics) {
@@ -455,14 +483,28 @@ public final class AutoReleaseController {
             double rollbackMaxFailureRate,
             double rollbackMaxTimeoutRate,
             double rollbackMaxPermissionRate,
-            Duration healthLookback
+            Duration healthLookback,
+            int canaryDwellHours
     ) {
         public Config {
             healthLookback = healthLookback != null ? healthLookback : Duration.ofDays(7);
+            if (canaryDwellHours < 0) canaryDwellHours = 0;
+        }
+
+        /** Backward-compatible constructor without canaryDwellHours. */
+        public Config(double minCandidateScore, int minEvidenceCount,
+                      int canaryMinAttempts, double canaryMaxFailureRate,
+                      double canaryMaxTimeoutRate, double canaryMaxPermissionRate,
+                      double rollbackMaxFailureRate, double rollbackMaxTimeoutRate,
+                      double rollbackMaxPermissionRate, Duration healthLookback) {
+            this(minCandidateScore, minEvidenceCount, canaryMinAttempts,
+                    canaryMaxFailureRate, canaryMaxTimeoutRate, canaryMaxPermissionRate,
+                    rollbackMaxFailureRate, rollbackMaxTimeoutRate, rollbackMaxPermissionRate,
+                    healthLookback, 24);
         }
 
         public static Config defaults() {
-            return new Config(0.80, 3, 5, 0.35, 0.20, 0.20, 0.45, 0.20, 0.20, Duration.ofDays(7));
+            return new Config(0.80, 3, 20, 0.10, 0.20, 0.20, 0.20, 0.20, 0.20, Duration.ofDays(7), 24);
         }
     }
 

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/AutoReleaseControllerTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/AutoReleaseControllerTest.java
@@ -37,7 +37,7 @@ class AutoReleaseControllerTest {
                 Path.of(".aceclaw/metrics/continuous-learning/replay-latest.json"), 0.65);
         var controller = new AutoReleaseController(
                 Clock.fixed(t0.plusSeconds(10), ZoneOffset.UTC),
-                new AutoReleaseController.Config(0.2, 1, 1, 0.5, 0.5, 0.5, 0.6, 0.6, 0.6, Duration.ofDays(7)),
+                new AutoReleaseController.Config(0.2, 1, 1, 0.5, 0.5, 0.5, 0.6, 0.6, 0.6, Duration.ofDays(7), 0),
                 validation);
 
         var first = controller.evaluateAll(tempDir, store, "test-1");
@@ -62,7 +62,7 @@ class AutoReleaseControllerTest {
                 Path.of(".aceclaw/metrics/continuous-learning/replay-latest.json"), 0.65);
         var controller = new AutoReleaseController(
                 Clock.fixed(t0.plusSeconds(10), ZoneOffset.UTC),
-                new AutoReleaseController.Config(0.2, 1, 1, 0.8, 0.8, 0.8, 0.2, 0.8, 0.8, Duration.ofDays(7)),
+                new AutoReleaseController.Config(0.2, 1, 1, 0.8, 0.8, 0.8, 0.2, 0.8, 0.8, Duration.ofDays(7), 0),
                 validation);
 
         controller.evaluateAll(tempDir, store, "bootstrap");
@@ -79,6 +79,52 @@ class AutoReleaseControllerTest {
                 .contains("AUTO_ROLLBACK_GUARDRAIL_BREACH");
         assertThat(rollback.releases()).anySatisfy(r ->
                 assertThat(r.stage()).isEqualTo(AutoReleaseController.Stage.SHADOW));
+    }
+
+    @Test
+    void canaryDwellTimePreventsEarlyPromotion() throws Exception {
+        var t0 = Instant.parse("2026-02-24T00:00:00Z");
+        var store = newStore(tempDir);
+        var candidate = promoteCandidate(store, t0);
+        writeDraft(tempDir, "dwell-skill", candidate.id());
+        writeReplayReport(tempDir, 0.10);
+
+        // 24h dwell time, with enough attempts and good metrics
+        var validation = new ValidationGateEngine(
+                Clock.fixed(t0, ZoneOffset.UTC), false, true,
+                Path.of(".aceclaw/metrics/continuous-learning/replay-latest.json"), 0.65);
+        // Use new 12-arg Config with 24h dwell
+        var config = new AutoReleaseController.Config(
+                0.2, 1, 1, 0.5, 0.5, 0.5, 0.6, 0.6, 0.6, Duration.ofDays(7), 24);
+
+        // Clock is only 10 seconds after t0 — dwell time not met
+        var controller = new AutoReleaseController(
+                Clock.fixed(t0.plusSeconds(10), ZoneOffset.UTC), config, validation);
+
+        // First eval: SHADOW → CANARY
+        var first = controller.evaluateAll(tempDir, store, "test-1");
+        assertThat(first.events()).extracting(AutoReleaseController.ReleaseEvent::toStage)
+                .containsExactly(AutoReleaseController.Stage.CANARY);
+
+        // Second eval: should NOT promote to ACTIVE (only 10s in canary, need 24h)
+        var second = controller.evaluateAll(tempDir, store, "test-2");
+        assertThat(second.events()).isEmpty();
+
+        // Third eval with clock 25h later: should promote to ACTIVE
+        var controller25h = new AutoReleaseController(
+                Clock.fixed(t0.plusSeconds(25 * 3600), ZoneOffset.UTC), config, validation);
+        var third = controller25h.evaluateAll(tempDir, store, "test-3");
+        assertThat(third.events()).extracting(AutoReleaseController.ReleaseEvent::toStage)
+                .contains(AutoReleaseController.Stage.ACTIVE);
+    }
+
+    @Test
+    void hardenedDefaultsAreStricter() {
+        var defaults = AutoReleaseController.Config.defaults();
+        assertThat(defaults.canaryMinAttempts()).isGreaterThanOrEqualTo(20);
+        assertThat(defaults.canaryMaxFailureRate()).isLessThanOrEqualTo(0.10);
+        assertThat(defaults.rollbackMaxFailureRate()).isLessThanOrEqualTo(0.20);
+        assertThat(defaults.canaryDwellHours()).isGreaterThanOrEqualTo(24);
     }
 
     private static CandidateStore newStore(Path projectRoot) throws Exception {


### PR DESCRIPTION
## Summary

- Tighten canary thresholds: `minAttempts` 5→20, `maxFailureRate` 0.35→0.10
- Tighten rollback thresholds: `maxFailureRate` 0.45→0.20
- Add `canaryDwellHours` (default 24h) — minimum time at CANARY before promotion to ACTIVE
- Add approach warning logging at 80% of threshold
- All thresholds configurable via `config.json`

Closes #289

## Test plan

- [x] `canaryDwellTimePreventsEarlyPromotion` — verifies dwell time blocks early promotion
- [x] `hardenedDefaultsAreStricter` — verifies new defaults meet P0 requirements
- [x] Existing tests updated for backward compatibility (10-arg Config constructor)
- [x] Full `./gradlew build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 24-hour minimum dwell time requirement before promoting skills from canary to active phase.
  * Introduced warning logs when metrics approach safety thresholds but guardrails remain unmet.

* **Improvements**
  * Stricter auto-release policies: increased minimum evidence requirements and reduced failure rate tolerances for safer rollouts.
  * Updated default safety thresholds across canary and rollback phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->