### PR TITLE
feat: add aceclaw-update command for pull + rebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ aceclaw                # Start AceClaw (auto-starts daemon)
 | `aceclaw-tui` | Open another TUI window (non-destructive, never restarts daemon) |
 | `aceclaw-restart` | Rebuild + restart daemon (no benchmarks, fastest restart) |
 | `aceclaw-dev` | Rebuild + restart + auto-benchmark on feature branches |
+| `aceclaw-update` | Pull latest code + rebuild (safe: skips restart if sessions active) |
 
 See [Multi-Session Model](docs/multi-session.md) for details on running multiple TUI windows.
 

--- a/install.sh
+++ b/install.sh
@@ -137,8 +137,9 @@ install_unix_symlinks() {
     ln -sf "$INSTALL_DIR/tui.sh" "$BIN_DIR/aceclaw-tui"
     ln -sf "$INSTALL_DIR/restart.sh" "$BIN_DIR/aceclaw-restart"
     ln -sf "$INSTALL_DIR/dev.sh" "$BIN_DIR/aceclaw-dev"
+    ln -sf "$INSTALL_DIR/update.sh" "$BIN_DIR/aceclaw-update"
 
-    ok "Installed: aceclaw, aceclaw-tui, aceclaw-restart, aceclaw-dev"
+    ok "Installed: aceclaw, aceclaw-tui, aceclaw-restart, aceclaw-dev, aceclaw-update"
 }
 
 install_windows_cmd() {
@@ -176,7 +177,16 @@ call "$CLI_BAT" daemon stop 2>nul
 call "$CLI_BAT" %*
 CMDEOF
 
-    ok "Installed: aceclaw.cmd, aceclaw-tui.cmd, aceclaw-restart.cmd, aceclaw-dev.cmd"
+    # aceclaw-update.cmd
+    cat > "$BIN_DIR/aceclaw-update.cmd" <<CMDEOF
+@echo off
+cd /d "%USERPROFILE%\.aceclaw\src"
+git pull --ff-only || (echo git pull failed & exit /b 1)
+call gradlew.bat :aceclaw-cli:installDist -q
+echo Update complete.
+CMDEOF
+
+    ok "Installed: aceclaw.cmd, aceclaw-tui.cmd, aceclaw-restart.cmd, aceclaw-dev.cmd, aceclaw-update.cmd"
     warn "Windows support is experimental — see https://github.com/xinhuagu/AceClaw/issues/357"
 }
 
@@ -223,8 +233,7 @@ main() {
     echo "    aceclaw-tui      Open another TUI window (non-destructive)"
     echo "    aceclaw-restart  Rebuild + restart daemon (no benchmarks)"
     echo "    aceclaw-dev      Rebuild + restart + benchmark checks"
-    echo ""
-    echo "  To update later:  cd $INSTALL_DIR && git pull && ./gradlew :aceclaw-cli:installDist -q"
+    echo "    aceclaw-update   Pull latest + rebuild (safe: skips daemon restart if sessions active)"
     echo ""
 }
 

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+# Update AceClaw: pull latest code, rebuild CLI, restart daemon if running.
+#
+# Usage: aceclaw-update
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+info()  { printf '  \033[1;34m>\033[0m %s\n' "$1"; }
+ok()    { printf '  \033[1;32m✓\033[0m %s\n' "$1"; }
+warn()  { printf '  \033[1;33m!\033[0m %s\n' "$1"; }
+fail()  { printf '  \033[1;31m✗\033[0m %s\n' "$1"; exit 1; }
+
+# Auto-detect JAVA_HOME if not set
+if [ -z "$JAVA_HOME" ]; then
+    DETECTED_JDK="$(/usr/libexec/java_home -v 21 2>/dev/null || true)"
+    if [ -n "$DETECTED_JDK" ] && [ -d "$DETECTED_JDK" ]; then
+        export JAVA_HOME="$DETECTED_JDK"
+    fi
+fi
+
+echo ""
+echo "  AceClaw Update"
+echo "  ──────────────"
+echo ""
+
+# Pull latest
+info "Pulling latest changes..."
+cd "$SCRIPT_DIR"
+OLD_HEAD=$(git rev-parse HEAD)
+git pull --ff-only || fail "git pull failed. Resolve conflicts manually in $SCRIPT_DIR"
+NEW_HEAD=$(git rev-parse HEAD)
+
+if [ "$OLD_HEAD" = "$NEW_HEAD" ]; then
+    ok "Already up to date"
+    echo ""
+    exit 0
+fi
+
+COMMIT_COUNT=$(git rev-list --count "$OLD_HEAD".."$NEW_HEAD")
+ok "Updated: $COMMIT_COUNT new commit(s)"
+
+# Rebuild
+info "Rebuilding CLI..."
+"$SCRIPT_DIR/gradlew" -p "$SCRIPT_DIR" :aceclaw-cli:installDist -q
+ok "Build complete"
+
+# Restart daemon if running
+CLI_BIN="$SCRIPT_DIR/aceclaw-cli/build/install/aceclaw-cli/bin/aceclaw-cli"
+if [ -S ~/.aceclaw/aceclaw.sock ]; then
+    ACTIVE_SESSIONS=$("$CLI_BIN" daemon status 2>/dev/null | sed -n 's/.*Active Sessions: *//p' || echo "0")
+    if [ "$ACTIVE_SESSIONS" -gt 0 ] 2>/dev/null; then
+        warn "Daemon has $ACTIVE_SESSIONS active session(s) — not restarting automatically"
+        echo "  Run 'aceclaw-restart' to restart the daemon when ready."
+    else
+        info "Restarting daemon..."
+        "$CLI_BIN" daemon stop 2>/dev/null || true
+        sleep 0.5
+        ok "Daemon stopped. It will auto-start on next aceclaw/aceclaw-tui launch."
+    fi
+else
+    ok "No daemon running — nothing to restart"
+fi
+
+echo ""
+ok "AceClaw updated successfully!"
+echo ""


### PR DESCRIPTION
## Summary
Add `update.sh` / `aceclaw-update` command that pulls latest code, rebuilds CLI, and safely handles running daemon.

## Behavior
- `git pull --ff-only` from ~/.aceclaw/src
- Rebuilds CLI with Gradle
- If daemon has active sessions → warns but does NOT restart (safe)
- If daemon is idle → stops it (auto-starts on next launch)
- If no daemon running → nothing to do

## Changes
- New `update.sh` script
- `install.sh` now creates `aceclaw-update` symlink (Unix) and `.cmd` (Windows)
- README updated with the new command

## Test plan
- [ ] Manual: run aceclaw-update when already up to date → shows 'Already up to date'
- [ ] Manual: run aceclaw-update with new commits → pulls, rebuilds, reports count
- [ ] Manual: run with active sessions → warns, does not restart