### PR TITLE
feat(tui): soften workspace-level HOLD reasons in /status drafts bracket

### DIFF
--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
@@ -2413,6 +2413,18 @@ public final class TerminalRepl {
         }
     }
 
+    /**
+     * Friendly one-line labels for reason codes that describe a workspace-level condition
+     * rather than a per-draft defect. These dominate freshly-initialized projects (no replay
+     * benchmark yet) and displaying the raw code made them look like something was broken.
+     * Per-draft codes (STATIC_*, SAFETY_*, DRY_RUN_*) are intentionally absent here — the raw
+     * code is the fastest way for a user to find the offending frontmatter and fix it.
+     */
+    private static final Map<String, String> FRIENDLY_DRAFT_HOLD_LABEL = Map.of(
+            "REPLAY_REPORT_MISSING", "no replay data",
+            "REPLAY_GATE_FAILED", "replay gate failed"
+    );
+
     private String skillDraftStatusSummary(Path projectRoot) {
         Objects.requireNonNull(projectRoot, "projectRoot");
         var snapshot = getSkillDraftSnapshot(projectRoot);
@@ -2450,7 +2462,11 @@ public final class TerminalRepl {
                 .max(Map.Entry.comparingByValue())
                 .map(Map.Entry::getKey)
                 .orElse(null);
-        return dominantReason != null ? base + " [" + dominantReason + "]" : base;
+        if (dominantReason == null) {
+            return base;
+        }
+        String display = FRIENDLY_DRAFT_HOLD_LABEL.getOrDefault(dominantReason, dominantReason);
+        return base + " [" + display + "]";
     }
 
     private SkillDraftEvent parseSkillDraftEvent(JsonNode node) {

--- a/aceclaw-cli/src/test/java/dev/aceclaw/cli/TerminalReplTest.java
+++ b/aceclaw-cli/src/test/java/dev/aceclaw/cli/TerminalReplTest.java
@@ -612,7 +612,66 @@ class TerminalReplTest {
         String summary = (String) invokePrivate(statusRepl, "skillDraftStatusSummary",
                 new Class<?>[]{Path.class}, tempDir);
         // BLOCK reason must not leak into the bracketed hint.
-        assertThat(summary).isEqualTo("2(p:0,h:1,b:1,n:0) [REPLAY_GATE_FAILED]");
+        assertThat(summary).isEqualTo("2(p:0,h:1,b:1,n:0) [replay gate failed]");
+    }
+
+    @Test
+    void skillDraftStatusSummary_replayReportMissingRendersAsFriendlyLabel() throws Exception {
+        // On a fresh workspace that has never generated replay-latest.json, every draft holds
+        // for REPLAY_REPORT_MISSING — which is a workspace-level "not set up" state, not a
+        // draft-level defect. The status line replaces the raw code with a softer label so
+        // the user sees "nothing to do here" instead of something that looks like a bug.
+        var statusRepl = newReplForProject(tempDir);
+        writeSkillDraftArtifacts(tempDir);
+        Path snapshot = tempDir.resolve(".aceclaw/metrics/continuous-learning/skill-draft-validation-snapshot.json");
+        Files.writeString(snapshot, """
+                {
+                  "updatedAt": "2026-04-17T12:00:00Z",
+                  "trigger": "auto-promotion",
+                  "drafts": [
+                    {
+                      "draftPath": ".aceclaw/skills-drafts/retry-safe/SKILL.md",
+                      "verdict": "hold",
+                      "reasons": [
+                        {"gate":"replay","code":"REPLAY_REPORT_MISSING","outcome":"hold","message":"Replay report not found"}
+                      ]
+                    }
+                  ]
+                }
+                """);
+
+        String summary = (String) invokePrivate(statusRepl, "skillDraftStatusSummary",
+                new Class<?>[]{Path.class}, tempDir);
+        assertThat(summary).isEqualTo("1(p:0,h:1,b:0,n:0) [no replay data]");
+    }
+
+    @Test
+    void skillDraftStatusSummary_perDraftReasonsKeepRawCode() throws Exception {
+        // Per-draft defects (STATIC_*, SAFETY_*, DRY_RUN_*) point at a specific frontmatter
+        // fix. The raw code is the fastest path to grep the audit log and find the offending
+        // draft, so we deliberately do NOT map them to friendly labels.
+        var statusRepl = newReplForProject(tempDir);
+        writeSkillDraftArtifacts(tempDir);
+        Path snapshot = tempDir.resolve(".aceclaw/metrics/continuous-learning/skill-draft-validation-snapshot.json");
+        Files.writeString(snapshot, """
+                {
+                  "updatedAt": "2026-04-17T12:00:00Z",
+                  "trigger": "auto-promotion",
+                  "drafts": [
+                    {
+                      "draftPath": ".aceclaw/skills-drafts/retry-safe/SKILL.md",
+                      "verdict": "hold",
+                      "reasons": [
+                        {"gate":"static","code":"STATIC_ALLOWED_TOOLS_POLICY_VIOLATION","outcome":"hold","message":"allowed-tools includes unsafe entries"}
+                      ]
+                    }
+                  ]
+                }
+                """);
+
+        String summary = (String) invokePrivate(statusRepl, "skillDraftStatusSummary",
+                new Class<?>[]{Path.class}, tempDir);
+        assertThat(summary).isEqualTo("1(p:0,h:1,b:0,n:0) [STATIC_ALLOWED_TOOLS_POLICY_VIOLATION]");
     }
 
     @Test
@@ -640,7 +699,7 @@ class TerminalReplTest {
 
         String summary = (String) invokePrivate(statusRepl, "skillDraftStatusSummary",
                 new Class<?>[]{Path.class}, tempDir);
-        assertThat(summary).isEqualTo("1(p:0,h:1,b:0,n:0) [REPLAY_GATE_FAILED]");
+        assertThat(summary).isEqualTo("1(p:0,h:1,b:0,n:0) [replay gate failed]");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Closes #414.
- On a fresh workspace (no replay benchmark yet) the learning status line used to show \`drafts=4(p:0,h:4,b:0,n:0) [REPLAY_REPORT_MISSING]\`, which looked broken even though nothing was wrong — the user just hadn't set up the pipeline yet.
- Map the two workspace-level reason codes to lowercase friendly labels. Per-draft codes (\`STATIC_*\`, \`SAFETY_*\`, \`DRY_RUN_*\`) deliberately fall through to the raw code since they point at a specific frontmatter fix.

## Before / After

Before:

\`\`\`
drafts=4(p:0,h:4,b:0,n:0) [REPLAY_REPORT_MISSING]
drafts=4(p:0,h:4,b:0,n:0) [REPLAY_GATE_FAILED]
drafts=2(p:0,h:1,b:1,n:0) [STATIC_ALLOWED_TOOLS_POLICY_VIOLATION]
\`\`\`

After:

\`\`\`
drafts=4(p:0,h:4,b:0,n:0) [no replay data]
drafts=4(p:0,h:4,b:0,n:0) [replay gate failed]
drafts=2(p:0,h:1,b:1,n:0) [STATIC_ALLOWED_TOOLS_POLICY_VIOLATION]   ← unchanged
\`\`\`

## Scope

Pure display layer in \`TerminalRepl.skillDraftStatusSummary\`. Single static map, ~15 lines.

No semantics change:
- Audit log still writes raw codes.
- Snapshot still writes raw codes.
- Inspecting via \`/skills drafts\` / audit log still shows the raw code for grep-ability.

Only the one-line status-bar display is softened.

## Test plan

- [x] \`./gradlew build\` — passes (53 tasks)
- [x] New: \`skillDraftStatusSummary_replayReportMissingRendersAsFriendlyLabel\`
- [x] New: \`skillDraftStatusSummary_perDraftReasonsKeepRawCode\`
- [x] Updated: \`skillDraftStatusSummary_dominantReasonOnlyReflectsHoldDrafts\` asserts \`[replay gate failed]\`
- [x] Updated: \`skillDraftStatusSummary_prefersSnapshotOverStaleAudit\` asserts \`[replay gate failed]\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)