### PR TITLE
fix: improve retry logic for Anthropic API rate limits

### DIFF
--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/AgentLoopConfig.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/AgentLoopConfig.java
@@ -17,6 +17,7 @@ import dev.aceclaw.infra.event.EventBus;
  * @param watchdog           optional watchdog timer for turn/time budget enforcement (null = disabled)
  * @param doomLoopDetector   optional session-scoped doom loop detector (null = disabled)
  * @param progressDetector   optional session-scoped progress detector (null = disabled)
+ * @param retryConfig        retry settings for transient API errors (null = use defaults)
  */
 public record AgentLoopConfig(
         String sessionId,
@@ -27,14 +28,22 @@ public record AgentLoopConfig(
         Integer maxIterations,
         WatchdogTimer watchdog,
         DoomLoopDetector doomLoopDetector,
-        ProgressDetector progressDetector
+        ProgressDetector progressDetector,
+        RetryConfig retryConfig
 ) {
 
     /** Default maximum ReAct iterations per turn when no override is provided. */
     public static final int DEFAULT_MAX_ITERATIONS = 25;
 
     /** Empty config with all integrations disabled. */
-    public static final AgentLoopConfig EMPTY = new AgentLoopConfig(null, null, null, null, null, null, null, null, null);
+    public static final AgentLoopConfig EMPTY = new AgentLoopConfig(null, null, null, null, null, null, null, null, null, null);
+
+    /**
+     * Resolves the effective retry config, falling back to defaults when null.
+     */
+    public RetryConfig effectiveRetryConfig() {
+        return retryConfig != null ? retryConfig : RetryConfig.DEFAULT;
+    }
 
     /**
      * Resolves the effective max iterations for this loop config.
@@ -60,6 +69,7 @@ public record AgentLoopConfig(
         private WatchdogTimer watchdog;
         private DoomLoopDetector doomLoopDetector;
         private ProgressDetector progressDetector;
+        private RetryConfig retryConfig;
 
         private Builder() {}
 
@@ -108,10 +118,15 @@ public record AgentLoopConfig(
             return this;
         }
 
+        public Builder retryConfig(RetryConfig retryConfig) {
+            this.retryConfig = retryConfig;
+            return this;
+        }
+
         public AgentLoopConfig build() {
             return new AgentLoopConfig(
                     sessionId, eventBus, permissionChecker, memoryHandler, metricsCollector,
-                    maxIterations, watchdog, doomLoopDetector, progressDetector);
+                    maxIterations, watchdog, doomLoopDetector, progressDetector, retryConfig);
         }
     }
 }

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/RetryConfig.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/RetryConfig.java
@@ -1,0 +1,55 @@
+package dev.aceclaw.core.agent;
+
+/**
+ * Configuration for retry behavior on transient API errors (rate-limit, overloaded).
+ *
+ * <p>Defaults are tuned for Claude Code OAuth token-bucket rate limiting,
+ * matching the Anthropic JS SDK's retry strategy.
+ *
+ * @param maxRetries       maximum retry attempts (0 = no retries)
+ * @param initialBackoffMs initial backoff delay in milliseconds (doubles each attempt)
+ * @param maxBackoffMs     ceiling for backoff delay in milliseconds
+ * @param jitterFactor     jitter as a fraction of backoff (0.0–1.0; e.g. 0.25 = ±25%)
+ */
+public record RetryConfig(
+        int maxRetries,
+        long initialBackoffMs,
+        long maxBackoffMs,
+        double jitterFactor
+) {
+
+    /** Default retry config matching Anthropic SDK behavior. */
+    public static final RetryConfig DEFAULT = new RetryConfig(5, 500, 60_000, 0.25);
+
+    public RetryConfig {
+        if (maxRetries < 0) {
+            throw new IllegalArgumentException("maxRetries must be >= 0, got " + maxRetries);
+        }
+        if (initialBackoffMs < 0) {
+            throw new IllegalArgumentException("initialBackoffMs must be >= 0, got " + initialBackoffMs);
+        }
+        if (maxBackoffMs < 0) {
+            throw new IllegalArgumentException("maxBackoffMs must be >= 0, got " + maxBackoffMs);
+        }
+        if (jitterFactor < 0.0 || jitterFactor > 1.0) {
+            throw new IllegalArgumentException("jitterFactor must be in [0.0, 1.0], got " + jitterFactor);
+        }
+    }
+
+    /**
+     * Calculates backoff delay for a given attempt (0-based).
+     * Uses exponential backoff with jitter, capped at {@link #maxBackoffMs()}.
+     *
+     * @param attempt    0-based attempt index
+     * @param retryAfterMs server-suggested delay in ms (-1 if not specified)
+     * @return delay in milliseconds
+     */
+    public long calculateBackoffMs(int attempt, long retryAfterMs) {
+        if (retryAfterMs > 0) {
+            return Math.min(retryAfterMs, maxBackoffMs);
+        }
+        long baseMs = initialBackoffMs * (1L << attempt);
+        long jitter = (long) (baseMs * jitterFactor * Math.random());
+        return Math.min(baseMs + jitter, maxBackoffMs);
+    }
+}

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/StreamingAgentLoop.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/StreamingAgentLoop.java
@@ -44,11 +44,7 @@ public final class StreamingAgentLoop {
     /** Extra wall-clock time granted per auto-extension. */
     private static final Duration EXTENSION_WALL_TIME = Duration.ofSeconds(300);
 
-    /** Maximum retry attempts for retryable in-stream errors (overloaded, rate-limit). */
-    private static final int STREAM_MAX_RETRIES = 3;
-
-    /** Maximum backoff delay in milliseconds for stream retries (cap for Retry-After). */
-    private static final long STREAM_MAX_BACKOFF_MS = 60_000;
+    // Retry constants removed — now driven by RetryConfig in AgentLoopConfig.
 
     private final LlmClient llmClient;
     private final ToolRegistry toolRegistry;
@@ -271,8 +267,9 @@ public final class StreamingAgentLoop {
                 var request = buildRequest(requestMessages);
 
                 // Stream the response with retry on transient errors (overloaded, rate-limit)
+                var retryConfig = config.effectiveRetryConfig();
                 StreamAccumulator accumulator = null;
-                for (int streamAttempt = 0; streamAttempt <= STREAM_MAX_RETRIES; streamAttempt++) {
+                for (int streamAttempt = 0; streamAttempt <= retryConfig.maxRetries(); streamAttempt++) {
                     accumulator = new StreamAccumulator(eventHandler);
                     var session = llmClient.streamMessage(request);
 
@@ -290,14 +287,15 @@ public final class StreamingAgentLoop {
 
                     // If stream succeeded or error is not retryable, break out
                     if (accumulator.error == null || !accumulator.error.isRetryable()
-                            || streamAttempt == STREAM_MAX_RETRIES) {
+                            || streamAttempt == retryConfig.maxRetries()) {
                         break;
                     }
 
                     // Retryable stream error — back off and retry
-                    long backoffMs = calculateStreamBackoff(accumulator.error, streamAttempt);
+                    long backoffMs = retryConfig.calculateBackoffMs(
+                            streamAttempt, accumulator.error.retryAfterMs());
                     log.warn("Retryable stream error (attempt {}/{}), backing off {}ms: {}",
-                            streamAttempt + 1, STREAM_MAX_RETRIES, backoffMs,
+                            streamAttempt + 1, retryConfig.maxRetries(), backoffMs,
                             accumulator.error.getMessage());
                     try {
                         Thread.sleep(backoffMs);
@@ -554,18 +552,6 @@ public final class StreamingAgentLoop {
         return pruneResult;
     }
 
-    /**
-     * Calculates backoff delay for a stream retry attempt.
-     * Respects Retry-After if present, otherwise uses exponential backoff with 20% jitter.
-     */
-    private static long calculateStreamBackoff(LlmException e, int attempt) {
-        if (e.retryAfterSeconds() > 0) {
-            return Math.min(e.retryAfterSeconds() * 1000L, STREAM_MAX_BACKOFF_MS);
-        }
-        long baseMs = 1000L * (1L << attempt); // 1s, 2s, 4s
-        long jitter = (long) (baseMs * 0.2 * Math.random());
-        return Math.min(baseMs + jitter, STREAM_MAX_BACKOFF_MS);
-    }
 
     private LlmRequest buildRequest(List<Message> messages) {
         int effectiveThinkingBudget = thinkingBudget;

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/llm/LlmException.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/llm/LlmException.java
@@ -9,36 +9,57 @@ package dev.aceclaw.core.llm;
 public class LlmException extends Exception {
 
     private final int statusCode;
-    private final long retryAfterSeconds;
+    private final long retryAfterMs;
+    private final Boolean serverShouldRetry;
 
     public LlmException(String message) {
         super(message);
         this.statusCode = -1;
-        this.retryAfterSeconds = -1;
+        this.retryAfterMs = -1;
+        this.serverShouldRetry = null;
     }
 
     public LlmException(String message, Throwable cause) {
         super(message, cause);
         this.statusCode = -1;
-        this.retryAfterSeconds = -1;
+        this.retryAfterMs = -1;
+        this.serverShouldRetry = null;
     }
 
     public LlmException(String message, int statusCode) {
         super(message);
         this.statusCode = statusCode;
-        this.retryAfterSeconds = -1;
+        this.retryAfterMs = -1;
+        this.serverShouldRetry = null;
     }
 
     public LlmException(String message, int statusCode, Throwable cause) {
         super(message, cause);
         this.statusCode = statusCode;
-        this.retryAfterSeconds = -1;
+        this.retryAfterMs = -1;
+        this.serverShouldRetry = null;
     }
 
     public LlmException(String message, int statusCode, long retryAfterSeconds) {
         super(message);
         this.statusCode = statusCode;
-        this.retryAfterSeconds = retryAfterSeconds;
+        this.retryAfterMs = retryAfterSeconds > 0 ? retryAfterSeconds * 1000L : -1;
+        this.serverShouldRetry = null;
+    }
+
+    /**
+     * Full constructor with millisecond-precision retry delay and server-side retry hint.
+     *
+     * @param message           error message
+     * @param statusCode        HTTP status code (-1 if not applicable)
+     * @param retryAfterMs      server-suggested delay in milliseconds (-1 if not specified)
+     * @param serverShouldRetry value of {@code x-should-retry} header (null if absent)
+     */
+    public LlmException(String message, int statusCode, long retryAfterMs, Boolean serverShouldRetry) {
+        super(message);
+        this.statusCode = statusCode;
+        this.retryAfterMs = retryAfterMs;
+        this.serverShouldRetry = serverShouldRetry;
     }
 
     /**
@@ -53,13 +74,25 @@ public class LlmException extends Exception {
      * Populated from the HTTP {@code Retry-After} header on 429 responses.
      */
     public long retryAfterSeconds() {
-        return retryAfterSeconds;
+        return retryAfterMs > 0 ? retryAfterMs / 1000L : -1;
+    }
+
+    /**
+     * Returns the server-suggested retry delay in milliseconds, or {@code -1} if not specified.
+     * Populated from {@code retry-after-ms} (preferred) or {@code Retry-After} headers.
+     */
+    public long retryAfterMs() {
+        return retryAfterMs;
     }
 
     /**
      * Whether this error is retryable (e.g. rate-limit or transient server error).
+     * Respects the {@code x-should-retry} header when present.
      */
     public boolean isRetryable() {
+        if (serverShouldRetry != null) {
+            return serverShouldRetry;
+        }
         return statusCode == 429 || statusCode == 529 || (statusCode >= 500 && statusCode < 600);
     }
 }

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
@@ -188,6 +188,10 @@ public final class AceClawConfig {
     private Map<String, List<HookMatcherFormat>> hooks;
     private boolean context1m;
     private List<String> extraAnthropicBetas;
+    private int retryMaxRetries;
+    private long retryInitialBackoffMs;
+    private long retryMaxBackoffMs;
+    private double retryJitterFactor;
 
     private AceClawConfig() {
         this.provider = "anthropic";
@@ -252,6 +256,10 @@ public final class AceClawConfig {
         this.providerModels = new java.util.HashMap<>();
         this.context1m = DEFAULT_CONTEXT_1M;
         this.extraAnthropicBetas = List.of();
+        this.retryMaxRetries = (int) dev.aceclaw.core.agent.RetryConfig.DEFAULT.maxRetries();
+        this.retryInitialBackoffMs = dev.aceclaw.core.agent.RetryConfig.DEFAULT.initialBackoffMs();
+        this.retryMaxBackoffMs = dev.aceclaw.core.agent.RetryConfig.DEFAULT.maxBackoffMs();
+        this.retryJitterFactor = dev.aceclaw.core.agent.RetryConfig.DEFAULT.jitterFactor();
     }
 
     /**
@@ -1189,6 +1197,14 @@ public final class AceClawConfig {
     }
 
     /**
+     * Returns the retry configuration assembled from config fields.
+     */
+    public dev.aceclaw.core.agent.RetryConfig retryConfig() {
+        return new dev.aceclaw.core.agent.RetryConfig(
+                retryMaxRetries, retryInitialBackoffMs, retryMaxBackoffMs, retryJitterFactor);
+    }
+
+    /**
      * Loads Claude CLI credentials with Keychain priority (macOS).
      * Falls back to credential files if Keychain is unavailable.
      */
@@ -1558,6 +1574,21 @@ public final class AceClawConfig {
                     .filter(b -> b != null && !b.isBlank())
                     .toList();
         }
+        if (fileConfig.retry != null) {
+            if (fileConfig.retry.maxRetries != null && fileConfig.retry.maxRetries >= 0) {
+                this.retryMaxRetries = fileConfig.retry.maxRetries;
+            }
+            if (fileConfig.retry.initialBackoffMs != null && fileConfig.retry.initialBackoffMs >= 0) {
+                this.retryInitialBackoffMs = fileConfig.retry.initialBackoffMs;
+            }
+            if (fileConfig.retry.maxBackoffMs != null && fileConfig.retry.maxBackoffMs >= 0) {
+                this.retryMaxBackoffMs = fileConfig.retry.maxBackoffMs;
+            }
+            if (fileConfig.retry.jitterFactor != null
+                    && fileConfig.retry.jitterFactor >= 0.0 && fileConfig.retry.jitterFactor <= 1.0) {
+                this.retryJitterFactor = fileConfig.retry.jitterFactor;
+            }
+        }
         if (fileConfig.subAgentAutoApproveTools != null && !fileConfig.subAgentAutoApproveTools.isEmpty()) {
             // Project config appends to global config (not replaces)
             var merged = new ArrayList<>(this.subAgentAutoApproveTools);
@@ -1644,6 +1675,18 @@ public final class AceClawConfig {
         public Map<String, List<HookMatcherFormat>> hooks;
         public Boolean context1m;
         public List<String> extraAnthropicBetas;
+        public RetryConfigFormat retry;
+    }
+
+    /**
+     * JSON structure for retry configuration.
+     * <pre>{ "maxRetries": 5, "initialBackoffMs": 500, "maxBackoffMs": 60000, "jitterFactor": 0.25 }</pre>
+     */
+    public static class RetryConfigFormat {
+        public Integer maxRetries;
+        public Long initialBackoffMs;
+        public Long maxBackoffMs;
+        public Double jitterFactor;
     }
 
     /**

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -462,6 +462,7 @@ public final class AceClawDaemon {
                 config.braveSearchApiKey() != null,
                 skillRegistry::formatDescriptions);
         agentHandler.setMcpInitFuture(mcpInitFuture);
+        agentHandler.setRetryConfig(config.retryConfig());
         agentHandler.setAdaptiveContinuationConfig(
                 config.adaptiveContinuationEnabled(),
                 config.adaptiveContinuationMaxSegments(),

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -273,6 +273,7 @@ public final class StreamingAgentHandler {
                 .watchdog(watchdog)
                 .doomLoopDetector(doomLoop)
                 .progressDetector(progress)
+                .retryConfig(retryConfig)
                 .build();
         var permissionAwareLoop = new StreamingAgentLoop(
                 getLlmClient(), permissionAwareRegistry,
@@ -1340,6 +1341,7 @@ public final class StreamingAgentHandler {
     private volatile int candidateInjectionMaxTokens = 1200;
     private boolean plannerEnabled = true;
     private int plannerThreshold = 5;
+    private dev.aceclaw.core.agent.RetryConfig retryConfig = dev.aceclaw.core.agent.RetryConfig.DEFAULT;
     private boolean adaptiveReplanEnabled = true;
     private int maxAgentTurns = 50;
     private int maxAgentWallTimeSec = 600;
@@ -1460,6 +1462,13 @@ public final class StreamingAgentHandler {
         this.mcpInitFuture = mcpInitFuture != null
                 ? mcpInitFuture
                 : CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Sets the retry configuration for transient API errors.
+     */
+    public void setRetryConfig(dev.aceclaw.core.agent.RetryConfig retryConfig) {
+        this.retryConfig = retryConfig != null ? retryConfig : dev.aceclaw.core.agent.RetryConfig.DEFAULT;
     }
 
     /**

--- a/aceclaw-llm/src/main/java/dev/aceclaw/llm/anthropic/AnthropicClient.java
+++ b/aceclaw-llm/src/main/java/dev/aceclaw/llm/anthropic/AnthropicClient.java
@@ -224,10 +224,11 @@ public final class AnthropicClient implements LlmClient {
 
                 if (statusCode != 200) {
                     log.error("Anthropic API error: status={}, body={}", statusCode, responseBody);
-                    long retryAfter = parseRetryAfter(httpResponse);
+                    long retryAfterMs = parseRetryAfterMs(httpResponse);
+                    Boolean shouldRetry = parseShouldRetry(httpResponse);
                     throw new LlmException(
                             "Anthropic API returned HTTP " + statusCode + ": " + responseBody,
-                            statusCode, retryAfter);
+                            statusCode, retryAfterMs, shouldRetry);
                 }
 
                 LlmResponse response = mapper.toResponse(responseBody);
@@ -288,10 +289,11 @@ public final class AnthropicClient implements LlmClient {
                     String errorBody = httpResponse.body()
                             .reduce("", (a, b) -> a + b);
                     log.error("Anthropic API stream error: status={}, body={}", statusCode, errorBody);
-                    long retryAfter = parseRetryAfter(httpResponse);
+                    long retryAfterMs = parseRetryAfterMs(httpResponse);
+                    Boolean shouldRetry = parseShouldRetry(httpResponse);
                     throw new LlmException(
                             "Anthropic API returned HTTP " + statusCode + ": " + errorBody,
-                            statusCode, retryAfter);
+                            statusCode, retryAfterMs, shouldRetry);
                 }
 
                 return new AnthropicStreamSession(httpResponse, mapper);
@@ -334,30 +336,53 @@ public final class AnthropicClient implements LlmClient {
 
     /**
      * Calculates backoff delay for a retry attempt.
-     * Uses exponential backoff (1s, 2s, 4s) with +/-20% jitter.
-     * Respects the Retry-After header if present (capped at 60s).
+     * Uses exponential backoff (0.5s, 1s, 2s, 4s, 8s) with ±25% jitter.
+     * Respects the retry-after-ms / Retry-After headers if present (capped at 60s).
      */
     private static long calculateBackoff(int attempt, LlmException e) {
-        if (e.retryAfterSeconds() > 0) {
-            return Math.min(e.retryAfterSeconds() * 1000L, MAX_BACKOFF_MS);
+        if (e.retryAfterMs() > 0) {
+            return Math.min(e.retryAfterMs(), MAX_BACKOFF_MS);
         }
-        long baseMs = 1000L * (1L << attempt); // 1s, 2s, 4s
-        double jitterFactor = 1.0 + 0.2 * (ThreadLocalRandom.current().nextDouble() * 2 - 1);
-        return Math.min((long) (baseMs * jitterFactor), MAX_BACKOFF_MS);
+        long baseMs = 500L * (1L << attempt); // 0.5s, 1s, 2s, 4s, 8s
+        long jitter = (long) (baseMs * 0.25 * Math.random());
+        return Math.min(baseMs + jitter, MAX_BACKOFF_MS);
     }
 
     /**
-     * Parses the Retry-After header from an HTTP response.
-     * Returns the delay in seconds, or -1 if not present or unparseable.
+     * Parses retry delay from HTTP response headers.
+     * Checks {@code retry-after-ms} first (millisecond precision),
+     * then falls back to {@code Retry-After} (second precision).
+     *
+     * @return delay in milliseconds, or -1 if not present
      */
-    private static long parseRetryAfter(HttpResponse<?> response) {
+    private static long parseRetryAfterMs(HttpResponse<?> response) {
+        // Prefer retry-after-ms for sub-second precision (Anthropic extension)
+        var msHeader = response.headers().firstValue("retry-after-ms").orElse(null);
+        if (msHeader != null) {
+            try {
+                long ms = Long.parseLong(msHeader.trim());
+                if (ms > 0) return ms;
+            } catch (NumberFormatException ignored) {}
+        }
+        // Fall back to standard Retry-After (seconds)
         var header = response.headers().firstValue("retry-after").orElse(null);
         if (header == null) return -1;
         try {
-            return Long.parseLong(header.trim());
+            return Long.parseLong(header.trim()) * 1000L;
         } catch (NumberFormatException e) {
             return -1;
         }
+    }
+
+    /**
+     * Parses the {@code x-should-retry} header from an HTTP response.
+     *
+     * @return true/false if header is present, null if absent
+     */
+    private static Boolean parseShouldRetry(HttpResponse<?> response) {
+        var header = response.headers().firstValue("x-should-retry").orElse(null);
+        if (header == null) return null;
+        return "true".equalsIgnoreCase(header.trim());
     }
 
     @FunctionalInterface


### PR DESCRIPTION
## Summary
- Add configurable `RetryConfig` record with defaults matching Anthropic SDK behavior (5 retries, 0.5s initial backoff, 25% jitter)
- Support `retry-after-ms` header (sub-second precision) and `x-should-retry` header
- Expose retry settings in `config.json` per-profile:
  ```json
  { "retry": { "maxRetries": 5, "initialBackoffMs": 500, "maxBackoffMs": 60000, "jitterFactor": 0.25 } }
  ```

## Test plan
- [x] `./gradlew clean compileJava` — all 13 modules compile
- [x] `./gradlew test` — all tests pass
- [ ] Manual: verify with OAuth token under rate limiting

Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configurable retry behavior with customizable max retries, backoff delays, and jitter factors
  * Enhanced retry handling with server-provided retry guidance (Retry-After headers and explicit server retry hints)
  * Retry configuration can now be set via configuration file

* **Bug Fixes**
  * Improved retry-after timing precision through millisecond-based calculations

* **Refactor**
  * Centralized retry logic into a unified configuration system across all retry operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->