### PR TITLE
Fix Ollama tool calling compatibility

### DIFF
--- a/aceclaw-llm/src/main/java/dev/aceclaw/llm/openai/OpenAICompatClient.java
+++ b/aceclaw-llm/src/main/java/dev/aceclaw/llm/openai/OpenAICompatClient.java
@@ -125,7 +125,7 @@ public final class OpenAICompatClient implements LlmClient {
 
         var jsonMapper = new ObjectMapper()
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        this.mapper = new OpenAIMapper(jsonMapper);
+        this.mapper = new OpenAIMapper(jsonMapper, providerName);
 
         log.info("OpenAI-compatible client created: provider={}, baseUrl={}, path={}, defaultModel={}",
                 providerName, this.baseUrl, this.completionsPath, defaultModel);

--- a/aceclaw-llm/src/main/java/dev/aceclaw/llm/openai/OpenAIMapper.java
+++ b/aceclaw-llm/src/main/java/dev/aceclaw/llm/openai/OpenAIMapper.java
@@ -31,9 +31,15 @@ import java.util.regex.Pattern;
 final class OpenAIMapper {
 
     private final ObjectMapper objectMapper;
+    private final String providerName;
 
     OpenAIMapper(ObjectMapper objectMapper) {
+        this(objectMapper, "");
+    }
+
+    OpenAIMapper(ObjectMapper objectMapper, String providerName) {
         this.objectMapper = objectMapper;
+        this.providerName = providerName != null ? providerName : "";
     }
 
     // -- Request mapping --
@@ -48,7 +54,7 @@ final class OpenAIMapper {
     String toRequestJson(LlmRequest request, boolean stream) {
         ObjectNode root = objectMapper.createObjectNode();
         root.put("model", request.model());
-        root.put("max_completion_tokens", request.maxTokens());
+        root.put(maxTokensFieldName(), request.maxTokens());
 
         if (request.temperature() >= 0.0) {
             root.put("temperature", request.temperature());
@@ -98,6 +104,12 @@ final class OpenAIMapper {
         }
 
         return root.toString();
+    }
+
+    private String maxTokensFieldName() {
+        // Ollama's OpenAI-compatible endpoint documents max_tokens rather than
+        // OpenAI's newer max_completion_tokens field.
+        return "ollama".equals(providerName) ? "max_tokens" : "max_completion_tokens";
     }
 
     /**

--- a/aceclaw-llm/src/main/java/dev/aceclaw/llm/openai/OpenAIStreamSession.java
+++ b/aceclaw-llm/src/main/java/dev/aceclaw/llm/openai/OpenAIStreamSession.java
@@ -47,6 +47,7 @@ final class OpenAIStreamSession implements StreamSession {
     // Tool call accumulation: stable key -> state. Ollama has emitted tool calls
     // without index in OpenAI-compatible streams, so id is used as a fallback.
     private final Map<String, ToolCallState> toolCallStates = new LinkedHashMap<>();
+    private int nextToolCallSeq;
     private StopReason lastStopReason;
 
     OpenAIStreamSession(HttpResponse<Stream<String>> response, OpenAIMapper mapper) {
@@ -152,7 +153,7 @@ final class OpenAIStreamSession implements StreamSession {
                 // Extract usage from top-level (OpenAI puts it at root when stream_options.include_usage=true)
                 Usage usage = mapper.parseUsage(root.path("usage"));
                 StopReason stopReason = StopReason.fromString(finishReason);
-                if (hasToolCalls && stopReason != StopReason.ERROR) {
+                if (hasToolCalls && stopReason == StopReason.END_TURN) {
                     stopReason = StopReason.TOOL_USE;
                 }
                 lastStopReason = stopReason;
@@ -215,32 +216,43 @@ final class OpenAIStreamSession implements StreamSession {
         String toolKey = toolCallKey(tc);
         ToolCallState state = toolCallStates.get(toolKey);
 
-        // New tool call
-        if (state == null) {
-            String tcId = tc.path("id").asText("");
-            JsonNode function = tc.path("function");
-            String name = function.path("name").asText("");
+        String tcId = tc.path("id").asText("");
+        JsonNode function = tc.path("function");
+        String name = function.path("name").asText("");
 
+        if (state == null) {
             int blockIndex = nextBlockIndex++;
             state = new ToolCallState(tcId, name, blockIndex);
             toolCallStates.put(toolKey, state);
         } else {
-            String tcId = tc.path("id").asText("");
             if (!tcId.isBlank() && state.id.isBlank()) {
                 state.id = tcId;
             }
-            JsonNode function = tc.path("function");
-            String name = function.path("name").asText("");
             if (!name.isBlank() && state.name.isBlank()) {
                 state.name = name;
             }
         }
 
-        // Accumulate arguments
-        JsonNode function = tc.path("function");
+        // Emit onContentBlockStart eagerly once id and name are known
+        if (!state.started && !state.id.isBlank() && !state.name.isBlank()) {
+            state.started = true;
+            handler.onContentBlockStart(new StreamEvent.ContentBlockStart(
+                    state.blockIndex, new ContentBlock.ToolUse(state.id, state.name, "")));
+            // Flush any arguments that were accumulated before id/name arrived
+            if (!state.argumentsBuilder.isEmpty()) {
+                handler.onToolUseDelta(new StreamEvent.ToolUseDelta(
+                        state.blockIndex, state.name, state.argumentsBuilder.toString()));
+            }
+        }
+
+        // Accumulate and stream arguments incrementally
         String argFragment = function.path("arguments").asText(null);
         if (argFragment != null) {
             state.argumentsBuilder.append(argFragment);
+            if (state.started) {
+                handler.onToolUseDelta(new StreamEvent.ToolUseDelta(
+                        state.blockIndex, state.name, argFragment));
+            }
         }
     }
 
@@ -252,11 +264,11 @@ final class OpenAIStreamSession implements StreamSession {
         if (!id.isBlank()) {
             return "id:" + id;
         }
-        String name = tc.path("function").path("name").asText("");
-        if (!name.isBlank()) {
-            return "name:" + name;
-        }
-        return "position:" + toolCallStates.size();
+        // No index or id available — assign a monotonic sequence number.
+        // This avoids collisions when the same tool is called multiple times
+        // (a "name:" key would merge them) and is stable across calls
+        // (unlike using map size which changes after insertion).
+        return "seq:" + nextToolCallSeq++;
     }
 
     /**
@@ -272,13 +284,16 @@ final class OpenAIStreamSession implements StreamSession {
             inTextBlock = false;
         }
         for (ToolCallState state : toolCallStates.values()) {
-            String arguments = state.argumentsBuilder.isEmpty()
-                    ? "{}"
-                    : state.argumentsBuilder.toString();
-            handler.onContentBlockStart(new StreamEvent.ContentBlockStart(
-                    state.blockIndex, new ContentBlock.ToolUse(state.id, state.name, "")));
-            handler.onToolUseDelta(new StreamEvent.ToolUseDelta(
-                    state.blockIndex, state.name, arguments));
+            if (!state.started) {
+                // Tool call never received id/name during streaming — emit with what we have
+                String arguments = state.argumentsBuilder.isEmpty()
+                        ? "{}"
+                        : state.argumentsBuilder.toString();
+                handler.onContentBlockStart(new StreamEvent.ContentBlockStart(
+                        state.blockIndex, new ContentBlock.ToolUse(state.id, state.name, "")));
+                handler.onToolUseDelta(new StreamEvent.ToolUseDelta(
+                        state.blockIndex, state.name, arguments));
+            }
             handler.onContentBlockStop(new StreamEvent.ContentBlockStop(state.blockIndex));
         }
         toolCallStates.clear();
@@ -288,10 +303,12 @@ final class OpenAIStreamSession implements StreamSession {
      * Tracks the accumulation state for a single tool call during streaming.
      */
     private static final class ToolCallState {
+        // Mutable: some providers (Ollama) may deliver id/name in later deltas
         String id;
         String name;
         final int blockIndex;
         final StringBuilder argumentsBuilder = new StringBuilder();
+        boolean started; // whether onContentBlockStart has been emitted
 
         ToolCallState(String id, String name, int blockIndex) {
             this.id = id != null ? id : "";

--- a/aceclaw-llm/src/main/java/dev/aceclaw/llm/openai/OpenAIStreamSession.java
+++ b/aceclaw-llm/src/main/java/dev/aceclaw/llm/openai/OpenAIStreamSession.java
@@ -12,7 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.http.HttpResponse;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
@@ -44,8 +44,10 @@ final class OpenAIStreamSession implements StreamSession {
     private boolean inReasoningBlock;
     private int reasoningBlockIndex;
 
-    // Tool call accumulation: index -> state
-    private final Map<Integer, ToolCallState> toolCallStates = new HashMap<>();
+    // Tool call accumulation: stable key -> state. Ollama has emitted tool calls
+    // without index in OpenAI-compatible streams, so id is used as a fallback.
+    private final Map<String, ToolCallState> toolCallStates = new LinkedHashMap<>();
+    private StopReason lastStopReason;
 
     OpenAIStreamSession(HttpResponse<Stream<String>> response, OpenAIMapper mapper) {
         this.response = response;
@@ -144,11 +146,16 @@ final class OpenAIStreamSession implements StreamSession {
 
             // Process finish_reason
             if (finishReason != null) {
+                boolean hasToolCalls = !toolCallStates.isEmpty();
                 flushOpenBlocks(handler);
 
                 // Extract usage from top-level (OpenAI puts it at root when stream_options.include_usage=true)
                 Usage usage = mapper.parseUsage(root.path("usage"));
                 StopReason stopReason = StopReason.fromString(finishReason);
+                if (hasToolCalls && stopReason != StopReason.ERROR) {
+                    stopReason = StopReason.TOOL_USE;
+                }
+                lastStopReason = stopReason;
                 handler.onMessageDelta(new StreamEvent.MessageDelta(stopReason, usage));
             }
         }
@@ -159,7 +166,9 @@ final class OpenAIStreamSession implements StreamSession {
             if (chunkUsage.inputTokens() > 0 || chunkUsage.outputTokens() > 0) {
                 // Emit MessageDelta with usage so token counts reach the client
                 flushOpenBlocks(handler);
-                handler.onMessageDelta(new StreamEvent.MessageDelta(StopReason.END_TURN, chunkUsage));
+                handler.onMessageDelta(new StreamEvent.MessageDelta(
+                        lastStopReason != null ? lastStopReason : StopReason.END_TURN,
+                        chunkUsage));
             }
         }
     }
@@ -191,8 +200,6 @@ final class OpenAIStreamSession implements StreamSession {
     }
 
     private void handleToolCallDelta(JsonNode tc, StreamEventHandler handler) {
-        int toolIndex = tc.path("index").asInt(0);
-
         // Close reasoning block if transitioning to tool calls
         if (inReasoningBlock) {
             handler.onContentBlockStop(new StreamEvent.ContentBlockStop(reasoningBlockIndex));
@@ -205,7 +212,8 @@ final class OpenAIStreamSession implements StreamSession {
             inTextBlock = false;
         }
 
-        ToolCallState state = toolCallStates.get(toolIndex);
+        String toolKey = toolCallKey(tc);
+        ToolCallState state = toolCallStates.get(toolKey);
 
         // New tool call
         if (state == null) {
@@ -215,10 +223,17 @@ final class OpenAIStreamSession implements StreamSession {
 
             int blockIndex = nextBlockIndex++;
             state = new ToolCallState(tcId, name, blockIndex);
-            toolCallStates.put(toolIndex, state);
-
-            handler.onContentBlockStart(new StreamEvent.ContentBlockStart(
-                    blockIndex, new ContentBlock.ToolUse(tcId, name, "")));
+            toolCallStates.put(toolKey, state);
+        } else {
+            String tcId = tc.path("id").asText("");
+            if (!tcId.isBlank() && state.id.isBlank()) {
+                state.id = tcId;
+            }
+            JsonNode function = tc.path("function");
+            String name = function.path("name").asText("");
+            if (!name.isBlank() && state.name.isBlank()) {
+                state.name = name;
+            }
         }
 
         // Accumulate arguments
@@ -226,9 +241,22 @@ final class OpenAIStreamSession implements StreamSession {
         String argFragment = function.path("arguments").asText(null);
         if (argFragment != null) {
             state.argumentsBuilder.append(argFragment);
-            handler.onToolUseDelta(new StreamEvent.ToolUseDelta(
-                    state.blockIndex, state.name, argFragment));
         }
+    }
+
+    private String toolCallKey(JsonNode tc) {
+        if (tc.has("index") && tc.path("index").canConvertToInt()) {
+            return "index:" + tc.path("index").asInt();
+        }
+        String id = tc.path("id").asText("");
+        if (!id.isBlank()) {
+            return "id:" + id;
+        }
+        String name = tc.path("function").path("name").asText("");
+        if (!name.isBlank()) {
+            return "name:" + name;
+        }
+        return "position:" + toolCallStates.size();
     }
 
     /**
@@ -244,6 +272,13 @@ final class OpenAIStreamSession implements StreamSession {
             inTextBlock = false;
         }
         for (ToolCallState state : toolCallStates.values()) {
+            String arguments = state.argumentsBuilder.isEmpty()
+                    ? "{}"
+                    : state.argumentsBuilder.toString();
+            handler.onContentBlockStart(new StreamEvent.ContentBlockStart(
+                    state.blockIndex, new ContentBlock.ToolUse(state.id, state.name, "")));
+            handler.onToolUseDelta(new StreamEvent.ToolUseDelta(
+                    state.blockIndex, state.name, arguments));
             handler.onContentBlockStop(new StreamEvent.ContentBlockStop(state.blockIndex));
         }
         toolCallStates.clear();
@@ -253,14 +288,14 @@ final class OpenAIStreamSession implements StreamSession {
      * Tracks the accumulation state for a single tool call during streaming.
      */
     private static final class ToolCallState {
-        final String id;
-        final String name;
+        String id;
+        String name;
         final int blockIndex;
         final StringBuilder argumentsBuilder = new StringBuilder();
 
         ToolCallState(String id, String name, int blockIndex) {
-            this.id = id;
-            this.name = name;
+            this.id = id != null ? id : "";
+            this.name = name != null ? name : "";
             this.blockIndex = blockIndex;
         }
     }

--- a/aceclaw-llm/src/test/java/dev/aceclaw/llm/openai/OpenAIMapperTest.java
+++ b/aceclaw-llm/src/test/java/dev/aceclaw/llm/openai/OpenAIMapperTest.java
@@ -46,6 +46,15 @@ class OpenAIMapperTest {
     }
 
     @Test
+    void toRequestJson_ollamaUsesLegacyMaxTokensField() throws Exception {
+        var ollamaMapper = new OpenAIMapper(objectMapper, "ollama");
+        JsonNode root = objectMapper.readTree(ollamaMapper.toRequestJson(baseRequest().build(), false));
+
+        assertThat(root.get("max_tokens").asInt()).isGreaterThan(0);
+        assertThat(root.has("max_completion_tokens")).isFalse();
+    }
+
+    @Test
     void systemPrompt_isFirstMessage() throws Exception {
         var request = baseRequest().systemPrompt("Be helpful").build();
         JsonNode root = objectMapper.readTree(mapper.toRequestJson(request, false));

--- a/aceclaw-llm/src/test/java/dev/aceclaw/llm/openai/OpenAIStreamSessionTest.java
+++ b/aceclaw-llm/src/test/java/dev/aceclaw/llm/openai/OpenAIStreamSessionTest.java
@@ -15,6 +15,7 @@ import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -23,6 +24,45 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class OpenAIStreamSessionTest {
+
+    @Test
+    void standardOpenAIIncrementalToolCallStreaming() {
+        var mapper = new OpenAIMapper(new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false));
+        var session = new OpenAIStreamSession(response(Stream.of(
+                // First chunk: tool call header with id, name, empty args
+                """
+                data: {"id":"chatcmpl-100","model":"gpt-4","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_abc","type":"function","function":{"name":"read_file","arguments":""}}]},"finish_reason":null}]}
+                """.strip(),
+                // Second chunk: argument fragment
+                """
+                data: {"id":"chatcmpl-100","model":"gpt-4","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"path\\":"}}]},"finish_reason":null}]}
+                """.strip(),
+                // Third chunk: argument fragment
+                """
+                data: {"id":"chatcmpl-100","model":"gpt-4","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\\"/tmp/a\\"}"}}]},"finish_reason":null}]}
+                """.strip(),
+                // Finish
+                """
+                data: {"id":"chatcmpl-100","model":"gpt-4","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":20,"completion_tokens":8}}
+                """.strip(),
+                "data: [DONE]"
+        )), mapper);
+
+        var handler = new CapturingHandler();
+        session.onEvent(handler);
+
+        // Verify incremental deltas were emitted (not batched at flush)
+        assertThat(handler.toolUseDeltaCount).as("should stream deltas incrementally").isGreaterThanOrEqualTo(2);
+        assertThat(handler.toolUses)
+                .extracting(ContentBlock.ToolUse::name)
+                .containsExactly("read_file");
+        assertThat(handler.toolUses)
+                .extracting(ContentBlock.ToolUse::inputJson)
+                .containsExactly("{\"path\":\"/tmp/a\"}");
+        assertThat(handler.stopReasons).containsOnly(StopReason.TOOL_USE);
+        assertThat(handler.completed).isTrue();
+    }
 
     @Test
     void ollamaToolCallsWithoutIndexAndStopFinishReasonStillBecomeToolUse() {
@@ -54,6 +94,27 @@ class OpenAIStreamSessionTest {
         assertThat(handler.completed).isTrue();
     }
 
+    @Test
+    void maxTokensToolCallStreamIsNotCoercedToToolUse() {
+        var mapper = new OpenAIMapper(new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false), "ollama");
+        var session = new OpenAIStreamSession(response(Stream.of(
+                """
+                data: {"id":"chatcmpl-915","model":"llama3.1","choices":[{"delta":{"role":"assistant","content":"","tool_calls":[{"id":"call_a","type":"function","function":{"name":"read_file","arguments":"{\\"path\\":"}}]},"index":0}]}
+                """.strip(),
+                """
+                data: {"id":"chatcmpl-915","model":"llama3.1","choices":[{"delta":{},"finish_reason":"length","index":0}]}
+                """.strip(),
+                "data: [DONE]"
+        )), mapper);
+
+        var handler = new CapturingHandler();
+        session.onEvent(handler);
+
+        assertThat(handler.stopReasons).containsOnly(StopReason.MAX_TOKENS);
+        assertThat(handler.completed).isTrue();
+    }
+
     private static HttpResponse<Stream<String>> response(Stream<String> body) {
         return new HttpResponse<>() {
             @Override public int statusCode() { return 200; }
@@ -67,38 +128,37 @@ class OpenAIStreamSessionTest {
         };
     }
 
+    /** Tracks multiple concurrent tool calls by block index (handles interleaved Start events). */
     private static final class CapturingHandler implements StreamEventHandler {
         private final List<ContentBlock.ToolUse> toolUses = new ArrayList<>();
         private final List<StopReason> stopReasons = new ArrayList<>();
-        private String currentToolUseId;
-        private String currentToolUseName;
-        private final StringBuilder currentArguments = new StringBuilder();
-        private boolean inToolUse;
+        private final Map<Integer, ToolAccumulator> activeTools = new LinkedHashMap<>();
+        private int toolUseDeltaCount;
         private boolean completed;
 
         @Override
         public void onContentBlockStart(StreamEvent.ContentBlockStart event) {
             if (event.block() instanceof ContentBlock.ToolUse toolUse) {
-                currentToolUseId = toolUse.id();
-                currentToolUseName = toolUse.name();
-                currentArguments.setLength(0);
-                inToolUse = true;
+                activeTools.put(event.index(), new ToolAccumulator(toolUse.id(), toolUse.name()));
             }
         }
 
         @Override
         public void onToolUseDelta(StreamEvent.ToolUseDelta event) {
             if (event.partialJson() != null) {
-                currentArguments.append(event.partialJson());
+                var acc = activeTools.get(event.index());
+                if (acc != null) {
+                    acc.arguments.append(event.partialJson());
+                }
+                toolUseDeltaCount++;
             }
         }
 
         @Override
         public void onContentBlockStop(StreamEvent.ContentBlockStop event) {
-            if (inToolUse) {
-                toolUses.add(new ContentBlock.ToolUse(
-                        currentToolUseId, currentToolUseName, currentArguments.toString()));
-                inToolUse = false;
+            var acc = activeTools.remove(event.index());
+            if (acc != null) {
+                toolUses.add(new ContentBlock.ToolUse(acc.id, acc.name, acc.arguments.toString()));
             }
         }
 
@@ -110,6 +170,16 @@ class OpenAIStreamSessionTest {
         @Override
         public void onComplete(StreamEvent.StreamComplete event) {
             completed = true;
+        }
+
+        private static final class ToolAccumulator {
+            final String id;
+            final String name;
+            final StringBuilder arguments = new StringBuilder();
+            ToolAccumulator(String id, String name) {
+                this.id = id;
+                this.name = name;
+            }
         }
     }
 }

--- a/aceclaw-llm/src/test/java/dev/aceclaw/llm/openai/OpenAIStreamSessionTest.java
+++ b/aceclaw-llm/src/test/java/dev/aceclaw/llm/openai/OpenAIStreamSessionTest.java
@@ -1,0 +1,115 @@
+package dev.aceclaw.llm.openai;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.aceclaw.core.llm.ContentBlock;
+import dev.aceclaw.core.llm.StopReason;
+import dev.aceclaw.core.llm.StreamEvent;
+import dev.aceclaw.core.llm.StreamEventHandler;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLSession;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OpenAIStreamSessionTest {
+
+    @Test
+    void ollamaToolCallsWithoutIndexAndStopFinishReasonStillBecomeToolUse() {
+        var mapper = new OpenAIMapper(new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false), "ollama");
+        var session = new OpenAIStreamSession(response(Stream.of(
+                """
+                data: {"id":"chatcmpl-914","model":"llama3.1","choices":[{"delta":{"role":"assistant","content":"","tool_calls":[{"id":"call_a","type":"function","function":{"name":"read_file","arguments":"{\\"path\\":\\"/tmp/a\\"}"}},{"id":"call_b","type":"function","function":{"name":"grep","arguments":"{\\"pattern\\":\\"TODO\\"}"}}]},"index":0}]}
+                """.strip(),
+                """
+                data: {"id":"chatcmpl-914","model":"llama3.1","choices":[{"delta":{"role":"assistant","content":""},"finish_reason":"stop","index":0}]}
+                """.strip(),
+                """
+                data: {"id":"chatcmpl-914","model":"llama3.1","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":3}}
+                """.strip(),
+                "data: [DONE]"
+        )), mapper);
+
+        var handler = new CapturingHandler();
+        session.onEvent(handler);
+
+        assertThat(handler.toolUses)
+                .extracting(ContentBlock.ToolUse::name)
+                .containsExactly("read_file", "grep");
+        assertThat(handler.toolUses)
+                .extracting(ContentBlock.ToolUse::inputJson)
+                .containsExactly("{\"path\":\"/tmp/a\"}", "{\"pattern\":\"TODO\"}");
+        assertThat(handler.stopReasons).containsOnly(StopReason.TOOL_USE);
+        assertThat(handler.completed).isTrue();
+    }
+
+    private static HttpResponse<Stream<String>> response(Stream<String> body) {
+        return new HttpResponse<>() {
+            @Override public int statusCode() { return 200; }
+            @Override public HttpRequest request() { return null; }
+            @Override public Optional<HttpResponse<Stream<String>>> previousResponse() { return Optional.empty(); }
+            @Override public HttpHeaders headers() { return HttpHeaders.of(Map.of(), (name, values) -> true); }
+            @Override public Stream<String> body() { return body; }
+            @Override public Optional<SSLSession> sslSession() { return Optional.empty(); }
+            @Override public URI uri() { return URI.create("http://localhost:11434/v1/chat/completions"); }
+            @Override public HttpClient.Version version() { return HttpClient.Version.HTTP_1_1; }
+        };
+    }
+
+    private static final class CapturingHandler implements StreamEventHandler {
+        private final List<ContentBlock.ToolUse> toolUses = new ArrayList<>();
+        private final List<StopReason> stopReasons = new ArrayList<>();
+        private String currentToolUseId;
+        private String currentToolUseName;
+        private final StringBuilder currentArguments = new StringBuilder();
+        private boolean inToolUse;
+        private boolean completed;
+
+        @Override
+        public void onContentBlockStart(StreamEvent.ContentBlockStart event) {
+            if (event.block() instanceof ContentBlock.ToolUse toolUse) {
+                currentToolUseId = toolUse.id();
+                currentToolUseName = toolUse.name();
+                currentArguments.setLength(0);
+                inToolUse = true;
+            }
+        }
+
+        @Override
+        public void onToolUseDelta(StreamEvent.ToolUseDelta event) {
+            if (event.partialJson() != null) {
+                currentArguments.append(event.partialJson());
+            }
+        }
+
+        @Override
+        public void onContentBlockStop(StreamEvent.ContentBlockStop event) {
+            if (inToolUse) {
+                toolUses.add(new ContentBlock.ToolUse(
+                        currentToolUseId, currentToolUseName, currentArguments.toString()));
+                inToolUse = false;
+            }
+        }
+
+        @Override
+        public void onMessageDelta(StreamEvent.MessageDelta event) {
+            stopReasons.add(event.stopReason());
+        }
+
+        @Override
+        public void onComplete(StreamEvent.StreamComplete event) {
+            completed = true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- use Ollama-compatible max_tokens request field instead of max_completion_tokens
- tolerate Ollama streaming tool calls without tool_call index
- normalize streamed tool_calls with finish_reason=stop into TOOL_USE so the agent executes tools
- add regression coverage for Ollama request mapping and streaming tool calls

## Tests
- ./gradlew :aceclaw-llm:test
- ./gradlew :aceclaw-core:test
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-provider support: requests adapt field names for provider-specific compatibility (e.g., Ollama).
  * Streaming: more robust tool-call streaming with stable ordering, improved stop-reason handling, and finer block lifecycle management.

* **Tests**
  * Added tests for Ollama-specific request formatting.
  * Added comprehensive streaming tool-call behavior tests, including ordering and stop-reason scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->