### PR TITLE
fix(learning): always call persist() so draft trigger fires on empty insights

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -691,7 +691,9 @@ public final class StreamingAgentHandler {
         });
     }
 
-    private void runPostRequestLearning(String sessionId,
+    // Package-private for testing: locks the caller-side contract that persist() is invoked
+    // on every post-request cycle, including when insights is empty. See #411.
+    void runPostRequestLearning(String sessionId,
                                         Path projectPath,
                                         dev.aceclaw.core.agent.Turn turn,
                                         List<AgentSession.ConversationMessage> sessionHistory,

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -701,8 +701,13 @@ public final class StreamingAgentHandler {
         if (selfImprovementEngine != null) {
             try {
                 insights = selfImprovementEngine.analyze(turn, sessionHistory, metricsSnapshot);
+                // Always call persist(), even with an empty insights list. persist() carries the
+                // draft re-evaluation trigger that refreshes the validation snapshot and reruns
+                // the release pipeline. Skipping persist on empty insights meant trivial turns
+                // (e.g. a "hi" with no extractable insights) left the validation snapshot stale,
+                // which silently blocked promotion indicators from advancing.
+                int persisted = selfImprovementEngine.persist(insights, sessionId, projectPath);
                 if (!insights.isEmpty()) {
-                    int persisted = selfImprovementEngine.persist(insights, sessionId, projectPath);
                     log.debug("Self-improvement: {} insights analyzed, {} persisted (session={})",
                             insights.size(), persisted, sessionId);
                 }

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/CandidatePipelineIntegrationTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/CandidatePipelineIntegrationTest.java
@@ -247,6 +247,26 @@ class CandidatePipelineIntegrationTest {
     }
 
     @Test
+    void triggerFiresEvenWithEmptyInsights() {
+        // Regression guard: trivial turns that produce no extractable insights (e.g. "hi")
+        // must still fire the draft re-evaluation trigger. Otherwise the validation snapshot
+        // goes stale on every no-insight turn, and promotion indicators don't advance.
+        // The StreamingAgentHandler caller-side must also call persist() unconditionally for
+        // this to hold end-to-end; this test locks the engine-side contract.
+        var triggerCalled = new java.util.concurrent.atomic.AtomicBoolean(false);
+        var errorDetector = new ErrorDetector(memoryStore);
+        var patternDetector = new PatternDetector(memoryStore);
+        var engineWithTrigger = new SelfImprovementEngine(
+                errorDetector, patternDetector, new FailureSignalDetector(),
+                memoryStore, null, candidateStore, true,
+                projectPath -> triggerCalled.set(true));
+
+        engineWithTrigger.persist(List.of(), "test-session", tempDir);
+
+        assertThat(triggerCalled.get()).isTrue();
+    }
+
+    @Test
     void triggerAlwaysFiresEvenWithoutNewPromotions() {
         // Trigger should always fire after persist() for idempotent re-evaluation,
         // regardless of whether new promotions occurred in this turn.

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/StreamingAgentHandlerPostLearningTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/StreamingAgentHandlerPostLearningTest.java
@@ -1,0 +1,80 @@
+package dev.aceclaw.daemon;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.aceclaw.core.agent.Turn;
+import dev.aceclaw.core.llm.Message;
+import dev.aceclaw.core.llm.StopReason;
+import dev.aceclaw.core.llm.Usage;
+import dev.aceclaw.memory.AutoMemoryStore;
+import dev.aceclaw.memory.CandidateStateMachine;
+import dev.aceclaw.memory.CandidateStore;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end guard for the caller-side contract fixed in #411: {@code StreamingAgentHandler}
+ * must invoke {@code SelfImprovementEngine.persist(...)} — and therefore fire the draft
+ * re-evaluation trigger — on every post-request cycle, including when the analyzer returns no
+ * insights. The engine-side analogue lives in
+ * {@code CandidatePipelineIntegrationTest.triggerFiresEvenWithEmptyInsights}; this test
+ * prevents a regression where the caller-side condition is put back and the engine-side test
+ * would still pass.
+ */
+class StreamingAgentHandlerPostLearningTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void noInsightTurnStillFiresDraftReevaluationTrigger() throws Exception {
+        var memoryStore = new AutoMemoryStore(tempDir);
+        memoryStore.load(tempDir);
+
+        var smConfig = new CandidateStateMachine.Config(1, 0.3, 1.0, 10, Set.of());
+        var candidateStore = new CandidateStore(tempDir, smConfig);
+        candidateStore.load();
+
+        var triggerFired = new AtomicBoolean(false);
+        var engine = new SelfImprovementEngine(
+                new ErrorDetector(memoryStore),
+                new PatternDetector(memoryStore),
+                new FailureSignalDetector(),
+                memoryStore,
+                null,
+                candidateStore,
+                true,
+                projectPath -> triggerFired.set(true));
+
+        var handler = new StreamingAgentHandler(null, null, null, null, new ObjectMapper());
+        handler.setSelfImprovementEngine(engine);
+
+        // A turn with only a plain assistant reply produces no insights — analyze() returns [].
+        // Before #411 this silently skipped persist(), which carries the trigger. After the
+        // fix persist() runs anyway and the trigger must fire.
+        var turn = new Turn(
+                List.of(Message.assistant("Hi! How can I help?")),
+                StopReason.END_TURN,
+                new Usage(3, 42));
+
+        handler.runPostRequestLearning(
+                "test-session",
+                tempDir,
+                turn,
+                List.of(),
+                Map.of(),
+                Set.of());
+
+        assertThat(triggerFired.get())
+                .as("Draft re-evaluation trigger must fire even when the turn produced no insights; "
+                        + "otherwise snapshot refresh stalls on trivial turns (see #411).")
+                .isTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- Follow-up to #410. `StreamingAgentHandler.runPostRequestLearning` only called `SelfImprovementEngine.persist()` when `analyze()` returned non-empty insights. But `persist()` is where the draft re-evaluation trigger lives — the trigger that reruns `ValidationGateEngine` and refreshes the current-state snapshot introduced in #410.
- On trivial turns (\"hi\", small acknowledgements, anything with no extractable insight), persist was skipped → no trigger → no snapshot refresh → release pipeline never re-evaluated.
- Users who merged #410 and then sent a low-signal first prompt saw the status line still reflecting pre-merge audit state, with no way to tell the new pipeline was actually running. (Reproduced live on main.)

## Why this is the right fix

The comment at `SelfImprovementEngine.java:302` already documents the intent: `// Always fire draft re-evaluation trigger`. The caller-side guard in `StreamingAgentHandler` contradicted that intent. This patch makes the caller match the documented contract.

Calling `persist()` on an empty list is two no-op iterations over the insights list plus one idempotent trigger invocation. The cost is negligible; the cost of a stale snapshot is user-visible confusion.

## Test

`CandidatePipelineIntegrationTest.triggerFiresEvenWithEmptyInsights` — locks the engine-side contract (`persist([]) → trigger still fires`). The other end of the contract (caller always calls persist) is enforced by inspection in this patch.

## Test plan

- [x] `./gradlew build` — passes (53 tasks, BUILD SUCCESSFUL)
- [x] New test: `triggerFiresEvenWithEmptyInsights`
- [x] All existing `CandidatePipelineIntegrationTest` tests still pass

Refs #408, follow-up to #410.

🤖 Generated with [Claude Code](https://claude.com/claude-code)