### PR TITLE
feat(memory): workspace-first retrieval priority in AutoMemoryStore

### DIFF
--- a/aceclaw-memory/src/main/java/dev/aceclaw/memory/AutoMemoryStore.java
+++ b/aceclaw-memory/src/main/java/dev/aceclaw/memory/AutoMemoryStore.java
@@ -649,7 +649,7 @@ public final class AutoMemoryStore {
         merged.addAll(global);
 
         if (limit > 0 && merged.size() > limit) {
-            return merged.subList(0, limit);
+            return List.copyOf(merged.subList(0, limit));
         }
         return merged;
     }

--- a/aceclaw-memory/src/test/java/dev/aceclaw/memory/AutoMemoryStoreTest.java
+++ b/aceclaw-memory/src/test/java/dev/aceclaw/memory/AutoMemoryStoreTest.java
@@ -570,7 +570,7 @@ class AutoMemoryStoreTest {
                 List.of("java"), "test", false, projectPath);
 
         var results = store.search("sealed interfaces", null, 10);
-        assertThat(results).hasSizeGreaterThanOrEqualTo(2);
+        assertThat(results).hasSize(2);
         // Workspace entry should come first
         assertThat(results.get(0).content()).contains("Workspace");
     }


### PR DESCRIPTION
## Summary
- query(), search(), and formatForPrompt() now return workspace entries before global entries
- Workspace entries fill the limit first; global entries only appear as fallback
- Implementation: workspaceFirstMerge() partitions by scope using existing entryFiles tracking

## Why
AutoMemoryStore loads both workspace and global entries into one list. Previously, query/search treated them equally — global entries could compete with workspace entries for limited prompt slots. Now workspace-specific memories always take priority for project-specific work.

## Test plan
- [x] queryReturnsWorkspaceEntriesBeforeGlobal
- [x] queryLimitPrefersWorkspaceEntries — limit 3 with 3+3 entries → only workspace
- [x] queryFillsGlobalWhenWorkspaceInsufficient — workspace not enough → global fills
- [x] queryWorksWithOnlyGlobalEntries — no workspace → global still works
- [x] searchReturnsWorkspaceEntriesBeforeGlobal
- [x] formatForPromptPrefersWorkspaceEntries — limit 1 → only workspace entry
- [x] All existing AutoMemoryStoreTest tests still pass

Closes #351

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Query and search now prioritize workspace entries before global entries and apply result limits after this workspace-first ordering.

* **Bug Fixes**
  * Adjusted ranking/limiting so limits reflect workspace-first combined results (avoids dropping workspace items when filling with global items).

* **Tests**
  * Added tests to validate workspace-first ordering and limit behavior.

* **Documentation**
  * Updated docs to explain workspace-first prioritization and limit semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->