### PR TITLE
fix: HealthMonitorTest timing flake and Windows daemon skip documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,9 @@ jobs:
             # macOS: run all modules except daemon integration tests (timing-sensitive)
             test-args: "-x generateReplayCases -x generateReplayReport -x preMergeCheck -x replayQualityGate -x benchmarkScorecard -x validateReplaySuite -x continuousLearningSmoke"
           - os: windows-latest
-            # Windows: skip daemon module entirely (Gradle worker JVM crash with AF_UNIX class scanning)
+            # Windows: skip daemon test module (Gradle test worker JVM crashes when forking
+            # tests in a module that references AF_UNIX classes, even with @DisabledOnOs).
+            # All other modules run their full test suites on Windows.
             test-args: "-x :aceclaw-daemon:test -x generateReplayCases -x generateReplayReport -x preMergeCheck -x replayQualityGate -x benchmarkScorecard -x validateReplaySuite -x continuousLearningSmoke"
     runs-on: ${{ matrix.os }}
     # Observational only — failures do not block PRs

--- a/aceclaw-infra/src/test/java/dev/aceclaw/infra/health/HealthMonitorTest.java
+++ b/aceclaw-infra/src/test/java/dev/aceclaw/infra/health/HealthMonitorTest.java
@@ -102,7 +102,7 @@ class HealthMonitorTest {
 
     @Test
     void periodicCheckRunsAutomatically() throws Exception {
-        var monitor = new HealthMonitor(null, Duration.ofMillis(100));
+        var monitor = new HealthMonitor(null, Duration.ofMillis(200));
         var callCount = new java.util.concurrent.atomic.AtomicInteger(0);
 
         monitor.register(new HealthCheck() {
@@ -115,10 +115,10 @@ class HealthMonitorTest {
 
         monitor.start();
         try {
-            // Wait for a few periodic checks (initial + periodic)
-            Thread.sleep(350);
-            // Should have been called at least 3 times (initial + ~3 periodic)
-            assertThat(callCount.get()).isGreaterThanOrEqualTo(3);
+            // Wait for periodic checks to fire (generous for slow CI runners)
+            Thread.sleep(800);
+            // Should have been called at least 2 times (initial + periodic)
+            assertThat(callCount.get()).isGreaterThanOrEqualTo(2);
         } finally {
             monitor.stop();
         }


### PR DESCRIPTION
## Step 7c of #370: Platform stability fixes

### Fix 1: HealthMonitorTest timing (macOS flake)
- Interval: 100ms → 200ms
- Sleep: 350ms → 800ms
- Threshold: ≥3 → ≥2 calls
- Prevents flaky failures on slow macOS CI runners

### Investigation: Windows daemon test worker crash
**Root cause**: Gradle's test worker JVM crashes (`Connection reset by peer`) when forking tests in a module that has classes referencing `UnixDomainSocketAddress` / `StandardProtocolFamily.UNIX`. Even with `@DisabledOnOs(OS.WINDOWS)` on the integration tests, the JVM dies during class scanning/loading.

**This is not an AceClaw code bug** — it's a Gradle/JVM platform interaction. The AF_UNIX classes exist in the daemon module's compiled bytecode. When Gradle forks a test worker on Windows, the JVM encounters these classes and crashes.

**Current mitigation**: Skip `:aceclaw-daemon:test` on Windows in platform-full. All other modules (cli, core, tools, memory, infra, security, mcp) run their full test suites on Windows successfully.

### Platform-full readiness
After this fix:
- **macOS full**: Should be green (timing flake fixed)
- **Windows full**: Green (all modules except daemon)
- Ready for 7c promotion to required once this run confirms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined health monitoring test parameters to account for slower periodic check intervals and improve test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->