### PR TITLE
fix: serialize concurrent MCP tool calls per server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.12] - 2026-04-10
+
+### Bug Fixes
+
+- Aceclaw-update fails on release installs when .git exists
 ## [0.3.11] - 2026-04-09
 
 ### Features

--- a/aceclaw-llm/src/main/java/dev/aceclaw/llm/openai/OpenAICompatClient.java
+++ b/aceclaw-llm/src/main/java/dev/aceclaw/llm/openai/OpenAICompatClient.java
@@ -125,7 +125,7 @@ public final class OpenAICompatClient implements LlmClient {
 
         var jsonMapper = new ObjectMapper()
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        this.mapper = new OpenAIMapper(jsonMapper);
+        this.mapper = new OpenAIMapper(jsonMapper, providerName);
 
         log.info("OpenAI-compatible client created: provider={}, baseUrl={}, path={}, defaultModel={}",
                 providerName, this.baseUrl, this.completionsPath, defaultModel);

--- a/aceclaw-llm/src/main/java/dev/aceclaw/llm/openai/OpenAIMapper.java
+++ b/aceclaw-llm/src/main/java/dev/aceclaw/llm/openai/OpenAIMapper.java
@@ -31,9 +31,15 @@ import java.util.regex.Pattern;
 final class OpenAIMapper {
 
     private final ObjectMapper objectMapper;
+    private final String providerName;
 
     OpenAIMapper(ObjectMapper objectMapper) {
+        this(objectMapper, "");
+    }
+
+    OpenAIMapper(ObjectMapper objectMapper, String providerName) {
         this.objectMapper = objectMapper;
+        this.providerName = providerName != null ? providerName : "";
     }
 
     // -- Request mapping --
@@ -48,7 +54,7 @@ final class OpenAIMapper {
     String toRequestJson(LlmRequest request, boolean stream) {
         ObjectNode root = objectMapper.createObjectNode();
         root.put("model", request.model());
-        root.put("max_completion_tokens", request.maxTokens());
+        root.put(maxTokensFieldName(), request.maxTokens());
 
         if (request.temperature() >= 0.0) {
             root.put("temperature", request.temperature());
@@ -98,6 +104,12 @@ final class OpenAIMapper {
         }
 
         return root.toString();
+    }
+
+    private String maxTokensFieldName() {
+        // Ollama's OpenAI-compatible endpoint documents max_tokens rather than
+        // OpenAI's newer max_completion_tokens field.
+        return "ollama".equals(providerName) ? "max_tokens" : "max_completion_tokens";
     }
 
     /**

--- a/aceclaw-llm/src/main/java/dev/aceclaw/llm/openai/OpenAIStreamSession.java
+++ b/aceclaw-llm/src/main/java/dev/aceclaw/llm/openai/OpenAIStreamSession.java
@@ -12,7 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.http.HttpResponse;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
@@ -44,8 +44,11 @@ final class OpenAIStreamSession implements StreamSession {
     private boolean inReasoningBlock;
     private int reasoningBlockIndex;
 
-    // Tool call accumulation: index -> state
-    private final Map<Integer, ToolCallState> toolCallStates = new HashMap<>();
+    // Tool call accumulation: stable key -> state. Ollama has emitted tool calls
+    // without index in OpenAI-compatible streams, so id is used as a fallback.
+    private final Map<String, ToolCallState> toolCallStates = new LinkedHashMap<>();
+    private int nextToolCallSeq;
+    private StopReason lastStopReason;
 
     OpenAIStreamSession(HttpResponse<Stream<String>> response, OpenAIMapper mapper) {
         this.response = response;
@@ -144,11 +147,16 @@ final class OpenAIStreamSession implements StreamSession {
 
             // Process finish_reason
             if (finishReason != null) {
+                boolean hasToolCalls = !toolCallStates.isEmpty();
                 flushOpenBlocks(handler);
 
                 // Extract usage from top-level (OpenAI puts it at root when stream_options.include_usage=true)
                 Usage usage = mapper.parseUsage(root.path("usage"));
                 StopReason stopReason = StopReason.fromString(finishReason);
+                if (hasToolCalls && stopReason == StopReason.END_TURN) {
+                    stopReason = StopReason.TOOL_USE;
+                }
+                lastStopReason = stopReason;
                 handler.onMessageDelta(new StreamEvent.MessageDelta(stopReason, usage));
             }
         }
@@ -159,7 +167,9 @@ final class OpenAIStreamSession implements StreamSession {
             if (chunkUsage.inputTokens() > 0 || chunkUsage.outputTokens() > 0) {
                 // Emit MessageDelta with usage so token counts reach the client
                 flushOpenBlocks(handler);
-                handler.onMessageDelta(new StreamEvent.MessageDelta(StopReason.END_TURN, chunkUsage));
+                handler.onMessageDelta(new StreamEvent.MessageDelta(
+                        lastStopReason != null ? lastStopReason : StopReason.END_TURN,
+                        chunkUsage));
             }
         }
     }
@@ -191,8 +201,6 @@ final class OpenAIStreamSession implements StreamSession {
     }
 
     private void handleToolCallDelta(JsonNode tc, StreamEventHandler handler) {
-        int toolIndex = tc.path("index").asInt(0);
-
         // Close reasoning block if transitioning to tool calls
         if (inReasoningBlock) {
             handler.onContentBlockStop(new StreamEvent.ContentBlockStop(reasoningBlockIndex));
@@ -205,30 +213,62 @@ final class OpenAIStreamSession implements StreamSession {
             inTextBlock = false;
         }
 
-        ToolCallState state = toolCallStates.get(toolIndex);
+        String toolKey = toolCallKey(tc);
+        ToolCallState state = toolCallStates.get(toolKey);
 
-        // New tool call
+        String tcId = tc.path("id").asText("");
+        JsonNode function = tc.path("function");
+        String name = function.path("name").asText("");
+
         if (state == null) {
-            String tcId = tc.path("id").asText("");
-            JsonNode function = tc.path("function");
-            String name = function.path("name").asText("");
-
             int blockIndex = nextBlockIndex++;
             state = new ToolCallState(tcId, name, blockIndex);
-            toolCallStates.put(toolIndex, state);
-
-            handler.onContentBlockStart(new StreamEvent.ContentBlockStart(
-                    blockIndex, new ContentBlock.ToolUse(tcId, name, "")));
+            toolCallStates.put(toolKey, state);
+        } else {
+            if (!tcId.isBlank() && state.id.isBlank()) {
+                state.id = tcId;
+            }
+            if (!name.isBlank() && state.name.isBlank()) {
+                state.name = name;
+            }
         }
 
-        // Accumulate arguments
-        JsonNode function = tc.path("function");
+        // Emit onContentBlockStart eagerly once id and name are known
+        if (!state.started && !state.id.isBlank() && !state.name.isBlank()) {
+            state.started = true;
+            handler.onContentBlockStart(new StreamEvent.ContentBlockStart(
+                    state.blockIndex, new ContentBlock.ToolUse(state.id, state.name, "")));
+            // Flush any arguments that were accumulated before id/name arrived
+            if (!state.argumentsBuilder.isEmpty()) {
+                handler.onToolUseDelta(new StreamEvent.ToolUseDelta(
+                        state.blockIndex, state.name, state.argumentsBuilder.toString()));
+            }
+        }
+
+        // Accumulate and stream arguments incrementally
         String argFragment = function.path("arguments").asText(null);
         if (argFragment != null) {
             state.argumentsBuilder.append(argFragment);
-            handler.onToolUseDelta(new StreamEvent.ToolUseDelta(
-                    state.blockIndex, state.name, argFragment));
+            if (state.started) {
+                handler.onToolUseDelta(new StreamEvent.ToolUseDelta(
+                        state.blockIndex, state.name, argFragment));
+            }
         }
+    }
+
+    private String toolCallKey(JsonNode tc) {
+        if (tc.has("index") && tc.path("index").canConvertToInt()) {
+            return "index:" + tc.path("index").asInt();
+        }
+        String id = tc.path("id").asText("");
+        if (!id.isBlank()) {
+            return "id:" + id;
+        }
+        // No index or id available — assign a monotonic sequence number.
+        // This avoids collisions when the same tool is called multiple times
+        // (a "name:" key would merge them) and is stable across calls
+        // (unlike using map size which changes after insertion).
+        return "seq:" + nextToolCallSeq++;
     }
 
     /**
@@ -244,6 +284,16 @@ final class OpenAIStreamSession implements StreamSession {
             inTextBlock = false;
         }
         for (ToolCallState state : toolCallStates.values()) {
+            if (!state.started) {
+                // Tool call never received id/name during streaming — emit with what we have
+                String arguments = state.argumentsBuilder.isEmpty()
+                        ? "{}"
+                        : state.argumentsBuilder.toString();
+                handler.onContentBlockStart(new StreamEvent.ContentBlockStart(
+                        state.blockIndex, new ContentBlock.ToolUse(state.id, state.name, "")));
+                handler.onToolUseDelta(new StreamEvent.ToolUseDelta(
+                        state.blockIndex, state.name, arguments));
+            }
             handler.onContentBlockStop(new StreamEvent.ContentBlockStop(state.blockIndex));
         }
         toolCallStates.clear();
@@ -253,14 +303,16 @@ final class OpenAIStreamSession implements StreamSession {
      * Tracks the accumulation state for a single tool call during streaming.
      */
     private static final class ToolCallState {
-        final String id;
-        final String name;
+        // Mutable: some providers (Ollama) may deliver id/name in later deltas
+        String id;
+        String name;
         final int blockIndex;
         final StringBuilder argumentsBuilder = new StringBuilder();
+        boolean started; // whether onContentBlockStart has been emitted
 
         ToolCallState(String id, String name, int blockIndex) {
-            this.id = id;
-            this.name = name;
+            this.id = id != null ? id : "";
+            this.name = name != null ? name : "";
             this.blockIndex = blockIndex;
         }
     }

--- a/aceclaw-llm/src/test/java/dev/aceclaw/llm/openai/OpenAIMapperTest.java
+++ b/aceclaw-llm/src/test/java/dev/aceclaw/llm/openai/OpenAIMapperTest.java
@@ -46,6 +46,15 @@ class OpenAIMapperTest {
     }
 
     @Test
+    void toRequestJson_ollamaUsesLegacyMaxTokensField() throws Exception {
+        var ollamaMapper = new OpenAIMapper(objectMapper, "ollama");
+        JsonNode root = objectMapper.readTree(ollamaMapper.toRequestJson(baseRequest().build(), false));
+
+        assertThat(root.get("max_tokens").asInt()).isGreaterThan(0);
+        assertThat(root.has("max_completion_tokens")).isFalse();
+    }
+
+    @Test
     void systemPrompt_isFirstMessage() throws Exception {
         var request = baseRequest().systemPrompt("Be helpful").build();
         JsonNode root = objectMapper.readTree(mapper.toRequestJson(request, false));

--- a/aceclaw-llm/src/test/java/dev/aceclaw/llm/openai/OpenAIStreamSessionTest.java
+++ b/aceclaw-llm/src/test/java/dev/aceclaw/llm/openai/OpenAIStreamSessionTest.java
@@ -1,0 +1,185 @@
+package dev.aceclaw.llm.openai;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.aceclaw.core.llm.ContentBlock;
+import dev.aceclaw.core.llm.StopReason;
+import dev.aceclaw.core.llm.StreamEvent;
+import dev.aceclaw.core.llm.StreamEventHandler;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLSession;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OpenAIStreamSessionTest {
+
+    @Test
+    void standardOpenAIIncrementalToolCallStreaming() {
+        var mapper = new OpenAIMapper(new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false));
+        var session = new OpenAIStreamSession(response(Stream.of(
+                // First chunk: tool call header with id, name, empty args
+                """
+                data: {"id":"chatcmpl-100","model":"gpt-4","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_abc","type":"function","function":{"name":"read_file","arguments":""}}]},"finish_reason":null}]}
+                """.strip(),
+                // Second chunk: argument fragment
+                """
+                data: {"id":"chatcmpl-100","model":"gpt-4","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"path\\":"}}]},"finish_reason":null}]}
+                """.strip(),
+                // Third chunk: argument fragment
+                """
+                data: {"id":"chatcmpl-100","model":"gpt-4","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\\"/tmp/a\\"}"}}]},"finish_reason":null}]}
+                """.strip(),
+                // Finish
+                """
+                data: {"id":"chatcmpl-100","model":"gpt-4","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":20,"completion_tokens":8}}
+                """.strip(),
+                "data: [DONE]"
+        )), mapper);
+
+        var handler = new CapturingHandler();
+        session.onEvent(handler);
+
+        // Verify incremental deltas were emitted (not batched at flush)
+        assertThat(handler.toolUseDeltaCount).as("should stream deltas incrementally").isGreaterThanOrEqualTo(2);
+        assertThat(handler.toolUses)
+                .extracting(ContentBlock.ToolUse::name)
+                .containsExactly("read_file");
+        assertThat(handler.toolUses)
+                .extracting(ContentBlock.ToolUse::inputJson)
+                .containsExactly("{\"path\":\"/tmp/a\"}");
+        assertThat(handler.stopReasons).containsOnly(StopReason.TOOL_USE);
+        assertThat(handler.completed).isTrue();
+    }
+
+    @Test
+    void ollamaToolCallsWithoutIndexAndStopFinishReasonStillBecomeToolUse() {
+        var mapper = new OpenAIMapper(new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false), "ollama");
+        var session = new OpenAIStreamSession(response(Stream.of(
+                """
+                data: {"id":"chatcmpl-914","model":"llama3.1","choices":[{"delta":{"role":"assistant","content":"","tool_calls":[{"id":"call_a","type":"function","function":{"name":"read_file","arguments":"{\\"path\\":\\"/tmp/a\\"}"}},{"id":"call_b","type":"function","function":{"name":"grep","arguments":"{\\"pattern\\":\\"TODO\\"}"}}]},"index":0}]}
+                """.strip(),
+                """
+                data: {"id":"chatcmpl-914","model":"llama3.1","choices":[{"delta":{"role":"assistant","content":""},"finish_reason":"stop","index":0}]}
+                """.strip(),
+                """
+                data: {"id":"chatcmpl-914","model":"llama3.1","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":3}}
+                """.strip(),
+                "data: [DONE]"
+        )), mapper);
+
+        var handler = new CapturingHandler();
+        session.onEvent(handler);
+
+        assertThat(handler.toolUses)
+                .extracting(ContentBlock.ToolUse::name)
+                .containsExactly("read_file", "grep");
+        assertThat(handler.toolUses)
+                .extracting(ContentBlock.ToolUse::inputJson)
+                .containsExactly("{\"path\":\"/tmp/a\"}", "{\"pattern\":\"TODO\"}");
+        assertThat(handler.stopReasons).containsOnly(StopReason.TOOL_USE);
+        assertThat(handler.completed).isTrue();
+    }
+
+    @Test
+    void maxTokensToolCallStreamIsNotCoercedToToolUse() {
+        var mapper = new OpenAIMapper(new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false), "ollama");
+        var session = new OpenAIStreamSession(response(Stream.of(
+                """
+                data: {"id":"chatcmpl-915","model":"llama3.1","choices":[{"delta":{"role":"assistant","content":"","tool_calls":[{"id":"call_a","type":"function","function":{"name":"read_file","arguments":"{\\"path\\":"}}]},"index":0}]}
+                """.strip(),
+                """
+                data: {"id":"chatcmpl-915","model":"llama3.1","choices":[{"delta":{},"finish_reason":"length","index":0}]}
+                """.strip(),
+                "data: [DONE]"
+        )), mapper);
+
+        var handler = new CapturingHandler();
+        session.onEvent(handler);
+
+        assertThat(handler.stopReasons).containsOnly(StopReason.MAX_TOKENS);
+        assertThat(handler.completed).isTrue();
+    }
+
+    private static HttpResponse<Stream<String>> response(Stream<String> body) {
+        return new HttpResponse<>() {
+            @Override public int statusCode() { return 200; }
+            @Override public HttpRequest request() { return null; }
+            @Override public Optional<HttpResponse<Stream<String>>> previousResponse() { return Optional.empty(); }
+            @Override public HttpHeaders headers() { return HttpHeaders.of(Map.of(), (name, values) -> true); }
+            @Override public Stream<String> body() { return body; }
+            @Override public Optional<SSLSession> sslSession() { return Optional.empty(); }
+            @Override public URI uri() { return URI.create("http://localhost:11434/v1/chat/completions"); }
+            @Override public HttpClient.Version version() { return HttpClient.Version.HTTP_1_1; }
+        };
+    }
+
+    /** Tracks multiple concurrent tool calls by block index (handles interleaved Start events). */
+    private static final class CapturingHandler implements StreamEventHandler {
+        private final List<ContentBlock.ToolUse> toolUses = new ArrayList<>();
+        private final List<StopReason> stopReasons = new ArrayList<>();
+        private final Map<Integer, ToolAccumulator> activeTools = new LinkedHashMap<>();
+        private int toolUseDeltaCount;
+        private boolean completed;
+
+        @Override
+        public void onContentBlockStart(StreamEvent.ContentBlockStart event) {
+            if (event.block() instanceof ContentBlock.ToolUse toolUse) {
+                activeTools.put(event.index(), new ToolAccumulator(toolUse.id(), toolUse.name()));
+            }
+        }
+
+        @Override
+        public void onToolUseDelta(StreamEvent.ToolUseDelta event) {
+            if (event.partialJson() != null) {
+                var acc = activeTools.get(event.index());
+                if (acc != null) {
+                    acc.arguments.append(event.partialJson());
+                }
+                toolUseDeltaCount++;
+            }
+        }
+
+        @Override
+        public void onContentBlockStop(StreamEvent.ContentBlockStop event) {
+            var acc = activeTools.remove(event.index());
+            if (acc != null) {
+                toolUses.add(new ContentBlock.ToolUse(acc.id, acc.name, acc.arguments.toString()));
+            }
+        }
+
+        @Override
+        public void onMessageDelta(StreamEvent.MessageDelta event) {
+            stopReasons.add(event.stopReason());
+        }
+
+        @Override
+        public void onComplete(StreamEvent.StreamComplete event) {
+            completed = true;
+        }
+
+        private static final class ToolAccumulator {
+            final String id;
+            final String name;
+            final StringBuilder arguments = new StringBuilder();
+            ToolAccumulator(String id, String name) {
+                this.id = id;
+                this.name = name;
+            }
+        }
+    }
+}

--- a/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpClientManager.java
+++ b/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpClientManager.java
@@ -243,8 +243,14 @@ public final class McpClientManager implements AutoCloseable {
         var results = new LinkedHashMap<String, Boolean>();
         for (var entry : clients.entrySet()) {
             var serverName = entry.getKey();
+            var lock = serverLocks.get(serverName);
             try {
-                entry.getValue().ping();
+                if (lock != null) lock.lock();
+                try {
+                    entry.getValue().ping();
+                } finally {
+                    if (lock != null) lock.unlock();
+                }
                 results.put(serverName, true);
                 statuses.put(serverName, ServerStatus.CONNECTED);
                 lastErrors.remove(serverName);
@@ -528,12 +534,14 @@ public final class McpClientManager implements AutoCloseable {
         // 1. Snapshot under lock
         Map<String, McpSyncClient> clientSnapshot;
         Map<String, ServerStatus> statusSnapshot;
+        Map<String, Lock> lockSnapshot;
         synchronized (this) {
             clientSnapshot = new LinkedHashMap<>(clients);
             statusSnapshot = new LinkedHashMap<>(statuses);
+            lockSnapshot = new LinkedHashMap<>(serverLocks);
         }
 
-        // 2. Ping outside the monitor — no lock held during I/O
+        // 2. Ping outside the monitor — per-server lock prevents racing with callTool()
         var pingResults = new LinkedHashMap<String, Boolean>();
         var pingErrors = new LinkedHashMap<String, String>();
         for (var serverName : serverConfigs.keySet()) {
@@ -542,8 +550,14 @@ public final class McpClientManager implements AutoCloseable {
                 pingResults.put(serverName, false);
                 continue;
             }
+            var lock = lockSnapshot.get(serverName);
             try {
-                client.ping();
+                if (lock != null) lock.lock();
+                try {
+                    client.ping();
+                } finally {
+                    if (lock != null) lock.unlock();
+                }
                 pingResults.put(serverName, true);
             } catch (Exception e) {
                 log.warn("MCP server '{}' ping failed: {}", serverName, e.getMessage());

--- a/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpClientManager.java
+++ b/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpClientManager.java
@@ -23,6 +23,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 
 /**
@@ -75,6 +77,7 @@ public final class McpClientManager implements AutoCloseable {
     private final Map<String, ServerStatus> statuses = new LinkedHashMap<>();
     private final List<Tool> bridgedTools = new ArrayList<>();
     private final Map<String, String> lastErrors = new LinkedHashMap<>();
+    private final Map<String, Lock> serverLocks = new LinkedHashMap<>();
     private final Map<String, Long> lastReconnectAttemptMillis = new LinkedHashMap<>();
     private Consumer<List<Tool>> onServerTools;
     private Consumer<String> onToolRemoved;
@@ -502,9 +505,10 @@ public final class McpClientManager implements AutoCloseable {
             return List.of();
         }
 
+        var lock = serverLocks.computeIfAbsent(serverName, k -> new ReentrantLock());
         var bridgedForServer = new ArrayList<Tool>();
         for (var mcpTool : tools) {
-            var bridged = McpToolBridge.create(serverName, mcpTool, client);
+            var bridged = McpToolBridge.create(serverName, mcpTool, client, lock);
             bridgedTools.add(bridged);
             bridgedForServer.add(bridged);
             log.debug("Bridged MCP tool: {}", bridged.name());

--- a/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpToolBridge.java
+++ b/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpToolBridge.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.locks.Lock;
 
 /**
  * Adapts an MCP tool to the AceClaw {@link Tool} interface.
@@ -30,14 +31,16 @@ public final class McpToolBridge implements Tool {
     private final String description;
     private final JsonNode inputSchema;
     private final McpSyncClient client;
+    private final Lock serverLock;
 
     private McpToolBridge(String qualifiedName, String mcpToolName, String description,
-                          JsonNode inputSchema, McpSyncClient client) {
+                          JsonNode inputSchema, McpSyncClient client, Lock serverLock) {
         this.qualifiedName = qualifiedName;
         this.mcpToolName = mcpToolName;
         this.description = description;
         this.inputSchema = inputSchema;
         this.client = client;
+        this.serverLock = serverLock;
     }
 
     /**
@@ -46,9 +49,11 @@ public final class McpToolBridge implements Tool {
      * @param serverName the MCP server name (from config)
      * @param mcpTool    the MCP tool definition
      * @param client     the MCP client for tool execution
+     * @param serverLock per-server lock to serialize requests over the shared transport
      * @return a new tool bridge instance
      */
-    public static McpToolBridge create(String serverName, McpSchema.Tool mcpTool, McpSyncClient client) {
+    public static McpToolBridge create(String serverName, McpSchema.Tool mcpTool,
+                                       McpSyncClient client, Lock serverLock) {
         var qualifiedName = "mcp__" + serverName + "__" + mcpTool.name();
 
         // Convert MCP input schema to Jackson JsonNode
@@ -63,7 +68,7 @@ public final class McpToolBridge implements Tool {
         }
 
         return new McpToolBridge(qualifiedName, mcpTool.name(),
-                mcpTool.description(), inputSchema, client);
+                mcpTool.description(), inputSchema, client, serverLock);
     }
 
     @Override
@@ -95,9 +100,17 @@ public final class McpToolBridge implements Tool {
             args = parsed;
         }
 
-        // Call the MCP tool
+        // Serialize requests per server — the MCP SDK's StdioClientTransport uses a
+        // Reactor unicast sink whose tryEmitNext() is not thread-safe; concurrent calls
+        // from parallel virtual threads cause FAIL_NON_SERIALIZED ("Failed to enqueue message").
         var request = new McpSchema.CallToolRequest(mcpToolName, args);
-        var result = client.callTool(request);
+        McpSchema.CallToolResult result;
+        serverLock.lock();
+        try {
+            result = client.callTool(request);
+        } finally {
+            serverLock.unlock();
+        }
 
         // Extract text content from the result
         var output = extractContent(result);

--- a/aceclaw-mcp/src/test/java/dev/aceclaw/mcp/McpClientManagerTest.java
+++ b/aceclaw-mcp/src/test/java/dev/aceclaw/mcp/McpClientManagerTest.java
@@ -12,9 +12,13 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -244,5 +248,85 @@ class McpClientManagerTest {
         manager = null; // prevent double-close in tearDown
 
         assertThat(removedTools).containsExactlyInAnyOrder("mcp__s__t1", "mcp__s__t2");
+    }
+
+    /**
+     * Verifies that ping() and callTool() on the same server cannot execute
+     * concurrently — both must acquire the per-server lock. Uses a mock client
+     * that detects concurrent access (simulating the StdioClientTransport
+     * unicast sink that rejects parallel emits).
+     */
+    @Test
+    void pingAndCallToolSerializedOnSameServer() throws Exception {
+        var concurrency = new AtomicInteger();
+        var maxConcurrency = new AtomicInteger();
+        var errors = new CopyOnWriteArrayList<String>();
+
+        var guardClient = mock(McpSyncClient.class);
+
+        // listTools — called during start() to discover tools
+        when(guardClient.listTools()).thenReturn(toolsResult("t"));
+
+        // callTool — tracks concurrency with 50ms hold time
+        when(guardClient.callTool(any(McpSchema.CallToolRequest.class))).thenAnswer(inv -> {
+            int current = concurrency.incrementAndGet();
+            maxConcurrency.updateAndGet(max -> Math.max(max, current));
+            if (current > 1) {
+                errors.add("Concurrent access in callTool: " + current);
+            }
+            try { Thread.sleep(50); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+            concurrency.decrementAndGet();
+            return new McpSchema.CallToolResult(List.of(new McpSchema.TextContent("ok")), false);
+        });
+
+        // ping — tracks concurrency with 50ms hold time
+        when(guardClient.ping()).thenAnswer(inv -> {
+            int current = concurrency.incrementAndGet();
+            maxConcurrency.updateAndGet(max -> Math.max(max, current));
+            if (current > 1) {
+                errors.add("Concurrent access in ping: " + current);
+            }
+            try { Thread.sleep(50); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+            concurrency.decrementAndGet();
+            return null;
+        });
+
+        var configs = Map.of("srv", dummyConfig("cmd"));
+        manager = new McpClientManager(configs, (name, config) -> guardClient);
+        manager.start();
+
+        assertThat(manager.bridgedTools()).hasSize(1);
+        var tool = manager.bridgedTools().getFirst();
+
+        // Fire callTool and ping concurrently
+        var startLatch = new CountDownLatch(1);
+        var doneLatch = new CountDownLatch(2);
+
+        Thread.ofVirtual().start(() -> {
+            try {
+                startLatch.await(5, TimeUnit.SECONDS);
+                tool.execute("{}");
+            } catch (Exception e) {
+                errors.add("callTool threw: " + e.getMessage());
+            } finally {
+                doneLatch.countDown();
+            }
+        });
+        Thread.ofVirtual().start(() -> {
+            try {
+                startLatch.await(5, TimeUnit.SECONDS);
+                manager.ping();
+            } catch (Exception e) {
+                errors.add("ping threw: " + e.getMessage());
+            } finally {
+                doneLatch.countDown();
+            }
+        });
+
+        startLatch.countDown();
+        assertThat(doneLatch.await(10, TimeUnit.SECONDS)).isTrue();
+
+        assertThat(errors).as("no concurrent access between ping and callTool").isEmpty();
+        assertThat(maxConcurrency.get()).as("lock must serialize ping vs callTool").isEqualTo(1);
     }
 }

--- a/aceclaw-mcp/src/test/java/dev/aceclaw/mcp/McpToolBridgeTest.java
+++ b/aceclaw-mcp/src/test/java/dev/aceclaw/mcp/McpToolBridgeTest.java
@@ -7,13 +7,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -103,5 +109,66 @@ class McpToolBridgeTest {
 
         assertThat(tool.inputSchema()).isNotNull();
         assertThat(tool.inputSchema().get("type").asText()).isEqualTo("object");
+    }
+
+    /**
+     * Simulates the real race: concurrent callTool() on a transport that rejects
+     * parallel emits (like StdioClientTransport's unicast Reactor sink).
+     * The mock client tracks concurrent invocations and records if >1 thread
+     * is inside callTool() at the same time. With the per-server lock this
+     * must never happen.
+     */
+    @Test
+    void concurrentCallToolSerializedByServerLock() throws Exception {
+        var concurrency = new AtomicInteger();
+        var maxConcurrency = new AtomicInteger();
+        var errors = new CopyOnWriteArrayList<String>();
+
+        var guardClient = mock(McpSyncClient.class);
+        when(guardClient.callTool(any(McpSchema.CallToolRequest.class))).thenAnswer(inv -> {
+            int current = concurrency.incrementAndGet();
+            maxConcurrency.updateAndGet(max -> Math.max(max, current));
+            if (current > 1) {
+                errors.add("Concurrent callTool detected: " + current + " threads");
+            }
+            try {
+                Thread.sleep(50); // simulate server processing time
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                concurrency.decrementAndGet();
+            }
+            return new McpSchema.CallToolResult(
+                    List.of(new McpSchema.TextContent("ok")), false);
+        });
+
+        var lock = new ReentrantLock();
+        var tools = new ArrayList<McpToolBridge>();
+        for (int i = 0; i < 4; i++) {
+            tools.add(McpToolBridge.create("srv", mcpTool("tool_" + i, "desc"),
+                    guardClient, lock));
+        }
+
+        var startLatch = new CountDownLatch(1);
+        var doneLatch = new CountDownLatch(4);
+
+        for (var tool : tools) {
+            Thread.ofVirtual().start(() -> {
+                try {
+                    startLatch.await(5, TimeUnit.SECONDS);
+                    tool.execute("{}");
+                } catch (Exception e) {
+                    errors.add(e.getMessage());
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown(); // release all threads simultaneously
+        assertThat(doneLatch.await(10, TimeUnit.SECONDS)).isTrue();
+
+        assertThat(errors).as("no concurrent access errors").isEmpty();
+        assertThat(maxConcurrency.get()).as("server lock must serialize to max 1 concurrent call").isEqualTo(1);
     }
 }

--- a/aceclaw-mcp/src/test/java/dev/aceclaw/mcp/McpToolBridgeTest.java
+++ b/aceclaw-mcp/src/test/java/dev/aceclaw/mcp/McpToolBridgeTest.java
@@ -9,6 +9,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -21,6 +23,8 @@ class McpToolBridgeTest {
     @Mock
     McpSyncClient client;
 
+    private final Lock serverLock = new ReentrantLock();
+
     private McpSchema.Tool mcpTool(String name, String description) {
         var schema = new McpSchema.JsonSchema("object", Map.of(), List.of(), null, null, null);
         return new McpSchema.Tool(name, null, description, schema, null, null, null);
@@ -28,21 +32,21 @@ class McpToolBridgeTest {
 
     @Test
     void toolNameFollowsConvention() {
-        var tool = McpToolBridge.create("my-server", mcpTool("do_thing", "Does a thing"), client);
+        var tool = McpToolBridge.create("my-server", mcpTool("do_thing", "Does a thing"), client, serverLock);
 
         assertThat(tool.name()).isEqualTo("mcp__my-server__do_thing");
     }
 
     @Test
     void descriptionPassedThrough() {
-        var tool = McpToolBridge.create("s", mcpTool("t", "My description"), client);
+        var tool = McpToolBridge.create("s", mcpTool("t", "My description"), client, serverLock);
 
         assertThat(tool.description()).isEqualTo("My description");
     }
 
     @Test
     void executeDelegatesToCallTool() throws Exception {
-        var tool = McpToolBridge.create("s", mcpTool("action", "desc"), client);
+        var tool = McpToolBridge.create("s", mcpTool("action", "desc"), client, serverLock);
 
         when(client.callTool(any(McpSchema.CallToolRequest.class)))
                 .thenReturn(new McpSchema.CallToolResult(
@@ -57,7 +61,7 @@ class McpToolBridgeTest {
 
     @Test
     void errorResultSetsIsError() throws Exception {
-        var tool = McpToolBridge.create("s", mcpTool("fail", "desc"), client);
+        var tool = McpToolBridge.create("s", mcpTool("fail", "desc"), client, serverLock);
 
         when(client.callTool(any(McpSchema.CallToolRequest.class)))
                 .thenReturn(new McpSchema.CallToolResult(
@@ -71,7 +75,7 @@ class McpToolBridgeTest {
 
     @Test
     void emptyInputHandledGracefully() throws Exception {
-        var tool = McpToolBridge.create("s", mcpTool("t", "desc"), client);
+        var tool = McpToolBridge.create("s", mcpTool("t", "desc"), client, serverLock);
 
         when(client.callTool(any(McpSchema.CallToolRequest.class)))
                 .thenReturn(new McpSchema.CallToolResult(List.of(), false));
@@ -83,7 +87,7 @@ class McpToolBridgeTest {
 
     @Test
     void nullInputHandledGracefully() throws Exception {
-        var tool = McpToolBridge.create("s", mcpTool("t", "desc"), client);
+        var tool = McpToolBridge.create("s", mcpTool("t", "desc"), client, serverLock);
 
         when(client.callTool(any(McpSchema.CallToolRequest.class)))
                 .thenReturn(new McpSchema.CallToolResult(List.of(), false));
@@ -95,7 +99,7 @@ class McpToolBridgeTest {
 
     @Test
     void inputSchemaExposed() {
-        var tool = McpToolBridge.create("s", mcpTool("t", "desc"), client);
+        var tool = McpToolBridge.create("s", mcpTool("t", "desc"), client, serverLock);
 
         assertThat(tool.inputSchema()).isNotNull();
         assertThat(tool.inputSchema().get("type").asText()).isEqualTo("object");

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=dev.aceclaw
-version=0.3.12-SNAPSHOT
+version=0.3.12

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=dev.aceclaw
-version=0.3.12
+version=0.3.13-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=dev.aceclaw
-version=0.3.11
+version=0.3.12-SNAPSHOT

--- a/update.sh
+++ b/update.sh
@@ -30,13 +30,15 @@ echo ""
 
 # ---------------------------------------------------------------------------
 # Detect mode: release install vs git checkout
+# A release install has a VERSION file; a git checkout has .git but no VERSION.
+# Some installs may have both (e.g. daemon-created .git for config tracking).
 # ---------------------------------------------------------------------------
-if [ -d "$SCRIPT_DIR/.git" ]; then
+if [ -f "$SCRIPT_DIR/VERSION" ] && [ -x "$SCRIPT_DIR/bin/aceclaw-cli" ]; then
+    : # Valid release install — proceed
+elif [ -d "$SCRIPT_DIR/.git" ]; then
     fail "This is a git checkout, not a release install. To update from source:
     cd $SCRIPT_DIR && git pull && ./gradlew :aceclaw-cli:installDist -q"
-fi
-
-if [ ! -f "$SCRIPT_DIR/VERSION" ] || [ ! -x "$SCRIPT_DIR/bin/aceclaw-cli" ]; then
+else
     fail "Not a valid release install (missing VERSION or bin/aceclaw-cli).
   If this is a source checkout, use: git pull && ./gradlew :aceclaw-cli:installDist -q"
 fi


### PR DESCRIPTION
## Summary
- MCP SDK's `StdioClientTransport.sendMessage()` uses a Reactor **unicast sink** (`tryEmitNext()`) that is not thread-safe — concurrent calls from parallel virtual threads cause `FAIL_NON_SERIALIZED` → `"Failed to enqueue message"`
- Add a per-server `ReentrantLock` in `McpClientManager`, shared across all `McpToolBridge` instances for the same server, to serialize `callTool()` invocations
- Cross-server parallelism is preserved; only same-server requests are serialized

## Root cause
```
StreamingAgentLoop (StructuredTaskScope)
  ├── VT1: McpToolBridge.execute() → client.callTool() → sendMessage() → outboundSink.tryEmitNext() ✓
  └── VT2: McpToolBridge.execute() → client.callTool() → sendMessage() → outboundSink.tryEmitNext() ✗ FAIL_NON_SERIALIZED
```

## Test plan
- [x] All existing `McpToolBridgeTest` and `McpClientManagerTest` tests pass
- [x] Full `./gradlew clean build` passes (67 tasks)
- [ ] Manual: trigger parallel tool calls to same MCP server, verify no "Failed to enqueue message" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Per‑server synchronization added so requests to the same server are serialized, preventing races and transport conflicts.

* **New Features / Enhancements**
  * Improved streaming of tool calls: stable per‑tool keys, incremental argument delivery, and more accurate stop‑reason mapping.
  * Provider-specific request mapping for token limits (adds compatibility with Ollama-style field names).

* **Tests**
  * New concurrency tests ensuring ping and tool invocations against the same server are serialized.

* **Chores**
  * Project version bumped and installer detection logic refined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->