### PR TITLE
fix: replan test broken by stream retry loop

### DIFF
--- a/aceclaw-core/src/test/java/dev/aceclaw/core/planner/SequentialPlanExecutorReplanTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/planner/SequentialPlanExecutorReplanTest.java
@@ -38,9 +38,11 @@ class SequentialPlanExecutorReplanTest {
         }
 
         void enqueueStreamError() {
+            // Use 400 (non-retryable) so StreamingAgentLoop's stream retry logic
+            // does not consume subsequent queued responses meant for later steps.
             streamResponses.add(List.of(
                     new StreamEvent.MessageStart("msg-mock", "mock-model"),
-                    new StreamEvent.StreamError(new LlmException("Step failed", 500))));
+                    new StreamEvent.StreamError(new LlmException("Step failed", 400))));
         }
 
         void enqueueSendResponse(String text) {


### PR DESCRIPTION
Mock error used HTTP 500 (retryable), new stream retry logic consumed the next queued response. Use 400 instead.

Generated with [Claude Code](https://claude.com/claude-code)