### PR TITLE
feat: enforce fresh replay artifacts in preMergeCheck

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,6 +97,7 @@ tasks.register("continuousLearningSmoke") {
 tasks.register<Exec>("replayQualityGate") {
     group = "verification"
     description = "Validates replay quality report against hard thresholds."
+    dependsOn("generateReplayReport")
 
     val replayReport = providers.gradleProperty("replayReport")
             .orElse("${rootDir}/.aceclaw/metrics/continuous-learning/replay-latest.json")
@@ -143,10 +144,11 @@ tasks.register<Exec>("replayQualityGate") {
 tasks.register<Exec>("generateReplayReport") {
     group = "verification"
     description = "Generates replay quality report from learning=off/on case results."
+    dependsOn("generateReplayCases")
 
     val replayCasesInput = providers.gradleProperty("replayCasesInput")
             .orElse(providers.gradleProperty("replayInput"))
-            .orElse("${rootDir}/docs/reports/samples/replay-cases-sample.json")
+            .orElse("${rootDir}/.aceclaw/metrics/continuous-learning/replay-cases.json")
     val replayCasesManifestInput = providers.gradleProperty("replayCasesManifestInput")
             .orElse("${rootDir}/.aceclaw/metrics/continuous-learning/replay-cases.manifest.json")
     val replayReport = providers.gradleProperty("replayReport")

--- a/docs/continuous-learning-operations.md
+++ b/docs/continuous-learning-operations.md
@@ -420,18 +420,40 @@ CI guardrail job:
 - Executes `./gradlew preMergeCheck`, which includes:
   - full `build`
   - `continuousLearningSmoke` focused tests (daemon/memory/core)
-  - `replayQualityGate` thresholds check (`scripts/replay-quality-gate.sh`)
+  - `replayQualityGate` → `generateReplayReport` → `generateReplayCases` (chained)
+
+Task dependency chain (enforced by Gradle):
+```
+preMergeCheck
+├── build
+├── continuousLearningSmoke
+└── replayQualityGate
+    └── generateReplayReport
+        └── generateReplayCases
+            ├── validateReplaySuite
+            └── :aceclaw-cli:runReplayCases
+```
+
+This ensures CI always evaluates freshly generated replay artifacts — never stale or sample data.
 
 Replay gate configuration:
 
 - Default report path: `.aceclaw/metrics/continuous-learning/replay-latest.json`
+- Default replay cases input: `.aceclaw/metrics/continuous-learning/replay-cases.json` (generated, not sample)
 - Default baseline thresholds file: `docs/reports/samples/learning-quality-gate-baseline.json`
 - Strict mode is the default for `preMergeCheck` (missing report fails the build).
-- Local override (only for exploratory runs): `./gradlew preMergeCheck -PreplayGateStrict=false`
-- Custom report path: `./gradlew preMergeCheck -PreplayReport=/path/to/replay.json`
-- Baseline override: `./gradlew preMergeCheck -PreplayBaseline=/path/to/baseline.json`
-- CI uses strict mode and can override report path with `ACECLAW_REPLAY_REPORT_PATH`.
-- CI first runs `generateReplayCases`, then `generateReplayReport`.
+
+Local exploratory runs (bypasses artifact generation):
+```bash
+# Skip fresh generation, use existing/sample artifacts:
+./gradlew replayQualityGate -PreplayCasesInput=docs/reports/samples/replay-cases-sample.json -PreplayGateStrict=false
+```
+
+Canonical CI runs (enforces fresh generation):
+```bash
+# Full pipeline — generates cases, report, then gates:
+./gradlew preMergeCheck -PreplayGateStrict=true
+```
 - CI default enforces anti-pattern false-positive gate:
   - `ACECLAW_REPLAY_ENFORCE_ANTI_PATTERN_FP_RATE=true`
   - threshold `ACECLAW_REPLAY_MAX_ANTI_PATTERN_FP_RATE=0.50`


### PR DESCRIPTION
## Summary

- **Task dependency chain enforced**: `preMergeCheck` → `replayQualityGate` → `generateReplayReport` → `generateReplayCases` — CI can no longer pass against stale artifacts
- **Default input fixed**: `generateReplayReport` now defaults to generated `replay-cases.json`, not sample JSON
- **Docs updated**: dependency chain documented, local vs CI behavior clarified

Closes #311

## Test plan

- [x] `./gradlew build` passes
- [x] Task graph verified: `preMergeCheck` transitively depends on fresh generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CI guardrail pipeline documentation to reflect the reorganized task execution flow for replay quality gate validation.
  * Added explicit guidance on local exploratory runs versus canonical CI runs.

* **Chores**
  * Reorganized task dependency chain to ensure replay cases are generated before quality gate validation.
  * Updated default configuration path for replay cases input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->