### PR TITLE
fix: unify sample_size semantics — report is single source of truth

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/BenchmarkScorecardCli.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/BenchmarkScorecardCli.java
@@ -3,7 +3,6 @@ package dev.aceclaw.daemon;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.aceclaw.core.stats.BenchmarkScorecard;
-import dev.aceclaw.core.stats.ReplayBenchmarkValidator;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -17,15 +16,12 @@ import java.util.Map;
  * <p>Exit code: 0 = pass, 1 = fail, 2 = error.
  *
  * <p>Usage: {@code java BenchmarkScorecardCli --replay-report <path>
- *   [--runtime-metrics <path>] [--output <path>] [--replay-prompts <path>]}
+ *   [--runtime-metrics <path>] [--output <path>]}
  *
- * <p>When {@code --replay-prompts} is provided, the CLI reads the prompts file,
- * computes the actual minimum per-category case count, and uses that as each
- * metric's effective sample_size (instead of the total case count from the
- * replay report). This enforces the two-layer threshold model: a suite may
- * pass structural validation (3 = can run) but still report {@code INSUFFICIENT_DATA}
- * in the scorecard when per-category coverage is below statistical significance
- * (10 = can trust).
+ * <p>The replay report's {@code sample_size} field is the effective per-category
+ * minimum (when {@code --replay-prompts} was passed to {@code generate-replay-report.sh})
+ * or total case count (fallback). The scorecard uses this directly against
+ * {@link BenchmarkScorecard#MIN_SAMPLE_SIZE} (10) to determine significance.
  */
 public final class BenchmarkScorecardCli {
 
@@ -33,19 +29,17 @@ public final class BenchmarkScorecardCli {
         String replayReportPath = null;
         String runtimeMetricsPath = null;
         String outputPath = null;
-        String replayPromptsPath = null;
 
         for (int i = 0; i < args.length; i++) {
             switch (args[i]) {
                 case "--replay-report" -> replayReportPath = args[++i];
                 case "--runtime-metrics" -> runtimeMetricsPath = args[++i];
                 case "--output" -> outputPath = args[++i];
-                case "--replay-prompts" -> replayPromptsPath = args[++i];
             }
         }
 
         if (replayReportPath == null) {
-            System.err.println("Usage: BenchmarkScorecardCli --replay-report <path> [--runtime-metrics <path>] [--output <path>] [--replay-prompts <path>]");
+            System.err.println("Usage: BenchmarkScorecardCli --replay-report <path> [--runtime-metrics <path>] [--output <path>]");
             System.exit(2);
             return;
         }
@@ -83,23 +77,6 @@ public final class BenchmarkScorecardCli {
         // Runtime metrics (runtime-latest.json) provide absolute rates which cannot
         // be substituted for deltas without misrepresenting the scorecard contract.
 
-        // When prompts file is available, compute actual min per-category count
-        // and use it as effective sample_size. This ensures scorecard reports
-        // INSUFFICIENT_DATA when per-category coverage is below significance (10),
-        // even when total case count is above 10.
-        if (replayPromptsPath != null) {
-            Path promptsPath = Path.of(replayPromptsPath);
-            if (Files.isRegularFile(promptsPath)) {
-                int effectiveSampleSize = computeMinPerCategory(mapper, promptsPath);
-                if (effectiveSampleSize > 0) {
-                    int cap = effectiveSampleSize;
-                    for (var key : sampleSizes.keySet()) {
-                        sampleSizes.computeIfPresent(key, (_, v) -> Math.min(v, cap));
-                    }
-                }
-            }
-        }
-
         // Evaluate scorecard
         var scorecard = BenchmarkScorecard.evaluate(replayDeltas, sampleSizes, lifecycleRates);
 
@@ -135,36 +112,6 @@ public final class BenchmarkScorecardCli {
         }
 
         System.exit(scorecard.pass() ? 0 : 1);
-    }
-
-    /**
-     * Reads the replay prompts file and returns the minimum case count
-     * across all required benchmark categories.
-     */
-    private static int computeMinPerCategory(ObjectMapper mapper, Path promptsPath) {
-        try {
-            JsonNode root = mapper.readTree(promptsPath.toFile());
-            JsonNode cases = root.path("cases");
-            if (!cases.isArray() || cases.isEmpty()) return 0;
-
-            var counts = new LinkedHashMap<String, Integer>();
-            for (JsonNode c : cases) {
-                String cat = c.path("category").asText("").trim().toLowerCase();
-                if (!cat.isEmpty()) {
-                    counts.merge(cat, 1, Integer::sum);
-                }
-            }
-
-            int min = Integer.MAX_VALUE;
-            for (String required : ReplayBenchmarkValidator.REQUIRED_CATEGORIES) {
-                int count = counts.getOrDefault(required, 0);
-                if (count < min) min = count;
-            }
-            return min == Integer.MAX_VALUE ? 0 : min;
-        } catch (Exception e) {
-            System.err.println("WARNING: Failed to read replay prompts for per-category count: " + e.getMessage());
-            return 0;
-        }
     }
 
     private static void extractMetric(JsonNode metrics, String name,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -157,6 +157,9 @@ tasks.register<Exec>("generateReplayReport") {
             .orElse("${rootDir}/.aceclaw/metrics/continuous-learning/anti-pattern-gate-feedback.json")
     val replayCandidateTransitionsPath = providers.gradleProperty("replayCandidateTransitionsPath")
             .orElse("${rootDir}/.aceclaw/memory/candidate-transitions.jsonl")
+    val replayPromptsInput = providers.gradleProperty("replayPromptsInput")
+            .orElse(providers.gradleProperty("replayInput"))
+            .orElse("${rootDir}/docs/reports/samples/replay-prompts-sample.json")
 
     commandLine(
             "bash",
@@ -165,6 +168,7 @@ tasks.register<Exec>("generateReplayReport") {
             "--manifest", replayCasesManifestInput.get(),
             "--anti-pattern-feedback", replayAntiPatternFeedbackPath.get(),
             "--candidate-transitions", replayCandidateTransitionsPath.get(),
+            "--replay-prompts", replayPromptsInput.get(),
             "--output", replayReport.get()
     )
 }
@@ -205,15 +209,11 @@ tasks.register<JavaExec>("benchmarkScorecard") {
             .orElse("${rootDir}/.aceclaw/metrics/continuous-learning/runtime-latest.json")
     val scorecardOutput = providers.gradleProperty("scorecardOutput")
             .orElse("${rootDir}/.aceclaw/metrics/continuous-learning/benchmark-scorecard.json")
-    val replayPrompts = providers.gradleProperty("replayPromptsInput")
-            .orElse(providers.gradleProperty("replayInput"))
-            .orElse("${rootDir}/docs/reports/samples/replay-prompts-sample.json")
 
     jvmArgs("--enable-preview")
     args("--replay-report", replayReport.get(),
          "--runtime-metrics", runtimeMetrics.get(),
-         "--output", scorecardOutput.get(),
-         "--replay-prompts", replayPrompts.get())
+         "--output", scorecardOutput.get())
 }
 
 tasks.register("preMergeCheck") {

--- a/docs/continuous-learning-operations.md
+++ b/docs/continuous-learning-operations.md
@@ -497,7 +497,7 @@ Canonical CI runs (enforces fresh generation):
     - Two-layer threshold model:
       - **3 = can run** (structural minimum): suite has enough cases per category to be valid. Enforced by `validate-replay-suite.sh`, Gradle, CI, and `ReplayBenchmarkValidator`.
       - **10 = can trust** (statistical significance): suite has enough cases for benchmark verdicts to be meaningful. Enforced by `BenchmarkScorecard.MIN_SAMPLE_SIZE`. Below this, metrics report `INSUFFICIENT_DATA` but the suite still passes validation.
-    - `BenchmarkScorecardCli` reads the prompts file (`--replay-prompts`) and computes the actual minimum per-category case count. This count — not the total case count from the replay report — is used as each metric's effective `sample_size` for significance evaluation.
+    - `generate-replay-report.sh` accepts `--replay-prompts` and computes the actual minimum per-category case count from the prompts file. This count is emitted as each replay metric's `sample_size` (instead of total case count). `BenchmarkScorecardCli` reads `sample_size` directly — no separate capping needed.
   - `ACECLAW_REPLAY_TIMEOUT_MS` (default: `180000`)
   - `ACECLAW_REPLAY_AUTO_APPROVE_PERMISSIONS` (default: `true`)
   - `ACECLAW_REPLAY_MAX_TOKEN_ESTIMATION_ERROR_RATIO` (default by event):

--- a/scripts/generate-replay-report.sh
+++ b/scripts/generate-replay-report.sh
@@ -6,10 +6,11 @@ OUTPUT=""
 MANIFEST=""
 ANTI_PATTERN_FEEDBACK=""
 CANDIDATE_TRANSITIONS=""
+REPLAY_PROMPTS=""
 
 usage() {
   cat <<USAGE
-Usage: ./scripts/generate-replay-report.sh --input <cases.json> [--output <report.json>] [--manifest <manifest.json>] [--anti-pattern-feedback <feedback.json>] [--candidate-transitions <transitions.jsonl>]
+Usage: ./scripts/generate-replay-report.sh --input <cases.json> [--output <report.json>] [--manifest <manifest.json>] [--anti-pattern-feedback <feedback.json>] [--candidate-transitions <transitions.jsonl>] [--replay-prompts <prompts.json>]
 
 Input schema:
 {
@@ -53,6 +54,7 @@ Options:
                    (default: .aceclaw/metrics/continuous-learning/anti-pattern-gate-feedback.json)
   --candidate-transitions <path> Candidate transitions JSONL
                    (default: .aceclaw/memory/candidate-transitions.jsonl)
+  --replay-prompts <path> Replay prompts suite JSON (for per-category sample_size)
   --help           Show this help.
 USAGE
 }
@@ -77,6 +79,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --candidate-transitions)
       CANDIDATE_TRANSITIONS="$2"
+      shift 2
+      ;;
+    --replay-prompts)
+      REPLAY_PROMPTS="$2"
       shift 2
       ;;
     --help)
@@ -193,6 +199,25 @@ fi
 
 mkdir -p "$(dirname "$OUTPUT")"
 
+# Compute effective sample_size from prompts file (min per required category).
+# Falls back to total case count when prompts file is not provided.
+EFFECTIVE_SAMPLE_SIZE=0
+MIN_PER_CATEGORY_COMPUTED="null"
+if [[ -n "$REPLAY_PROMPTS" && -f "$REPLAY_PROMPTS" ]]; then
+  required_cats=(error_recovery user_correction workflow_reuse adversarial)
+  min_cat=999999
+  for cat in "${required_cats[@]}"; do
+    count="$(jq -r --arg c "$cat" '[.cases[] | select(.category == $c)] | length' "$REPLAY_PROMPTS" 2>/dev/null || echo "0")"
+    if [[ "$count" -lt "$min_cat" ]]; then
+      min_cat="$count"
+    fi
+  done
+  if [[ "$min_cat" -lt 999999 && "$min_cat" -gt 0 ]]; then
+    EFFECTIVE_SAMPLE_SIZE="$min_cat"
+    MIN_PER_CATEGORY_COMPUTED="$min_cat"
+  fi
+fi
+
 if ! branch_name="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"; then
   branch_name="unknown"
 fi
@@ -210,6 +235,8 @@ jq \
   --arg manifest_expected_sha "$manifest_expected_sha" \
   --arg manifest_actual_sha "$manifest_actual_sha" \
   --arg manifest_verified "$manifest_verified" \
+  --argjson effective_sample_size "$EFFECTIVE_SAMPLE_SIZE" \
+  --argjson min_per_category_computed "$MIN_PER_CATEGORY_COMPUTED" \
   '
   def bucket(ft):
     if ft == "permission" then "permission"
@@ -250,6 +277,7 @@ jq \
     ];
 
   (.cases | length) as $n
+  | (if $effective_sample_size > 0 then $effective_sample_size else $n end) as $ss
   | (([.cases[] | .off.success | if . then 1 else 0 end] | add) / $n) as $success_off
   | (([.cases[] | .on.success | if . then 1 else 0 end] | add) / $n) as $success_on
   | (([.cases[] | .off.tokens] | add) / $n) as $tokens_off
@@ -309,25 +337,25 @@ jq \
           value: ($success_on - $success_off),
           target: 0.00,
           status: "measured",
-          sample_size: $n
+          sample_size: $ss
         },
         replay_token_delta: {
           value: ($tokens_on - $tokens_off),
           target: 200.00,
           status: "measured",
-          sample_size: $n
+          sample_size: $ss
         },
         replay_latency_delta_ms: {
           value: ($latency_on - $latency_off),
           target: 500.00,
           status: "measured",
-          sample_size: $n
+          sample_size: $ss
         },
         replay_failure_distribution_delta: {
           value: $l1,
           target: 0.15,
           status: "measured",
-          sample_size: $n
+          sample_size: $ss
         },
         token_estimation_error_ratio_max: {
           value: $token_err_max,
@@ -357,6 +385,9 @@ jq \
         }
       },
       diagnostics: {
+        total_cases: $n,
+        min_cases_per_required_category: $min_per_category_computed,
+        effective_sample_size: $ss,
         success_rate_off: $success_off,
         success_rate_on: $success_on,
         avg_tokens_off: $tokens_off,


### PR DESCRIPTION
## Summary
Move per-category sample_size computation from BenchmarkScorecardCli into generate-replay-report.sh, making the report the single source of truth.

## Before
- Report emits `sample_size: 12` (total cases)
- Scorecard CLI reads prompts file, caps to 3 (min/category)
- Report says 12, scorecard says 3 — inconsistent

## After
- Report accepts `--replay-prompts`, computes actual min/category, emits as `sample_size`
- Scorecard CLI reads `sample_size` directly — no capping
- Report and scorecard agree on the same number

## Behavior
| Suite | min/category | sample_size | Scorecard |
|-------|-------------|-------------|-----------|
| CI-short (12 cases) | 3 | 3 | INSUFFICIENT_DATA |
| Full (25 cases) | 5 | 5 | INSUFFICIENT_DATA |
| Proper (40+ cases) | 10+ | 10+ | PASS/FAIL verdicts |
| No prompts (fallback) | n/a | total cases | depends on total |

## Test plan
- [x] Report without `--replay-prompts` → sample_size = total cases (backward compatible)
- [x] Report with CI-short prompts → sample_size = 3
- [x] Report with full prompts → sample_size = 5
- [x] Diagnostics include total_cases, min_cases_per_required_category, effective_sample_size
- [x] Java compiles, all tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the benchmark scorecard CLI by removing `--replay-prompts` argument support
  * Sample size values are now sourced directly from replay reports rather than being derived from prompt files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->