### PR TITLE
fix: register MCP tools incrementally per server

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -301,7 +301,9 @@ public final class AceClawDaemon {
 
         // MCP servers (config-driven external tool providers)
         // Started asynchronously to avoid blocking daemon boot (npx downloads can be slow).
-        // A CompletableFuture is exposed so request-time code can await readiness with a bounded timeout.
+        // Tools are registered incrementally as each server connects, so one slow/failing server
+        // does not block tools from already-succeeded servers.
+        // The mcpInitFuture completes once the first server's tools are available (or all fail).
         var mcpConfig = McpServerConfig.load(workingDir);
         var mcpInitFuture = new java.util.concurrent.CompletableFuture<Void>();
         if (!mcpConfig.isEmpty()) {
@@ -314,16 +316,21 @@ public final class AceClawDaemon {
             log.info("MCP: {} server(s) configured, initializing in background...", mcpConfig.size());
             Thread.ofVirtual().name("mcp-init").start(() -> {
                 try {
-                    mcpManager.start();
-                    for (var tool : mcpManager.bridgedTools()) {
-                        toolRegistry.register(tool);
-                    }
-                    log.info("MCP: {} servers, {} tools registered (async)",
-                            mcpConfig.size(), mcpManager.bridgedTools().size());
+                    mcpManager.start(tools -> {
+                        // Register each server's tools as soon as they are discovered
+                        for (var tool : tools) {
+                            toolRegistry.register(tool);
+                        }
+                        log.info("MCP: registered {} tool(s) incrementally", tools.size());
+                        // Complete the future on the first successful server so requests
+                        // don't wait for slow/failing servers
+                        mcpInitFuture.complete(null);
+                    });
+                    // If no server succeeded, the future is still pending — complete it now
                     mcpInitFuture.complete(null);
                 } catch (Exception e) {
                     log.error("MCP initialization failed: {}", e.getMessage(), e);
-                    mcpInitFuture.completeExceptionally(e);
+                    mcpInitFuture.complete(null);
                 }
             });
         } else {

--- a/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpClientManager.java
+++ b/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpClientManager.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 /**
  * Manages the lifecycle of MCP server connections (stdio, SSE, and streamable HTTP).
@@ -68,6 +69,20 @@ public final class McpClientManager implements AutoCloseable {
      * Failed servers are logged and skipped; the daemon still starts normally.
      */
     public void start() {
+        start(null);
+    }
+
+    /**
+     * Starts all configured MCP servers with an optional per-server callback.
+     *
+     * <p>When a server connects and its tools are discovered, the callback is invoked immediately
+     * with the newly bridged tools. This allows callers to register tools incrementally rather
+     * than waiting for all servers to finish — so one slow or failing server does not block
+     * tools from already-succeeded servers.
+     *
+     * @param onServerTools callback invoked per server with its bridged tools, or null to skip
+     */
+    public void start(Consumer<List<Tool>> onServerTools) {
         for (var entry : serverConfigs.entrySet()) {
             var serverName = entry.getKey();
             var config = entry.getValue();
@@ -98,7 +113,12 @@ public final class McpClientManager implements AutoCloseable {
             if (client != null) {
                 clients.put(serverName, client);
                 statuses.put(serverName, ServerStatus.CONNECTED);
+                var toolsBefore = bridgedTools.size();
                 discoverAndBridgeTools(serverName, client);
+                if (onServerTools != null && bridgedTools.size() > toolsBefore) {
+                    onServerTools.accept(
+                            Collections.unmodifiableList(bridgedTools.subList(toolsBefore, bridgedTools.size())));
+                }
             } else {
                 statuses.put(serverName, ServerStatus.FAILED);
                 log.error("MCP server '{}' failed to start after {} attempts: {}",


### PR DESCRIPTION
## Summary
- A slow/failing MCP server (e.g. context7 retrying 3x over ~47s) blocked tool registration for already-succeeded servers (e.g. drawio)
- Added per-server callback to `McpClientManager.start()` so each server's tools are registered immediately on connect
- `mcpInitFuture` now completes on the first successful server, not after all servers finish

## Test plan
- [ ] Verify drawio MCP tools are available within 5s even when another MCP server is misconfigured
- [ ] Verify `./gradlew :aceclaw-mcp:compileJava :aceclaw-daemon:compileJava` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated MCP initialization to register tools incrementally as servers are discovered via callback mechanism, replacing batch registration approach.
  * Improved tool discovery responsiveness with per-server callbacks that invoke as each server's tools are bridged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->