### PR TITLE
feat: baseline collector auto-reads runtime metrics

### DIFF
--- a/scripts/collect-continuous-learning-baseline.sh
+++ b/scripts/collect-continuous-learning-baseline.sh
@@ -134,20 +134,44 @@ as_json_value() {
   fi
 }
 
+RUNTIME_METRICS_PATH="$PROJECT_ROOT/.aceclaw/metrics/continuous-learning/runtime-latest.json"
+INJECTION_AUDIT_PATH="$PROJECT_ROOT/.aceclaw/memory/injection-audit.jsonl"
+
+read_runtime_metric() {
+  local key="$1"
+  if [[ -f "$RUNTIME_METRICS_PATH" ]] && command -v jq >/dev/null 2>&1; then
+    local status
+    status="$(jq -r ".metrics.\"$key\".status // \"\"" "$RUNTIME_METRICS_PATH" 2>/dev/null)"
+    if [[ "$status" == "measured" ]]; then
+      jq -r ".metrics.\"$key\".value // \"null\"" "$RUNTIME_METRICS_PATH" 2>/dev/null
+      return 0
+    fi
+  fi
+  return 1
+}
+
 metric_json() {
   local key="$1"
   local target
   local val="null"
   local status="pending_instrumentation"
+  local source=""
 
   target="$(target_for_key "$key")"
+
+  # Priority: 1) manual override, 2) runtime-latest.json, 3) pending
   if override="$(find_override "$key")"; then
     val="$override"
     status="measured"
+    source="manual_override"
+  elif runtime_val="$(read_runtime_metric "$key")"; then
+    val="$runtime_val"
+    status="measured"
+    source="runtime-latest.json"
   fi
 
-  printf '    "%s": {"value": %s, "target": %s, "status": "%s"}' \
-    "$key" "$(as_json_value "$val")" "$target" "$status"
+  printf '    "%s": {"value": %s, "target": %s, "status": "%s", "source": "%s"}' \
+    "$key" "$(as_json_value "$val")" "$target" "$status" "$source"
 }
 
 TESTS_STATUS="not_run"
@@ -233,8 +257,9 @@ metric_keys=(
 
   echo "  },"
   echo "  \"notes\": ["
-  echo "    \"Use --metric key=value overrides to inject measured values from replay/log exports.\"," 
-  echo "    \"Metrics without instrumentation are emitted as pending_instrumentation.\""
+  echo "    \"Core metrics are auto-read from runtime-latest.json when available.\","
+  echo "    \"Use --metric key=value overrides only for debugging or missing data.\","
+  echo "    \"Metrics without runtime data are emitted as pending_instrumentation.\""
   echo "  ]"
   echo "}"
 } > "$OUTPUT"


### PR DESCRIPTION
## Summary

Baseline collector now auto-reads `runtime-latest.json` for core metrics instead of requiring `--metric` overrides. Each metric output includes `source` field (`runtime-latest.json`, `manual_override`, or empty for pending).

Closes #308

## Test plan

- [x] `./gradlew build` passes
- [x] Script syntax verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds automatic reading of `runtime-latest.json` to the baseline collector script, eliminating the need for `--metric` overrides for standard metrics. The priority chain (manual override → runtime file → pending) is correctly implemented and the new `source` field in JSON output cleanly identifies where each metric value came from.

- The logic in `read_runtime_metric` is correct: it checks `jq` availability, guards on file existence, and only emits a value when `status == "measured"`.
- `INJECTION_AUDIT_PATH` (line 138) is defined but never referenced anywhere in the script — it should either be used or removed.
- Both `jq` calls in `read_runtime_metric` interpolate `$key` directly into the filter string; using `jq --arg` is the idiomatic form that avoids any future quoting fragility.
- `runtime_val` is not declared `local` inside `metric_json`, allowing it to leak into the global shell scope (same pre-existing issue exists for `override`).

<h3>Confidence Score: 4/5</h3>

- Safe to merge; changes are additive and well-structured with only minor style issues.
- The core logic is sound — the priority chain, `jq` guards, and status checks are all correct. The three issues found are all style/best-practice level (dead variable, interpolation style, missing `local`), none of which cause a runtime bug in the current codebase.
- No files require special attention beyond the three style notes in `scripts/collect-continuous-learning-baseline.sh`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/collect-continuous-learning-baseline.sh | Adds `read_runtime_metric` to auto-populate metrics from `runtime-latest.json` with correct priority order (manual override > runtime file > pending). Three minor style issues: `INJECTION_AUDIT_PATH` is declared but never used, `jq` filters use bash string interpolation instead of `--arg`, and `runtime_val` is not declared `local`. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: scripts/collect-continuous-learning-baseline.sh
Line: 138

Comment:
**Unused variable — dead code**

`INJECTION_AUDIT_PATH` is declared here but is never referenced anywhere else in the script. Either this was meant to be used in this PR (and was forgotten), or it should be removed to keep the script clean.

```suggestion
RUNTIME_METRICS_PATH="$PROJECT_ROOT/.aceclaw/metrics/continuous-learning/runtime-latest.json"
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: scripts/collect-continuous-learning-baseline.sh
Line: 144-146

Comment:
**Prefer `jq --arg` over bash string interpolation in filters**

Both `jq` calls interpolate `$key` directly into the filter string. While the keys are all statically defined alphanumeric+underscore strings (so there's no real injection risk today), using `--arg` is the idiomatic, safer form that avoids any quoting fragility if new keys are ever added.

```suggestion
    status="$(jq -r --arg k "$key" '.metrics[$k].status // ""' "$RUNTIME_METRICS_PATH" 2>/dev/null)"
    if [[ "$status" == "measured" ]]; then
      jq -r --arg k "$key" '.metrics[$k].value // "null"' "$RUNTIME_METRICS_PATH" 2>/dev/null
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: scripts/collect-continuous-learning-baseline.sh
Line: 167-170

Comment:
**`runtime_val` not declared `local`**

`runtime_val` leaks into the global shell scope because it lacks a `local` declaration, mirroring the pre-existing behaviour of `override`. While this doesn't cause a functional bug today (each loop iteration overwrites it), declaring it `local` inside `metric_json` would make the scoping explicit and consistent.

```suggestion
  elif local runtime_val; runtime_val="$(read_runtime_metric "$key")"; then
```

Or, more portably, add `local runtime_val` alongside the other local declarations at the top of the function and keep the `elif` line unchanged.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["feat: baseline colle..."](https://github.com/xinhuagu/aceclaw/commit/9ed0da9f16a03f1ad5fe61f755312fb307e9a0a8)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->