### PR TITLE
Fix MCP tool registration race

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -296,8 +296,10 @@ public final class AceClawDaemon {
         }
 
         // MCP servers (config-driven external tool providers)
-        // Started asynchronously to avoid blocking daemon boot (npx downloads can be slow)
+        // Started asynchronously to avoid blocking daemon boot (npx downloads can be slow).
+        // A CompletableFuture is exposed so request-time code can await readiness with a bounded timeout.
         var mcpConfig = McpServerConfig.load(workingDir);
+        var mcpInitFuture = new java.util.concurrent.CompletableFuture<Void>();
         if (!mcpConfig.isEmpty()) {
             var mcpManager = new McpClientManager(mcpConfig);
             shutdownManager.register(new ShutdownManager.ShutdownParticipant() {
@@ -305,6 +307,7 @@ public final class AceClawDaemon {
                 @Override public int priority() { return 85; }
                 @Override public void onShutdown() { mcpManager.close(); }
             });
+            log.info("MCP: {} server(s) configured, initializing in background...", mcpConfig.size());
             Thread.ofVirtual().name("mcp-init").start(() -> {
                 try {
                     mcpManager.start();
@@ -313,11 +316,14 @@ public final class AceClawDaemon {
                     }
                     log.info("MCP: {} servers, {} tools registered (async)",
                             mcpConfig.size(), mcpManager.bridgedTools().size());
+                    mcpInitFuture.complete(null);
                 } catch (Exception e) {
                     log.error("MCP initialization failed: {}", e.getMessage(), e);
+                    mcpInitFuture.completeExceptionally(e);
                 }
             });
-            log.info("MCP: {} server(s) configured, initializing in background...", mcpConfig.size());
+        } else {
+            mcpInitFuture.complete(null);
         }
 
         log.info("Registered {} base tools", toolRegistry.size());
@@ -442,9 +448,9 @@ public final class AceClawDaemon {
                 markdownStore,
                 config.provider(),
                 promptBudget,
-                toolNames,
                 config.braveSearchApiKey() != null,
                 skillRegistry::formatDescriptions);
+        agentHandler.setMcpInitFuture(mcpInitFuture);
         agentHandler.setAdaptiveContinuationConfig(
                 config.adaptiveContinuationEnabled(),
                 config.adaptiveContinuationMaxSegments(),

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -94,6 +94,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
 import java.util.function.Function;
 
 /**
@@ -228,8 +229,16 @@ public final class StreamingAgentHandler {
         // Create a StreamEventHandler that forwards events via the cancel-aware context
         var eventHandler = new StreamingNotificationHandler(cancelContext, objectMapper);
 
+        // Wait briefly for asynchronous MCP initialization so prompt assembly and
+        // request-scoped tool execution both see the same registry contents.
+        awaitMcpInitForRequest();
+
+        var requestTools = snapshotCurrentTools();
+        var requestToolNames = toolNames(requestTools);
+
         // Wrap tools with permission checking and hooks for this request
-        var permissionAwareRegistry = createPermissionAwareRegistry(cancelContext, sessionId, eventHandler);
+        var permissionAwareRegistry = createPermissionAwareRegistry(
+                requestTools, cancelContext, sessionId, eventHandler);
 
         // Get or create a session-scoped metrics collector so tool stats accumulate across turns
         var metricsCollector = sessionMetrics.computeIfAbsent(sessionId, _ -> new ToolMetricsCollector());
@@ -253,11 +262,8 @@ public final class StreamingAgentHandler {
         var doomLoop = sessionDoomLoops.computeIfAbsent(sessionId, _ -> new DoomLoopDetector());
         var progress = sessionProgressDetectors.computeIfAbsent(sessionId, _ -> new ProgressDetector());
 
-        var promptAssembly = assembleSystemPromptForRequest(sessionId, session, prompt);
+        var promptAssembly = assembleSystemPromptForRequest(sessionId, session, prompt, requestToolNames);
         var effectiveCompactor = createRequestCompactor(sessionId, promptAssembly.prompt());
-        var requestToolNames = permissionAwareRegistry.all().stream()
-                .map(Tool::name)
-                .collect(java.util.stream.Collectors.toUnmodifiableSet());
 
         // Create a temporary agent loop with the permission-aware registry, compaction and metrics
         var agentConfig = AgentLoopConfig.builder()
@@ -1224,10 +1230,14 @@ public final class StreamingAgentHandler {
      * Tools that need user approval will use the StreamContext to ask the client.
      */
     private ToolRegistry createPermissionAwareRegistry(
-            CancelAwareStreamContext context, String sessionId, StreamEventHandler eventHandler) {
+            List<Tool> requestTools,
+            CancelAwareStreamContext context,
+            String sessionId,
+            StreamEventHandler eventHandler) {
         Objects.requireNonNull(context, "context");
         Objects.requireNonNull(sessionId, "sessionId");
         Objects.requireNonNull(eventHandler, "eventHandler");
+        Objects.requireNonNull(requestTools, "requestTools");
         var registry = new ToolRegistry();
         var antiPatternGate = AntiPatternPreExecutionGate.fromStores(
                 memoryStore,
@@ -1245,7 +1255,7 @@ public final class StreamingAgentHandler {
         // Build a session-scoped read/write pair so relative paths always resolve to this session project.
         var sessionWriteFileTool = new WriteFileTool(sessionProject);
         var sessionReadFileTool = new ReadFileTool(sessionProject, sessionWriteFileTool.readFiles());
-        for (var tool : toolRegistry.all()) {
+        for (var tool : requestTools) {
             Tool effectiveTool = materializeSessionScopedTool(
                     tool, sessionProject, sessionReadFileTool, sessionWriteFileTool, sessionId, eventHandler);
             registry.register(new PermissionAwareTool(
@@ -1316,7 +1326,8 @@ public final class StreamingAgentHandler {
     private Path workingDir;
     private String provider;
     private SystemPromptBudget systemPromptBudget = SystemPromptBudget.DEFAULT;
-    private Set<String> registeredToolNames = Set.of();
+    private volatile CompletableFuture<Void> mcpInitFuture = CompletableFuture.completedFuture(null);
+    private static final long MCP_REQUEST_TIMEOUT_MS = 5_000;
     private boolean hasBraveApiKey;
     private Function<String, String> skillDescriptionsProvider = ignored -> "";
     private int contextWindowTokens;
@@ -1428,13 +1439,11 @@ public final class StreamingAgentHandler {
     public void setContextAssemblyConfig(MarkdownMemoryStore markdownStore,
                                          String provider,
                                          SystemPromptBudget systemPromptBudget,
-                                         Set<String> registeredToolNames,
                                          boolean hasBraveApiKey,
                                          Function<String, String> skillDescriptionsProvider) {
         this.markdownStore = markdownStore;
         this.provider = provider;
         this.systemPromptBudget = systemPromptBudget != null ? systemPromptBudget : SystemPromptBudget.DEFAULT;
-        this.registeredToolNames = registeredToolNames != null ? Set.copyOf(registeredToolNames) : Set.of();
         this.hasBraveApiKey = hasBraveApiKey;
         this.skillDescriptionsProvider = skillDescriptionsProvider != null
                 ? sessionId -> {
@@ -1442,6 +1451,49 @@ public final class StreamingAgentHandler {
                     return descriptions != null ? descriptions : "";
                 }
                 : ignored -> "";
+    }
+
+    /**
+     * Sets the MCP initialization future so request-time code can await readiness.
+     */
+    public void setMcpInitFuture(CompletableFuture<Void> mcpInitFuture) {
+        this.mcpInitFuture = mcpInitFuture != null
+                ? mcpInitFuture
+                : CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Awaits MCP initialization with a bounded timeout so request-time prompt assembly
+     * and request-scoped tool registry creation observe a consistent view of available tools.
+     */
+    private void awaitMcpInitForRequest() {
+        var future = this.mcpInitFuture;
+        if (!future.isDone()) {
+            try {
+                future.get(MCP_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+                log.debug("MCP init completed within request timeout");
+            } catch (TimeoutException e) {
+                log.warn("MCP init not ready within {}ms; proceeding without MCP tools for this request. "
+                                + "If this is the first startup or an MCP server is downloading dependencies, "
+                                + "retrying the request after startup completes may help.",
+                        MCP_REQUEST_TIMEOUT_MS);
+            } catch (Exception e) {
+                log.warn("MCP init failed: {}", e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Returns an immutable snapshot of the currently registered tools.
+     */
+    private List<Tool> snapshotCurrentTools() {
+        return List.copyOf(toolRegistry.all());
+    }
+
+    private Set<String> toolNames(List<Tool> tools) {
+        return tools.stream()
+                .map(Tool::name)
+                .collect(Collectors.toUnmodifiableSet());
     }
 
     /**
@@ -1723,7 +1775,7 @@ public final class StreamingAgentHandler {
     }
 
     private SystemPromptLoader.RequestAssembly assembleSystemPromptForRequest(
-            String sessionId, AgentSession session, String prompt) {
+            String sessionId, AgentSession session, String prompt, Set<String> requestToolNames) {
         if (session == null || session.projectPath() == null) {
             return new SystemPromptLoader.RequestAssembly(getSystemPrompt(sessionId), List.of(), List.of(), List.of());
         }
@@ -1744,7 +1796,7 @@ public final class StreamingAgentHandler {
                 getModelForSession(sessionId),
                 provider,
                 systemPromptBudget,
-                registeredToolNames,
+                requestToolNames,
                 hasBraveApiKey,
                 candidateStore,
                 config,
@@ -1786,6 +1838,8 @@ public final class StreamingAgentHandler {
                     ContextEstimator.estimateTokens(prompt),
                     systemPromptBudget);
         }
+        awaitMcpInitForRequest();
+        var requestToolNames = toolNames(snapshotCurrentTools());
         var activePaths = inferActiveFilePaths(effectiveQuery, session.messages(), session.projectPath());
         var config = new CandidatePromptAssembler.Config(
                 candidateInjectionEnabled,
@@ -1800,7 +1854,7 @@ public final class StreamingAgentHandler {
                 getModelForSession(sessionId),
                 provider,
                 systemPromptBudget,
-                registeredToolNames,
+                requestToolNames,
                 hasBraveApiKey,
                 candidateStore,
                 config,

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/DaemonIntegrationTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/DaemonIntegrationTest.java
@@ -3,6 +3,8 @@ package dev.aceclaw.daemon;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import dev.aceclaw.core.agent.Tool;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import dev.aceclaw.core.agent.StreamingAgentLoop;
 import dev.aceclaw.core.agent.ToolRegistry;
@@ -39,6 +41,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -538,6 +541,86 @@ class DaemonIntegrationTest {
 
     @Test
     @Order(7)
+    void testAgentPromptWaitsForMcpInitBeforeBuildingRequestRegistry() throws Exception {
+        var toolRegistry = extractToolRegistry(agentHandlerRef);
+        var delayedMcpToolName = "mcp__demo__echo";
+        var mcpReady = new CompletableFuture<Void>();
+        agentHandlerRef.setMcpInitFuture(mcpReady);
+
+        Thread.ofVirtual().start(() -> {
+            try {
+                Thread.sleep(100);
+                toolRegistry.register(new Tool() {
+                    @Override
+                    public String name() {
+                        return delayedMcpToolName;
+                    }
+
+                    @Override
+                    public String description() {
+                        return "Test MCP tool registered after daemon startup.";
+                    }
+
+                    @Override
+                    public JsonNode inputSchema() {
+                        return JsonNodeFactory.instance.objectNode().put("type", "object");
+                    }
+
+                    @Override
+                    public ToolResult execute(String inputJson) {
+                        return new ToolResult("mcp echo ok", false);
+                    }
+                });
+                mcpReady.complete(null);
+            } catch (Exception e) {
+                mcpReady.completeExceptionally(e);
+            }
+        });
+
+        try (var channel = connectToSocket()) {
+            String sessionId = createSession(channel, 1);
+
+            mockLlm.enqueueResponse(MockLlmClient.toolUseResponse(
+                    "Using the MCP tool now.",
+                    "toolu_mcp_001",
+                    delayedMcpToolName,
+                    "{}"
+            ));
+            mockLlm.enqueueResponse(MockLlmClient.textResponse(
+                    "The delayed MCP tool executed successfully."));
+
+            var promptParams = objectMapper.createObjectNode();
+            promptParams.put("sessionId", sessionId);
+            promptParams.put("prompt", "Use the delayed MCP echo tool.");
+
+            var result = sendPromptAndHandlePermissions(channel, promptParams, 2, true);
+
+            var response = result.finalResponse();
+            assertThat(response.has("result")).isTrue();
+            assertThat(response.get("result").get("response").asText())
+                    .isEqualTo("The delayed MCP tool executed successfully.");
+
+            var toolCompleted = result.notifications().stream()
+                    .filter(n -> "stream.tool_completed".equals(n.get("method").asText()))
+                    .findFirst();
+            assertThat(toolCompleted).isPresent();
+            assertThat(toolCompleted.get().path("params").path("name").asText()).isEqualTo(delayedMcpToolName);
+            assertThat(toolCompleted.get().path("params").path("isError").asBoolean()).isFalse();
+
+            var requests = mockLlm.capturedRequests();
+            assertThat(requests).hasSize(2);
+            assertThat(requests.getFirst().tools())
+                    .extracting(def -> def.name())
+                    .contains(delayedMcpToolName);
+
+            destroySession(channel, sessionId, 3);
+        } finally {
+            agentHandlerRef.setMcpInitFuture(CompletableFuture.completedFuture(null));
+        }
+    }
+
+    @Test
+    @Order(8)
     void testAgentPromptWithWriteFileTool() throws Exception {
         try (var channel = connectToSocket()) {
             String sessionId = createSession(channel, 1);
@@ -575,7 +658,7 @@ class DaemonIntegrationTest {
     }
 
     @Test
-    @Order(8)
+    @Order(9)
     void testAgentPromptWithPermissionDenied() throws Exception {
         try (var channel = connectToSocket()) {
             String sessionId = createSession(channel, 1);
@@ -615,7 +698,7 @@ class DaemonIntegrationTest {
     }
 
     @Test
-    @Order(9)
+    @Order(10)
     void testMultiTurnConversation() throws Exception {
         try (var channel = connectToSocket()) {
             String sessionId = createSession(channel, 1);
@@ -1390,6 +1473,59 @@ class DaemonIntegrationTest {
         }
     }
 
+    @Test
+    @Order(999)
+    void testInspectContextWaitsForDelayedToolRegistration() throws Exception {
+        var session = sessionManager.createSession(workDir);
+        var toolRegistry = extractToolRegistry(agentHandlerRef);
+        var delayedToolName = "screen_capture";
+
+        try {
+            var initialInspection = agentHandlerRef.inspectContext(session.id(), "Check the UI state.");
+            assertThat(initialInspection.prompt()).doesNotContain("**screen_capture**");
+
+            var mcpReady = new CompletableFuture<Void>();
+            agentHandlerRef.setMcpInitFuture(mcpReady);
+
+            Thread.ofVirtual().start(() -> {
+                try {
+                    Thread.sleep(100);
+                    toolRegistry.register(new Tool() {
+                        @Override
+                        public String name() {
+                            return delayedToolName;
+                        }
+
+                        @Override
+                        public String description() {
+                            return "Delayed test tool for inspectContext coverage.";
+                        }
+
+                        @Override
+                        public JsonNode inputSchema() {
+                            return JsonNodeFactory.instance.objectNode().put("type", "object");
+                        }
+
+                        @Override
+                        public ToolResult execute(String inputJson) {
+                            return new ToolResult("inspect ok", false);
+                        }
+                    });
+                    mcpReady.complete(null);
+                } catch (Exception e) {
+                    mcpReady.completeExceptionally(e);
+                }
+            });
+
+            var inspection = agentHandlerRef.inspectContext(session.id(), "Check the UI state.");
+            assertThat(inspection.prompt()).contains("**screen_capture**");
+            assertThat(inspection.prompt()).contains("LAST RESORT ONLY");
+        } finally {
+            agentHandlerRef.setMcpInitFuture(CompletableFuture.completedFuture(null));
+            sessionManager.destroySession(session.id());
+        }
+    }
+
     // -- Helper methods --
 
     private SocketChannel connectToSocket() throws IOException {
@@ -1407,6 +1543,12 @@ class DaemonIntegrationTest {
         var params = objectMapper.createObjectNode().put("project", projectPath.toString());
         var response = sendAndReceive(channel, "session.create", params, requestId);
         return response.get("result").get("sessionId").asText();
+    }
+
+    private ToolRegistry extractToolRegistry(StreamingAgentHandler handler) throws Exception {
+        var field = StreamingAgentHandler.class.getDeclaredField("toolRegistry");
+        field.setAccessible(true);
+        return (ToolRegistry) field.get(handler);
     }
 
     private void destroySession(SocketChannel channel, String sessionId, int requestId) throws Exception {


### PR DESCRIPTION
## Summary
- wait for bounded MCP initialization before building the request-scoped tool registry
- switch request-time prompt assembly and inspectContext to use the live tool set
- add integration coverage for delayed MCP registration on both prompt execution and context inspection paths

## Why
The previous fix only refreshed tool names during prompt assembly. That still allowed a request to advertise MCP tools after initialization completed while executing against a stale request-scoped registry built before MCP registration, which could still produce Unknown tool failures.

This change moves the readiness gate to the start of request handling so prompt assembly and tool execution observe the same registry contents.

## Testing
- ./gradlew :aceclaw-daemon:test --tests dev.aceclaw.daemon.DaemonIntegrationTest.testAgentPromptWaitsForMcpInitBeforeBuildingRequestRegistry
- ./gradlew :aceclaw-daemon:test --tests dev.aceclaw.daemon.DaemonIntegrationTest.testInspectContextWaitsForDelayedToolRegistration
- ./gradlew :aceclaw-daemon:test --tests dev.aceclaw.daemon.DaemonIntegrationTest.testAgentPromptWithReadFileTool

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Asynchronous MCP initialization with a coordinated readiness signal.
  * Per-request, permission-aware tool selection so requests use a live snapshot of registered tools.
  * Dynamic tool registration honored during in-flight requests.

* **Improvements**
  * Bounded wait with timeout and logging for service readiness to improve reliability.
  * System prompt assembly now uses request-specific tool information.

* **Tests**
  * Added integration tests verifying wait-for-registration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->