### PR TITLE
feat(status): surface cumulative LLM request count in /status

### DIFF
--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/ContextMonitor.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/ContextMonitor.java
@@ -42,6 +42,8 @@ public final class ContextMonitor {
 
     /** Cumulative output tokens across all turns in the session. */
     private long totalOutputTokens;
+    /** Cumulative LLM API request count across all turns in the session. */
+    private long totalLlmRequests;
     /** Number of compaction events observed in the session. */
     private int compactionCount;
     /** Number of compaction events that stopped after phase 1 pruning. */
@@ -142,6 +144,24 @@ public final class ContextMonitor {
      */
     public synchronized long totalOutput() {
         return totalOutputTokens;
+    }
+
+    /**
+     * Accumulates the LLM API request count from a completed turn. Tracked separately from
+     * token totals because requests and tokens are independent axes: a retry-heavy turn can
+     * burn many requests on few tokens, and a large-context turn can use many tokens in one
+     * request. Displayed on {@code /status}; the per-turn count is already shown inline.
+     */
+    public synchronized void recordLlmRequests(int turnLlmRequests) {
+        if (turnLlmRequests <= 0) return;
+        this.totalLlmRequests += turnLlmRequests;
+    }
+
+    /**
+     * Returns cumulative LLM API request count across all turns.
+     */
+    public synchronized long totalLlmRequests() {
+        return totalLlmRequests;
     }
 
     /**

--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/TaskHandle.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/TaskHandle.java
@@ -43,6 +43,14 @@ public final class TaskHandle {
     /** Whether background completion has been displayed to the user. */
     private final AtomicBoolean completionNotified = new AtomicBoolean(false);
 
+    /**
+     * Whether this task's usage (tokens, LLM requests) has been accumulated into session
+     * totals. Kept separate from {@link #completionNotified} because display and accounting
+     * have different idempotency requirements — a task can be rendered multiple times (e.g.
+     * /fg after auto-display, or a /fg path not marking notified) but must be counted once.
+     */
+    private final AtomicBoolean usageAccounted = new AtomicBoolean(false);
+
     /** When the task was submitted. */
     private final Instant startedAt;
 
@@ -127,6 +135,14 @@ public final class TaskHandle {
      * (i.e., the notification hasn't been shown yet).
      */
     public boolean markNotified() { return completionNotified.compareAndSet(false, true); }
+
+    /**
+     * Marks this task's usage as accounted into session-level totals. Returns true if this
+     * is the first call — callers should accumulate tokens / LLM request counts only when
+     * this returns true, so renders through different paths (/fg, auto-display, fallback
+     * notify) don't inflate the counters.
+     */
+    public boolean markUsageAccounted() { return usageAccounted.compareAndSet(false, true); }
 
     public Thread streamThread() { return streamThread; }
     public void setStreamThread(Thread thread) { this.streamThread = thread; }

--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
@@ -1223,9 +1223,14 @@ public final class TerminalRepl {
             // NOT the per-call value — using it would cause erratic usage % jumps.
             // If no streaming usage was received, keep the monitor's existing per-call value (0 means "no update").
             long perCallContext = handle.liveInputTokens();
-            contextMonitor.recordTurnComplete(turnIn, turnOut, perCallContext);
-            contextMonitor.recordLlmRequests(llmRequests);
-            contextMonitor.checkThresholds(log);
+            // Guarded: same handle can reach renderTaskCompletion through multiple paths
+            // (foreground completion, /fg rendezvous, fallback notify). Only the first render
+            // should feed session totals or the user-visible counters double-count.
+            if (handle.markUsageAccounted()) {
+                contextMonitor.recordTurnComplete(turnIn, turnOut, perCallContext);
+                contextMonitor.recordLlmRequests(llmRequests);
+                contextMonitor.checkThresholds(log);
+            }
 
             // For display, use the monitor's authoritative value which handles the
             // perCallContext=0 case by preserving the last known streaming value.
@@ -1509,9 +1514,11 @@ public final class TerminalRepl {
         if (!handle.markNotified()) return;
 
         try {
-            // Record turn usage in ContextMonitor (background tasks skip renderTaskCompletion)
+            // Record turn usage in ContextMonitor (background tasks skip renderTaskCompletion).
+            // Guarded: a subsequent /fg on this already-completed handle would re-enter
+            // renderTaskCompletion and try to account again; see markUsageAccounted contract.
             JsonNode bgResult = handle.result();
-            if (bgResult != null) {
+            if (bgResult != null && handle.markUsageAccounted()) {
                 JsonNode bgUsageResult = bgResult.get("result");
                 if (bgUsageResult != null && bgUsageResult.has("usage")) {
                     var bgUsage = bgUsageResult.get("usage");

--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
@@ -1224,6 +1224,7 @@ public final class TerminalRepl {
             // If no streaming usage was received, keep the monitor's existing per-call value (0 means "no update").
             long perCallContext = handle.liveInputTokens();
             contextMonitor.recordTurnComplete(turnIn, turnOut, perCallContext);
+            contextMonitor.recordLlmRequests(llmRequests);
             contextMonitor.checkThresholds(log);
 
             // For display, use the monitor's authoritative value which handles the
@@ -1516,8 +1517,10 @@ public final class TerminalRepl {
                     var bgUsage = bgUsageResult.get("usage");
                     int bgTurnIn = bgUsage.path("inputTokens").asInt(0);
                     int bgTurnOut = bgUsage.path("outputTokens").asInt(0);
+                    int bgLlmRequests = bgUsage.path("llmRequests").asInt(0);
                     long bgPerCall = handle.liveInputTokens();
                     contextMonitor.recordTurnComplete(bgTurnIn, bgTurnOut, bgPerCall);
+                    contextMonitor.recordLlmRequests(bgLlmRequests);
                     contextMonitor.checkThresholds(log);
                 }
             }
@@ -3006,6 +3009,8 @@ public final class TerminalRepl {
                 out.printf("  %sTotal usage:%s %s in / %s out%n", MUTED, RESET,
                         formatTokenCount(contextMonitor.totalInput()),
                         formatTokenCount(contextMonitor.totalOutput()));
+                out.printf("  %sLLM requests:%s %d%n", MUTED, RESET,
+                        contextMonitor.totalLlmRequests());
                 out.printf("  %sTasks:%s       %d running%n", MUTED, RESET,
                         taskManager.runningCount());
                 out.println();

--- a/aceclaw-cli/src/test/java/dev/aceclaw/cli/ContextMonitorTest.java
+++ b/aceclaw-cli/src/test/java/dev/aceclaw/cli/ContextMonitorTest.java
@@ -24,6 +24,30 @@ class ContextMonitorTest {
     }
 
     @Test
+    void recordLlmRequestsAccumulatesAcrossTurns() {
+        var monitor = new ContextMonitor(200_000);
+
+        monitor.recordLlmRequests(1);
+        monitor.recordLlmRequests(3);
+        monitor.recordLlmRequests(2);
+
+        assertThat(monitor.totalLlmRequests()).isEqualTo(6);
+    }
+
+    @Test
+    void recordLlmRequestsIgnoresZeroAndNegativeValues() {
+        // A turn with no LLM call (e.g. cancelled before send) reports llmRequests=0 in the
+        // usage payload. The counter must not advance on those, and must never go backward.
+        var monitor = new ContextMonitor(200_000);
+
+        monitor.recordLlmRequests(2);
+        monitor.recordLlmRequests(0);
+        monitor.recordLlmRequests(-1);
+
+        assertThat(monitor.totalLlmRequests()).isEqualTo(2);
+    }
+
+    @Test
     void recentTrendCanFallAndThenStabilize() {
         var monitor = new ContextMonitor(100_000);
 

--- a/aceclaw-cli/src/test/java/dev/aceclaw/cli/ContextMonitorTest.java
+++ b/aceclaw-cli/src/test/java/dev/aceclaw/cli/ContextMonitorTest.java
@@ -35,6 +35,31 @@ class ContextMonitorTest {
     }
 
     @Test
+    void guardedAccountingSkipsSecondRenderOfSameTask() {
+        // Models the scenario that motivated TaskHandle.markUsageAccounted: a completed task
+        // can reach renderTaskCompletion through multiple paths in TerminalRepl (e.g. /fg
+        // rendering the result, then notifyCompletedBackgroundTasks picking up the same
+        // unmarked handle). The guard ensures the ContextMonitor is incremented only once.
+        var monitor = new ContextMonitor(200_000);
+        var accounted = new java.util.concurrent.atomic.AtomicBoolean(false);
+
+        // First render path acquires the guard and accounts.
+        if (accounted.compareAndSet(false, true)) {
+            monitor.recordTurnComplete(1_000, 400, 0);
+            monitor.recordLlmRequests(3);
+        }
+        // Second render path for the same task finds the guard already set.
+        if (accounted.compareAndSet(false, true)) {
+            monitor.recordTurnComplete(1_000, 400, 0);
+            monitor.recordLlmRequests(3);
+        }
+
+        assertThat(monitor.totalInput()).isEqualTo(1_000);
+        assertThat(monitor.totalOutput()).isEqualTo(400);
+        assertThat(monitor.totalLlmRequests()).isEqualTo(3);
+    }
+
+    @Test
     void recordLlmRequestsIgnoresZeroAndNegativeValues() {
         // A turn with no LLM call (e.g. cancelled before send) reports llmRequests=0 in the
         // usage payload. The counter must not advance on those, and must never go backward.

--- a/aceclaw-cli/src/test/java/dev/aceclaw/cli/TerminalReplTest.java
+++ b/aceclaw-cli/src/test/java/dev/aceclaw/cli/TerminalReplTest.java
@@ -133,6 +133,23 @@ class TerminalReplTest {
         assertThat(output).contains("Peak:");
         assertThat(output).contains("Pruning:");
         assertThat(output).contains("trend=");
+        assertThat(output).contains("LLM requests:");
+    }
+
+    @Test
+    void status_reflectsCumulativeLlmRequestCount() throws Exception {
+        // Simulate two completed turns that each consumed multiple LLM calls (e.g. tool use
+        // loops) by pushing the counts directly into the monitor; /status must surface the sum.
+        ContextMonitor monitor = (ContextMonitor) getPrivateField(repl, "contextMonitor");
+        monitor.recordLlmRequests(3);
+        monitor.recordLlmRequests(2);
+
+        repl.handleSlashCommand(out, "/status", null);
+
+        // Label and value are separated by an ANSI reset sequence in the rendered output,
+        // so match each segment independently rather than as a concatenated substring.
+        String stripped = outputBuffer.toString().replaceAll("\u001B\\[[0-9;]*m", "");
+        assertThat(stripped).contains("LLM requests: 5");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Closes #412.
- \`/status\` now shows a \`LLM requests: N\` line under \`Total usage\`, accumulating the per-turn count that was already displayed on the turn summary (added in #407).
- Tracked as a separate counter on \`ContextMonitor\` because requests and tokens are independent axes (retry-heavy turn = many requests on few tokens; large-context turn = many tokens on one request).

## Before / After

Before:

\`\`\`
Total usage: 14K in / 3.2K out
Tasks:       0 running
\`\`\`

After:

\`\`\`
Total usage:  14K in / 3.2K out
LLM requests: 8
Tasks:        0 running
\`\`\`

## Implementation

- \`ContextMonitor.recordLlmRequests(int)\` + \`totalLlmRequests()\` getter. Guards against zero/negative values (cancel-before-send paths).
- \`TerminalRepl\` calls it at both turn-complete sites (foreground and background task notification). The background path also now reads \`llmRequests\` from the JSON-RPC usage payload — it was previously dropping that field.
- One extra line in the \`/status\` printer.

## Test plan

- [x] \`./gradlew build\` — passes (53 tasks, BUILD SUCCESSFUL)
- [x] \`ContextMonitorTest.recordLlmRequestsAccumulatesAcrossTurns\` — sums across calls
- [x] \`ContextMonitorTest.recordLlmRequestsIgnoresZeroAndNegativeValues\` — guards
- [x] \`TerminalReplTest.status_reflectsCumulativeLlmRequestCount\` — E2E: push counts into monitor, run \`/status\`, assert rendered output contains \`LLM requests: 5\`
- [x] \`status_showsSessionInfo\` updated to assert the new label is present

## Out of scope

Per #412: no persistence across daemon restarts, no cost estimation (separate concern), no multi-session aggregation. Counter scope matches the existing \`ContextMonitor\` (per-CLI-session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session-level tracking for cumulative LLM API request counts with automatic accumulation across conversation turns
  * Extended `/status` command to display the total LLM request count for the current session

* **Tests**
  * Added unit tests to validate request count accumulation behavior
  * Added integration test to verify `/status` command correctly displays cumulative count

<!-- end of auto-generated comment: release notes by coderabbit.ai -->