### PR TITLE
fix: AutoReleaseControllerTest clock drift causing release failures

### DIFF
--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/AutoReleaseControllerTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/AutoReleaseControllerTest.java
@@ -128,9 +128,13 @@ class AutoReleaseControllerTest {
     }
 
     private static CandidateStore newStore(Path projectRoot) throws Exception {
+        return newStore(projectRoot, Instant.parse("2026-02-24T00:01:00Z"));
+    }
+
+    private static CandidateStore newStore(Path projectRoot, Instant clockAt) throws Exception {
         var cfg = new CandidateStateMachine.Config(1, 0.2, 0.9, 3, Duration.ofDays(30),
                 Duration.ofDays(7), 1, 0.9, 10, Duration.ZERO, Set.of());
-        var store = new CandidateStore(projectRoot, cfg);
+        var store = new CandidateStore(projectRoot, cfg, Clock.fixed(clockAt, ZoneOffset.UTC));
         store.load();
         return store;
     }
@@ -160,6 +164,7 @@ class AutoReleaseControllerTest {
                 "src:2",
                 at.plusSeconds(30)
         ));
+
         store.evaluateAll();
         return store.byState(CandidateState.PROMOTED).getFirst();
     }

--- a/aceclaw-memory/src/main/java/dev/aceclaw/memory/CandidateStore.java
+++ b/aceclaw-memory/src/main/java/dev/aceclaw/memory/CandidateStore.java
@@ -68,6 +68,15 @@ public final class CandidateStore {
         this(aceclawHome, DEFAULT_RECENT_WINDOW, DEFAULT_MERGE_THRESHOLD, smConfig);
     }
 
+    /**
+     * Creates a store with a fixed clock for testing.
+     */
+    public CandidateStore(Path aceclawHome, CandidateStateMachine.Config smConfig, Clock clock) throws IOException {
+        this(aceclawHome, DEFAULT_RECENT_WINDOW, DEFAULT_MERGE_THRESHOLD, smConfig,
+                DEFAULT_RETENTION, DEFAULT_DECAY_HALF_LIFE, DEFAULT_DECAY_GRACE,
+                DEFAULT_MAINTENANCE_INTERVAL, clock);
+    }
+
     CandidateStore(Path aceclawHome, Duration recentWindow, double mergeThreshold) throws IOException {
         this(aceclawHome, recentWindow, mergeThreshold, CandidateStateMachine.Config.defaults());
     }


### PR DESCRIPTION
Tests used hardcoded 2026-02-24 timestamps with Clock.systemUTC(). After 2026-03-24, evidence events fell outside the 30-day rolling window, causing windowMetrics.attempts=0 and promotion gate failure.

Fix: CandidateStore now accepts a Clock parameter. Tests use Clock.fixed() matching test timestamps.

This was blocking the v0.2.1 release workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure with improved time handling for deterministic test execution.

* **Refactor**
  * Extended internal constructor to support additional configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->