### PR TITLE
fix: resolve symlinks in update.sh, tui.sh, restart.sh

### DIFF
--- a/restart.sh
+++ b/restart.sh
@@ -6,7 +6,14 @@
 #   provider: anthropic (default), openai, openai-codex, ollama, copilot, groq
 set -e
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Resolve symlinks to find the real script location (not the symlink dir)
+SELF="$0"
+while [ -L "$SELF" ]; do
+    DIR="$(cd "$(dirname "$SELF")" && pwd)"
+    SELF="$(readlink "$SELF")"
+    case "$SELF" in /*) ;; *) SELF="$DIR/$SELF" ;; esac
+done
+SCRIPT_DIR="$(cd "$(dirname "$SELF")" && pwd)"
 
 # Parse optional provider
 PROVIDER=""

--- a/tui.sh
+++ b/tui.sh
@@ -9,8 +9,14 @@
 #   Example: ./tui.sh ollama
 set -e
 
-# Resolve the AceClaw repo root from the script's own location
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Resolve symlinks to find the real script location (not the symlink dir)
+SELF="$0"
+while [ -L "$SELF" ]; do
+    DIR="$(cd "$(dirname "$SELF")" && pwd)"
+    SELF="$(readlink "$SELF")"
+    case "$SELF" in /*) ;; *) SELF="$DIR/$SELF" ;; esac
+done
+SCRIPT_DIR="$(cd "$(dirname "$SELF")" && pwd)"
 
 # Parse optional provider
 PROVIDER=""

--- a/update.sh
+++ b/update.sh
@@ -4,7 +4,14 @@
 # Usage: aceclaw-update
 set -e
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Resolve symlinks to find the real script location (not the symlink dir)
+SELF="$0"
+while [ -L "$SELF" ]; do
+    DIR="$(cd "$(dirname "$SELF")" && pwd)"
+    SELF="$(readlink "$SELF")"
+    case "$SELF" in /*) ;; *) SELF="$DIR/$SELF" ;; esac
+done
+SCRIPT_DIR="$(cd "$(dirname "$SELF")" && pwd)"
 
 info()  { printf '  \033[1;34m>\033[0m %s\n' "$1"; }
 ok()    { printf '  \033[1;32m✓\033[0m %s\n' "$1"; }


### PR DESCRIPTION
SCRIPT_DIR used `dirname $0` which points to the symlink's directory (e.g. ~/bin), not the actual repo. Now follows the symlink chain with `readlink` before resolving dirname. Fixes aceclaw-update, aceclaw-tui, aceclaw-restart when invoked via symlink.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved symlink handling in build and utility scripts to ensure correct path resolution when scripts are invoked through symbolic links, enhancing reliability and consistency across different invocation methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->