### PR TITLE
fix: review findings from PRs 312-315 (3 P1 + 5 P2)

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/BenchmarkScorecardCli.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/BenchmarkScorecardCli.java
@@ -46,32 +46,43 @@ public final class BenchmarkScorecardCli {
         // Parse replay report metrics
         Path replayPath = Path.of(replayReportPath);
         if (Files.isRegularFile(replayPath)) {
-            JsonNode report = mapper.readTree(replayPath.toFile());
-            JsonNode metrics = report.path("metrics");
-            extractMetric(metrics, "replay_success_rate_delta", replayDeltas, sampleSizes);
-            extractMetric(metrics, "replay_token_delta", replayDeltas, sampleSizes);
-            extractMetric(metrics, "replay_latency_delta_ms", replayDeltas, sampleSizes);
-            extractMetric(metrics, "replay_failure_distribution_delta", replayDeltas, sampleSizes);
+            try {
+                JsonNode report = mapper.readTree(replayPath.toFile());
+                JsonNode metrics = report.path("metrics");
+                extractMetric(metrics, "replay_success_rate_delta", replayDeltas, sampleSizes);
+                extractMetric(metrics, "replay_token_delta", replayDeltas, sampleSizes);
+                extractMetric(metrics, "replay_latency_delta_ms", replayDeltas, sampleSizes);
+                extractMetric(metrics, "replay_failure_distribution_delta", replayDeltas, sampleSizes);
 
-            // Lifecycle metrics from the report
-            extractMetric(metrics, "promotion_rate", lifecycleRates, sampleSizes);
-            extractMetric(metrics, "demotion_rate", lifecycleRates, sampleSizes);
-            extractMetric(metrics, "rollback_rate", lifecycleRates, sampleSizes);
+                // Lifecycle metrics from the report
+                extractMetric(metrics, "promotion_rate", lifecycleRates, sampleSizes);
+                extractMetric(metrics, "demotion_rate", lifecycleRates, sampleSizes);
+                extractMetric(metrics, "rollback_rate", lifecycleRates, sampleSizes);
+            } catch (Exception e) {
+                System.err.println("Failed to parse replay report: " + e.getMessage());
+                System.exit(2);
+                return;
+            }
         }
 
         // Parse runtime metrics if available
         if (runtimeMetricsPath != null) {
             Path runtimePath = Path.of(runtimeMetricsPath);
             if (Files.isRegularFile(runtimePath)) {
-                JsonNode runtime = mapper.readTree(runtimePath.toFile());
-                JsonNode metrics = runtime.path("metrics");
-                extractMetric(metrics, "first_try_success_rate", replayDeltas, sampleSizes);
-                // Map to delta name expected by scorecard
-                Double ftsr = replayDeltas.remove("first_try_success_rate");
-                if (ftsr != null) {
-                    replayDeltas.put("first_try_success_rate_delta", ftsr);
-                    sampleSizes.put("first_try_success_rate_delta",
-                            sampleSizes.getOrDefault("first_try_success_rate", 0));
+                try {
+                    JsonNode runtime = mapper.readTree(runtimePath.toFile());
+                    JsonNode metrics = runtime.path("metrics");
+                    extractMetric(metrics, "first_try_success_rate", replayDeltas, sampleSizes);
+                    // Map to delta name expected by scorecard
+                    Double ftsr = replayDeltas.remove("first_try_success_rate");
+                    if (ftsr != null) {
+                        replayDeltas.put("first_try_success_rate_delta", ftsr);
+                        sampleSizes.put("first_try_success_rate_delta",
+                                sampleSizes.getOrDefault("first_try_success_rate", 0));
+                    }
+                } catch (Exception e) {
+                    System.err.println("Warning: failed to parse runtime metrics: " + e.getMessage());
+                    // Non-fatal — scorecard can evaluate without runtime metrics
                 }
             }
         }

--- a/docs/continuous-learning-operations.md
+++ b/docs/continuous-learning-operations.md
@@ -421,17 +421,20 @@ CI guardrail job:
   - full `build`
   - `continuousLearningSmoke` focused tests (daemon/memory/core)
   - `replayQualityGate` → `generateReplayReport` → `generateReplayCases` (chained)
+  - `benchmarkScorecard` — compact 8-metric verdict (effectiveness/efficiency/safety)
 
 Task dependency chain (enforced by Gradle):
 ```
 preMergeCheck
 ├── build
 ├── continuousLearningSmoke
-└── replayQualityGate
-    └── generateReplayReport
-        └── generateReplayCases
-            ├── validateReplaySuite
-            └── :aceclaw-cli:runReplayCases
+├── replayQualityGate
+│   └── generateReplayReport
+│       └── generateReplayCases
+│           ├── validateReplaySuite
+│           └── :aceclaw-cli:runReplayCases
+└── benchmarkScorecard
+    └── generateReplayReport (shared, runs once)
 ```
 
 This ensures CI always evaluates freshly generated replay artifacts — never stale or sample data.

--- a/docs/reports/samples/replay-prompts-pr-sample.json
+++ b/docs/reports/samples/replay-prompts-pr-sample.json
@@ -3,7 +3,7 @@
     {
       "id": "core-list-project-files",
       "prompt": "List the top-level files in this repository and summarize what each module does in one line.",
-      "category": "core",
+      "category": "workflow_reuse",
       "owner": "platform-core",
       "risk_level": "low",
       "labels": [
@@ -17,7 +17,7 @@
     {
       "id": "core-build-entrypoints",
       "prompt": "Find the main Gradle entry tasks in this repo and explain what each verification task does.",
-      "category": "core",
+      "category": "workflow_reuse",
       "owner": "platform-core",
       "risk_level": "low",
       "labels": [
@@ -31,7 +31,7 @@
     {
       "id": "core-module-boundaries",
       "prompt": "Summarize the responsibility boundaries among aceclaw-core, aceclaw-daemon, and aceclaw-cli.",
-      "category": "core",
+      "category": "workflow_reuse",
       "owner": "platform-core",
       "risk_level": "medium",
       "labels": [
@@ -45,7 +45,7 @@
     {
       "id": "tools-find-candidate-config",
       "prompt": "Find where candidate injection is configured and show the key config names.",
-      "category": "tools",
+      "category": "workflow_reuse",
       "owner": "platform-core",
       "risk_level": "medium",
       "labels": [
@@ -59,7 +59,7 @@
     {
       "id": "tools-locate-gate-script",
       "prompt": "Find the replay quality gate script and summarize all enforced metrics.",
-      "category": "tools",
+      "category": "workflow_reuse",
       "owner": "quality-team",
       "risk_level": "medium",
       "labels": [
@@ -73,7 +73,7 @@
     {
       "id": "tools-manifest-verification",
       "prompt": "Locate where replay manifest checksum is verified and explain failure behavior.",
-      "category": "tools",
+      "category": "workflow_reuse",
       "owner": "quality-team",
       "risk_level": "high",
       "labels": [
@@ -87,7 +87,7 @@
     {
       "id": "permissions-readonly-scan",
       "prompt": "Scan the repository for files mentioning permission and summarize observed permission levels.",
-      "category": "permissions",
+      "category": "user_correction",
       "owner": "security-team",
       "risk_level": "high",
       "labels": [
@@ -101,7 +101,7 @@
     {
       "id": "permissions-no-write-plan",
       "prompt": "Given a read-only constraint, provide a safe plan to inspect replay scripts without modifying files.",
-      "category": "permissions",
+      "category": "user_correction",
       "owner": "security-team",
       "risk_level": "medium",
       "labels": [
@@ -115,7 +115,7 @@
     {
       "id": "permissions-ci-guardrails",
       "prompt": "Summarize permission-related guardrails in CI and local pre-merge checks.",
-      "category": "permissions",
+      "category": "user_correction",
       "owner": "security-team",
       "risk_level": "medium",
       "labels": [
@@ -129,7 +129,7 @@
     {
       "id": "timeouts-long-task",
       "prompt": "Find large files and suggest a strategy to avoid timeout when scanning them.",
-      "category": "timeouts",
+      "category": "error_recovery",
       "owner": "runtime-team",
       "risk_level": "medium",
       "timeout_ms": 300000,
@@ -144,7 +144,7 @@
     {
       "id": "timeouts-large-search",
       "prompt": "Design a command sequence to search many files while reducing timeout risk and keeping accuracy.",
-      "category": "timeouts",
+      "category": "error_recovery",
       "owner": "runtime-team",
       "risk_level": "medium",
       "timeout_ms": 300000,
@@ -159,7 +159,7 @@
     {
       "id": "timeouts-stepwise-strategy",
       "prompt": "In 6 bullets, provide a timeout-safe chunking strategy for auditing a large codebase.",
-      "category": "timeouts",
+      "category": "error_recovery",
       "owner": "runtime-team",
       "risk_level": "medium",
       "timeout_ms": 300000,
@@ -174,7 +174,7 @@
     {
       "id": "regression-candidate-gate",
       "prompt": "Explain how replay quality gate blocks merge when replay metrics regress.",
-      "category": "regression",
+      "category": "adversarial",
       "owner": "quality-team",
       "risk_level": "high",
       "labels": [
@@ -188,7 +188,7 @@
     {
       "id": "regression-success-rate-drop",
       "prompt": "Describe what should happen when replay_success_rate_delta goes below zero in strict mode.",
-      "category": "regression",
+      "category": "adversarial",
       "owner": "quality-team",
       "risk_level": "high",
       "labels": [
@@ -202,7 +202,7 @@
     {
       "id": "regression-failure-distribution",
       "prompt": "Explain why a large replay_failure_distribution_delta indicates potential quality regression.",
-      "category": "regression",
+      "category": "adversarial",
       "owner": "quality-team",
       "risk_level": "high",
       "labels": [

--- a/scripts/collect-continuous-learning-baseline.sh
+++ b/scripts/collect-continuous-learning-baseline.sh
@@ -140,11 +140,19 @@ INJECTION_AUDIT_PATH="$PROJECT_ROOT/.aceclaw/memory/injection-audit.jsonl"
 read_runtime_metric() {
   local key="$1"
   if [[ -f "$RUNTIME_METRICS_PATH" ]] && command -v jq >/dev/null 2>&1; then
+    if ! jq empty "$RUNTIME_METRICS_PATH" 2>/dev/null; then
+      echo "WARNING: runtime-latest.json exists but contains invalid JSON" >&2
+      return 1
+    fi
     local status
     status="$(jq -r ".metrics.\"$key\".status // \"\"" "$RUNTIME_METRICS_PATH" 2>/dev/null)"
     if [[ "$status" == "measured" ]]; then
-      jq -r ".metrics.\"$key\".value // \"null\"" "$RUNTIME_METRICS_PATH" 2>/dev/null
-      return 0
+      local val
+      val="$(jq -r ".metrics.\"$key\".value" "$RUNTIME_METRICS_PATH" 2>/dev/null)"
+      if [[ "$val" != "null" && -n "$val" ]]; then
+        printf '%s' "$val"
+        return 0
+      fi
     fi
   fi
   return 1
@@ -155,7 +163,7 @@ metric_json() {
   local target
   local val="null"
   local status="pending_instrumentation"
-  local source=""
+  local source="none"
 
   target="$(target_for_key "$key")"
 


### PR DESCRIPTION
## Summary

Fixes from code review of PRs #312-#315:

- **P1** Docs: add `benchmarkScorecard` to preMergeCheck dependency diagram
- **P1** Fix `replay-prompts-pr-sample.json` old categories → canonical taxonomy
- **P1** `BenchmarkScorecardCli`: wrap JSON parsing in try-catch, proper exit code 2
- **P2** Baseline collector: validate JSON integrity, skip null values, set `source="none"` for pending, add corruption warning

## Test plan

- [x] `./gradlew build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses 3 P1 and 5 P2 findings from the previous batch of PRs (#312–315), covering a missing CI task in documentation, stale taxonomy values in a sample fixture, defensive error handling in the Java CLI, and several robustness improvements to the baseline-collection shell script.

**Changes:**
- **`docs/continuous-learning-operations.md`**: Adds `benchmarkScorecard` as a sibling of `replayQualityGate` under `preMergeCheck` in both the prose description and the ASCII dependency tree — correctly reflecting the Gradle task wiring.
- **`docs/reports/samples/replay-prompts-pr-sample.json`**: Migrates all 15 test-case categories from the old informal taxonomy (`core`, `tools`, `permissions`, `timeouts`, `regression`) to the canonical taxonomy (`workflow_reuse`, `user_correction`, `error_recovery`, `adversarial`). All IDs, prompts, and other metadata are preserved.
- **`BenchmarkScorecardCli.java`**: Wraps both JSON-parsing blocks in `try-catch`. Replay-report parse failures are treated as fatal (exit code 2), while runtime-metrics failures are treated as non-fatal (a warning is printed and the scorecard proceeds without them). The differentiation is well-reasoned and consistent with the class-level Javadoc.
- **`collect-continuous-learning-baseline.sh`**: Adds a `jq empty` JSON-integrity check before reading runtime metrics, fixes `read_runtime_metric` so it correctly returns 1 (instead of the literal string `"null"`) when a value is absent, and initialises the `source` field to `"none"` for pending metrics. One P2 issue: because `read_runtime_metric` is called once per metric key (~21 times), a corrupt `runtime-latest.json` will cause the corruption warning to be printed 21 times.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — all changes are targeted bug fixes and documentation corrections with no broad behavioural regressions.
- The Java and JSON changes are clean and correct. The shell script improvements are solid but have one minor UX issue where a corrupt `runtime-latest.json` causes the same warning to be emitted 21 times. No functional correctness issues were found.
- scripts/collect-continuous-learning-baseline.sh — repeated corruption warning per metric key

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| aceclaw-daemon/src/main/java/dev/aceclaw/daemon/BenchmarkScorecardCli.java | Wraps both JSON parsing blocks in try-catch: replay-report failures are fatal (exit 2) and runtime-metrics failures are non-fatal (warning only, scorecard proceeds). Logic is correct and error handling is well-differentiated. |
| docs/continuous-learning-operations.md | Adds `benchmarkScorecard` as a sibling dependency of `replayQualityGate` under `preMergeCheck` in both the prose bullet list and the ASCII dependency tree. Documentation matches the intended Gradle task wiring. |
| docs/reports/samples/replay-prompts-pr-sample.json | Migrates all 15 test-case categories from the old taxonomy (core, tools, permissions, timeouts, regression) to the canonical taxonomy (workflow_reuse, user_correction, error_recovery, adversarial). All IDs, prompts, and metadata are preserved. |
| scripts/collect-continuous-learning-baseline.sh | Adds JSON integrity validation via `jq empty`, fixes the null-value guard so `read_runtime_metric` returns 1 instead of emitting the literal string "null", and initialises `source` to "none" for pending metrics. One issue: the corruption warning fires once per metric key (~21×) when the file is invalid. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: scripts/collect-continuous-learning-baseline.sh
Line: 143-146

Comment:
**Corruption warning emitted once per metric key**

`read_runtime_metric` is called from inside `metric_json`, which is invoked for every entry in `metric_keys` (currently 21 keys). If `runtime-latest.json` is corrupt, the `WARNING: runtime-latest.json exists but contains invalid JSON` message will be printed 21 times — once per metric — making the output very noisy.

Consider validating the file a single time before the metric-collection loop using a module-level flag variable, then skipping the per-call `jq empty` check once the file is already known to be invalid. This would ensure the warning is printed exactly once regardless of how many metrics are queried.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fix: review findings..."](https://github.com/xinhuagu/aceclaw/commit/07a80b21421621dd18f2cbbfe233f2a1082bc239)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->