### PR TITLE
feat: align coverage rules across script, Gradle, CI, and Java

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
     env:
       REPLAY_FULL_MODE: ${{ vars.ACECLAW_REPLAY_FULL_MODE || 'false' }}
       REPLAY_PROMPTS_PATH: ${{ vars.ACECLAW_REPLAY_PROMPTS_PATH || (vars.ACECLAW_REPLAY_FULL_MODE == 'true' && 'docs/reports/samples/replay-prompts-sample.json' || 'docs/reports/samples/replay-prompts-ci-short.json') }}
+      # CI-short uses 1 (fast smoke); full mode uses 5 (coverage); canonical default is 3
       REPLAY_SUITE_MIN_PER_CATEGORY: ${{ vars.ACECLAW_REPLAY_SUITE_MIN_PER_CATEGORY || (vars.ACECLAW_REPLAY_FULL_MODE == 'true' && '5' || '1') }}
       REPLAY_MAX_TOKEN_ESTIMATION_ERROR_RATIO: ${{ vars.ACECLAW_REPLAY_MAX_TOKEN_ESTIMATION_ERROR_RATIO || (vars.ACECLAW_REPLAY_FULL_MODE == 'true' && '0.25' || '0.65') }}
       REPLAY_FAIL_ON_LATENCY: ${{ vars.ACECLAW_REPLAY_FAIL_ON_LATENCY || 'false' }}

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/stats/ReplayBenchmarkValidator.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/stats/ReplayBenchmarkValidator.java
@@ -23,8 +23,19 @@ import java.util.Set;
  */
 public final class ReplayBenchmarkValidator {
 
-    /** Minimum cases per category for statistical significance. */
+    /**
+     * Minimum cases per category for statistical significance in benchmark results.
+     * Below this, metrics are reported as INSUFFICIENT_DATA.
+     */
     public static final int MIN_CASES_PER_CATEGORY = 10;
+
+    /**
+     * Minimum cases per category for suite schema validation (structural coverage).
+     * Matches the default in {@code validate-replay-suite.sh} and Gradle's
+     * {@code replaySuiteMinPerCategory}. Lower than {@link #MIN_CASES_PER_CATEGORY}
+     * because suite validation checks structure, not statistical power.
+     */
+    public static final int MIN_CASES_FOR_SUITE_VALIDATION = 3;
 
     /** Required benchmark categories. */
     public static final Set<String> REQUIRED_CATEGORIES = Set.of(

--- a/docs/continuous-learning-operations.md
+++ b/docs/continuous-learning-operations.md
@@ -476,9 +476,11 @@ Canonical CI runs (enforces fresh generation):
   - `ACECLAW_REPLAY_PROMPTS_PATH` default:
     - full mode (`true`): `docs/reports/samples/replay-prompts-sample.json`
     - default (`false`): `docs/reports/samples/replay-prompts-ci-short.json` (5 short cases)
-  - `ACECLAW_REPLAY_SUITE_MIN_PER_CATEGORY` default:
-    - full mode (`true`): `5`
-    - default (`false`): `1`
+  - `ACECLAW_REPLAY_SUITE_MIN_PER_CATEGORY` — minimum cases per benchmark category:
+    - CI short mode (`false`): `1` (fast smoke)
+    - CI full mode (`true`): `5` (coverage)
+    - Script/Gradle canonical default: `3` (structural validation)
+    - Java `ReplayBenchmarkValidator.MIN_CASES_PER_CATEGORY`: `10` (statistical significance, different purpose)
   - `ACECLAW_REPLAY_TIMEOUT_MS` (default: `180000`)
   - `ACECLAW_REPLAY_AUTO_APPROVE_PERMISSIONS` (default: `true`)
   - `ACECLAW_REPLAY_MAX_TOKEN_ESTIMATION_ERROR_RATIO` (default by event):

--- a/scripts/validate-replay-suite.sh
+++ b/scripts/validate-replay-suite.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 INPUT=""
-MIN_PER_CATEGORY=1
+MIN_PER_CATEGORY=3
 
 usage() {
   cat <<USAGE
@@ -10,7 +10,7 @@ Usage: ./scripts/validate-replay-suite.sh [options]
 
 Options:
   --input <path>             Replay prompts suite JSON path.
-  --min-per-category <n>     Minimum cases for each required category (default: 1).
+  --min-per-category <n>     Minimum cases for each required category (default: 3).
   --help                     Show this help.
 
 Required case fields:


### PR DESCRIPTION
## Summary

Unify minimum-per-category defaults across all 4 enforcement points:

| Context | Before | After | Purpose |
|---------|--------|-------|---------|
| Script default | 1 | **3** | Canonical structural validation |
| Gradle default | 3 | 3 | Already aligned |
| CI short mode | 1 | 1 | Fast smoke (explicit override) |
| CI full mode | 5 | 5 | Already aligned |
| Java validator | 10 | 10 | Statistical significance (different purpose) |

Added `MIN_CASES_FOR_SUITE_VALIDATION = 3` constant and documented the tiered model.

Closes #310

## Test plan

- [x] `./gradlew build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
