### PR TITLE
fix: canaryDwellHours env var + operations runbook sync

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
@@ -45,6 +45,7 @@ import java.util.Map;
  *   <li>{@code ACECLAW_MAX_AGENT_HARD_TURNS} → maxAgentHardTurns (hard turn ceiling, default 0 = 3x soft)</li>
  *   <li>{@code ACECLAW_MAX_AGENT_HARD_WALL_TIME_SEC} → maxAgentHardWallTimeSec (hard wall ceiling, default 0 = 3x soft)</li>
  *   <li>{@code ACECLAW_LOG_LEVEL} → logLevel</li>
+ *   <li>{@code ACECLAW_SKILL_AUTO_RELEASE_CANARY_DWELL_HOURS} → skillAutoReleaseCanaryDwellHours (minimum hours at CANARY before ACTIVE, default 24)</li>
  *   <li>{@code BRAVE_SEARCH_API_KEY} → braveSearchApiKey</li>
  * </ul>
  */
@@ -596,6 +597,16 @@ public final class AceClawConfig {
             } catch (NumberFormatException e) {
                 log.warn("Invalid ACECLAW_SKILL_AUTO_RELEASE_HEALTH_LOOKBACK_HOURS: {}",
                         envSkillAutoReleaseLookbackHours);
+            }
+        }
+        var envSkillAutoReleaseCanaryDwellHours = System.getenv("ACECLAW_SKILL_AUTO_RELEASE_CANARY_DWELL_HOURS");
+        if (envSkillAutoReleaseCanaryDwellHours != null && !envSkillAutoReleaseCanaryDwellHours.isBlank()) {
+            try {
+                config.skillAutoReleaseCanaryDwellHours =
+                        Math.max(0, Integer.parseInt(envSkillAutoReleaseCanaryDwellHours));
+            } catch (NumberFormatException e) {
+                log.warn("Invalid ACECLAW_SKILL_AUTO_RELEASE_CANARY_DWELL_HOURS: {}",
+                        envSkillAutoReleaseCanaryDwellHours);
             }
         }
 

--- a/docs/continuous-learning-operations.md
+++ b/docs/continuous-learning-operations.md
@@ -34,11 +34,12 @@ Config keys in `.aceclaw/config.json`:
 - `skillAutoReleaseEnabled` (`bool`, default `true`)
 - `skillAutoReleaseMinCandidateScore` (`double`, default `0.80`)
 - `skillAutoReleaseMinEvidence` (`int`, default `3`)
-- `skillAutoReleaseCanaryMinAttempts` (`int`, default `5`)
-- `skillAutoReleaseCanaryMaxFailureRate` (`double`, default `0.35`)
+- `skillAutoReleaseCanaryMinAttempts` (`int`, default `20`)
+- `skillAutoReleaseCanaryMaxFailureRate` (`double`, default `0.10`)
 - `skillAutoReleaseCanaryMaxTimeoutRate` (`double`, default `0.20`)
 - `skillAutoReleaseCanaryMaxPermissionBlockRate` (`double`, default `0.20`)
-- `skillAutoReleaseRollbackMaxFailureRate` (`double`, default `0.45`)
+- `skillAutoReleaseCanaryDwellHours` (`int`, default `24` — minimum hours at CANARY before promotion to ACTIVE)
+- `skillAutoReleaseRollbackMaxFailureRate` (`double`, default `0.20`)
 - `skillAutoReleaseRollbackMaxTimeoutRate` (`double`, default `0.20`)
 - `skillAutoReleaseRollbackMaxPermissionBlockRate` (`double`, default `0.20`)
 - `skillAutoReleaseActiveMaxFailureRate` (`double`, legacy alias for rollback failure threshold)
@@ -66,6 +67,7 @@ Environment overrides:
 - `ACECLAW_SKILL_AUTO_RELEASE_ROLLBACK_MAX_PERMISSION_BLOCK_RATE`
 - `ACECLAW_SKILL_AUTO_RELEASE_ACTIVE_MAX_FAILURE_RATE`
 - `ACECLAW_SKILL_AUTO_RELEASE_HEALTH_LOOKBACK_HOURS`
+- `ACECLAW_SKILL_AUTO_RELEASE_CANARY_DWELL_HOURS`
 
 JVM/system properties:
 


### PR DESCRIPTION
## Summary

Fixes two review findings from #289 guardrail hardening:

- **P1**: Add `ACECLAW_SKILL_AUTO_RELEASE_CANARY_DWELL_HOURS` env var — without this, env-only deployments had no way to override the 24h dwell time
- **P2**: Update `docs/continuous-learning-operations.md` to reflect hardened defaults (20 min attempts, 0.10 canary failure rate, 0.20 rollback failure rate, new canaryDwellHours knob)

## Test plan

- [x] `./gradlew build` passes
- [x] Env var follows same pattern as existing `ACECLAW_SKILL_AUTO_RELEASE_*` vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)
