### PR TITLE
feat: injection audit log for per-turn learning attribution

### DIFF
--- a/aceclaw-memory/src/main/java/dev/aceclaw/memory/InjectionAuditLog.java
+++ b/aceclaw-memory/src/main/java/dev/aceclaw/memory/InjectionAuditLog.java
@@ -1,0 +1,189 @@
+package dev.aceclaw.memory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Append-only audit log for candidate injection events.
+ *
+ * <p>Records what was injected, why, at what cost, and links to the
+ * turn outcome — enabling {@code learning_hit_rate} computation and
+ * per-injection forensics.
+ *
+ * <p>Output: {@code ~/.aceclaw/memory/injection-audit.jsonl}
+ */
+public final class InjectionAuditLog {
+
+    private static final Logger log = LoggerFactory.getLogger(InjectionAuditLog.class);
+    private static final String AUDIT_FILE = "injection-audit.jsonl";
+
+    private final Path auditFile;
+    private final ObjectMapper mapper;
+
+    public InjectionAuditLog(Path memoryDir) {
+        Objects.requireNonNull(memoryDir, "memoryDir");
+        this.auditFile = memoryDir.resolve(AUDIT_FILE);
+        this.mapper = new ObjectMapper().registerModule(new JavaTimeModule());
+    }
+
+    /**
+     * A single injected candidate with its metadata at injection time.
+     */
+    public record InjectedCandidate(
+            String candidateId,
+            String content,
+            String toolTag,
+            double score,
+            int evidenceCount,
+            double relevanceScore,
+            int estimatedTokens
+    ) {}
+
+    /**
+     * An injection event — one per agent turn where candidates are injected.
+     */
+    public record InjectionEvent(
+            Instant timestamp,
+            String sessionId,
+            String queryHint,
+            List<InjectedCandidate> candidates,
+            int totalTokensUsed,
+            int tokenBudget,
+            int candidatesConsidered,
+            int candidatesInjected
+    ) {
+        public InjectionEvent {
+            candidates = candidates != null ? List.copyOf(candidates) : List.of();
+            queryHint = queryHint != null ? queryHint : "";
+        }
+    }
+
+    /**
+     * An outcome linked to a prior injection event.
+     */
+    public record InjectionOutcome(
+            Instant timestamp,
+            String sessionId,
+            List<String> candidateIds,
+            boolean success,
+            boolean severeFailure,
+            String outcomeNote
+    ) {
+        public InjectionOutcome {
+            candidateIds = candidateIds != null ? List.copyOf(candidateIds) : List.of();
+        }
+    }
+
+    /**
+     * Records an injection event (called at prompt assembly time).
+     */
+    public void recordInjection(InjectionEvent event) {
+        Objects.requireNonNull(event, "event");
+        appendRecord("injection", event);
+    }
+
+    /**
+     * Records the outcome of a turn that had injected candidates.
+     */
+    public void recordOutcome(InjectionOutcome outcome) {
+        Objects.requireNonNull(outcome, "outcome");
+        appendRecord("outcome", outcome);
+    }
+
+    /**
+     * Computes learning_hit_rate from the audit log.
+     * Hit rate = turns with injected candidates that succeeded / total turns with injected candidates.
+     *
+     * @return hit rate [0.0, 1.0], or NaN if no data
+     */
+    public double computeHitRate() {
+        if (!Files.isRegularFile(auditFile)) {
+            return Double.NaN;
+        }
+        try {
+            int totalOutcomes = 0;
+            int successfulOutcomes = 0;
+            for (String line : Files.readAllLines(auditFile)) {
+                if (line.isBlank()) continue;
+                var node = mapper.readTree(line);
+                if (!"outcome".equals(node.path("type").asText())) continue;
+                var data = node.path("data");
+                if (data.isMissingNode()) continue;
+                totalOutcomes++;
+                if (data.path("success").asBoolean(false)) {
+                    successfulOutcomes++;
+                }
+            }
+            if (totalOutcomes == 0) return Double.NaN;
+            return (double) successfulOutcomes / totalOutcomes;
+        } catch (IOException e) {
+            log.warn("Failed to compute hit rate from {}: {}", auditFile, e.getMessage());
+            return Double.NaN;
+        }
+    }
+
+    /**
+     * Returns a summary of injection audit statistics.
+     */
+    public AuditSummary summarize() {
+        if (!Files.isRegularFile(auditFile)) {
+            return new AuditSummary(0, 0, 0, 0, Double.NaN);
+        }
+        try {
+            int injections = 0;
+            int outcomes = 0;
+            int successfulOutcomes = 0;
+            int totalCandidatesInjected = 0;
+            for (String line : Files.readAllLines(auditFile)) {
+                if (line.isBlank()) continue;
+                var node = mapper.readTree(line);
+                String type = node.path("type").asText("");
+                if ("injection".equals(type)) {
+                    injections++;
+                    totalCandidatesInjected += node.path("data").path("candidatesInjected").asInt(0);
+                } else if ("outcome".equals(type)) {
+                    outcomes++;
+                    if (node.path("data").path("success").asBoolean(false)) {
+                        successfulOutcomes++;
+                    }
+                }
+            }
+            double hitRate = outcomes > 0 ? (double) successfulOutcomes / outcomes : Double.NaN;
+            return new AuditSummary(injections, outcomes, successfulOutcomes, totalCandidatesInjected, hitRate);
+        } catch (IOException e) {
+            log.warn("Failed to summarize injection audit: {}", e.getMessage());
+            return new AuditSummary(0, 0, 0, 0, Double.NaN);
+        }
+    }
+
+    public record AuditSummary(
+            int totalInjections,
+            int totalOutcomes,
+            int successfulOutcomes,
+            int totalCandidatesInjected,
+            double hitRate
+    ) {}
+
+    private void appendRecord(String type, Object data) {
+        try {
+            Files.createDirectories(auditFile.getParent());
+            var node = mapper.createObjectNode();
+            node.put("type", type);
+            node.set("data", mapper.valueToTree(data));
+            Files.writeString(auditFile, mapper.writeValueAsString(node) + "\n",
+                    StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+        } catch (IOException e) {
+            log.warn("Failed to write injection audit record: {}", e.getMessage());
+        }
+    }
+}

--- a/aceclaw-memory/src/test/java/dev/aceclaw/memory/InjectionAuditLogTest.java
+++ b/aceclaw-memory/src/test/java/dev/aceclaw/memory/InjectionAuditLogTest.java
@@ -1,0 +1,116 @@
+package dev.aceclaw.memory;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+class InjectionAuditLogTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void recordInjection_writesJsonlLine() throws Exception {
+        var auditLog = new InjectionAuditLog(tempDir);
+        var event = new InjectionAuditLog.InjectionEvent(
+                Instant.now(), "session-1", "fix bug",
+                List.of(new InjectionAuditLog.InjectedCandidate(
+                        "cand-1", "retry flaky commands", "bash", 0.85, 3, 0.72, 45)),
+                45, 1200, 5, 1);
+
+        auditLog.recordInjection(event);
+
+        Path auditFile = tempDir.resolve("injection-audit.jsonl");
+        assertThat(auditFile).exists();
+        var lines = Files.readAllLines(auditFile);
+        assertThat(lines).hasSize(1);
+        assertThat(lines.getFirst()).contains("\"type\":\"injection\"");
+        assertThat(lines.getFirst()).contains("cand-1");
+    }
+
+    @Test
+    void recordOutcome_writesJsonlLine() throws Exception {
+        var auditLog = new InjectionAuditLog(tempDir);
+        var outcome = new InjectionAuditLog.InjectionOutcome(
+                Instant.now(), "session-1", List.of("cand-1"), true, false, "end_turn");
+
+        auditLog.recordOutcome(outcome);
+
+        Path auditFile = tempDir.resolve("injection-audit.jsonl");
+        var lines = Files.readAllLines(auditFile);
+        assertThat(lines).hasSize(1);
+        assertThat(lines.getFirst()).contains("\"type\":\"outcome\"");
+        assertThat(lines.getFirst()).contains("\"success\":true");
+    }
+
+    @Test
+    void computeHitRate_withMixedOutcomes() throws Exception {
+        var auditLog = new InjectionAuditLog(tempDir);
+
+        // 2 successes, 1 failure = 66.7% hit rate
+        auditLog.recordOutcome(new InjectionAuditLog.InjectionOutcome(
+                Instant.now(), "s1", List.of("c1"), true, false, "end_turn"));
+        auditLog.recordOutcome(new InjectionAuditLog.InjectionOutcome(
+                Instant.now(), "s2", List.of("c1"), true, false, "end_turn"));
+        auditLog.recordOutcome(new InjectionAuditLog.InjectionOutcome(
+                Instant.now(), "s3", List.of("c1"), false, true, "error"));
+
+        assertThat(auditLog.computeHitRate()).isCloseTo(0.6667, within(0.01));
+    }
+
+    @Test
+    void computeHitRate_noData_returnsNaN() {
+        var auditLog = new InjectionAuditLog(tempDir);
+        assertThat(auditLog.computeHitRate()).isNaN();
+    }
+
+    @Test
+    void computeHitRate_ignoresInjectionRecords() throws Exception {
+        var auditLog = new InjectionAuditLog(tempDir);
+
+        // Only injection records, no outcomes
+        auditLog.recordInjection(new InjectionAuditLog.InjectionEvent(
+                Instant.now(), "s1", "query", List.of(), 0, 1200, 0, 0));
+
+        assertThat(auditLog.computeHitRate()).isNaN();
+    }
+
+    @Test
+    void summarize_aggregatesCorrectly() throws Exception {
+        var auditLog = new InjectionAuditLog(tempDir);
+
+        auditLog.recordInjection(new InjectionAuditLog.InjectionEvent(
+                Instant.now(), "s1", "query",
+                List.of(new InjectionAuditLog.InjectedCandidate(
+                        "c1", "content", "bash", 0.9, 5, 0.8, 30)),
+                30, 1200, 10, 1));
+        auditLog.recordInjection(new InjectionAuditLog.InjectionEvent(
+                Instant.now(), "s2", "query", List.of(), 0, 1200, 5, 0));
+        auditLog.recordOutcome(new InjectionAuditLog.InjectionOutcome(
+                Instant.now(), "s1", List.of("c1"), true, false, "end_turn"));
+        auditLog.recordOutcome(new InjectionAuditLog.InjectionOutcome(
+                Instant.now(), "s2", List.of("c1"), false, false, "max_tokens"));
+
+        var summary = auditLog.summarize();
+        assertThat(summary.totalInjections()).isEqualTo(2);
+        assertThat(summary.totalOutcomes()).isEqualTo(2);
+        assertThat(summary.successfulOutcomes()).isEqualTo(1);
+        assertThat(summary.totalCandidatesInjected()).isEqualTo(1);
+        assertThat(summary.hitRate()).isCloseTo(0.5, within(0.01));
+    }
+
+    @Test
+    void summarize_emptyLog_returnsZeros() {
+        var auditLog = new InjectionAuditLog(tempDir);
+        var summary = auditLog.summarize();
+        assertThat(summary.totalInjections()).isEqualTo(0);
+        assertThat(summary.hitRate()).isNaN();
+    }
+}


### PR DESCRIPTION
## Summary

Add `InjectionAuditLog` — append-only JSONL recording what candidates were injected, why, at what token cost, and whether the turn succeeded. Enables `learning_hit_rate` as a measured metric.

**Records:**
- `injection` events: candidate IDs, scores, relevance, token cost/budget
- `outcome` events: session linkage, success/failure, outcome note

**Computes:**
- `learning_hit_rate` = successful outcomes / total outcomes with injections
- `AuditSummary` with injection count, candidate count, hit rate

Closes #286

## Test plan

- [x] `InjectionAuditLogTest` — 7 tests covering record/read/compute/summarize
- [x] `./gradlew build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Implemented a new audit logging feature that records all injection events and outcomes with full traceability to a persistent log file for compliance and analysis
* Added built-in analytics capabilities to compute injection success hit rates and generate audit summaries providing comprehensive insights into injection performance, candidate usage patterns, and success metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->