### PR TITLE
feat: wire BenchmarkScorecard into CI via Gradle task

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/BenchmarkScorecardCli.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/BenchmarkScorecardCli.java
@@ -1,0 +1,123 @@
+package dev.aceclaw.daemon;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.aceclaw.core.stats.BenchmarkScorecard;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * CLI entry point that reads replay report and runtime metrics,
+ * evaluates the {@link BenchmarkScorecard}, and prints the verdict.
+ *
+ * <p>Exit code: 0 = pass, 1 = fail, 2 = error.
+ *
+ * <p>Usage: {@code java BenchmarkScorecardCli --replay-report <path> [--runtime-metrics <path>]}
+ */
+public final class BenchmarkScorecardCli {
+
+    public static void main(String[] args) throws Exception {
+        String replayReportPath = null;
+        String runtimeMetricsPath = null;
+        String outputPath = null;
+
+        for (int i = 0; i < args.length; i++) {
+            switch (args[i]) {
+                case "--replay-report" -> replayReportPath = args[++i];
+                case "--runtime-metrics" -> runtimeMetricsPath = args[++i];
+                case "--output" -> outputPath = args[++i];
+            }
+        }
+
+        if (replayReportPath == null) {
+            System.err.println("Usage: BenchmarkScorecardCli --replay-report <path> [--runtime-metrics <path>] [--output <path>]");
+            System.exit(2);
+            return;
+        }
+
+        var mapper = new ObjectMapper();
+        var replayDeltas = new LinkedHashMap<String, Double>();
+        var sampleSizes = new LinkedHashMap<String, Integer>();
+        var lifecycleRates = new LinkedHashMap<String, Double>();
+
+        // Parse replay report metrics
+        Path replayPath = Path.of(replayReportPath);
+        if (Files.isRegularFile(replayPath)) {
+            JsonNode report = mapper.readTree(replayPath.toFile());
+            JsonNode metrics = report.path("metrics");
+            extractMetric(metrics, "replay_success_rate_delta", replayDeltas, sampleSizes);
+            extractMetric(metrics, "replay_token_delta", replayDeltas, sampleSizes);
+            extractMetric(metrics, "replay_latency_delta_ms", replayDeltas, sampleSizes);
+            extractMetric(metrics, "replay_failure_distribution_delta", replayDeltas, sampleSizes);
+
+            // Lifecycle metrics from the report
+            extractMetric(metrics, "promotion_rate", lifecycleRates, sampleSizes);
+            extractMetric(metrics, "demotion_rate", lifecycleRates, sampleSizes);
+            extractMetric(metrics, "rollback_rate", lifecycleRates, sampleSizes);
+        }
+
+        // Parse runtime metrics if available
+        if (runtimeMetricsPath != null) {
+            Path runtimePath = Path.of(runtimeMetricsPath);
+            if (Files.isRegularFile(runtimePath)) {
+                JsonNode runtime = mapper.readTree(runtimePath.toFile());
+                JsonNode metrics = runtime.path("metrics");
+                extractMetric(metrics, "first_try_success_rate", replayDeltas, sampleSizes);
+                // Map to delta name expected by scorecard
+                Double ftsr = replayDeltas.remove("first_try_success_rate");
+                if (ftsr != null) {
+                    replayDeltas.put("first_try_success_rate_delta", ftsr);
+                    sampleSizes.put("first_try_success_rate_delta",
+                            sampleSizes.getOrDefault("first_try_success_rate", 0));
+                }
+            }
+        }
+
+        // Evaluate scorecard
+        var scorecard = BenchmarkScorecard.evaluate(replayDeltas, sampleSizes, lifecycleRates);
+
+        // Print summary
+        System.out.println(scorecard.toSummary());
+
+        // Write JSON output if requested
+        if (outputPath != null) {
+            Path out = Path.of(outputPath);
+            if (out.getParent() != null) Files.createDirectories(out.getParent());
+            var root = mapper.createObjectNode();
+            root.put("pass", scorecard.pass());
+            var metricsArray = root.putArray("metrics");
+            for (var m : scorecard.metrics()) {
+                var node = mapper.createObjectNode();
+                node.put("name", m.name());
+                node.put("value", Double.isNaN(m.value()) ? null : mapper.getNodeFactory().numberNode(m.value()));
+                node.put("threshold", m.threshold());
+                node.put("direction", m.direction());
+                node.put("category", m.category().name());
+                node.put("status", m.status().name());
+                node.put("sample_size", m.sampleSize());
+                node.put("detail", m.detail());
+                metricsArray.add(node);
+            }
+            var failuresArray = root.putArray("failures");
+            scorecard.failures().forEach(failuresArray::add);
+            Files.writeString(out, mapper.writerWithDefaultPrettyPrinter().writeValueAsString(root) + "\n");
+        }
+
+        System.exit(scorecard.pass() ? 0 : 1);
+    }
+
+    private static void extractMetric(JsonNode metrics, String name,
+                                       Map<String, Double> values, Map<String, Integer> sizes) {
+        JsonNode m = metrics.path(name);
+        if (m.isMissingNode()) return;
+        String status = m.path("status").asText("");
+        if (!"measured".equals(status)) return;
+        JsonNode valueNode = m.get("value");
+        if (valueNode == null || valueNode.isNull()) return;
+        values.put(name, valueNode.asDouble());
+        sizes.put(name, m.path("sample_size").asInt(0));
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -192,8 +192,28 @@ tasks.register("generateReplayCases") {
     dependsOn("validateReplaySuite", ":aceclaw-cli:runReplayCases")
 }
 
+tasks.register<JavaExec>("benchmarkScorecard") {
+    group = "verification"
+    description = "Evaluates self-learning benchmark scorecard from replay and runtime metrics."
+    dependsOn("generateReplayReport")
+    mainClass.set("dev.aceclaw.daemon.BenchmarkScorecardCli")
+    classpath = project(":aceclaw-daemon").sourceSets["main"].runtimeClasspath
+
+    val replayReport = providers.gradleProperty("replayReport")
+            .orElse("${rootDir}/.aceclaw/metrics/continuous-learning/replay-latest.json")
+    val runtimeMetrics = providers.gradleProperty("runtimeMetrics")
+            .orElse("${rootDir}/.aceclaw/metrics/continuous-learning/runtime-latest.json")
+    val scorecardOutput = providers.gradleProperty("scorecardOutput")
+            .orElse("${rootDir}/.aceclaw/metrics/continuous-learning/benchmark-scorecard.json")
+
+    jvmArgs("--enable-preview")
+    args("--replay-report", replayReport.get(),
+         "--runtime-metrics", runtimeMetrics.get(),
+         "--output", scorecardOutput.get())
+}
+
 tasks.register("preMergeCheck") {
     group = "verification"
-    description = "Single pre-merge quality gate: build, smoke, and replay quality thresholds."
-    dependsOn("build", "continuousLearningSmoke", "replayQualityGate")
+    description = "Single pre-merge quality gate: build, smoke, replay, and benchmark scorecard."
+    dependsOn("build", "continuousLearningSmoke", "replayQualityGate", "benchmarkScorecard")
 }


### PR DESCRIPTION
## Summary

- **`BenchmarkScorecardCli`**: reads replay + runtime metrics, evaluates scorecard, prints CI summary, exits 0/1
- **`benchmarkScorecard` Gradle task**: depends on `generateReplayReport`, outputs `benchmark-scorecard.json`
- **`preMergeCheck`** now depends on `benchmarkScorecard` — CI gets compact verdict

Closes #309

## Test plan

- [x] `./gradlew build` passes
- [x] `BenchmarkScorecardTest` covers scorecard evaluation logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires `BenchmarkScorecardCli` into the Gradle build as a new `benchmarkScorecard` task and adds it to the `preMergeCheck` gate, so CI now gets a compact pass/fail verdict from the self-learning benchmark scorecard after every replay run. The Gradle task plumbing in `build.gradle.kts` is clean and consistent with existing task patterns.

**Key issues found:**
- **Safety gate silently disabled**: `BenchmarkScorecardCli` extracts lifecycle metrics under the keys `"promotion_rate"` and `"demotion_rate"`, but `BenchmarkScorecard.evaluate()` looks them up as `"promotion_precision"` and `"false_learning_rate"`. Those two SAFETY-category metrics will permanently resolve to `INSUFFICIENT_DATA`, meaning the safety thresholds (`promotion_precision ≥ 0.80`, `false_learning_rate ≤ 0.10`) are never actually evaluated, even when data is present in the report.
- **Stale `sampleSizes` key**: After the `first_try_success_rate` → `first_try_success_rate_delta` rename in `replayDeltas`, the original key is not removed from `sampleSizes`, leaving a dangling entry.
- **Ambiguous `ObjectNode.put` call for NaN values**: The ternary `Double.isNaN(m.value()) ? null : mapper.getNodeFactory().numberNode(m.value())` mixes a `null` operand with a `DoubleNode`, calling a non-standard `put(String, JsonNode)` overload. Using `putNull` and `put(String, double)` explicitly would be clearer and more portable across Jackson versions.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is — the safety gate metrics are silently never evaluated due to a key name mismatch.
- The lifecycle metric key mismatch is a concrete logic bug: `promotion_precision` and `false_learning_rate` will always show as INSUFFICIENT_DATA regardless of actual data, effectively disabling two of the three SAFETY-category thresholds that the scorecard is designed to enforce. This undermines the stated goal of the CI gate for those safety signals.
- aceclaw-daemon/src/main/java/dev/aceclaw/daemon/BenchmarkScorecardCli.java — the lifecycle metric extraction key names need to be reconciled with BenchmarkScorecard.evaluate()'s expected keys.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| aceclaw-daemon/src/main/java/dev/aceclaw/daemon/BenchmarkScorecardCli.java | New CLI entry point for the benchmark scorecard. Contains a logic bug where lifecycle metrics are extracted with wrong key names ("promotion_rate"/"demotion_rate" instead of "promotion_precision"/"false_learning_rate"), causing those safety metrics to be permanently INSUFFICIENT_DATA. Also has a stale sampleSizes key after the first_try_success_rate rename. |
| build.gradle.kts | Adds benchmarkScorecard JavaExec task wired correctly with configurable property overrides, and adds it as a dependency of preMergeCheck. Consistent with existing task patterns in the file. No issues. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: aceclaw-daemon/src/main/java/dev/aceclaw/daemon/BenchmarkScorecardCli.java
Line: 56-59

Comment:
**Lifecycle metric keys don't match scorecard expectations**

`BenchmarkScorecard.evaluate()` looks up `"promotion_precision"` and `"false_learning_rate"` from `lifecycleRates`, but this code extracts `"promotion_rate"` and `"demotion_rate"` instead. As a result, those two safety metrics will always resolve to `Double.NaN` → `INSUFFICIENT_DATA` and will never be properly evaluated, effectively disabling two thirds of the safety gate.

Only `"rollback_rate"` is matched correctly.

You likely need to either extract the keys the scorecard actually expects, or add explicit rename mappings (similar to the `first_try_success_rate` → `first_try_success_rate_delta` mapping below):

```suggestion
            extractMetric(metrics, "promotion_precision", lifecycleRates, sampleSizes);
            extractMetric(metrics, "false_learning_rate", lifecycleRates, sampleSizes);
            extractMetric(metrics, "rollback_rate", lifecycleRates, sampleSizes);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: aceclaw-daemon/src/main/java/dev/aceclaw/daemon/BenchmarkScorecardCli.java
Line: 69-75

Comment:
**Stale `sampleSizes` key left after rename**

After removing `"first_try_success_rate"` from `replayDeltas`, the corresponding entry in `sampleSizes` is never cleaned up. The stale `"first_try_success_rate"` key remains in `sampleSizes` even though `replayDeltas` no longer has it. While this doesn't cause incorrect behaviour today (the scorecard only looks up `"first_try_success_rate_delta"`), it's inconsistent and could cause confusion.

```suggestion
                extractMetric(metrics, "first_try_success_rate", replayDeltas, sampleSizes);
                // Map to delta name expected by scorecard
                Double ftsr = replayDeltas.remove("first_try_success_rate");
                Integer ftsrSize = sampleSizes.remove("first_try_success_rate");
                if (ftsr != null) {
                    replayDeltas.put("first_try_success_rate_delta", ftsr);
                    sampleSizes.put("first_try_success_rate_delta",
                            ftsrSize != null ? ftsrSize : 0);
                }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: aceclaw-daemon/src/main/java/dev/aceclaw/daemon/BenchmarkScorecardCli.java
Line: 95

Comment:
**NaN handling uses ambiguous `put` overload**

When `m.value()` is `NaN`, the ternary resolves to `null` and the result of `mapper.getNodeFactory().numberNode(m.value())` is a `DoubleNode`. The resulting ternary type is `DoubleNode` (a `JsonNode` subtype), but `ObjectNode.put(String, JsonNode)` is not a standard Jackson API method — the canonical method is `set(String, JsonNode)`. Using `putNull` for the NaN branch is explicit and avoids any overload-resolution ambiguity:

```suggestion
                node.putNull("value");
```
…and separately handle the non-NaN case, e.g.:

```java
if (Double.isNaN(m.value())) {
    node.putNull("value");
} else {
    node.put("value", m.value());
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["feat: wire Benchmark..."](https://github.com/xinhuagu/aceclaw/commit/8d656ea2c242c4ae28587aa1d010f00aea4bce50)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->