### PR TITLE
Show LLM request count in turn summary

### DIFF
--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
@@ -1215,6 +1215,7 @@ public final class TerminalRepl {
             var usage = result.get("usage");
             int turnIn = usage.path("inputTokens").asInt(0);
             int turnOut = usage.path("outputTokens").asInt(0);
+            int llmRequests = usage.path("llmRequests").asInt(0);
 
             // Use the per-call liveInputTokens for context display (actual context occupation).
             // The JSON-RPC result's inputTokens is cumulative across all API calls in the turn,
@@ -1232,10 +1233,11 @@ public final class TerminalRepl {
             String elapsed = elapsedMs >= 1000
                     ? String.format("%.1fs", elapsedMs / 1000.0)
                     : elapsedMs + "ms";
+            String llmRequestText = llmRequests > 0 ? "  " + llmRequests + " LLM req" : "";
 
             out.println();
-            out.printf("%s%s  %d in / %d out  %s%s%n",
-                    MUTED, elapsed, turnIn, turnOut,
+            out.printf("%s%s%s  %d in / %d out  %s%s%n",
+                    MUTED, elapsed, llmRequestText, turnIn, turnOut,
                     sessionInfo.contextWindowTokens() > 0
                             ? "context " + formatTokenCount(displayContext) + "/"
                               + formatTokenCount(sessionInfo.contextWindowTokens())

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/AgentLoop.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/AgentLoop.java
@@ -94,6 +94,7 @@ public final class AgentLoop {
         int totalOutputTokens = 0;
         int totalCacheCreationTokens = 0;
         int totalCacheReadTokens = 0;
+        int llmRequestCount = 0;
         int maxIterations = config.effectiveMaxIterations();
 
         try {
@@ -102,6 +103,7 @@ public final class AgentLoop {
 
                 // Build and send the LLM request
                 var request = buildRequest(allMessages);
+                llmRequestCount++;
                 var response = llmClient.sendMessage(request);
 
                 // Accumulate usage
@@ -124,7 +126,8 @@ public final class AgentLoop {
                         var totalUsage = new Usage(
                                 totalInputTokens, totalOutputTokens,
                                 totalCacheCreationTokens, totalCacheReadTokens);
-                        var turn = new Turn(newMessages, response.stopReason(), totalUsage);
+                        var turn = new Turn(newMessages, response.stopReason(), totalUsage,
+                                llmRequestCount);
                         long durationMs = System.currentTimeMillis() - turnStart;
                         publishEvent(new AgentEvent.TurnCompleted(
                                 config.sessionId(), turnNumber, durationMs, Instant.now()));
@@ -160,7 +163,8 @@ public final class AgentLoop {
             var totalUsage = new Usage(
                     totalInputTokens, totalOutputTokens,
                     totalCacheCreationTokens, totalCacheReadTokens);
-            var turn = new Turn(newMessages, StopReason.END_TURN, totalUsage, null, true);
+            var turn = new Turn(newMessages, StopReason.END_TURN, totalUsage, null, true,
+                    llmRequestCount);
             long durationMs = System.currentTimeMillis() - turnStart;
             publishEvent(new AgentEvent.TurnCompleted(
                     config.sessionId(), turnNumber, durationMs, Instant.now()));

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/StreamingAgentLoop.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/StreamingAgentLoop.java
@@ -167,6 +167,7 @@ public final class StreamingAgentLoop {
         int totalOutputTokens = 0;
         int totalCacheCreationTokens = 0;
         int totalCacheReadTokens = 0;
+        int llmRequestCount = 0;
 
         // Track actual input tokens from API for accurate compaction decisions
         int lastInputTokens = -1;
@@ -223,7 +224,7 @@ public final class StreamingAgentLoop {
                     log.info("Cancellation detected before LLM call (iteration {})", iteration + 1);
                     var turn = buildCancelledTurn(newMessages, totalInputTokens, totalOutputTokens,
                             totalCacheCreationTokens, totalCacheReadTokens, compactionResult,
-                            softBudgetStopped);
+                            softBudgetStopped, llmRequestCount);
                     publishTurnCompleted(turnNumber, turnStart);
                     return turn;
                 }
@@ -271,6 +272,7 @@ public final class StreamingAgentLoop {
                 StreamAccumulator accumulator = null;
                 for (int streamAttempt = 0; streamAttempt <= retryConfig.maxRetries(); streamAttempt++) {
                     accumulator = new StreamAccumulator(eventHandler);
+                    llmRequestCount++;
                     var session = llmClient.streamMessage(request);
 
                     // Register the session with the cancellation token so cancel() propagates
@@ -337,7 +339,8 @@ public final class StreamingAgentLoop {
                         totalCacheReadTokens += accumulator.usage.cacheReadInputTokens();
                     }
                     var turn = buildCancelledTurn(newMessages, totalInputTokens, totalOutputTokens,
-                            totalCacheCreationTokens, totalCacheReadTokens, compactionResult);
+                            totalCacheCreationTokens, totalCacheReadTokens, compactionResult,
+                            llmRequestCount);
                     publishTurnCompleted(turnNumber, turnStart);
                     return turn;
                 }
@@ -383,7 +386,8 @@ public final class StreamingAgentLoop {
                         var totalUsage = new Usage(
                                 totalInputTokens, totalOutputTokens,
                                 totalCacheCreationTokens, totalCacheReadTokens);
-                        var turn = new Turn(newMessages, stopReason, totalUsage, compactionResult);
+                        var turn = new Turn(newMessages, stopReason, totalUsage, compactionResult,
+                                llmRequestCount);
                         publishTurnCompleted(turnNumber, turnStart);
                         return turn;
                     }
@@ -417,7 +421,8 @@ public final class StreamingAgentLoop {
                         if (cancellationToken != null && cancellationToken.isCancelled()) {
                             log.info("Cancellation detected after tool execution (iteration {})", iteration + 1);
                             var turn = buildCancelledTurn(newMessages, totalInputTokens, totalOutputTokens,
-                                    totalCacheCreationTokens, totalCacheReadTokens, compactionResult);
+                                    totalCacheCreationTokens, totalCacheReadTokens, compactionResult,
+                                    llmRequestCount);
                             publishTurnCompleted(turnNumber, turnStart);
                             return turn;
                         }
@@ -430,7 +435,8 @@ public final class StreamingAgentLoop {
             var totalUsage = new Usage(
                     totalInputTokens, totalOutputTokens,
                     totalCacheCreationTokens, totalCacheReadTokens);
-            var turn = new Turn(newMessages, StopReason.END_TURN, totalUsage, compactionResult, true);
+            var turn = new Turn(newMessages, StopReason.END_TURN, totalUsage, compactionResult,
+                    true, llmRequestCount);
             publishTurnCompleted(turnNumber, turnStart);
             return turn;
         } catch (LlmException e) {
@@ -454,9 +460,11 @@ public final class StreamingAgentLoop {
     private Turn buildCancelledTurn(List<Message> newMessages,
                                     int totalInputTokens, int totalOutputTokens,
                                     int totalCacheCreationTokens, int totalCacheReadTokens,
-                                    CompactionResult compactionResult) {
+                                    CompactionResult compactionResult,
+                                    int llmRequestCount) {
         return buildCancelledTurn(newMessages, totalInputTokens, totalOutputTokens,
-                totalCacheCreationTokens, totalCacheReadTokens, compactionResult, false);
+                totalCacheCreationTokens, totalCacheReadTokens, compactionResult, false,
+                llmRequestCount);
     }
 
     /**
@@ -466,7 +474,8 @@ public final class StreamingAgentLoop {
                                     int totalInputTokens, int totalOutputTokens,
                                     int totalCacheCreationTokens, int totalCacheReadTokens,
                                     CompactionResult compactionResult,
-                                    boolean softBudgetStopped) {
+                                    boolean softBudgetStopped,
+                                    int llmRequestCount) {
         var totalUsage = new Usage(totalInputTokens, totalOutputTokens,
                 totalCacheCreationTokens, totalCacheReadTokens);
         var watchdog = config.watchdog();
@@ -476,7 +485,7 @@ public final class StreamingAgentLoop {
             reason = "soft_budget_no_progress";
         }
         return new Turn(newMessages, StopReason.END_TURN, totalUsage, compactionResult,
-                false, budgetExhausted, reason);
+                false, budgetExhausted, reason, llmRequestCount);
     }
 
     /**

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/Turn.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/Turn.java
@@ -12,21 +12,21 @@ import java.util.List;
  * @param newMessages      all messages produced during this turn (assistant messages and tool results)
  * @param finalStopReason  the stop reason from the last LLM call
  * @param totalUsage       aggregated token usage across all LLM calls in this turn
- * @param llmRequestCount  number of LLM requests sent during this turn
  * @param compactionResult        context compaction result, or null if no compaction occurred
  * @param maxIterationsReached    whether the loop hit max-iterations guardrail
  * @param budgetExhausted         whether the turn was stopped by a watchdog budget limit
  * @param budgetExhaustionReason  the budget that was exhausted: {@code "turn_budget"}, {@code "time_budget"}, or null
+ * @param llmRequestCount  number of LLM API requests sent during this turn (attempts, including retries)
  */
 public record Turn(
         List<Message> newMessages,
         StopReason finalStopReason,
         Usage totalUsage,
-        int llmRequestCount,
         CompactionResult compactionResult,
         boolean maxIterationsReached,
         boolean budgetExhausted,
-        String budgetExhaustionReason
+        String budgetExhaustionReason,
+        int llmRequestCount
 ) {
 
     public Turn {
@@ -38,7 +38,7 @@ public record Turn(
      * Creates a turn result without compaction info (backward-compatible).
      */
     public Turn(List<Message> newMessages, StopReason finalStopReason, Usage totalUsage) {
-        this(newMessages, finalStopReason, totalUsage, 0, null, false, false, null);
+        this(newMessages, finalStopReason, totalUsage, null, false, false, null, 0);
     }
 
     /**
@@ -46,15 +46,15 @@ public record Turn(
      */
     public Turn(List<Message> newMessages, StopReason finalStopReason, Usage totalUsage,
                 int llmRequestCount) {
-        this(newMessages, finalStopReason, totalUsage, llmRequestCount, null, false, false, null);
+        this(newMessages, finalStopReason, totalUsage, null, false, false, null, llmRequestCount);
     }
 
     /**
-     * Creates a turn result with optional compaction info (backward-compatible).
+     * Creates a turn result with optional compaction info.
      */
     public Turn(List<Message> newMessages, StopReason finalStopReason, Usage totalUsage,
                 CompactionResult compactionResult) {
-        this(newMessages, finalStopReason, totalUsage, 0, compactionResult, false, false, null);
+        this(newMessages, finalStopReason, totalUsage, compactionResult, false, false, null, 0);
     }
 
     /**
@@ -62,17 +62,17 @@ public record Turn(
      */
     public Turn(List<Message> newMessages, StopReason finalStopReason, Usage totalUsage,
                 CompactionResult compactionResult, int llmRequestCount) {
-        this(newMessages, finalStopReason, totalUsage, llmRequestCount, compactionResult,
-                false, false, null);
+        this(newMessages, finalStopReason, totalUsage, compactionResult, false, false, null,
+                llmRequestCount);
     }
 
     /**
-     * Creates a turn result with compaction and max-iterations info (backward-compatible).
+     * Creates a turn result with compaction and max-iterations info.
      */
     public Turn(List<Message> newMessages, StopReason finalStopReason, Usage totalUsage,
                 CompactionResult compactionResult, boolean maxIterationsReached) {
-        this(newMessages, finalStopReason, totalUsage, 0, compactionResult, maxIterationsReached,
-                false, null);
+        this(newMessages, finalStopReason, totalUsage, compactionResult, maxIterationsReached,
+                false, null, 0);
     }
 
     /**
@@ -81,29 +81,18 @@ public record Turn(
     public Turn(List<Message> newMessages, StopReason finalStopReason, Usage totalUsage,
                 CompactionResult compactionResult, boolean maxIterationsReached,
                 int llmRequestCount) {
-        this(newMessages, finalStopReason, totalUsage, llmRequestCount, compactionResult,
-                maxIterationsReached, false, null);
+        this(newMessages, finalStopReason, totalUsage, compactionResult, maxIterationsReached,
+                false, null, llmRequestCount);
     }
 
     /**
-     * Creates a turn result with budget info and an LLM request count.
+     * Creates a turn result with full status info (budget exhaustion).
      */
     public Turn(List<Message> newMessages, StopReason finalStopReason, Usage totalUsage,
                 CompactionResult compactionResult, boolean maxIterationsReached,
                 boolean budgetExhausted, String budgetExhaustionReason) {
-        this(newMessages, finalStopReason, totalUsage, 0, compactionResult,
-                maxIterationsReached, budgetExhausted, budgetExhaustionReason);
-    }
-
-    /**
-     * Creates a turn result with full status info and an LLM request count.
-     */
-    public Turn(List<Message> newMessages, StopReason finalStopReason, Usage totalUsage,
-                CompactionResult compactionResult, boolean maxIterationsReached,
-                boolean budgetExhausted, String budgetExhaustionReason,
-                int llmRequestCount) {
-        this(newMessages, finalStopReason, totalUsage, llmRequestCount, compactionResult,
-                maxIterationsReached, budgetExhausted, budgetExhaustionReason);
+        this(newMessages, finalStopReason, totalUsage, compactionResult, maxIterationsReached,
+                budgetExhausted, budgetExhaustionReason, 0);
     }
 
     /**

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/Turn.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/Turn.java
@@ -12,6 +12,7 @@ import java.util.List;
  * @param newMessages      all messages produced during this turn (assistant messages and tool results)
  * @param finalStopReason  the stop reason from the last LLM call
  * @param totalUsage       aggregated token usage across all LLM calls in this turn
+ * @param llmRequestCount  number of LLM requests sent during this turn
  * @param compactionResult        context compaction result, or null if no compaction occurred
  * @param maxIterationsReached    whether the loop hit max-iterations guardrail
  * @param budgetExhausted         whether the turn was stopped by a watchdog budget limit
@@ -21,6 +22,7 @@ public record Turn(
         List<Message> newMessages,
         StopReason finalStopReason,
         Usage totalUsage,
+        int llmRequestCount,
         CompactionResult compactionResult,
         boolean maxIterationsReached,
         boolean budgetExhausted,
@@ -29,13 +31,22 @@ public record Turn(
 
     public Turn {
         newMessages = newMessages != null ? List.copyOf(newMessages) : List.of();
+        llmRequestCount = Math.max(0, llmRequestCount);
     }
 
     /**
      * Creates a turn result without compaction info (backward-compatible).
      */
     public Turn(List<Message> newMessages, StopReason finalStopReason, Usage totalUsage) {
-        this(newMessages, finalStopReason, totalUsage, null, false, false, null);
+        this(newMessages, finalStopReason, totalUsage, 0, null, false, false, null);
+    }
+
+    /**
+     * Creates a turn result with an LLM request count.
+     */
+    public Turn(List<Message> newMessages, StopReason finalStopReason, Usage totalUsage,
+                int llmRequestCount) {
+        this(newMessages, finalStopReason, totalUsage, llmRequestCount, null, false, false, null);
     }
 
     /**
@@ -43,7 +54,16 @@ public record Turn(
      */
     public Turn(List<Message> newMessages, StopReason finalStopReason, Usage totalUsage,
                 CompactionResult compactionResult) {
-        this(newMessages, finalStopReason, totalUsage, compactionResult, false, false, null);
+        this(newMessages, finalStopReason, totalUsage, 0, compactionResult, false, false, null);
+    }
+
+    /**
+     * Creates a turn result with compaction info and an LLM request count.
+     */
+    public Turn(List<Message> newMessages, StopReason finalStopReason, Usage totalUsage,
+                CompactionResult compactionResult, int llmRequestCount) {
+        this(newMessages, finalStopReason, totalUsage, llmRequestCount, compactionResult,
+                false, false, null);
     }
 
     /**
@@ -51,7 +71,39 @@ public record Turn(
      */
     public Turn(List<Message> newMessages, StopReason finalStopReason, Usage totalUsage,
                 CompactionResult compactionResult, boolean maxIterationsReached) {
-        this(newMessages, finalStopReason, totalUsage, compactionResult, maxIterationsReached, false, null);
+        this(newMessages, finalStopReason, totalUsage, 0, compactionResult, maxIterationsReached,
+                false, null);
+    }
+
+    /**
+     * Creates a turn result with compaction, max-iterations info, and an LLM request count.
+     */
+    public Turn(List<Message> newMessages, StopReason finalStopReason, Usage totalUsage,
+                CompactionResult compactionResult, boolean maxIterationsReached,
+                int llmRequestCount) {
+        this(newMessages, finalStopReason, totalUsage, llmRequestCount, compactionResult,
+                maxIterationsReached, false, null);
+    }
+
+    /**
+     * Creates a turn result with budget info and an LLM request count.
+     */
+    public Turn(List<Message> newMessages, StopReason finalStopReason, Usage totalUsage,
+                CompactionResult compactionResult, boolean maxIterationsReached,
+                boolean budgetExhausted, String budgetExhaustionReason) {
+        this(newMessages, finalStopReason, totalUsage, 0, compactionResult,
+                maxIterationsReached, budgetExhausted, budgetExhaustionReason);
+    }
+
+    /**
+     * Creates a turn result with full status info and an LLM request count.
+     */
+    public Turn(List<Message> newMessages, StopReason finalStopReason, Usage totalUsage,
+                CompactionResult compactionResult, boolean maxIterationsReached,
+                boolean budgetExhausted, String budgetExhaustionReason,
+                int llmRequestCount) {
+        this(newMessages, finalStopReason, totalUsage, llmRequestCount, compactionResult,
+                maxIterationsReached, budgetExhausted, budgetExhaustionReason);
     }
 
     /**

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/planner/SequentialPlanExecutor.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/planner/SequentialPlanExecutor.java
@@ -195,7 +195,8 @@ public final class SequentialPlanExecutor implements PlanExecutor {
                         null,
                         System.currentTimeMillis() - stepStart,
                         usage.inputTokens(),
-                        usage.outputTokens());
+                        usage.outputTokens(),
+                        turn.llmRequestCount());
                 stepResults.add(result);
 
                 mutablePlan = mutablePlan.withStepStatus(step.stepId(), StepStatus.COMPLETED)
@@ -252,7 +253,8 @@ public final class SequentialPlanExecutor implements PlanExecutor {
                                 null,
                                 System.currentTimeMillis() - stepStart,
                                 fbUsage.inputTokens(),
-                                fbUsage.outputTokens());
+                                fbUsage.outputTokens(),
+                                fallbackTurn.llmRequestCount());
                         stepResults.add(fallbackResult);
 
                         mutablePlan = mutablePlan.withStepStatus(step.stepId(), StepStatus.COMPLETED)

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/planner/StepResult.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/planner/StepResult.java
@@ -9,6 +9,7 @@ package dev.aceclaw.core.planner;
  * @param durationMs   wall-clock time spent on this step
  * @param inputTokens  input tokens consumed by this step
  * @param outputTokens output tokens consumed by this step
+ * @param llmRequestCount number of LLM requests sent while executing this step
  */
 public record StepResult(
         boolean success,
@@ -16,8 +17,18 @@ public record StepResult(
         String error,
         long durationMs,
         int inputTokens,
-        int outputTokens
+        int outputTokens,
+        int llmRequestCount
 ) {
+
+    public StepResult {
+        llmRequestCount = Math.max(0, llmRequestCount);
+    }
+
+    public StepResult(boolean success, String output, String error,
+                      long durationMs, int inputTokens, int outputTokens) {
+        this(success, output, error, durationMs, inputTokens, outputTokens, 0);
+    }
 
     /**
      * Total tokens consumed by this step (input + output).

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/agent/AgentLoopIntegrationTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/agent/AgentLoopIntegrationTest.java
@@ -263,6 +263,66 @@ class AgentLoopIntegrationTest {
         assertThat(turn.finalStopReason()).isEqualTo(StopReason.END_TURN);
     }
 
+    @Test
+    void singleLlmCallReportsOneRequest() throws Exception {
+        var llm = new FakeLlmClient(List.of(
+                new LlmResponse("id", "model", List.of(new ContentBlock.Text("Hello")),
+                        StopReason.END_TURN, new Usage(10, 5, 0, 0))
+        ));
+        var loop = new AgentLoop(llm, new ToolRegistry(), "model", null);
+        var turn = loop.runTurn("hi", List.of());
+
+        assertThat(turn.llmRequestCount()).isEqualTo(1);
+    }
+
+    @Test
+    void multiIterationToolUseCountsAllLlmRequests() throws Exception {
+        var toolUse = new ContentBlock.ToolUse("t1", "echo", "{}");
+        var llm = new FakeLlmClient(List.of(
+                new LlmResponse("id", "model", List.of(toolUse),
+                        StopReason.TOOL_USE, new Usage(10, 5, 0, 0)),
+                new LlmResponse("id", "model", List.of(new ContentBlock.Text("Done")),
+                        StopReason.END_TURN, new Usage(10, 5, 0, 0))
+        ));
+
+        var registry = new ToolRegistry();
+        registry.register(new StubTool("echo", "echoed"));
+
+        var loop = new AgentLoop(llm, registry, "model", null);
+        var turn = loop.runTurn("do something", List.of());
+
+        assertThat(turn.llmRequestCount()).isEqualTo(2);
+    }
+
+    @Test
+    void maxIterationsReachedCountsAllLlmRequests() throws Exception {
+        var llmCalls = new AtomicInteger();
+        var llm = new LlmClient() {
+            @Override public String provider() { return "test"; }
+            @Override public String defaultModel() { return "test-model"; }
+
+            @Override
+            public LlmResponse sendMessage(LlmRequest request) {
+                int seq = llmCalls.incrementAndGet();
+                var toolUse = new ContentBlock.ToolUse("t" + seq, "missing_tool", "{}");
+                return new LlmResponse(
+                        "id-" + seq, "model", List.of(toolUse), StopReason.TOOL_USE, new Usage(1, 1, 0, 0));
+            }
+
+            @Override
+            public StreamSession streamMessage(LlmRequest request) {
+                throw new UnsupportedOperationException();
+            }
+        };
+
+        var config = AgentLoopConfig.builder().maxIterations(5).build();
+        var loop = new AgentLoop(llm, new ToolRegistry(), "model", null, config);
+        var turn = loop.runTurn("loop forever", List.of());
+
+        assertThat(turn.maxIterationsReached()).isTrue();
+        assertThat(turn.llmRequestCount()).isEqualTo(5);
+    }
+
     // -- Test helpers --
 
     private static final ObjectMapper JSON = new ObjectMapper();

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/planner/SequentialPlanExecutorTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/planner/SequentialPlanExecutorTest.java
@@ -233,6 +233,26 @@ class SequentialPlanExecutorTest {
     }
 
     @Test
+    void stepResultsCarryLlmRequestCount() throws LlmException {
+        var client = new SimpleMockLlmClient();
+        client.enqueueTextResponse("result 1");
+        client.enqueueTextResponse("result 2");
+
+        var plan = createTestPlan(2);
+        var loop = createLoop(client);
+        var executor = new SequentialPlanExecutor();
+
+        var result = executor.execute(plan, loop, new ArrayList<>(), noOpHandler, null);
+
+        assertTrue(result.success());
+        // Each step makes exactly 1 LLM streaming call
+        for (var sr : result.stepResults()) {
+            assertEquals(1, sr.llmRequestCount(),
+                    "Each single-call step should report 1 LLM request");
+        }
+    }
+
+    @Test
     void buildStepPrompt_includesPreviousResults() {
         var plan = createTestPlan(3);
         var previousResults = List.of(

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AgentHandler.java
@@ -83,6 +83,7 @@ public final class AgentHandler {
         usageNode.put("inputTokens", turn.totalUsage().inputTokens());
         usageNode.put("outputTokens", turn.totalUsage().outputTokens());
         usageNode.put("totalTokens", turn.totalUsage().totalTokens());
+        usageNode.put("llmRequests", turn.llmRequestCount());
         result.set("usage", usageNode);
 
         log.info("Agent turn complete: sessionId={}, stopReason={}, tokens={}",

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/FilePlanCheckpointStore.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/FilePlanCheckpointStore.java
@@ -427,17 +427,20 @@ public final class FilePlanCheckpointStore implements PlanCheckpointStore {
             String error,
             long durationMs,
             int inputTokens,
-            int outputTokens
+            int outputTokens,
+            int llmRequestCount
     ) {
         static StepResultDto from(StepResult result) {
             return new StepResultDto(
                     result.success(), result.output(), result.error(),
-                    result.durationMs(), result.inputTokens(), result.outputTokens()
+                    result.durationMs(), result.inputTokens(), result.outputTokens(),
+                    result.llmRequestCount()
             );
         }
 
         StepResult toDomain() {
-            return new StepResult(success, output, error, durationMs, inputTokens, outputTokens);
+            return new StepResult(success, output, error, durationMs, inputTokens,
+                    outputTokens, llmRequestCount);
         }
     }
 }

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -559,10 +559,12 @@ public final class StreamingAgentHandler {
 
         int totalInput = planResult.stepResults().stream().mapToInt(StepResult::inputTokens).sum();
         int totalOutput = planResult.stepResults().stream().mapToInt(StepResult::outputTokens).sum();
+        int totalLlmRequests = planResult.stepResults().stream().mapToInt(StepResult::llmRequestCount).sum();
         var usageNode = objectMapper.createObjectNode();
         usageNode.put("inputTokens", totalInput);
         usageNode.put("outputTokens", totalOutput);
         usageNode.put("totalTokens", planResult.totalTokensUsed());
+        usageNode.put("llmRequests", totalLlmRequests);
         result.set("usage", usageNode);
 
         log.info("Planned task complete: sessionId={}, success={}, steps={}/{}, tokens={}",
@@ -632,6 +634,7 @@ public final class StreamingAgentHandler {
         usageNode.put("inputTokens", turn.totalUsage().inputTokens());
         usageNode.put("outputTokens", turn.totalUsage().outputTokens());
         usageNode.put("totalTokens", turn.totalUsage().totalTokens());
+        usageNode.put("llmRequests", turn.llmRequestCount());
         result.set("usage", usageNode);
 
         if (turn.wasCompacted()) {
@@ -720,7 +723,9 @@ public final class StreamingAgentHandler {
     private dev.aceclaw.core.agent.Turn syntheticTurn(PlanExecutionResult planResult, StopReason stopReason) {
         int totalInput = planResult.stepResults().stream().mapToInt(StepResult::inputTokens).sum();
         int totalOutput = planResult.stepResults().stream().mapToInt(StepResult::outputTokens).sum();
-        return new dev.aceclaw.core.agent.Turn(planResult.messages(), stopReason, new dev.aceclaw.core.llm.Usage(totalInput, totalOutput));
+        int totalLlmRequests = planResult.stepResults().stream().mapToInt(StepResult::llmRequestCount).sum();
+        return new dev.aceclaw.core.agent.Turn(planResult.messages(), stopReason,
+                new dev.aceclaw.core.llm.Usage(totalInput, totalOutput), totalLlmRequests);
     }
 
     private static String shortenSessionId(String sessionId) {
@@ -997,6 +1002,7 @@ public final class StreamingAgentHandler {
         int totalOutput = 0;
         int totalCacheCreate = 0;
         int totalCacheRead = 0;
+        int totalLlmRequests = 0;
         String reason = "single_segment";
         int segments = 0;
         int continuationCount = 0;
@@ -1041,6 +1047,7 @@ public final class StreamingAgentHandler {
             totalOutput += turn.totalUsage().outputTokens();
             totalCacheCreate += turn.totalUsage().cacheCreationInputTokens();
             totalCacheRead += turn.totalUsage().cacheReadInputTokens();
+            totalLlmRequests += turn.llmRequestCount();
             conversation.addAll(turn.newMessages());
 
             String signature = normalizeSignature(turn.text());
@@ -1091,7 +1098,7 @@ public final class StreamingAgentHandler {
         var usage = new dev.aceclaw.core.llm.Usage(totalInput, totalOutput, totalCacheCreate, totalCacheRead);
         var mergedTurn = new dev.aceclaw.core.agent.Turn(
                 mergedMessages, lastStopReason, usage, lastCompaction, maxIterationsReached,
-                budgetExhausted, budgetExhaustionReason);
+                budgetExhausted, budgetExhaustionReason, totalLlmRequests);
         return new AdaptiveTurnResult(
                 mergedTurn,
                 segments <= 0 ? 1 : segments,
@@ -2605,10 +2612,12 @@ public final class StreamingAgentHandler {
 
         int totalInput = planResult.stepResults().stream().mapToInt(StepResult::inputTokens).sum();
         int totalOutput = planResult.stepResults().stream().mapToInt(StepResult::outputTokens).sum();
+        int totalLlmRequests = planResult.stepResults().stream().mapToInt(StepResult::llmRequestCount).sum();
         var usageNode = objectMapper.createObjectNode();
         usageNode.put("inputTokens", totalInput);
         usageNode.put("outputTokens", totalOutput);
         usageNode.put("totalTokens", planResult.totalTokensUsed());
+        usageNode.put("llmRequests", totalLlmRequests);
         result.set("usage", usageNode);
 
         log.info("Resumed plan complete: sessionId={}, success={}, steps={}/{}, tokens={}",

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -1028,6 +1028,17 @@ public final class StreamingAgentHandler {
             continuationCount = Math.max(0, segment - 1);
             lastStopReason = turn.finalStopReason();
             maxIterationsReached = turn.maxIterationsReached();
+            if (turn.wasCompacted()) {
+                lastCompaction = turn.compactionResult();
+            }
+            mergedMessages.addAll(turn.newMessages());
+            totalInput += turn.totalUsage().inputTokens();
+            totalOutput += turn.totalUsage().outputTokens();
+            totalCacheCreate += turn.totalUsage().cacheCreationInputTokens();
+            totalCacheRead += turn.totalUsage().cacheReadInputTokens();
+            totalLlmRequests += turn.llmRequestCount();
+            conversation.addAll(turn.newMessages());
+
             if (turn.budgetExhausted()) {
                 budgetExhausted = true;
                 budgetExhaustionReason = turn.budgetExhaustionReason();
@@ -1039,16 +1050,6 @@ public final class StreamingAgentHandler {
                 reason = "cancelled";
                 break;
             }
-            if (turn.wasCompacted()) {
-                lastCompaction = turn.compactionResult();
-            }
-            mergedMessages.addAll(turn.newMessages());
-            totalInput += turn.totalUsage().inputTokens();
-            totalOutput += turn.totalUsage().outputTokens();
-            totalCacheCreate += turn.totalUsage().cacheCreationInputTokens();
-            totalCacheRead += turn.totalUsage().cacheReadInputTokens();
-            totalLlmRequests += turn.llmRequestCount();
-            conversation.addAll(turn.newMessages());
 
             String signature = normalizeSignature(turn.text());
             if (!signature.isEmpty() && signature.equals(prevSignature)) {

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/DaemonIntegrationTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/DaemonIntegrationTest.java
@@ -471,6 +471,9 @@ class DaemonIntegrationTest {
                     .isEqualTo("Hello! I'm AceClaw, your AI assistant.");
             assertThat(responseResult.get("stopReason").asText()).isEqualTo("END_TURN");
             assertThat(responseResult.has("usage")).isTrue();
+            var usage = responseResult.get("usage");
+            assertThat(usage.has("llmRequests")).isTrue();
+            assertThat(usage.get("llmRequests").asInt()).isEqualTo(1);
 
             // Verify the LLM was called with the right prompt
             var requests = mockLlm.capturedRequests();

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/FilePlanCheckpointStoreTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/FilePlanCheckpointStoreTest.java
@@ -243,6 +243,45 @@ class FilePlanCheckpointStoreTest {
     }
 
     @Test
+    void llmRequestCount_preservedAfterRoundTrip() {
+        var plan = samplePlan("plan-llm", 2);
+        var results = List.of(
+                new StepResult(true, "step1 done", null, 100, 50, 25, 3),
+                new StepResult(true, "step2 done", null, 200, 80, 40, 7));
+        var cp = new PlanCheckpoint("plan-llm", "s1", "ws", "goal", plan,
+                results, 1, List.of(), PlanCheckpoint.CheckpointStatus.ACTIVE,
+                null, List.of(), Instant.now(), Instant.now());
+        store.save(cp);
+
+        var loaded = store.load("plan-llm").orElseThrow();
+        var loadedResults = loaded.completedStepResults();
+        assertEquals(2, loadedResults.size());
+        assertEquals(3, loadedResults.get(0).llmRequestCount());
+        assertEquals(7, loadedResults.get(1).llmRequestCount());
+    }
+
+    @Test
+    void llmRequestCount_defaultsToZeroForLegacyCheckpoints() throws IOException {
+        // Simulate a checkpoint file written before llmRequestCount existed:
+        // StepResult JSON without the llmRequestCount field.
+        var plan = samplePlan("plan-legacy", 1);
+        var results = List.of(new StepResult(true, "done", null, 100, 50, 25));
+        var cp = new PlanCheckpoint("plan-legacy", "s1", "ws", "goal", plan,
+                results, 0, List.of(), PlanCheckpoint.CheckpointStatus.ACTIVE,
+                null, List.of(), Instant.now(), Instant.now());
+        store.save(cp);
+
+        // Read the raw JSON file and strip the llmRequestCount field to simulate legacy format
+        var checkpointFile = tempDir.resolve("plan-legacy.checkpoint.json");
+        var json = Files.readString(checkpointFile);
+        var stripped = json.replaceAll(",?\"llmRequestCount\":\\d+", "");
+        Files.writeString(checkpointFile, stripped);
+
+        var loaded = store.load("plan-legacy").orElseThrow();
+        assertEquals(0, loaded.completedStepResults().get(0).llmRequestCount());
+    }
+
+    @Test
     void cleanup_deletesOldCheckpoints() {
         // Save a checkpoint with very old updatedAt
         var now = Instant.now();


### PR DESCRIPTION
## Summary
- Track number of LLM API requests per turn and propagate through `Turn`, `StepResult`, and JSON-RPC usage payload
- Display "N LLM req" in CLI turn summary line (hidden when 0)
- Fix adaptive continuation loop to accumulate turn data before early-exit checks, preventing undercount on budget/cancel paths
- Maintain source compatibility: `llmRequestCount` appended at end of `Turn` record, all pre-existing constructor overloads preserved

## Test plan
- [x] `AgentLoopIntegrationTest`: single call (1), multi-iteration tool use (2), max-iterations (5)
- [x] `SequentialPlanExecutorTest`: each plan step carries `llmRequestCount == 1`
- [x] `FilePlanCheckpointStoreTest`: round-trip preserves non-zero counts; legacy checkpoints default to 0
- [x] `DaemonIntegrationTest`: JSON-RPC response `usage.llmRequests == 1`
- [x] Full test suite green (`./gradlew test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Track and surface LLM request counts across turns and plan steps; counts are shown in CLI completion lines, API usage payloads, and persisted in plan checkpoints for better observability.
* **Tests**
  * Added integration and unit tests validating per-turn and per-step LLM request counts, checkpoint serialization round-trips, and API/CLI usage payloads include the new metric.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->