### PR TITLE
fix(validation): write current-state snapshot so TUI reflects live verdict

### DIFF
--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
@@ -2421,8 +2421,11 @@ public final class TerminalRepl {
                 case "block" -> block++;
                 default -> pending++;
             }
-            if (!"pass".equals(draft.validationVerdict())) {
-                // First reason is the primary gate failure; collapsed into a count for the status line.
+            if ("hold".equals(draft.validationVerdict())) {
+                // Only HOLD drafts feed the dominant-reason indicator. BLOCK issues are already
+                // visible as `b:N` in the counts and have different remediation paths (edit the
+                // draft file); the status line's bracketed hint is specifically for diagnosing
+                // why otherwise-valid drafts are stuck short of release.
                 draft.validationReasons().stream().findFirst().ifPresent(reason -> {
                     String code = reason.split(":", 2)[0].trim();
                     if (!code.isBlank()) {

--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
@@ -2551,9 +2551,11 @@ public final class TerminalRepl {
     }
 
     private Map<String, SkillValidationStatus> loadSkillValidationStatuses(Path snapshotPath, Path auditPath) {
-        var fromSnapshot = loadSkillValidationSnapshot(snapshotPath);
-        if (!fromSnapshot.isEmpty()) {
-            return fromSnapshot;
+        // Snapshot is the authoritative current-state view. If the file exists we trust it even
+        // when the drafts array is empty — "no drafts right now" is a valid current state and
+        // must not be masked by stale HOLD entries from the append-only audit tail.
+        if (Files.isRegularFile(snapshotPath)) {
+            return loadSkillValidationSnapshot(snapshotPath);
         }
         return loadSkillValidationStatuses(auditPath);
     }

--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
@@ -92,6 +92,7 @@ public final class TerminalRepl {
     private static final String CL_REPLAY_REPORT = "replay-latest.json";
     private static final String CL_RELEASE_STATE = "skill-release-state.json";
     private static final String CL_VALIDATION_AUDIT = "skill-draft-validation-audit.jsonl";
+    private static final String CL_VALIDATION_SNAPSHOT = "skill-draft-validation-snapshot.json";
     private static final String CL_CANDIDATES = ".aceclaw/memory/candidates.jsonl";
     private static final String CL_DRAFTS_DIR = ".aceclaw/skills-drafts";
     private static final Path HOME_CANDIDATES_PATH = Path.of(
@@ -2412,6 +2413,7 @@ public final class TerminalRepl {
         int pass = 0;
         int hold = 0;
         int block = 0;
+        var reasonCounts = new LinkedHashMap<String, Integer>();
         for (var draft : snapshot.drafts().values()) {
             switch (draft.validationVerdict()) {
                 case "pass" -> pass++;
@@ -2419,9 +2421,23 @@ public final class TerminalRepl {
                 case "block" -> block++;
                 default -> pending++;
             }
+            if (!"pass".equals(draft.validationVerdict())) {
+                // First reason is the primary gate failure; collapsed into a count for the status line.
+                draft.validationReasons().stream().findFirst().ifPresent(reason -> {
+                    String code = reason.split(":", 2)[0].trim();
+                    if (!code.isBlank()) {
+                        reasonCounts.merge(code, 1, Integer::sum);
+                    }
+                });
+            }
         }
-        return snapshot.drafts().size()
+        String base = snapshot.drafts().size()
                 + "(p:" + pass + ",h:" + hold + ",b:" + block + ",n:" + pending + ")";
+        String dominantReason = reasonCounts.entrySet().stream()
+                .max(Map.Entry.comparingByValue())
+                .map(Map.Entry::getKey)
+                .orElse(null);
+        return dominantReason != null ? base + " [" + dominantReason + "]" : base;
     }
 
     private SkillDraftEvent parseSkillDraftEvent(JsonNode node) {
@@ -2495,6 +2511,7 @@ public final class TerminalRepl {
         }
 
         Map<String, SkillValidationStatus> validations = loadSkillValidationStatuses(
+                projectRoot.resolve(CL_METRICS_DIR).resolve(CL_VALIDATION_SNAPSHOT),
                 projectRoot.resolve(CL_METRICS_DIR).resolve(CL_VALIDATION_AUDIT));
         Map<String, SkillReleaseStatus> releases = loadSkillReleaseStatuses(
                 projectRoot.resolve(CL_METRICS_DIR).resolve(CL_RELEASE_STATE));
@@ -2531,6 +2548,53 @@ public final class TerminalRepl {
             return new SkillDraftSnapshot(Map.of());
         }
         return new SkillDraftSnapshot(drafts);
+    }
+
+    private Map<String, SkillValidationStatus> loadSkillValidationStatuses(Path snapshotPath, Path auditPath) {
+        var fromSnapshot = loadSkillValidationSnapshot(snapshotPath);
+        if (!fromSnapshot.isEmpty()) {
+            return fromSnapshot;
+        }
+        return loadSkillValidationStatuses(auditPath);
+    }
+
+    private Map<String, SkillValidationStatus> loadSkillValidationSnapshot(Path snapshotPath) {
+        var statuses = new LinkedHashMap<String, SkillValidationStatus>();
+        if (!Files.isRegularFile(snapshotPath)) {
+            return statuses;
+        }
+        try {
+            JsonNode root = statusMapper.readTree(snapshotPath.toFile());
+            if (root == null) return statuses;
+            JsonNode drafts = root.path("drafts");
+            if (!drafts.isArray()) return statuses;
+            for (JsonNode node : drafts) {
+                String draftPath = node.path("draftPath").asText("");
+                if (draftPath.isBlank()) continue;
+                var reasons = new ArrayList<String>();
+                JsonNode arr = node.path("reasons");
+                if (arr.isArray()) {
+                    for (JsonNode reason : arr) {
+                        String code = reason.path("code").asText("");
+                        String message = reason.path("message").asText("");
+                        if (!code.isBlank() && !message.isBlank()) {
+                            reasons.add(sanitizeTerminalText(code + ": " + message));
+                        } else if (!code.isBlank()) {
+                            reasons.add(sanitizeTerminalText(code));
+                        } else if (!message.isBlank()) {
+                            reasons.add(sanitizeTerminalText(message));
+                        }
+                    }
+                }
+                statuses.put(draftPath, new SkillValidationStatus(
+                        sanitizeTerminalText(node.path("verdict").asText("pending")),
+                        reasons
+                ));
+            }
+        } catch (Exception e) {
+            log.debug("Failed to parse skill draft validation snapshot: {}", e.getMessage());
+        }
+        return statuses;
     }
 
     private Map<String, SkillValidationStatus> loadSkillValidationStatuses(Path auditPath) {

--- a/aceclaw-cli/src/test/java/dev/aceclaw/cli/TerminalReplTest.java
+++ b/aceclaw-cli/src/test/java/dev/aceclaw/cli/TerminalReplTest.java
@@ -527,12 +527,12 @@ class TerminalReplTest {
     }
 
     @Test
-    void skillDraftStatusSummary_corruptSnapshotFallsBackToAudit() throws Exception {
+    void skillDraftStatusSummary_corruptSnapshotYieldsPendingNotStaleAudit() throws Exception {
         var statusRepl = newReplForProject(tempDir);
         writeSkillDraftArtifacts(tempDir);
-        // Snapshot file exists but contains unparseable JSON. Loader logs and returns empty;
-        // Files.isRegularFile is still true so we stay on snapshot path — verdict becomes pending.
-        // (Treating a corrupt snapshot as "no current state" is safer than silently serving stale audit.)
+        // Snapshot file exists but is unparseable. We deliberately DO NOT fall back to the
+        // audit tail — that would silently serve stale verdicts, the exact bug this PR fixes.
+        // Instead drafts read as "pending", signaling to the user that current state is unknown.
         Path snapshot = tempDir.resolve(".aceclaw/metrics/continuous-learning/skill-draft-validation-snapshot.json");
         Files.writeString(snapshot, "{ not json");
 

--- a/aceclaw-cli/src/test/java/dev/aceclaw/cli/TerminalReplTest.java
+++ b/aceclaw-cli/src/test/java/dev/aceclaw/cli/TerminalReplTest.java
@@ -542,6 +542,63 @@ class TerminalReplTest {
     }
 
     @Test
+    void skillDraftStatusSummary_dominantReasonOnlyReflectsHoldDrafts() throws Exception {
+        // Two drafts: one HOLD (replay gate failed), one BLOCK (missing description).
+        // The bracketed dominant-reason indicator is meant to diagnose stuck HOLD state, not
+        // BLOCK (which is a draft-file defect visible from `b:N` and inspected separately).
+        var statusRepl = newReplForProject(tempDir);
+        Path holdDraft = tempDir.resolve(".aceclaw/skills-drafts/hold-one/SKILL.md");
+        Path blockDraft = tempDir.resolve(".aceclaw/skills-drafts/block-one/SKILL.md");
+        Files.createDirectories(holdDraft.getParent());
+        Files.createDirectories(blockDraft.getParent());
+        Files.writeString(holdDraft, """
+                ---
+                name: "hold-one"
+                description: "Held by replay"
+                disable-model-invocation: true
+                ---
+                # Hold
+                """);
+        Files.writeString(blockDraft, """
+                ---
+                name: "block-one"
+                description: "Blocked by missing model field override policy"
+                disable-model-invocation: true
+                ---
+                # Block
+                """);
+        Path snapshot = tempDir.resolve(".aceclaw/metrics/continuous-learning/skill-draft-validation-snapshot.json");
+        Files.createDirectories(snapshot.getParent());
+        Files.writeString(snapshot, """
+                {
+                  "updatedAt": "2026-04-17T12:00:00Z",
+                  "trigger": "auto-promotion",
+                  "drafts": [
+                    {
+                      "draftPath": ".aceclaw/skills-drafts/hold-one/SKILL.md",
+                      "verdict": "hold",
+                      "reasons": [
+                        {"gate":"replay","code":"REPLAY_GATE_FAILED","outcome":"hold","message":"token_err exceeds threshold"}
+                      ]
+                    },
+                    {
+                      "draftPath": ".aceclaw/skills-drafts/block-one/SKILL.md",
+                      "verdict": "block",
+                      "reasons": [
+                        {"gate":"static","code":"STATIC_FRONTMATTER_MISSING","outcome":"block","message":"missing frontmatter"}
+                      ]
+                    }
+                  ]
+                }
+                """);
+
+        String summary = (String) invokePrivate(statusRepl, "skillDraftStatusSummary",
+                new Class<?>[]{Path.class}, tempDir);
+        // BLOCK reason must not leak into the bracketed hint.
+        assertThat(summary).isEqualTo("2(p:0,h:1,b:1,n:0) [REPLAY_GATE_FAILED]");
+    }
+
+    @Test
     void skillDraftStatusSummary_prefersSnapshotOverStaleAudit() throws Exception {
         var statusRepl = newReplForProject(tempDir);
         writeSkillDraftArtifacts(tempDir);

--- a/aceclaw-cli/src/test/java/dev/aceclaw/cli/TerminalReplTest.java
+++ b/aceclaw-cli/src/test/java/dev/aceclaw/cli/TerminalReplTest.java
@@ -527,6 +527,21 @@ class TerminalReplTest {
     }
 
     @Test
+    void skillDraftStatusSummary_corruptSnapshotFallsBackToAudit() throws Exception {
+        var statusRepl = newReplForProject(tempDir);
+        writeSkillDraftArtifacts(tempDir);
+        // Snapshot file exists but contains unparseable JSON. Loader logs and returns empty;
+        // Files.isRegularFile is still true so we stay on snapshot path — verdict becomes pending.
+        // (Treating a corrupt snapshot as "no current state" is safer than silently serving stale audit.)
+        Path snapshot = tempDir.resolve(".aceclaw/metrics/continuous-learning/skill-draft-validation-snapshot.json");
+        Files.writeString(snapshot, "{ not json");
+
+        String summary = (String) invokePrivate(statusRepl, "skillDraftStatusSummary",
+                new Class<?>[]{Path.class}, tempDir);
+        assertThat(summary).isEqualTo("1(p:0,h:0,b:0,n:1)");
+    }
+
+    @Test
     void skillDraftStatusSummary_prefersSnapshotOverStaleAudit() throws Exception {
         var statusRepl = newReplForProject(tempDir);
         writeSkillDraftArtifacts(tempDir);

--- a/aceclaw-cli/src/test/java/dev/aceclaw/cli/TerminalReplTest.java
+++ b/aceclaw-cli/src/test/java/dev/aceclaw/cli/TerminalReplTest.java
@@ -517,13 +517,41 @@ class TerminalReplTest {
     }
 
     @Test
-    void skillDraftStatusSummary_includesVerdictCounts() throws Exception {
+    void skillDraftStatusSummary_includesVerdictCountsAndDominantReason() throws Exception {
         var statusRepl = newReplForProject(tempDir);
         writeSkillDraftArtifacts(tempDir);
 
         String summary = (String) invokePrivate(statusRepl, "skillDraftStatusSummary",
                 new Class<?>[]{Path.class}, tempDir);
-        assertThat(summary).isEqualTo("1(p:0,h:1,b:0,n:0)");
+        assertThat(summary).isEqualTo("1(p:0,h:1,b:0,n:0) [STATIC_ALLOWED_TOOLS_POLICY_VIOLATION]");
+    }
+
+    @Test
+    void skillDraftStatusSummary_prefersSnapshotOverStaleAudit() throws Exception {
+        var statusRepl = newReplForProject(tempDir);
+        writeSkillDraftArtifacts(tempDir);
+        // Audit says HOLD/REPLAY_REPORT_MISSING (stale), snapshot says HOLD/REPLAY_GATE_FAILED (current).
+        // The status line must reflect the snapshot so users see the actual current gate failure.
+        Path snapshot = tempDir.resolve(".aceclaw/metrics/continuous-learning/skill-draft-validation-snapshot.json");
+        Files.writeString(snapshot, """
+                {
+                  "updatedAt": "2026-04-17T12:00:00Z",
+                  "trigger": "auto-promotion",
+                  "drafts": [
+                    {
+                      "draftPath": ".aceclaw/skills-drafts/retry-safe/SKILL.md",
+                      "verdict": "hold",
+                      "reasons": [
+                        {"gate":"replay","code":"REPLAY_GATE_FAILED","outcome":"hold","message":"token_estimation_error_ratio_p95 exceeds threshold"}
+                      ]
+                    }
+                  ]
+                }
+                """);
+
+        String summary = (String) invokePrivate(statusRepl, "skillDraftStatusSummary",
+                new Class<?>[]{Path.class}, tempDir);
+        assertThat(summary).isEqualTo("1(p:0,h:1,b:0,n:0) [REPLAY_GATE_FAILED]");
     }
 
     @Test

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/ValidationGateEngine.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/ValidationGateEngine.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
@@ -33,6 +34,7 @@ public final class ValidationGateEngine {
     private static final String DRAFTS_DIR = ".aceclaw/skills-drafts";
     private static final String AUDIT_DIR = ".aceclaw/metrics/continuous-learning";
     private static final String AUDIT_FILE = "skill-draft-validation-audit.jsonl";
+    private static final String SNAPSHOT_FILE = "skill-draft-validation-snapshot.json";
 
     private static final String DEFAULT_REPLAY_REPORT = ".aceclaw/metrics/continuous-learning/replay-latest.json";
 
@@ -88,6 +90,7 @@ public final class ValidationGateEngine {
             decisions.add(validateSingle(projectRoot, draftFile, normalizedTrigger, replay));
         }
         var changed = writeAudit(projectRoot, decisions);
+        writeSnapshot(projectRoot, decisions, normalizedTrigger);
         return summarize(projectRoot, decisions, changed);
     }
 
@@ -98,6 +101,7 @@ public final class ValidationGateEngine {
         var replay = evaluateReplay(projectRoot);
         var decision = validateSingle(projectRoot, draftPath, normalizedTrigger, replay);
         var changed = writeAudit(projectRoot, List.of(decision));
+        mergeSnapshot(projectRoot, List.of(decision), normalizedTrigger);
         return summarize(projectRoot, List.of(decision), changed);
     }
 
@@ -274,6 +278,88 @@ public final class ValidationGateEngine {
             changed.add(d);
         }
         return List.copyOf(changed);
+    }
+
+    /**
+     * Writes a current-state snapshot of every draft's verdict, overwriting prior contents.
+     *
+     * <p>The append-only audit file is deduped by (draftPath, verdict) to bound growth,
+     * which means a HOLD whose underlying reason silently shifts (e.g. REPLAY_REPORT_MISSING
+     * → REPLAY_GATE_FAILED once the report appears but metrics still fail) never produces a
+     * new audit entry. The snapshot is the authoritative "what is true right now" view —
+     * consumers that need current state (TUI, metrics collectors) should read it instead of
+     * the audit tail.
+     */
+    private void writeSnapshot(Path projectRoot, List<DraftDecision> decisions, String trigger) throws IOException {
+        Path snapshotPath = projectRoot.resolve(AUDIT_DIR).resolve(SNAPSHOT_FILE);
+        Files.createDirectories(snapshotPath.getParent());
+        var root = mapper.createObjectNode();
+        root.put("updatedAt", Instant.now(clock).toString());
+        root.put("trigger", trigger);
+        var arr = mapper.createArrayNode();
+        for (var d : decisions) {
+            arr.add(draftDecisionToJson(d));
+        }
+        root.set("drafts", arr);
+        Files.writeString(
+                snapshotPath,
+                mapper.writerWithDefaultPrettyPrinter().writeValueAsString(root),
+                StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
+    }
+
+    /**
+     * Merges a partial decision list into the existing snapshot without dropping other drafts.
+     * Used by {@link #validateSingleDraft} so single-draft validation doesn't erase sibling state.
+     */
+    private void mergeSnapshot(Path projectRoot, List<DraftDecision> decisions, String trigger) throws IOException {
+        Path snapshotPath = projectRoot.resolve(AUDIT_DIR).resolve(SNAPSHOT_FILE);
+        Files.createDirectories(snapshotPath.getParent());
+        var merged = new LinkedHashMap<String, com.fasterxml.jackson.databind.JsonNode>();
+        if (Files.isRegularFile(snapshotPath)) {
+            try {
+                JsonNode existing = mapper.readTree(snapshotPath.toFile());
+                if (existing != null && existing.path("drafts").isArray()) {
+                    for (JsonNode node : existing.path("drafts")) {
+                        String key = node.path("draftPath").asText("");
+                        if (!key.isBlank()) merged.put(key, node);
+                    }
+                }
+            } catch (Exception ignored) {
+                // corrupt snapshot: rebuild from supplied decisions
+            }
+        }
+        for (var d : decisions) {
+            merged.put(d.draftPath(), draftDecisionToJson(d));
+        }
+        var root = mapper.createObjectNode();
+        root.put("updatedAt", Instant.now(clock).toString());
+        root.put("trigger", trigger);
+        var arr = mapper.createArrayNode();
+        merged.values().forEach(arr::add);
+        root.set("drafts", arr);
+        Files.writeString(
+                snapshotPath,
+                mapper.writerWithDefaultPrettyPrinter().writeValueAsString(root),
+                StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
+    }
+
+    private com.fasterxml.jackson.databind.node.ObjectNode draftDecisionToJson(DraftDecision d) {
+        var node = mapper.createObjectNode();
+        node.put("draftPath", d.draftPath());
+        node.put("verdict", d.verdict().name().toLowerCase(Locale.ROOT));
+        node.put("evaluatedAt", d.evaluatedAt().toString());
+        node.put("trigger", d.trigger());
+        var reasonArray = mapper.createArrayNode();
+        for (var r : d.reasons()) {
+            var rn = mapper.createObjectNode();
+            rn.put("gate", r.gate());
+            rn.put("code", r.code());
+            rn.put("outcome", r.outcome().name().toLowerCase(Locale.ROOT));
+            rn.put("message", r.message());
+            reasonArray.add(rn);
+        }
+        node.set("reasons", reasonArray);
+        return node;
     }
 
     /**

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/ValidationGateEngine.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/ValidationGateEngine.java
@@ -2,12 +2,18 @@ package dev.aceclaw.daemon;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -30,6 +36,8 @@ import java.util.Objects;
  * </ul>
  */
 public final class ValidationGateEngine {
+
+    private static final Logger log = LoggerFactory.getLogger(ValidationGateEngine.class);
 
     private static final String DRAFTS_DIR = ".aceclaw/skills-drafts";
     private static final String AUDIT_DIR = ".aceclaw/metrics/continuous-learning";
@@ -301,10 +309,7 @@ public final class ValidationGateEngine {
             arr.add(draftDecisionToJson(d));
         }
         root.set("drafts", arr);
-        Files.writeString(
-                snapshotPath,
-                mapper.writerWithDefaultPrettyPrinter().writeValueAsString(root),
-                StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
+        atomicWriteJson(snapshotPath, root);
     }
 
     /**
@@ -314,7 +319,7 @@ public final class ValidationGateEngine {
     private void mergeSnapshot(Path projectRoot, List<DraftDecision> decisions, String trigger) throws IOException {
         Path snapshotPath = projectRoot.resolve(AUDIT_DIR).resolve(SNAPSHOT_FILE);
         Files.createDirectories(snapshotPath.getParent());
-        var merged = new LinkedHashMap<String, com.fasterxml.jackson.databind.JsonNode>();
+        var merged = new LinkedHashMap<String, JsonNode>();
         if (Files.isRegularFile(snapshotPath)) {
             try {
                 JsonNode existing = mapper.readTree(snapshotPath.toFile());
@@ -324,8 +329,9 @@ public final class ValidationGateEngine {
                         if (!key.isBlank()) merged.put(key, node);
                     }
                 }
-            } catch (Exception ignored) {
-                // corrupt snapshot: rebuild from supplied decisions
+            } catch (Exception e) {
+                log.debug("Corrupt validation snapshot at {}; rebuilding from supplied decisions: {}",
+                        snapshotPath, e.getMessage());
             }
         }
         for (var d : decisions) {
@@ -337,13 +343,28 @@ public final class ValidationGateEngine {
         var arr = mapper.createArrayNode();
         merged.values().forEach(arr::add);
         root.set("drafts", arr);
-        Files.writeString(
-                snapshotPath,
-                mapper.writerWithDefaultPrettyPrinter().writeValueAsString(root),
-                StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
+        atomicWriteJson(snapshotPath, root);
     }
 
-    private com.fasterxml.jackson.databind.node.ObjectNode draftDecisionToJson(DraftDecision d) {
+    /**
+     * Writes JSON to a temp sibling and atomically renames over the target. Guarantees readers
+     * either see the prior snapshot or the new one, never a half-written truncated file.
+     */
+    private void atomicWriteJson(Path target, JsonNode root) throws IOException {
+        String content = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(root);
+        Path tmp = target.resolveSibling(target.getFileName().toString() + ".tmp");
+        Files.writeString(tmp, content,
+                StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
+        try {
+            Files.move(tmp, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+        } catch (AtomicMoveNotSupportedException e) {
+            // Rare — some filesystems (e.g. cross-device) can't do atomic rename. Fall back to
+            // a non-atomic replace; the window is shorter than truncate-in-place.
+            Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+
+    private ObjectNode draftDecisionToJson(DraftDecision d) {
         var node = mapper.createObjectNode();
         node.put("draftPath", d.draftPath());
         node.put("verdict", d.verdict().name().toLowerCase(Locale.ROOT));

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/ValidationGateEngine.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/ValidationGateEngine.java
@@ -79,6 +79,9 @@ public final class ValidationGateEngine {
 
         Path draftsRoot = projectRoot.resolve(DRAFTS_DIR);
         if (!Files.isDirectory(draftsRoot)) {
+            // No drafts directory is a valid current state. Clear the snapshot so consumers
+            // don't keep seeing stale entries after the last draft (or the whole dir) is removed.
+            writeSnapshot(projectRoot, List.of(), normalizedTrigger);
             return new ValidationSummary(
                     0, 0, 0, 0, List.of(), List.of(), projectRoot.resolve(AUDIT_DIR).resolve(AUDIT_FILE));
         }

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/ValidationGateEngine.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/ValidationGateEngine.java
@@ -323,6 +323,7 @@ public final class ValidationGateEngine {
         Path snapshotPath = projectRoot.resolve(AUDIT_DIR).resolve(SNAPSHOT_FILE);
         Files.createDirectories(snapshotPath.getParent());
         var merged = new LinkedHashMap<String, JsonNode>();
+        boolean seededFromSnapshot = false;
         if (Files.isRegularFile(snapshotPath)) {
             try {
                 JsonNode existing = mapper.readTree(snapshotPath.toFile());
@@ -331,11 +332,21 @@ public final class ValidationGateEngine {
                         String key = node.path("draftPath").asText("");
                         if (!key.isBlank()) merged.put(key, node);
                     }
+                    seededFromSnapshot = true;
                 }
             } catch (Exception e) {
-                log.debug("Corrupt validation snapshot at {}; rebuilding from supplied decisions: {}",
+                log.debug("Corrupt validation snapshot at {}; falling back to audit seed: {}",
                         snapshotPath, e.getMessage());
             }
+        }
+        if (!seededFromSnapshot) {
+            // Bootstrap case (snapshot missing or corrupt). Without this, a single-draft
+            // validate (via the skill.draft.validate RPC) would write a snapshot containing
+            // only the targeted draft, and the TUI — which now trusts the snapshot — would
+            // regress every sibling to "pending" even if they had prior known verdicts.
+            // Seed from the audit tail so siblings keep their last-known verdict until the
+            // next full validateAll run refreshes them.
+            merged.putAll(seedFromAudit(projectRoot));
         }
         for (var d : decisions) {
             merged.put(d.draftPath(), draftDecisionToJson(d));
@@ -347,6 +358,33 @@ public final class ValidationGateEngine {
         merged.values().forEach(arr::add);
         root.set("drafts", arr);
         atomicWriteJson(snapshotPath, root);
+    }
+
+    /**
+     * Builds a per-draft seed map from the audit log's last-seen entry per draftPath.
+     * The audit is deduped by (draftPath, verdict) so the reasons captured here may be stale
+     * relative to the current evaluation, but they are strictly no worse than what the TUI
+     * would have shown when reading the audit directly — which is exactly the fallback we
+     * replaced. Used only when the snapshot itself is missing or corrupt.
+     */
+    private LinkedHashMap<String, JsonNode> seedFromAudit(Path projectRoot) {
+        var seed = new LinkedHashMap<String, JsonNode>();
+        Path auditPath = projectRoot.resolve(AUDIT_DIR).resolve(AUDIT_FILE);
+        if (!Files.isRegularFile(auditPath)) return seed;
+        try {
+            for (var line : Files.readAllLines(auditPath)) {
+                if (line.isBlank()) continue;
+                JsonNode node = mapper.readTree(line);
+                if (node == null) continue;
+                String draftPath = node.path("draftPath").asText("");
+                if (draftPath.isBlank()) continue;
+                // Last write wins — audit is chronological, later entries supersede earlier.
+                seed.put(draftPath, node);
+            }
+        } catch (Exception e) {
+            log.debug("Failed to seed snapshot from audit at {}: {}", auditPath, e.getMessage());
+        }
+        return seed;
     }
 
     /**

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/ValidationGateEngineTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/ValidationGateEngineTest.java
@@ -1,5 +1,6 @@
 package dev.aceclaw.daemon;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -264,6 +265,68 @@ class ValidationGateEngineTest {
                 ".aceclaw/metrics/continuous-learning/skill-draft-validation-snapshot.json");
         var root = new ObjectMapper().readTree(snapshotPath.toFile());
         assertThat(root.path("drafts").size()).isEqualTo(2);
+    }
+
+    @Test
+    void validateSingleDraftSeedsSnapshotFromAuditWhenSnapshotMissing() throws Exception {
+        // Regression guard for a reviewer-found hole: if skill.draft.validate (RPC) is called
+        // before any full validateAll — or after the snapshot has been deleted — mergeSnapshot
+        // previously produced a snapshot containing only the targeted draft. The TUI trusts
+        // the snapshot over the audit, so every sibling would regress to "pending" despite
+        // having known prior verdicts in the audit. Fix: seed from audit when snapshot absent.
+        Path firstDraft = tempDir.resolve(".aceclaw/skills-drafts/retry-safe/SKILL.md");
+        Files.createDirectories(firstDraft.getParent());
+        Files.writeString(firstDraft, """
+                ---
+                name: "retry-safe"
+                description: "Retry with bounded timeout"
+                allowed-tools: [bash, read_file]
+                disable-model-invocation: true
+                ---
+                # Draft Skill
+                """);
+        Path siblingDraft = tempDir.resolve(".aceclaw/skills-drafts/sibling/SKILL.md");
+        Files.createDirectories(siblingDraft.getParent());
+        Files.writeString(siblingDraft, """
+                ---
+                name: "sibling"
+                description: "Unrelated draft"
+                allowed-tools: [bash]
+                disable-model-invocation: true
+                ---
+                # Sibling
+                """);
+
+        // Pre-existing audit with sibling's last-known verdict. No snapshot file exists.
+        Path auditPath = tempDir.resolve(
+                ".aceclaw/metrics/continuous-learning/skill-draft-validation-audit.jsonl");
+        Files.createDirectories(auditPath.getParent());
+        Files.writeString(auditPath, """
+                {"draftPath":".aceclaw/skills-drafts/sibling/SKILL.md","verdict":"hold","reasons":[{"gate":"replay","code":"REPLAY_REPORT_MISSING","outcome":"hold","message":"replay missing"}]}
+                """);
+        writeReplayReport(0.10);
+
+        var engine = new ValidationGateEngine(
+                fixedClock(), false, true,
+                Path.of(".aceclaw/metrics/continuous-learning/replay-latest.json"),
+                0.65);
+        engine.validateSingleDraft(tempDir, firstDraft, "rpc-single");
+
+        Path snapshotPath = tempDir.resolve(
+                ".aceclaw/metrics/continuous-learning/skill-draft-validation-snapshot.json");
+        var root = new ObjectMapper().readTree(snapshotPath.toFile());
+        var drafts = root.path("drafts");
+        assertThat(drafts.size()).isEqualTo(2);
+
+        // Sibling keeps its audit-seeded verdict rather than disappearing into "pending".
+        boolean siblingFound = false;
+        for (JsonNode d : drafts) {
+            if (".aceclaw/skills-drafts/sibling/SKILL.md".equals(d.path("draftPath").asText())) {
+                siblingFound = true;
+                assertThat(d.path("verdict").asText()).isEqualTo("hold");
+            }
+        }
+        assertThat(siblingFound).isTrue();
     }
 
     @Test

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/ValidationGateEngineTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/ValidationGateEngineTest.java
@@ -266,6 +266,42 @@ class ValidationGateEngineTest {
         assertThat(root.path("drafts").size()).isEqualTo(2);
     }
 
+    @Test
+    void validateAllClearsSnapshotWhenDraftsDirectoryDisappears() throws Exception {
+        // Seed a snapshot as if a previous run had produced HOLD decisions.
+        writeDraft("""
+                ---
+                name: "retry-safe"
+                description: "Retry with bounded timeout"
+                allowed-tools: [bash]
+                disable-model-invocation: true
+                ---
+                # Draft Skill
+                """);
+        var engine = new ValidationGateEngine(
+                fixedClock(), false, true,
+                Path.of(".aceclaw/metrics/continuous-learning/replay-latest.json"),
+                0.65);
+        engine.validateAll(tempDir, "first-run");
+
+        // User wipes the drafts directory. Next validateAll must clear the snapshot so
+        // downstream consumers don't keep serving the stale HOLD entries.
+        Path draftsDir = tempDir.resolve(".aceclaw/skills-drafts");
+        Files.walk(draftsDir)
+                .sorted(java.util.Comparator.reverseOrder())
+                .forEach(p -> { try { Files.delete(p); } catch (Exception ignored) {} });
+
+        engine.validateAll(tempDir, "post-wipe");
+
+        Path snapshotPath = tempDir.resolve(
+                ".aceclaw/metrics/continuous-learning/skill-draft-validation-snapshot.json");
+        assertThat(snapshotPath).isRegularFile();
+        var root = new ObjectMapper().readTree(snapshotPath.toFile());
+        assertThat(root.path("trigger").asText()).isEqualTo("post-wipe");
+        assertThat(root.path("drafts").isArray()).isTrue();
+        assertThat(root.path("drafts").size()).isZero();
+    }
+
     private static Clock fixedClock() {
         return Clock.fixed(Instant.parse("2026-02-24T00:00:00Z"), ZoneOffset.UTC);
     }

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/ValidationGateEngineTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/ValidationGateEngineTest.java
@@ -1,5 +1,6 @@
 package dev.aceclaw.daemon;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -170,6 +171,99 @@ class ValidationGateEngineTest {
                   }
                 }
                 """.formatted(tokenErrorRatio));
+    }
+
+    @Test
+    void snapshotReflectsCurrentVerdictEvenWhenAuditIsDeduped() throws Exception {
+        // First run produces REPLAY_REPORT_MISSING.
+        writeDraft("""
+                ---
+                name: "retry-safe"
+                description: "Retry with bounded timeout"
+                allowed-tools: [bash, read_file]
+                disable-model-invocation: true
+                ---
+
+                # Draft Skill
+                ## Strategy
+                - Keep retries bounded
+                """);
+        var engine = new ValidationGateEngine(
+                fixedClock(), false, true,
+                Path.of(".aceclaw/metrics/continuous-learning/replay-latest.json"),
+                0.65);
+        engine.validateAll(tempDir, "first-run");
+
+        // Second run: replay report now exists but exceeds the threshold.
+        // The verdict stays HOLD, so writeAudit dedups — audit does NOT get a new entry.
+        // The snapshot, however, must reflect the new reason code.
+        writeReplayReport(1.43);
+        engine.validateAll(tempDir, "second-run");
+
+        Path snapshotPath = tempDir.resolve(
+                ".aceclaw/metrics/continuous-learning/skill-draft-validation-snapshot.json");
+        assertThat(snapshotPath).isRegularFile();
+
+        var mapper = new ObjectMapper();
+        var root = mapper.readTree(snapshotPath.toFile());
+        assertThat(root.path("trigger").asText()).isEqualTo("second-run");
+        var drafts = root.path("drafts");
+        assertThat(drafts.isArray()).isTrue();
+        assertThat(drafts.size()).isEqualTo(1);
+        var draft = drafts.get(0);
+        assertThat(draft.path("verdict").asText()).isEqualTo("hold");
+        var reasons = draft.path("reasons");
+        assertThat(reasons.isArray()).isTrue();
+        assertThat(reasons.get(0).path("code").asText()).isEqualTo("REPLAY_GATE_FAILED");
+
+        // Audit file still reflects only the original verdict change (dedup intact).
+        Path auditPath = tempDir.resolve(
+                ".aceclaw/metrics/continuous-learning/skill-draft-validation-audit.jsonl");
+        var auditLines = Files.readAllLines(auditPath);
+        assertThat(auditLines).hasSize(1);
+        assertThat(auditLines.getFirst()).contains("REPLAY_REPORT_MISSING");
+    }
+
+    @Test
+    void validateSingleDraftMergesIntoSnapshotWithoutErasingSiblings() throws Exception {
+        // Two drafts; validateAll populates snapshot with both.
+        Path firstDraft = tempDir.resolve(".aceclaw/skills-drafts/retry-safe/SKILL.md");
+        Files.createDirectories(firstDraft.getParent());
+        Files.writeString(firstDraft, """
+                ---
+                name: "retry-safe"
+                description: "Retry with bounded timeout"
+                allowed-tools: [bash, read_file]
+                disable-model-invocation: true
+                ---
+                # Draft Skill
+                """);
+        Path secondDraft = tempDir.resolve(".aceclaw/skills-drafts/other/SKILL.md");
+        Files.createDirectories(secondDraft.getParent());
+        Files.writeString(secondDraft, """
+                ---
+                name: "other"
+                description: "Another draft"
+                allowed-tools: [bash]
+                disable-model-invocation: true
+                ---
+                # Draft Skill
+                """);
+        writeReplayReport(0.10);
+
+        var engine = new ValidationGateEngine(
+                fixedClock(), false, true,
+                Path.of(".aceclaw/metrics/continuous-learning/replay-latest.json"),
+                0.65);
+        engine.validateAll(tempDir, "initial");
+
+        // Re-validate only the first draft; snapshot must still contain both entries.
+        engine.validateSingleDraft(tempDir, firstDraft, "manual-recheck");
+
+        Path snapshotPath = tempDir.resolve(
+                ".aceclaw/metrics/continuous-learning/skill-draft-validation-snapshot.json");
+        var root = new ObjectMapper().readTree(snapshotPath.toFile());
+        assertThat(root.path("drafts").size()).isEqualTo(2);
     }
 
     private static Clock fixedClock() {


### PR DESCRIPTION
## Summary

- Partially addresses #408: the learning status line's stale HOLD reason.
- `ValidationGateEngine` now writes a current-state snapshot (`skill-draft-validation-snapshot.json`) on every validate call, overwriting previous contents.
- `TerminalRepl` reads the snapshot when present (falls back to audit tail), and appends the dominant non-pass reason code to the `drafts=...` status fragment.

## Why

Investigation of #408 revealed that the validation pipeline *is* running on every turn — but the append-only audit file is deduped by `(draftPath, verdict)`. When a HOLD's underlying reason silently shifts (e.g. `REPLAY_REPORT_MISSING` → `REPLAY_GATE_FAILED` once the replay report appears but the token-error metric still exceeds threshold), no new audit entry is written. The TUI, which reads the audit tail, then reports a stale reason forever.

This is a history-vs-current-state problem. The audit is fine as history; what was missing is a current-state view. Added a snapshot file that is the authoritative "what is true right now" view — consumers that need current state (TUI, future metrics collectors) read it.

## Before / After

Before (status line shows stale reason from weeks-old audit entry):
```
learning | drafts=4(p:0,h:4,b:0,n:0)
```
(no reason code; user must grep audit to find out why)

After (snapshot is overwritten on every validate, TUI surfaces dominant reason):
```
learning | drafts=4(p:0,h:4,b:0,n:0) [REPLAY_GATE_FAILED]
```

## Scope

This PR intentionally does NOT:
- Change audit dedup semantics (keeping history bounded is the right design).
- Adjust the `maxTokenEstimationErrorRatio` threshold (already configurable via `ACECLAW_SKILL_DRAFT_VALIDATION_MAX_TOKEN_ESTIMATION_ERROR_RATIO`).
- Touch the FAILURE_SIGNAL pollution problem (tracked separately in #409).

Consumers that need history (auditors) continue to use the jsonl log. Consumers that need current state (TUI, dashboards) read the snapshot.

## Test plan

- [x] `./gradlew build` — passes (48 tasks, BUILD SUCCESSFUL)
- [x] New: `ValidationGateEngineTest.snapshotReflectsCurrentVerdictEvenWhenAuditIsDeduped` — verifies that on a second run where the reason code shifts (`REPLAY_REPORT_MISSING` → `REPLAY_GATE_FAILED`) but the verdict stays HOLD, the audit is NOT appended (dedup intact) but the snapshot reflects the new reason.
- [x] New: `ValidationGateEngineTest.validateSingleDraftMergesIntoSnapshotWithoutErasingSiblings` — verifies single-draft re-validation merges rather than overwrites.
- [x] Updated: `TerminalReplTest.skillDraftStatusSummary_includesVerdictCountsAndDominantReason` — now asserts the reason suffix.
- [x] New: `TerminalReplTest.skillDraftStatusSummary_prefersSnapshotOverStaleAudit` — verifies the TUI trusts the snapshot over stale audit state.

Refs #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added validation snapshot metrics file for tracking draft verdicts and failure reasons.
  * Enhanced skill draft status reporting to display the dominant validation failure reason alongside verdict counts.
  * Implemented snapshot-based validation status tracking that prioritizes current snapshots over legacy audit data.

* **Bug Fixes**
  * Resolved stale audit data usage by preferring up-to-date validation snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->