### PR TITLE
Fix daemon start behavior and MCP config loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,9 @@ All commands installed by `install.sh`. Every command that accepts `[provider]` 
 The daemon is a persistent JVM process that runs in the background. It auto-starts when you run `aceclaw`, but can be managed directly:
 
 ```bash
-aceclaw daemon start    # Start daemon in foreground (for debugging)
+aceclaw daemon start              # Start daemon in background
+aceclaw daemon start -p copilot   # Start background daemon with provider override
+aceclaw daemon start --foreground # Start daemon in foreground (for debugging)
 aceclaw daemon stop     # Gracefully stop daemon
 aceclaw daemon status   # Show health, version, model, active sessions
 ```

--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/AceClawMain.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/AceClawMain.java
@@ -44,7 +44,7 @@ public final class AceClawMain implements Runnable {
     @Override
     public void run() {
         // Pre-flight: if copilot provider and no cached OAuth token, run device-code flow
-        ensureCopilotAuth();
+        ensureCopilotAuth(null);
 
         try (DaemonClient client = DaemonStarter.ensureRunning()) {
 
@@ -145,10 +145,14 @@ public final class AceClawMain implements Runnable {
      * If the active provider is "copilot" and no cached OAuth token exists,
      * runs the interactive device-code flow before starting the daemon.
      */
-    private static void ensureCopilotAuth() {
+    static void ensureCopilotAuth(String providerOverride) {
         try {
-            AceClawConfig config = AceClawConfig.load(null);
-            if (!"copilot".equals(config.provider())) {
+            String effectiveProvider = providerOverride;
+            if (effectiveProvider == null || effectiveProvider.isBlank()) {
+                AceClawConfig config = AceClawConfig.load(null);
+                effectiveProvider = config.provider();
+            }
+            if (!"copilot".equalsIgnoreCase(effectiveProvider)) {
                 return;
             }
             // Check if we already have a cached OAuth token
@@ -341,21 +345,58 @@ public final class AceClawMain implements Runnable {
     }
 
     /**
-     * Starts the daemon in the foreground (blocking).
+     * Starts the daemon, defaulting to background mode.
      */
     @Command(
         name = "start",
-        description = "Start the daemon in foreground"
+        description = "Start the daemon (background by default; use --foreground for debugging)"
     )
     static final class DaemonStartCommand implements Runnable {
+        @Option(
+                names = {"-p", "--provider"},
+                description = "Provider override for this daemon start (e.g. anthropic, copilot, openai)"
+        )
+        String provider;
+
+        @Option(
+                names = {"-f", "--foreground"},
+                description = "Run in foreground and keep this terminal attached"
+        )
+        boolean foreground;
+
         @Override
         public void run() {
-            System.out.println("Starting AceClaw daemon in foreground...");
-            var daemon = AceClawDaemon.createDefault();
+            String providerOverride = provider == null || provider.isBlank()
+                    ? null
+                    : provider.trim().toLowerCase();
+            ensureCopilotAuth(providerOverride);
             try {
-                daemon.start();
+                if (foreground) {
+                    System.out.println("Starting AceClaw daemon in foreground...");
+                    var daemon = providerOverride == null
+                            ? AceClawDaemon.createDefault()
+                            : AceClawDaemon.createDefault(providerOverride);
+                    daemon.start();
+                    return;
+                }
+
+                boolean started = DaemonStarter.ensureStarted(providerOverride);
+                if (started) {
+                    System.out.println("Daemon started in background.");
+                } else if (providerOverride != null) {
+                    System.out.println("Daemon is already running. Stop it first to switch provider.");
+                } else {
+                    System.out.println("Daemon is already running.");
+                }
             } catch (AceClawDaemon.DaemonException e) {
                 System.err.println("Daemon failed to start: " + e.getMessage());
+                System.exit(1);
+            } catch (IOException e) {
+                System.err.println("Failed to start daemon: " + e.getMessage());
+                System.exit(1);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                System.err.println("Interrupted while starting daemon");
                 System.exit(1);
             }
         }

--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/DaemonStarter.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/DaemonStarter.java
@@ -62,7 +62,7 @@ public final class DaemonStarter {
 
         // Daemon not running; start it
         log.info("Daemon not running; starting...");
-        startDaemonProcess();
+        startDaemonProcess(null);
 
         // Wait for the socket to become available
         if (!waitForSocket()) {
@@ -75,6 +75,31 @@ public final class DaemonStarter {
         client.connect();
         log.info("Connected to newly started daemon");
         return client;
+    }
+
+    /**
+     * Ensures the daemon is running in the background.
+     *
+     * @param providerOverride optional provider override for the newly spawned daemon
+     * @return true if a new daemon process was started, false if one was already running
+     * @throws IOException if the daemon cannot be started
+     * @throws InterruptedException if waiting for the socket is interrupted
+     */
+    public static boolean ensureStarted(String providerOverride) throws IOException, InterruptedException {
+        if (isDaemonRunning()) {
+            log.debug("Daemon already running; background start skipped");
+            return false;
+        }
+
+        log.info("Daemon not running; starting...");
+        startDaemonProcess(providerOverride);
+
+        if (!waitForSocket()) {
+            throw new IOException(
+                    "Daemon did not start within " + START_TIMEOUT_MS + "ms. "
+                            + "Check logs at " + DAEMON_LOG);
+        }
+        return true;
     }
 
     /**
@@ -110,7 +135,7 @@ public final class DaemonStarter {
 
     // -- Daemon process launch ---------------------------------------------
 
-    private static void startDaemonProcess() throws IOException {
+    private static void startDaemonProcess(String providerOverride) throws IOException {
         Files.createDirectories(LOG_DIR);
 
         Platform platform = Platform.detect();
@@ -119,6 +144,7 @@ public final class DaemonStarter {
             case MACOS -> buildMacOSLauncher();
             case WINDOWS -> buildWindowsLauncher();
         };
+        applyProviderOverride(pb, providerOverride);
 
         // Inherit the CLI's working directory so tools resolve paths
         // relative to the user's project, not ~/.aceclaw/
@@ -126,6 +152,13 @@ public final class DaemonStarter {
         Process process = pb.start();
         log.info("Daemon process started (PID {}, platform={}); logs at {}",
                 process.pid(), platform, DAEMON_LOG);
+    }
+
+    private static void applyProviderOverride(ProcessBuilder pb, String providerOverride) {
+        if (providerOverride == null || providerOverride.isBlank()) {
+            return;
+        }
+        pb.environment().put("ACECLAW_PROVIDER", providerOverride.trim().toLowerCase(Locale.ROOT));
     }
 
     /**

--- a/aceclaw-cli/src/test/java/dev/aceclaw/cli/AceClawMainTest.java
+++ b/aceclaw-cli/src/test/java/dev/aceclaw/cli/AceClawMainTest.java
@@ -1,0 +1,42 @@
+package dev.aceclaw.cli;
+
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AceClawMainTest {
+
+    @Test
+    void daemonStartAcceptsShortProviderOption() {
+        var command = new AceClawMain.DaemonStartCommand();
+        new CommandLine(command).parseArgs("-p", "copilot");
+
+        assertThat(command.provider).isEqualTo("copilot");
+    }
+
+    @Test
+    void daemonStartAcceptsLongProviderOption() {
+        var command = new AceClawMain.DaemonStartCommand();
+        new CommandLine(command).parseArgs("--provider", "openai");
+
+        assertThat(command.provider).isEqualTo("openai");
+    }
+
+    @Test
+    void daemonStartDefaultsToBackgroundMode() {
+        var command = new AceClawMain.DaemonStartCommand();
+        new CommandLine(command).parseArgs();
+
+        assertThat(command.foreground).isFalse();
+    }
+
+    @Test
+    void daemonStartAcceptsForegroundFlag() {
+        var command = new AceClawMain.DaemonStartCommand();
+        new CommandLine(command).parseArgs("--foreground", "-p", "copilot");
+
+        assertThat(command.foreground).isTrue();
+        assertThat(command.provider).isEqualTo("copilot");
+    }
+}

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
@@ -261,6 +261,18 @@ public final class AceClawConfig {
      * @return the merged configuration
      */
     public static AceClawConfig load(Path projectPath) {
+        return load(projectPath, null);
+    }
+
+    /**
+     * Loads configuration from global and project config files, with env var overrides
+     * and an optional provider override used by foreground startup paths.
+     *
+     * @param projectPath the project working directory (may be null)
+     * @param providerOverride optional provider override (may be null)
+     * @return the merged configuration
+     */
+    public static AceClawConfig load(Path projectPath, String providerOverride) {
         var config = new AceClawConfig();
 
         // 1. Load global config
@@ -291,6 +303,9 @@ public final class AceClawConfig {
         // 4. Environment variables (highest precedence)
         if (envProvider != null && !envProvider.isBlank()) {
             config.provider = envProvider.toLowerCase();
+        }
+        if (providerOverride != null && !providerOverride.isBlank()) {
+            config.provider = providerOverride.trim().toLowerCase();
         }
         var envBaseUrl = System.getenv("ACECLAW_BASE_URL");
         if (envBaseUrl != null && !envBaseUrl.isBlank()) {

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -117,12 +117,16 @@ public final class AceClawDaemon {
     private volatile boolean running;
 
     private AceClawDaemon(Path homeDir) {
+        this(homeDir, null);
+    }
+
+    private AceClawDaemon(Path homeDir, String providerOverride) {
         this.homeDir = homeDir;
         this.startedAt = Instant.now();
 
         // Load configuration (files + env vars)
         Path workingDir = Path.of(System.getProperty("user.dir"));
-        this.config = AceClawConfig.load(workingDir);
+        this.config = AceClawConfig.load(workingDir, providerOverride);
 
         // Infrastructure
         this.objectMapper = createObjectMapper();
@@ -1880,6 +1884,14 @@ public final class AceClawDaemon {
     public static AceClawDaemon createDefault() {
         var home = Path.of(System.getProperty("user.home"), ".aceclaw");
         return new AceClawDaemon(home);
+    }
+
+    /**
+     * Creates a daemon with the default home directory and a provider override.
+     */
+    public static AceClawDaemon createDefault(String providerOverride) {
+        var home = Path.of(System.getProperty("user.home"), ".aceclaw");
+        return new AceClawDaemon(home, providerOverride);
     }
 
     /**

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/AceClawConfigTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/AceClawConfigTest.java
@@ -1,0 +1,22 @@
+package dev.aceclaw.daemon;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AceClawConfigTest {
+
+    @Test
+    void loadAppliesProviderOverrideWhenSupplied() {
+        var config = AceClawConfig.load(null, "copilot");
+
+        assertThat(config.provider()).isEqualTo("copilot");
+    }
+
+    @Test
+    void loadNormalizesProviderOverrideToLowerCase() {
+        var config = AceClawConfig.load(null, "OpenAI-Codex");
+
+        assertThat(config.provider()).isEqualTo("openai-codex");
+    }
+}

--- a/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpServerConfig.java
+++ b/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpServerConfig.java
@@ -18,9 +18,11 @@ import java.util.Map;
  *
  * <p>Config loading order (later overrides earlier):
  * <ol>
- *   <li>{@code ~/.aceclaw/mcp-servers.json} (global)</li>
+ *   <li>{@code ~/.aceclaw/config.json} (global AceClaw config, {@code mcpServers} key)</li>
+ *   <li>{@code ~/.aceclaw/mcp-servers.json} (global dedicated MCP config)</li>
  *   <li>{@code {project}/.mcp.json} (project, Claude Code compatible)</li>
- *   <li>{@code {project}/.aceclaw/mcp-servers.json} (project AceClaw-specific)</li>
+ *   <li>{@code {project}/.aceclaw/config.json} (project AceClaw config, {@code mcpServers} key)</li>
+ *   <li>{@code {project}/.aceclaw/mcp-servers.json} (project AceClaw-specific dedicated MCP config)</li>
  * </ol>
  *
  * <p>Supports stdio, SSE, and streamable HTTP transports:
@@ -108,16 +110,23 @@ public final class McpServerConfig {
      */
     public static Map<String, ServerEntry> load(Path workingDir) {
         var result = new LinkedHashMap<String, ServerEntry>();
+        var aceclawHome = Path.of(System.getProperty("user.home"), ".aceclaw");
 
-        // 1. Global: ~/.aceclaw/mcp-servers.json
-        var globalConfig = Path.of(System.getProperty("user.home"), ".aceclaw", "mcp-servers.json");
-        mergeFrom(result, globalConfig);
+        // 1. Global: ~/.aceclaw/config.json
+        mergeFrom(result, aceclawHome.resolve("config.json"));
 
-        // 2. Project: {workingDir}/.mcp.json (Claude Code compatible)
+        // 2. Global: ~/.aceclaw/mcp-servers.json
+        mergeFrom(result, aceclawHome.resolve("mcp-servers.json"));
+
+        // 3. Project: {workingDir}/.mcp.json (Claude Code compatible)
         mergeFrom(result, workingDir.resolve(".mcp.json"));
 
-        // 3. Project: {workingDir}/.aceclaw/mcp-servers.json
-        mergeFrom(result, workingDir.resolve(".aceclaw").resolve("mcp-servers.json"));
+        // 4. Project: {workingDir}/.aceclaw/config.json
+        var projectAceClawDir = workingDir.resolve(".aceclaw");
+        mergeFrom(result, projectAceClawDir.resolve("config.json"));
+
+        // 5. Project: {workingDir}/.aceclaw/mcp-servers.json
+        mergeFrom(result, projectAceClawDir.resolve("mcp-servers.json"));
 
         if (!result.isEmpty()) {
             log.info("Loaded {} MCP server(s): {}", result.size(), result.keySet());

--- a/aceclaw-mcp/src/test/java/dev/aceclaw/mcp/McpServerConfigTest.java
+++ b/aceclaw-mcp/src/test/java/dev/aceclaw/mcp/McpServerConfigTest.java
@@ -58,6 +58,28 @@ class McpServerConfigTest {
     }
 
     @Test
+    void loadGlobalAceClawConfigJson() throws IOException {
+        var aceclawDir = tempDir.resolve(".aceclaw");
+        Files.createDirectories(aceclawDir);
+        Files.writeString(aceclawDir.resolve("config.json"), """
+                {
+                  "mcpServers": {
+                    "drawio": {
+                      "command": "npx",
+                      "args": ["@next-ai-drawio/mcp-server@latest"]
+                    }
+                  }
+                }
+                """);
+
+        var result = McpServerConfig.load(tempDir);
+
+        assertThat(result).containsKey("drawio");
+        assertThat(result.get("drawio").command()).isEqualTo("npx");
+        assertThat(result.get("drawio").args()).containsExactly("@next-ai-drawio/mcp-server@latest");
+    }
+
+    @Test
     void parseValidSseConfig() throws IOException {
         var config = """
                 {
@@ -147,6 +169,33 @@ class McpServerConfigTest {
 
         assertThat(result.get("server-a").command()).isEqualTo("new");
         assertThat(result.get("server-b").command()).isEqualTo("keep");
+    }
+
+    @Test
+    void projectAceClawConfigOverridesClaudeCompatibleConfig() throws IOException {
+        Files.writeString(tempDir.resolve(".mcp.json"), """
+                {
+                  "mcpServers": {
+                    "drawio": { "command": "old" }
+                  }
+                }
+                """);
+
+        var aceclawDir = tempDir.resolve(".aceclaw");
+        Files.createDirectories(aceclawDir);
+        Files.writeString(aceclawDir.resolve("config.json"), """
+                {
+                  "mcpServers": {
+                    "drawio": { "command": "new" },
+                    "context7": { "command": "ctx" }
+                  }
+                }
+                """);
+
+        var result = McpServerConfig.load(tempDir);
+
+        assertThat(result.get("drawio").command()).isEqualTo("new");
+        assertThat(result.get("context7").command()).isEqualTo("ctx");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- make aceclaw daemon start run in the background by default and add --foreground for the old blocking debug mode
- add -p/--provider support for aceclaw daemon start so foreground and background startup can override provider consistently
- load mcpServers from AceClaw config.json files in addition to dedicated MCP config files
- add targeted CLI, daemon config, and MCP config tests

## Why
Two user-facing issues were coupled here:

1. aceclaw daemon start looked broken because it always ran in foreground and held the terminal open.
2. MCP servers configured in ~/.aceclaw/config.json were never loaded, so tools like mcp__drawio__create_diagram stayed unavailable even though the config looked correct.

This change makes daemon startup match normal user expectations and restores MCP config compatibility with the existing AceClaw config file.

## Testing
- ./gradlew :aceclaw-cli:test --tests dev.aceclaw.cli.AceClawMainTest
- ./gradlew :aceclaw-daemon:test --tests dev.aceclaw.daemon.AceClawConfigTest
- ./gradlew :aceclaw-mcp:test --tests dev.aceclaw.mcp.McpServerConfigTest