### PR TITLE
docs: platform support matrix — Windows experimental, macOS/Linux full

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,16 @@ export ACECLAW_PROVIDER="openai"   # or groq, together, mistral
 export OPENAI_API_KEY="sk-..."
 ```
 
+## Platform Support
+
+| Platform | Status | IPC | CI |
+|----------|--------|-----|-----|
+| **Linux** | Fully supported | AF_UNIX | Full test suite |
+| **macOS** | Fully supported | AF_UNIX | Smoke tests |
+| **Windows 10 1803+** | Experimental | AF_UNIX (JEP 380) | Smoke tests |
+
+Windows requires Java 21 runtime and Windows 10 version 1803 or later (for AF_UNIX socket support). See [Windows UDS Spike](docs/windows-uds-spike.md) for technical details.
+
 ## Tech Stack
 
 Java 21 (preview features) · Gradle 8.14 · Picocli 4.7.6 · JLine3 3.27.1 · Jackson 2.18.2 · GraalVM Native Image · JUnit 5

--- a/docs/windows-uds-spike.md
+++ b/docs/windows-uds-spike.md
@@ -76,8 +76,13 @@ Uses `DaemonConnection.connect()` internally. No platform-specific code.
 - **Low risk**: Users on Windows 10 pre-1803 (2017) cannot use AF_UNIX. This is acceptable for a JDK 21 project (JDK 21 itself requires modern Windows).
 - **Low risk**: Some enterprise environments disable AF_UNIX. Mitigation: clear error message on `SocketException` at startup.
 
-## Impact on Subsequent Steps
+## Implementation Status
 
-- **Step 2** (DaemonStarter refactoring): Confirmed as the correct next step. No transport changes needed.
-- **Step 3** (Runtime bring-up): UdsListener and DaemonConnection need no changes. Focus on DaemonStarter, DaemonLock, and file permission handling.
-- **Step 5** (Scripts): `.cmd` wrappers are sufficient; no shell emulation needed.
+All steps completed:
+
+- **Step 1**: Spike confirmed AF_UNIX works on Windows 10 1803+ with JDK 21
+- **Step 2**: DaemonStarter refactored into platform-aware launchers (Linux/macOS/Windows)
+- **Step 3**: ReadFileTool charset detection uses BOM on Windows (fail-safe, no guessing)
+- **Step 4**: CI runs Windows + macOS smoke tests (assemble + targeted cross-platform tests)
+- **Step 5**: Native `.cmd` wrappers for Windows (aceclaw, aceclaw-tui, aceclaw-restart, aceclaw-update)
+- **Step 6**: README platform support matrix, Windows marked as experimental


### PR DESCRIPTION
## Step 6 of #357: Release and docs close-out

- README: platform support table (Linux full, macOS full, Windows 10 1803+ experimental)
- windows-uds-spike.md: updated implementation status for all completed steps
- No code changes, no behavioral changes

Closes #357