### PR TITLE
feat(core): LLM request attribution — full A.1 + A.2 (#419)

### DIFF
--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/AgentLoop.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/AgentLoop.java
@@ -95,7 +95,7 @@ public final class AgentLoop {
         int totalCacheCreationTokens = 0;
         int totalCacheReadTokens = 0;
         int llmRequestCount = 0;
-        var attributionBuilder = dev.aceclaw.core.llm.RequestAttribution.builder();
+        var attributionBuilder = RequestAttribution.builder();
         int maxIterations = config.effectiveMaxIterations();
 
         try {
@@ -105,7 +105,7 @@ public final class AgentLoop {
                 // Build and send the LLM request
                 var request = buildRequest(allMessages);
                 llmRequestCount++;
-                attributionBuilder.record(dev.aceclaw.core.llm.RequestSource.MAIN_TURN);
+                attributionBuilder.record(RequestSource.MAIN_TURN);
                 var response = llmClient.sendMessage(request);
 
                 // Accumulate usage

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/AgentLoop.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/AgentLoop.java
@@ -77,6 +77,18 @@ public final class AgentLoop {
      * @throws LlmException if the LLM call fails
      */
     public Turn runTurn(String userPrompt, List<Message> conversationHistory) throws LlmException {
+        return runTurn(userPrompt, conversationHistory, RequestSource.MAIN_TURN);
+    }
+
+    /**
+     * Runs a single agent turn attributing every LLM request to an explicit
+     * {@link RequestSource}. Callers that issue a turn outside the normal interactive path
+     * (e.g. SequentialPlanExecutor fallback paths attribute as FALLBACK) pass the relevant
+     * source here so the resulting Turn's requestAttribution reflects what actually produced
+     * the work.
+     */
+    public Turn runTurn(String userPrompt, List<Message> conversationHistory,
+                        RequestSource defaultSource) throws LlmException {
         long turnStart = System.currentTimeMillis();
         int turnNumber = (int) conversationHistory.stream()
                 .filter(m -> m instanceof Message.UserMessage).count() + 1;
@@ -105,7 +117,7 @@ public final class AgentLoop {
                 // Build and send the LLM request
                 var request = buildRequest(allMessages);
                 llmRequestCount++;
-                attributionBuilder.record(RequestSource.MAIN_TURN);
+                attributionBuilder.record(defaultSource);
                 var response = llmClient.sendMessage(request);
 
                 // Accumulate usage

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/AgentLoop.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/AgentLoop.java
@@ -95,6 +95,7 @@ public final class AgentLoop {
         int totalCacheCreationTokens = 0;
         int totalCacheReadTokens = 0;
         int llmRequestCount = 0;
+        var attributionBuilder = dev.aceclaw.core.llm.RequestAttribution.builder();
         int maxIterations = config.effectiveMaxIterations();
 
         try {
@@ -104,6 +105,7 @@ public final class AgentLoop {
                 // Build and send the LLM request
                 var request = buildRequest(allMessages);
                 llmRequestCount++;
+                attributionBuilder.record(dev.aceclaw.core.llm.RequestSource.MAIN_TURN);
                 var response = llmClient.sendMessage(request);
 
                 // Accumulate usage
@@ -127,7 +129,8 @@ public final class AgentLoop {
                                 totalInputTokens, totalOutputTokens,
                                 totalCacheCreationTokens, totalCacheReadTokens);
                         var turn = new Turn(newMessages, response.stopReason(), totalUsage,
-                                llmRequestCount);
+                                null, false, false, null, llmRequestCount,
+                                attributionBuilder.build());
                         long durationMs = System.currentTimeMillis() - turnStart;
                         publishEvent(new AgentEvent.TurnCompleted(
                                 config.sessionId(), turnNumber, durationMs, Instant.now()));
@@ -164,7 +167,7 @@ public final class AgentLoop {
                     totalInputTokens, totalOutputTokens,
                     totalCacheCreationTokens, totalCacheReadTokens);
             var turn = new Turn(newMessages, StopReason.END_TURN, totalUsage, null, true,
-                    llmRequestCount);
+                    false, null, llmRequestCount, attributionBuilder.build());
             long durationMs = System.currentTimeMillis() - turnStart;
             publishEvent(new AgentEvent.TurnCompleted(
                     config.sessionId(), turnNumber, durationMs, Instant.now()));

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/CompactionResult.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/CompactionResult.java
@@ -1,6 +1,7 @@
 package dev.aceclaw.core.agent;
 
 import dev.aceclaw.core.llm.Message;
+import dev.aceclaw.core.llm.RequestAttribution;
 
 import java.util.List;
 
@@ -12,18 +13,34 @@ import java.util.List;
  * @param compactedTokenEstimate estimated tokens after compaction
  * @param phaseReached          the deepest compaction phase that was executed
  * @param extractedContext      key context items extracted during Phase 0 (memory flush)
+ * @param requestAttribution    LLM requests this compaction made — empty for phase NONE/PRUNED,
+ *                              one COMPACTION_SUMMARY request for phase SUMMARIZED. Callers fold
+ *                              this into the parent turn's attribution so the summary call is
+ *                              counted and categorised separately from the main turn
  */
 public record CompactionResult(
         List<Message> compactedMessages,
         int originalTokenEstimate,
         int compactedTokenEstimate,
         Phase phaseReached,
-        List<String> extractedContext
+        List<String> extractedContext,
+        RequestAttribution requestAttribution
 ) {
 
     public CompactionResult {
         compactedMessages = List.copyOf(compactedMessages);
         extractedContext = List.copyOf(extractedContext);
+        requestAttribution = requestAttribution != null ? requestAttribution : RequestAttribution.empty();
+    }
+
+    /** Backward-compatible constructor used by callers that predate request attribution. */
+    public CompactionResult(List<Message> compactedMessages,
+                            int originalTokenEstimate,
+                            int compactedTokenEstimate,
+                            Phase phaseReached,
+                            List<String> extractedContext) {
+        this(compactedMessages, originalTokenEstimate, compactedTokenEstimate, phaseReached,
+                extractedContext, RequestAttribution.empty());
     }
 
     /**

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/MessageCompactor.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/MessageCompactor.java
@@ -197,10 +197,11 @@ public final class MessageCompactor {
         if (prunedEstimate <= config.pruneTargetTokens()) {
             return new CompactionResult(
                     pruned, originalEstimate, prunedEstimate,
-                    CompactionResult.Phase.PRUNED, extractedContext);
+                    CompactionResult.Phase.PRUNED, extractedContext,
+                    RequestAttribution.empty());
         }
 
-        // Phase 2: LLM summarization
+        // Phase 2: LLM summarization — issues one COMPACTION_SUMMARY request.
         var summarized = summarizeMessages(pruned, systemPrompt);
         int summarizedEstimate = ContextEstimator.estimateFullContext(
                 systemPrompt, List.of(), summarized);
@@ -210,9 +211,12 @@ public final class MessageCompactor {
                 prunedEstimate, summarizedEstimate, pruned.size(), summarized.size(),
                 String.format("%.1f", reduction));
 
+        var attribution = RequestAttribution.builder()
+                .record(RequestSource.COMPACTION_SUMMARY)
+                .build();
         return new CompactionResult(
                 summarized, originalEstimate, summarizedEstimate,
-                CompactionResult.Phase.SUMMARIZED, extractedContext);
+                CompactionResult.Phase.SUMMARIZED, extractedContext, attribution);
     }
 
     // -- Phase 0: Memory Flush -----------------------------------------------

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/StreamingAgentLoop.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/StreamingAgentLoop.java
@@ -139,7 +139,7 @@ public final class StreamingAgentLoop {
      */
     public Turn runTurn(String userPrompt, List<Message> conversationHistory, StreamEventHandler handler)
             throws LlmException {
-        return runTurn(userPrompt, conversationHistory, handler, null);
+        return runTurn(userPrompt, conversationHistory, handler, null, RequestSource.MAIN_TURN);
     }
 
     /**
@@ -147,6 +147,22 @@ public final class StreamingAgentLoop {
      */
     public Turn runTurn(String userPrompt, List<Message> conversationHistory,
                         StreamEventHandler handler, CancellationToken cancellationToken)
+            throws LlmException {
+        return runTurn(userPrompt, conversationHistory, handler, cancellationToken,
+                RequestSource.MAIN_TURN);
+    }
+
+    /**
+     * Runs a single agent turn with streaming, cancellation, and an explicit default
+     * {@link RequestSource} used to attribute every MAIN_TURN-style LLM request produced by
+     * this turn. Callers issuing a non-normal turn (e.g. SequentialPlanExecutor fallback
+     * steps attribute as FALLBACK) pass the appropriate source here; CONTINUATION and
+     * COMPACTION_SUMMARY are still set internally based on loop state, overriding the
+     * caller-provided default only for those specific requests.
+     */
+    public Turn runTurn(String userPrompt, List<Message> conversationHistory,
+                        StreamEventHandler handler, CancellationToken cancellationToken,
+                        RequestSource defaultSource)
             throws LlmException {
         var eventHandler = handler != null ? handler : new StreamEventHandler() {};
         this.activeCancellationToken = cancellationToken;
@@ -169,6 +185,11 @@ public final class StreamingAgentLoop {
         int totalCacheReadTokens = 0;
         int llmRequestCount = 0;
         var attributionBuilder = RequestAttribution.builder();
+        // Flipped true immediately after compaction mutates the message list. The next
+        // iteration's LLM call resumes on the compacted conversation with the injected
+        // "continuation instruction" user message, so that request is attributed as
+        // CONTINUATION rather than MAIN_TURN. Reset after the request is recorded.
+        boolean postCompaction = false;
 
         // Track actual input tokens from API for accurate compaction decisions
         int lastInputTokens = -1;
@@ -249,6 +270,16 @@ public final class StreamingAgentLoop {
                         // Compaction ran this iteration and mutated allMessages;
                         // use compacted version for the request.
                         requestMessages = allMessages;
+                        // Absorb the compaction's own LLM request(s) — currently at most one
+                        // COMPACTION_SUMMARY — into the turn totals. Without this, summaries
+                        // ran invisibly (not reflected in llmRequestCount or attribution).
+                        var compactionAttribution = compactionResult.requestAttribution();
+                        if (compactionAttribution.total() > 0) {
+                            attributionBuilder.merge(compactionAttribution);
+                            llmRequestCount += compactionAttribution.total();
+                        }
+                        // Next request resumes on the compacted conversation.
+                        postCompaction = true;
                     }
                 }
 
@@ -274,7 +305,11 @@ public final class StreamingAgentLoop {
                 for (int streamAttempt = 0; streamAttempt <= retryConfig.maxRetries(); streamAttempt++) {
                     accumulator = new StreamAccumulator(eventHandler);
                     llmRequestCount++;
-                    attributionBuilder.record(RequestSource.MAIN_TURN);
+                    // CONTINUATION wins over defaultSource only for the first request after
+                    // compaction; MAIN_TURN / FALLBACK apply in normal iterations. Retries of
+                    // a single LLM call fold into the same source per the #419 decision.
+                    RequestSource source = postCompaction ? RequestSource.CONTINUATION : defaultSource;
+                    attributionBuilder.record(source);
                     var session = llmClient.streamMessage(request);
 
                     // Register the session with the cancellation token so cancel() propagates
@@ -308,6 +343,9 @@ public final class StreamingAgentLoop {
                         throw new LlmException("Stream retry interrupted", ie);
                     }
                 }
+                // This iteration's LLM call (plus any retries) is done; consume the flag so
+                // only the first post-compaction request is attributed as CONTINUATION.
+                postCompaction = false;
 
                 // Checkpoint 2: after stream completes
                 if (cancellationToken != null && cancellationToken.isCancelled()) {

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/StreamingAgentLoop.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/StreamingAgentLoop.java
@@ -168,7 +168,7 @@ public final class StreamingAgentLoop {
         int totalCacheCreationTokens = 0;
         int totalCacheReadTokens = 0;
         int llmRequestCount = 0;
-        var attributionBuilder = dev.aceclaw.core.llm.RequestAttribution.builder();
+        var attributionBuilder = RequestAttribution.builder();
 
         // Track actual input tokens from API for accurate compaction decisions
         int lastInputTokens = -1;
@@ -274,7 +274,7 @@ public final class StreamingAgentLoop {
                 for (int streamAttempt = 0; streamAttempt <= retryConfig.maxRetries(); streamAttempt++) {
                     accumulator = new StreamAccumulator(eventHandler);
                     llmRequestCount++;
-                    attributionBuilder.record(dev.aceclaw.core.llm.RequestSource.MAIN_TURN);
+                    attributionBuilder.record(RequestSource.MAIN_TURN);
                     var session = llmClient.streamMessage(request);
 
                     // Register the session with the cancellation token so cancel() propagates
@@ -464,7 +464,7 @@ public final class StreamingAgentLoop {
                                     int totalCacheCreationTokens, int totalCacheReadTokens,
                                     CompactionResult compactionResult,
                                     int llmRequestCount,
-                                    dev.aceclaw.core.llm.RequestAttribution attribution) {
+                                    RequestAttribution attribution) {
         return buildCancelledTurn(newMessages, totalInputTokens, totalOutputTokens,
                 totalCacheCreationTokens, totalCacheReadTokens, compactionResult, false,
                 llmRequestCount, attribution);
@@ -479,7 +479,7 @@ public final class StreamingAgentLoop {
                                     CompactionResult compactionResult,
                                     boolean softBudgetStopped,
                                     int llmRequestCount,
-                                    dev.aceclaw.core.llm.RequestAttribution attribution) {
+                                    RequestAttribution attribution) {
         var totalUsage = new Usage(totalInputTokens, totalOutputTokens,
                 totalCacheCreationTokens, totalCacheReadTokens);
         var watchdog = config.watchdog();
@@ -490,7 +490,7 @@ public final class StreamingAgentLoop {
         }
         return new Turn(newMessages, StopReason.END_TURN, totalUsage, compactionResult,
                 false, budgetExhausted, reason, llmRequestCount,
-                attribution != null ? attribution : dev.aceclaw.core.llm.RequestAttribution.empty());
+                attribution != null ? attribution : RequestAttribution.empty());
     }
 
     /**

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/StreamingAgentLoop.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/StreamingAgentLoop.java
@@ -168,6 +168,7 @@ public final class StreamingAgentLoop {
         int totalCacheCreationTokens = 0;
         int totalCacheReadTokens = 0;
         int llmRequestCount = 0;
+        var attributionBuilder = dev.aceclaw.core.llm.RequestAttribution.builder();
 
         // Track actual input tokens from API for accurate compaction decisions
         int lastInputTokens = -1;
@@ -224,7 +225,7 @@ public final class StreamingAgentLoop {
                     log.info("Cancellation detected before LLM call (iteration {})", iteration + 1);
                     var turn = buildCancelledTurn(newMessages, totalInputTokens, totalOutputTokens,
                             totalCacheCreationTokens, totalCacheReadTokens, compactionResult,
-                            softBudgetStopped, llmRequestCount);
+                            softBudgetStopped, llmRequestCount, attributionBuilder.build());
                     publishTurnCompleted(turnNumber, turnStart);
                     return turn;
                 }
@@ -273,6 +274,7 @@ public final class StreamingAgentLoop {
                 for (int streamAttempt = 0; streamAttempt <= retryConfig.maxRetries(); streamAttempt++) {
                     accumulator = new StreamAccumulator(eventHandler);
                     llmRequestCount++;
+                    attributionBuilder.record(dev.aceclaw.core.llm.RequestSource.MAIN_TURN);
                     var session = llmClient.streamMessage(request);
 
                     // Register the session with the cancellation token so cancel() propagates
@@ -340,7 +342,7 @@ public final class StreamingAgentLoop {
                     }
                     var turn = buildCancelledTurn(newMessages, totalInputTokens, totalOutputTokens,
                             totalCacheCreationTokens, totalCacheReadTokens, compactionResult,
-                            llmRequestCount);
+                            llmRequestCount, attributionBuilder.build());
                     publishTurnCompleted(turnNumber, turnStart);
                     return turn;
                 }
@@ -387,7 +389,7 @@ public final class StreamingAgentLoop {
                                 totalInputTokens, totalOutputTokens,
                                 totalCacheCreationTokens, totalCacheReadTokens);
                         var turn = new Turn(newMessages, stopReason, totalUsage, compactionResult,
-                                llmRequestCount);
+                                false, false, null, llmRequestCount, attributionBuilder.build());
                         publishTurnCompleted(turnNumber, turnStart);
                         return turn;
                     }
@@ -422,7 +424,7 @@ public final class StreamingAgentLoop {
                             log.info("Cancellation detected after tool execution (iteration {})", iteration + 1);
                             var turn = buildCancelledTurn(newMessages, totalInputTokens, totalOutputTokens,
                                     totalCacheCreationTokens, totalCacheReadTokens, compactionResult,
-                                    llmRequestCount);
+                                    llmRequestCount, attributionBuilder.build());
                             publishTurnCompleted(turnNumber, turnStart);
                             return turn;
                         }
@@ -436,7 +438,7 @@ public final class StreamingAgentLoop {
                     totalInputTokens, totalOutputTokens,
                     totalCacheCreationTokens, totalCacheReadTokens);
             var turn = new Turn(newMessages, StopReason.END_TURN, totalUsage, compactionResult,
-                    true, llmRequestCount);
+                    true, false, null, llmRequestCount, attributionBuilder.build());
             publishTurnCompleted(turnNumber, turnStart);
             return turn;
         } catch (LlmException e) {
@@ -461,10 +463,11 @@ public final class StreamingAgentLoop {
                                     int totalInputTokens, int totalOutputTokens,
                                     int totalCacheCreationTokens, int totalCacheReadTokens,
                                     CompactionResult compactionResult,
-                                    int llmRequestCount) {
+                                    int llmRequestCount,
+                                    dev.aceclaw.core.llm.RequestAttribution attribution) {
         return buildCancelledTurn(newMessages, totalInputTokens, totalOutputTokens,
                 totalCacheCreationTokens, totalCacheReadTokens, compactionResult, false,
-                llmRequestCount);
+                llmRequestCount, attribution);
     }
 
     /**
@@ -475,7 +478,8 @@ public final class StreamingAgentLoop {
                                     int totalCacheCreationTokens, int totalCacheReadTokens,
                                     CompactionResult compactionResult,
                                     boolean softBudgetStopped,
-                                    int llmRequestCount) {
+                                    int llmRequestCount,
+                                    dev.aceclaw.core.llm.RequestAttribution attribution) {
         var totalUsage = new Usage(totalInputTokens, totalOutputTokens,
                 totalCacheCreationTokens, totalCacheReadTokens);
         var watchdog = config.watchdog();
@@ -485,7 +489,8 @@ public final class StreamingAgentLoop {
             reason = "soft_budget_no_progress";
         }
         return new Turn(newMessages, StopReason.END_TURN, totalUsage, compactionResult,
-                false, budgetExhausted, reason, llmRequestCount);
+                false, budgetExhausted, reason, llmRequestCount,
+                attribution != null ? attribution : dev.aceclaw.core.llm.RequestAttribution.empty());
     }
 
     /**

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/Turn.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/Turn.java
@@ -1,6 +1,7 @@
 package dev.aceclaw.core.agent;
 
 import dev.aceclaw.core.llm.Message;
+import dev.aceclaw.core.llm.RequestAttribution;
 import dev.aceclaw.core.llm.StopReason;
 import dev.aceclaw.core.llm.Usage;
 
@@ -17,6 +18,9 @@ import java.util.List;
  * @param budgetExhausted         whether the turn was stopped by a watchdog budget limit
  * @param budgetExhaustionReason  the budget that was exhausted: {@code "turn_budget"}, {@code "time_budget"}, or null
  * @param llmRequestCount  number of LLM API requests sent during this turn (attempts, including retries)
+ * @param requestAttribution  breakdown of llmRequestCount by {@link dev.aceclaw.core.llm.RequestSource};
+ *                            the invariant {@code requestAttribution.total() == llmRequestCount} holds
+ *                            whenever both are populated by the agent loop
  */
 public record Turn(
         List<Message> newMessages,
@@ -26,19 +30,22 @@ public record Turn(
         boolean maxIterationsReached,
         boolean budgetExhausted,
         String budgetExhaustionReason,
-        int llmRequestCount
+        int llmRequestCount,
+        RequestAttribution requestAttribution
 ) {
 
     public Turn {
         newMessages = newMessages != null ? List.copyOf(newMessages) : List.of();
         llmRequestCount = Math.max(0, llmRequestCount);
+        requestAttribution = requestAttribution != null ? requestAttribution : RequestAttribution.empty();
     }
 
     /**
      * Creates a turn result without compaction info (backward-compatible).
      */
     public Turn(List<Message> newMessages, StopReason finalStopReason, Usage totalUsage) {
-        this(newMessages, finalStopReason, totalUsage, null, false, false, null, 0);
+        this(newMessages, finalStopReason, totalUsage, null, false, false, null, 0,
+                RequestAttribution.empty());
     }
 
     /**
@@ -46,7 +53,8 @@ public record Turn(
      */
     public Turn(List<Message> newMessages, StopReason finalStopReason, Usage totalUsage,
                 int llmRequestCount) {
-        this(newMessages, finalStopReason, totalUsage, null, false, false, null, llmRequestCount);
+        this(newMessages, finalStopReason, totalUsage, null, false, false, null, llmRequestCount,
+                RequestAttribution.empty());
     }
 
     /**
@@ -54,7 +62,8 @@ public record Turn(
      */
     public Turn(List<Message> newMessages, StopReason finalStopReason, Usage totalUsage,
                 CompactionResult compactionResult) {
-        this(newMessages, finalStopReason, totalUsage, compactionResult, false, false, null, 0);
+        this(newMessages, finalStopReason, totalUsage, compactionResult, false, false, null, 0,
+                RequestAttribution.empty());
     }
 
     /**
@@ -63,7 +72,7 @@ public record Turn(
     public Turn(List<Message> newMessages, StopReason finalStopReason, Usage totalUsage,
                 CompactionResult compactionResult, int llmRequestCount) {
         this(newMessages, finalStopReason, totalUsage, compactionResult, false, false, null,
-                llmRequestCount);
+                llmRequestCount, RequestAttribution.empty());
     }
 
     /**
@@ -72,7 +81,7 @@ public record Turn(
     public Turn(List<Message> newMessages, StopReason finalStopReason, Usage totalUsage,
                 CompactionResult compactionResult, boolean maxIterationsReached) {
         this(newMessages, finalStopReason, totalUsage, compactionResult, maxIterationsReached,
-                false, null, 0);
+                false, null, 0, RequestAttribution.empty());
     }
 
     /**
@@ -82,7 +91,7 @@ public record Turn(
                 CompactionResult compactionResult, boolean maxIterationsReached,
                 int llmRequestCount) {
         this(newMessages, finalStopReason, totalUsage, compactionResult, maxIterationsReached,
-                false, null, llmRequestCount);
+                false, null, llmRequestCount, RequestAttribution.empty());
     }
 
     /**
@@ -92,7 +101,19 @@ public record Turn(
                 CompactionResult compactionResult, boolean maxIterationsReached,
                 boolean budgetExhausted, String budgetExhaustionReason) {
         this(newMessages, finalStopReason, totalUsage, compactionResult, maxIterationsReached,
-                budgetExhausted, budgetExhaustionReason, 0);
+                budgetExhausted, budgetExhaustionReason, 0, RequestAttribution.empty());
+    }
+
+    /**
+     * Creates a turn result with full status info (budget exhaustion) and LLM request count.
+     */
+    public Turn(List<Message> newMessages, StopReason finalStopReason, Usage totalUsage,
+                CompactionResult compactionResult, boolean maxIterationsReached,
+                boolean budgetExhausted, String budgetExhaustionReason,
+                int llmRequestCount) {
+        this(newMessages, finalStopReason, totalUsage, compactionResult, maxIterationsReached,
+                budgetExhausted, budgetExhaustionReason, llmRequestCount,
+                RequestAttribution.empty());
     }
 
     /**

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/llm/RequestAttribution.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/llm/RequestAttribution.java
@@ -113,6 +113,20 @@ public record RequestAttribution(Map<RequestSource, Integer> bySource, int total
             return this;
         }
 
+        /**
+         * Folds another attribution's per-source counts into this builder. Used by the
+         * streaming loop to absorb compaction-summary requests produced by MessageCompactor
+         * into the parent turn's attribution, and by plan executors to aggregate step
+         * attributions into a plan-level total.
+         */
+        public Builder merge(RequestAttribution other) {
+            if (other == null || other.total == 0) return this;
+            for (Map.Entry<RequestSource, Integer> e : other.bySource.entrySet()) {
+                record(e.getKey(), e.getValue());
+            }
+            return this;
+        }
+
         public int total() {
             return total;
         }

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/llm/RequestAttribution.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/llm/RequestAttribution.java
@@ -62,6 +62,7 @@ public record RequestAttribution(Map<RequestSource, Integer> bySource, int total
      * Returns the count attributed to the given source, or zero if that source never fired.
      */
     public int count(RequestSource source) {
+        Objects.requireNonNull(source, "source");
         return bySource.getOrDefault(source, 0);
     }
 

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/llm/RequestAttribution.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/llm/RequestAttribution.java
@@ -1,0 +1,125 @@
+package dev.aceclaw.core.llm;
+
+import java.util.EnumMap;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Breakdown of LLM request counts by {@link RequestSource}. Used to attribute the
+ * aggregate {@code llmRequestCount} on {@link dev.aceclaw.core.agent.Turn} and related
+ * result types so consumers can see which execution paths drive premium-request spend.
+ *
+ * <p>The invariant {@link #total()} {@code ==} sum of per-source counts is enforced by
+ * construction — the record exposes a read-only map and computes the total once.
+ *
+ * <p>Instances are immutable; use {@link Builder} to accumulate counts over a scope,
+ * then call {@link Builder#build()} to materialise the final snapshot.
+ */
+public record RequestAttribution(Map<RequestSource, Integer> bySource, int total) {
+
+    private static final RequestAttribution EMPTY =
+            new RequestAttribution(Collections.emptyMap(), 0);
+
+    public RequestAttribution {
+        Objects.requireNonNull(bySource, "bySource");
+        if (total < 0) {
+            throw new IllegalArgumentException("total must be non-negative: " + total);
+        }
+        int sum = 0;
+        for (Map.Entry<RequestSource, Integer> e : bySource.entrySet()) {
+            if (e.getKey() == null) {
+                throw new IllegalArgumentException("null source in bySource map");
+            }
+            int count = e.getValue() == null ? 0 : e.getValue();
+            if (count < 0) {
+                throw new IllegalArgumentException(
+                        "negative count for " + e.getKey() + ": " + count);
+            }
+            sum += count;
+        }
+        if (sum != total) {
+            throw new IllegalArgumentException(
+                    "total " + total + " does not match sum of per-source counts " + sum);
+        }
+        // Defensive copy, preserving EnumMap iteration order for deterministic JSON.
+        var copy = new EnumMap<RequestSource, Integer>(RequestSource.class);
+        for (Map.Entry<RequestSource, Integer> e : bySource.entrySet()) {
+            int count = e.getValue() == null ? 0 : e.getValue();
+            if (count > 0) {
+                copy.put(e.getKey(), count);
+            }
+        }
+        bySource = Collections.unmodifiableMap(copy);
+    }
+
+    /** The canonical empty attribution, representing "no LLM requests recorded". */
+    public static RequestAttribution empty() {
+        return EMPTY;
+    }
+
+    /**
+     * Returns the count attributed to the given source, or zero if that source never fired.
+     */
+    public int count(RequestSource source) {
+        return bySource.getOrDefault(source, 0);
+    }
+
+    /**
+     * Merges two attributions into a new one. Counts add per source; the resulting total
+     * equals this.total + other.total.
+     */
+    public RequestAttribution merge(RequestAttribution other) {
+        if (other == null || other.total == 0) return this;
+        if (this.total == 0) return other;
+        var merged = new EnumMap<RequestSource, Integer>(RequestSource.class);
+        for (Map.Entry<RequestSource, Integer> e : this.bySource.entrySet()) {
+            merged.merge(e.getKey(), e.getValue(), Integer::sum);
+        }
+        for (Map.Entry<RequestSource, Integer> e : other.bySource.entrySet()) {
+            merged.merge(e.getKey(), e.getValue(), Integer::sum);
+        }
+        return new RequestAttribution(merged, this.total + other.total);
+    }
+
+    /** Starts a new mutable accumulator. */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Mutable accumulator for a single scope (one turn, one plan step, one planner call).
+     * Not thread-safe; call sites are expected to be single-threaded per scope.
+     */
+    public static final class Builder {
+        private final EnumMap<RequestSource, Integer> counts =
+                new EnumMap<>(RequestSource.class);
+        private int total;
+
+        private Builder() {}
+
+        public Builder record(RequestSource source) {
+            return record(source, 1);
+        }
+
+        public Builder record(RequestSource source, int count) {
+            Objects.requireNonNull(source, "source");
+            if (count < 0) {
+                throw new IllegalArgumentException("count must be non-negative: " + count);
+            }
+            if (count == 0) return this;
+            counts.merge(source, count, Integer::sum);
+            total += count;
+            return this;
+        }
+
+        public int total() {
+            return total;
+        }
+
+        public RequestAttribution build() {
+            if (total == 0) return EMPTY;
+            return new RequestAttribution(counts, total);
+        }
+    }
+}

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/llm/RequestSource.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/llm/RequestSource.java
@@ -1,0 +1,30 @@
+package dev.aceclaw.core.llm;
+
+/**
+ * Identifies which execution path issued an LLM request, so the daemon can attribute
+ * cumulative request counts by source. Used to build the baseline data needed to tune
+ * Copilot premium-request spending (issue #418/#419) without guessing.
+ *
+ * <p>Per the pre-implementation decision on #419, retries are folded into their parent
+ * source rather than carrying a dedicated {@code RETRY} category. A main-turn retry
+ * therefore increments {@link #MAIN_TURN} by two, not one each for main + retry.
+ */
+public enum RequestSource {
+    /** Normal streaming or non-streaming agent turn — the ReAct iteration request. */
+    MAIN_TURN,
+
+    /** An upfront planning request issued by {@code LLMTaskPlanner}. */
+    PLANNER,
+
+    /** A continuation iteration that resumes a turn after context compaction. */
+    CONTINUATION,
+
+    /** A plan step executed as a fallback path (e.g. step retry inside the plan executor). */
+    FALLBACK,
+
+    /** An adaptive replan request issued after a plan step fails. */
+    REPLAN,
+
+    /** The LLM summarization request issued during context compaction's phase 2. */
+    COMPACTION_SUMMARY
+}

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/planner/AdaptiveReplanner.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/planner/AdaptiveReplanner.java
@@ -6,6 +6,8 @@ import dev.aceclaw.core.llm.LlmClient;
 import dev.aceclaw.core.llm.LlmException;
 import dev.aceclaw.core.llm.LlmRequest;
 import dev.aceclaw.core.llm.Message;
+import dev.aceclaw.core.llm.RequestAttribution;
+import dev.aceclaw.core.llm.RequestSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,6 +85,17 @@ public final class AdaptiveReplanner {
      * @throws LlmException if the LLM call fails
      */
     public ReplanResult replan(ReplanTrigger trigger) throws LlmException {
+        return replan(trigger, null);
+    }
+
+    /**
+     * Attribution-aware variant. Records one {@link RequestSource#REPLAN} entry per LLM
+     * request on the supplied builder if non-null. Pre-attempt escalations (e.g. hitting
+     * the attempt cap) return without issuing an LLM call, so nothing is recorded in that
+     * path — the attribution total matches actual API cost.
+     */
+    public ReplanResult replan(ReplanTrigger trigger, RequestAttribution.Builder attribution)
+            throws LlmException {
         Objects.requireNonNull(trigger, "trigger");
 
         if (trigger.replanAttempt() > MAX_REPLAN_ATTEMPTS) {
@@ -103,6 +116,9 @@ public final class AdaptiveReplanner {
                 .build();
 
         var response = llmClient.sendMessage(request);
+        if (attribution != null) {
+            attribution.record(RequestSource.REPLAN);
+        }
         var text = response.text();
 
         if (text == null || text.isBlank()) {

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/planner/PlanExecutionResult.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/planner/PlanExecutionResult.java
@@ -1,6 +1,7 @@
 package dev.aceclaw.core.planner;
 
 import dev.aceclaw.core.llm.Message;
+import dev.aceclaw.core.llm.RequestAttribution;
 
 import java.util.List;
 import java.util.Objects;
@@ -14,6 +15,10 @@ import java.util.Objects;
  * @param totalDurationMs wall-clock time for the entire plan execution
  * @param success         whether all attempted steps completed successfully
  * @param totalTokensUsed total tokens consumed across all steps
+ * @param requestAttribution aggregated LLM request breakdown across all step results plus any
+ *                            REPLAN requests made during execution. Does NOT include the
+ *                            upfront PLANNER request; that's issued by the caller before the
+ *                            executor runs and must be merged separately
  */
 public record PlanExecutionResult(
         TaskPlan plan,
@@ -21,12 +26,25 @@ public record PlanExecutionResult(
         List<Message> messages,
         long totalDurationMs,
         boolean success,
-        int totalTokensUsed
+        int totalTokensUsed,
+        RequestAttribution requestAttribution
 ) {
 
     public PlanExecutionResult {
         Objects.requireNonNull(plan, "plan");
         stepResults = stepResults != null ? List.copyOf(stepResults) : List.of();
         messages = messages != null ? List.copyOf(messages) : List.of();
+        requestAttribution = requestAttribution != null ? requestAttribution : RequestAttribution.empty();
+    }
+
+    /** Backward-compatible constructor for callers predating request attribution. */
+    public PlanExecutionResult(TaskPlan plan,
+                               List<StepResult> stepResults,
+                               List<Message> messages,
+                               long totalDurationMs,
+                               boolean success,
+                               int totalTokensUsed) {
+        this(plan, stepResults, messages, totalDurationMs, success, totalTokensUsed,
+                RequestAttribution.empty());
     }
 }

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/planner/SequentialPlanExecutor.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/planner/SequentialPlanExecutor.java
@@ -5,6 +5,8 @@ import dev.aceclaw.core.agent.StreamingAgentLoop;
 import dev.aceclaw.core.agent.WatchdogTimer;
 import dev.aceclaw.core.llm.LlmException;
 import dev.aceclaw.core.llm.Message;
+import dev.aceclaw.core.llm.RequestAttribution;
+import dev.aceclaw.core.llm.RequestSource;
 import dev.aceclaw.core.llm.StreamEventHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -121,6 +123,10 @@ public final class SequentialPlanExecutor implements PlanExecutor {
         // Global replan budget for the entire plan execution (not per-step).
         // This prevents runaway replanning across multiple failing steps.
         int replanAttempt = 0;
+        // Aggregated attribution across step turns + replan LLM calls. Upfront PLANNER
+        // requests happen before the executor is invoked so they're not in this total;
+        // the caller (StreamingAgentHandler) merges its own planner count on top.
+        var replanAttribution = RequestAttribution.builder();
 
         stepLoop:
         for (int i = 0; i < plan.steps().size(); i++) {
@@ -184,7 +190,8 @@ public final class SequentialPlanExecutor implements PlanExecutor {
             String stepPrompt = buildStepPrompt(step, i, plan, stepResults);
 
             try {
-                var turn = agentLoop.runTurn(stepPrompt, allMessages, handler, cancellationToken);
+                var turn = agentLoop.runTurn(stepPrompt, allMessages, handler, cancellationToken,
+                        RequestSource.MAIN_TURN);
                 allMessages.addAll(turn.newMessages());
                 generatedMessages.addAll(turn.newMessages());
 
@@ -196,7 +203,8 @@ public final class SequentialPlanExecutor implements PlanExecutor {
                         System.currentTimeMillis() - stepStart,
                         usage.inputTokens(),
                         usage.outputTokens(),
-                        turn.llmRequestCount());
+                        turn.llmRequestCount(),
+                        turn.requestAttribution());
                 stepResults.add(result);
 
                 mutablePlan = mutablePlan.withStepStatus(step.stepId(), StepStatus.COMPLETED)
@@ -242,7 +250,8 @@ public final class SequentialPlanExecutor implements PlanExecutor {
                     try {
                         String fallbackPrompt = buildFallbackPrompt(step, e.getMessage());
                         var fallbackTurn = agentLoop.runTurn(
-                                fallbackPrompt, allMessages, handler, cancellationToken);
+                                fallbackPrompt, allMessages, handler, cancellationToken,
+                                RequestSource.FALLBACK);
                         allMessages.addAll(fallbackTurn.newMessages());
                         generatedMessages.addAll(fallbackTurn.newMessages());
 
@@ -254,7 +263,8 @@ public final class SequentialPlanExecutor implements PlanExecutor {
                                 System.currentTimeMillis() - stepStart,
                                 fbUsage.inputTokens(),
                                 fbUsage.outputTokens(),
-                                fallbackTurn.llmRequestCount());
+                                fallbackTurn.llmRequestCount(),
+                                fallbackTurn.requestAttribution());
                         stepResults.add(fallbackResult);
 
                         mutablePlan = mutablePlan.withStepStatus(step.stepId(), StepStatus.COMPLETED)
@@ -317,7 +327,7 @@ public final class SequentialPlanExecutor implements PlanExecutor {
                             stepFailureMessage, completedSummaries, remaining, replanAttempt);
 
                     try {
-                        var replanResult = replanner.replan(trigger);
+                        var replanResult = replanner.replan(trigger, replanAttribution);
                         switch (replanResult) {
                             case ReplanResult.Revised revised -> {
                                 var oldPlan = mutablePlan;
@@ -401,13 +411,22 @@ public final class SequentialPlanExecutor implements PlanExecutor {
         log.info("Plan execution finished: success={}, steps={}/{}, duration={}ms, tokens={}",
                 allSuccess, stepResults.size(), plan.steps().size(), totalDuration, totalTokens);
 
+        // Fold per-step turn attributions into the plan-level total, on top of any REPLAN
+        // requests the executor made directly. The PLANNER request that produced `plan`
+        // itself happens one level up in the caller and is merged there.
+        var planAttribution = replanAttribution;
+        for (var step : stepResults) {
+            planAttribution.merge(step.requestAttribution());
+        }
+
         return new PlanExecutionResult(
                 mutablePlan,
                 stepResults,
                 generatedMessages,
                 totalDuration,
                 allSuccess,
-                totalTokens);
+                totalTokens,
+                planAttribution.build());
     }
 
     /**

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/planner/StepResult.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/planner/StepResult.java
@@ -1,15 +1,18 @@
 package dev.aceclaw.core.planner;
 
+import dev.aceclaw.core.llm.RequestAttribution;
+
 /**
  * Result of executing a single plan step.
  *
- * @param success      whether the step completed successfully
- * @param output       text output produced during this step
- * @param error        error message if the step failed (null on success)
- * @param durationMs   wall-clock time spent on this step
- * @param inputTokens  input tokens consumed by this step
- * @param outputTokens output tokens consumed by this step
- * @param llmRequestCount number of LLM requests sent while executing this step
+ * @param success          whether the step completed successfully
+ * @param output           text output produced during this step
+ * @param error            error message if the step failed (null on success)
+ * @param durationMs       wall-clock time spent on this step
+ * @param inputTokens      input tokens consumed by this step
+ * @param outputTokens     output tokens consumed by this step
+ * @param llmRequestCount  number of LLM requests sent while executing this step
+ * @param requestAttribution breakdown of {@code llmRequestCount} by {@link dev.aceclaw.core.llm.RequestSource}
  */
 public record StepResult(
         boolean success,
@@ -18,16 +21,26 @@ public record StepResult(
         long durationMs,
         int inputTokens,
         int outputTokens,
-        int llmRequestCount
+        int llmRequestCount,
+        RequestAttribution requestAttribution
 ) {
 
     public StepResult {
         llmRequestCount = Math.max(0, llmRequestCount);
+        requestAttribution = requestAttribution != null ? requestAttribution : RequestAttribution.empty();
     }
 
     public StepResult(boolean success, String output, String error,
                       long durationMs, int inputTokens, int outputTokens) {
-        this(success, output, error, durationMs, inputTokens, outputTokens, 0);
+        this(success, output, error, durationMs, inputTokens, outputTokens, 0,
+                RequestAttribution.empty());
+    }
+
+    public StepResult(boolean success, String output, String error,
+                      long durationMs, int inputTokens, int outputTokens,
+                      int llmRequestCount) {
+        this(success, output, error, durationMs, inputTokens, outputTokens, llmRequestCount,
+                RequestAttribution.empty());
     }
 
     /**

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/planner/TaskPlanner.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/planner/TaskPlanner.java
@@ -1,6 +1,8 @@
 package dev.aceclaw.core.planner;
 
 import dev.aceclaw.core.llm.LlmException;
+import dev.aceclaw.core.llm.RequestAttribution;
+import dev.aceclaw.core.llm.RequestSource;
 import dev.aceclaw.core.llm.ToolDefinition;
 
 import java.util.List;
@@ -19,4 +21,23 @@ public interface TaskPlanner {
      * @throws LlmException if plan generation fails
      */
     TaskPlan plan(String goal, List<ToolDefinition> availableTools) throws LlmException;
+
+    /**
+     * Attribution-aware variant. Implementations that make LLM calls during plan generation
+     * should record one {@link RequestSource#PLANNER} entry per request on the supplied
+     * builder (if non-null). The default implementation just records a single PLANNER entry
+     * after the underlying {@link #plan} call succeeds — suitable for planners that make
+     * exactly one LLM request per invocation, which covers every planner in-tree today.
+     *
+     * @param attribution builder to record requests into; may be {@code null} if the caller
+     *                    doesn't care about attribution
+     */
+    default TaskPlan plan(String goal, List<ToolDefinition> availableTools,
+                          RequestAttribution.Builder attribution) throws LlmException {
+        var result = plan(goal, availableTools);
+        if (attribution != null) {
+            attribution.record(RequestSource.PLANNER);
+        }
+        return result;
+    }
 }

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/agent/AgentLoopIntegrationTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/agent/AgentLoopIntegrationTest.java
@@ -300,6 +300,24 @@ class AgentLoopIntegrationTest {
     }
 
     @Test
+    void fallbackOverloadAttributesRequestsToFallback() throws Exception {
+        // When SequentialPlanExecutor retries a failed step via the fallback path, it invokes
+        // runTurn with RequestSource.FALLBACK so the same Turn.requestAttribution distinguishes
+        // the retry work from the normal MAIN_TURN flow. This test pins that entry-point.
+        var llm = new FakeLlmClient(List.of(
+                new LlmResponse("id", "model", List.of(new ContentBlock.Text("done")),
+                        StopReason.END_TURN, new Usage(10, 5, 0, 0))
+        ));
+        var loop = new AgentLoop(llm, new ToolRegistry(), "model", null);
+
+        var turn = loop.runTurn("fallback attempt", List.of(), RequestSource.FALLBACK);
+
+        assertThat(turn.llmRequestCount()).isEqualTo(1);
+        assertThat(turn.requestAttribution().count(RequestSource.FALLBACK)).isEqualTo(1);
+        assertThat(turn.requestAttribution().count(RequestSource.MAIN_TURN)).isZero();
+    }
+
+    @Test
     void multiIterationToolUseCountsAllLlmRequests() throws Exception {
         var toolUse = new ContentBlock.ToolUse("t1", "echo", "{}");
         var llm = new FakeLlmClient(List.of(

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/agent/AgentLoopIntegrationTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/agent/AgentLoopIntegrationTest.java
@@ -276,6 +276,30 @@ class AgentLoopIntegrationTest {
     }
 
     @Test
+    void turnAttributionMatchesLlmRequestCountAsMainTurn() throws Exception {
+        // Invariant from #419: sum(requestAttribution.bySource().values()) == llmRequestCount.
+        // All requests from AgentLoop attribute to MAIN_TURN; other sources (PLANNER, REPLAN,
+        // COMPACTION_SUMMARY, FALLBACK, CONTINUATION) are wired in follow-up slices.
+        var toolUse = new ContentBlock.ToolUse("t1", "echo", "{}");
+        var llm = new FakeLlmClient(List.of(
+                new LlmResponse("id", "model", List.of(toolUse),
+                        StopReason.TOOL_USE, new Usage(10, 5, 0, 0)),
+                new LlmResponse("id", "model", List.of(new ContentBlock.Text("Done")),
+                        StopReason.END_TURN, new Usage(10, 5, 0, 0))
+        ));
+        var registry = new ToolRegistry();
+        registry.register(new StubTool("echo", "echoed"));
+        var loop = new AgentLoop(llm, registry, "model", null);
+
+        var turn = loop.runTurn("do something", List.of());
+
+        assertThat(turn.llmRequestCount()).isEqualTo(2);
+        assertThat(turn.requestAttribution().total()).isEqualTo(turn.llmRequestCount());
+        assertThat(turn.requestAttribution().count(RequestSource.MAIN_TURN))
+                .isEqualTo(turn.llmRequestCount());
+    }
+
+    @Test
     void multiIterationToolUseCountsAllLlmRequests() throws Exception {
         var toolUse = new ContentBlock.ToolUse("t1", "echo", "{}");
         var llm = new FakeLlmClient(List.of(

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/agent/StreamingAgentLoopRequestPruningTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/agent/StreamingAgentLoopRequestPruningTest.java
@@ -6,6 +6,7 @@ import dev.aceclaw.core.llm.LlmException;
 import dev.aceclaw.core.llm.LlmRequest;
 import dev.aceclaw.core.llm.LlmResponse;
 import dev.aceclaw.core.llm.Message;
+import dev.aceclaw.core.llm.RequestSource;
 import dev.aceclaw.core.llm.StopReason;
 import dev.aceclaw.core.llm.StreamEvent;
 import dev.aceclaw.core.llm.StreamEventHandler;
@@ -60,6 +61,27 @@ class StreamingAgentLoopRequestPruningTest {
         var originalToolResult = (Message.UserMessage) history.get(1);
         var originalBlock = (ContentBlock.ToolResult) originalToolResult.content().getFirst();
         assertThat(originalBlock.content()).isEqualTo(largeContent);
+    }
+
+    @Test
+    void streamingTurnAttributesAllRequestsToMainTurn() throws Exception {
+        // Parallel to the AgentLoop-side invariant test. StreamingAgentLoop has its own
+        // llmRequestCount++ site and several Turn-construction paths (END_TURN, max-iterations,
+        // multiple buildCancelledTurn overloads). All of them must populate requestAttribution
+        // with the same count, attributed to MAIN_TURN.
+        var llm = new CapturingStreamingLlmClient();
+        var config = new CompactionConfig(1_000, 100, 0.85, 0.60, 1);
+        var compactor = new MessageCompactor(llm, "model", config);
+        var loop = new StreamingAgentLoop(
+                llm, new ToolRegistry(), "model", null, 100, 0, 1_000, compactor,
+                AgentLoopConfig.EMPTY);
+
+        var turn = loop.runTurn("hi", List.of(), new StreamEventHandler() {});
+
+        assertThat(turn.llmRequestCount()).isEqualTo(1);
+        assertThat(turn.requestAttribution().total()).isEqualTo(turn.llmRequestCount());
+        assertThat(turn.requestAttribution().count(RequestSource.MAIN_TURN))
+                .isEqualTo(turn.llmRequestCount());
     }
 
     private static final class CapturingStreamingLlmClient implements LlmClient {

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/llm/RequestAttributionTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/llm/RequestAttributionTest.java
@@ -1,0 +1,110 @@
+package dev.aceclaw.core.llm;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RequestAttributionTest {
+
+    @Test
+    void emptyAttributionHasZeroTotal() {
+        var a = RequestAttribution.empty();
+        assertThat(a.total()).isZero();
+        assertThat(a.bySource()).isEmpty();
+        assertThat(a.count(RequestSource.MAIN_TURN)).isZero();
+    }
+
+    @Test
+    void builderRecordsAndSums() {
+        var a = RequestAttribution.builder()
+                .record(RequestSource.MAIN_TURN)
+                .record(RequestSource.MAIN_TURN)
+                .record(RequestSource.PLANNER)
+                .build();
+
+        assertThat(a.total()).isEqualTo(3);
+        assertThat(a.count(RequestSource.MAIN_TURN)).isEqualTo(2);
+        assertThat(a.count(RequestSource.PLANNER)).isEqualTo(1);
+        assertThat(a.count(RequestSource.REPLAN)).isZero();
+    }
+
+    @Test
+    void builderBatchRecordAddsGivenCount() {
+        var a = RequestAttribution.builder()
+                .record(RequestSource.MAIN_TURN, 5)
+                .record(RequestSource.COMPACTION_SUMMARY, 2)
+                .build();
+
+        assertThat(a.total()).isEqualTo(7);
+        assertThat(a.count(RequestSource.MAIN_TURN)).isEqualTo(5);
+    }
+
+    @Test
+    void builderIgnoresZeroCount() {
+        var a = RequestAttribution.builder()
+                .record(RequestSource.MAIN_TURN, 0)
+                .record(RequestSource.PLANNER, 3)
+                .build();
+
+        assertThat(a.total()).isEqualTo(3);
+        assertThat(a.bySource()).containsOnlyKeys(RequestSource.PLANNER);
+    }
+
+    @Test
+    void builderRejectsNegativeCount() {
+        var b = RequestAttribution.builder();
+        assertThatThrownBy(() -> b.record(RequestSource.MAIN_TURN, -1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void mergeSumsCountsPerSource() {
+        var a = RequestAttribution.builder()
+                .record(RequestSource.MAIN_TURN, 3)
+                .record(RequestSource.PLANNER, 1)
+                .build();
+        var b = RequestAttribution.builder()
+                .record(RequestSource.MAIN_TURN, 2)
+                .record(RequestSource.REPLAN, 1)
+                .build();
+
+        var merged = a.merge(b);
+
+        assertThat(merged.total()).isEqualTo(7);
+        assertThat(merged.count(RequestSource.MAIN_TURN)).isEqualTo(5);
+        assertThat(merged.count(RequestSource.PLANNER)).isEqualTo(1);
+        assertThat(merged.count(RequestSource.REPLAN)).isEqualTo(1);
+    }
+
+    @Test
+    void mergeWithEmptyIsIdentity() {
+        var a = RequestAttribution.builder().record(RequestSource.MAIN_TURN, 4).build();
+
+        assertThat(a.merge(RequestAttribution.empty())).isEqualTo(a);
+        assertThat(RequestAttribution.empty().merge(a)).isEqualTo(a);
+        assertThat(a.merge(null)).isEqualTo(a);
+    }
+
+    @Test
+    void constructorEnforcesTotalMatchesSum() {
+        // Invariant from the issue discussion: sum(bySource.values()) == total.
+        // Directly constructing with a mismatched total must fail loud, not silently drift.
+        Map<RequestSource, Integer> counts = new EnumMap<>(RequestSource.class);
+        counts.put(RequestSource.MAIN_TURN, 3);
+
+        assertThatThrownBy(() -> new RequestAttribution(counts, 5))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not match");
+    }
+
+    @Test
+    void bySourceMapIsUnmodifiable() {
+        var a = RequestAttribution.builder().record(RequestSource.MAIN_TURN).build();
+        assertThatThrownBy(() -> a.bySource().put(RequestSource.PLANNER, 1))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+}

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/llm/RequestAttributionTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/llm/RequestAttributionTest.java
@@ -130,6 +130,16 @@ class RequestAttributionTest {
     }
 
     @Test
+    void countRejectsNullSource() {
+        // Per CLAUDE.md: method parameters passed to downstream calls must fail fast on
+        // null rather than silently returning a plausible-looking zero.
+        var a = RequestAttribution.builder().record(RequestSource.MAIN_TURN).build();
+        assertThatThrownBy(() -> a.count(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("source");
+    }
+
+    @Test
     void bySourceMapIsUnmodifiable() {
         var a = RequestAttribution.builder().record(RequestSource.MAIN_TURN).build();
         assertThatThrownBy(() -> a.bySource().put(RequestSource.PLANNER, 1))

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/llm/RequestAttributionTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/llm/RequestAttributionTest.java
@@ -81,6 +81,34 @@ class RequestAttributionTest {
     }
 
     @Test
+    void builderMergeFoldsAnotherAttributionIntoThisBuilder() {
+        // Used by the streaming loop to absorb a CompactionResult's request attribution
+        // into the parent turn's running builder, and by SequentialPlanExecutor to fold
+        // per-step attributions into the plan total. Each per-source count must add.
+        var compactionAttr = RequestAttribution.builder()
+                .record(RequestSource.COMPACTION_SUMMARY)
+                .build();
+        var turnBuilder = RequestAttribution.builder()
+                .record(RequestSource.MAIN_TURN, 2);
+
+        turnBuilder.merge(compactionAttr);
+
+        var snapshot = turnBuilder.build();
+        assertThat(snapshot.total()).isEqualTo(3);
+        assertThat(snapshot.count(RequestSource.MAIN_TURN)).isEqualTo(2);
+        assertThat(snapshot.count(RequestSource.COMPACTION_SUMMARY)).isEqualTo(1);
+    }
+
+    @Test
+    void builderMergeToleratesNullAndEmpty() {
+        var b = RequestAttribution.builder().record(RequestSource.MAIN_TURN);
+        b.merge(null);
+        b.merge(RequestAttribution.empty());
+
+        assertThat(b.total()).isEqualTo(1);
+    }
+
+    @Test
     void mergeWithEmptyIsIdentity() {
         var a = RequestAttribution.builder().record(RequestSource.MAIN_TURN, 4).build();
 

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/planner/AdaptiveReplannerTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/planner/AdaptiveReplannerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import java.time.Instant;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 class AdaptiveReplannerTest {
@@ -104,6 +105,37 @@ class AdaptiveReplannerTest {
         assertInstanceOf(ReplanResult.Escalated.class, result);
         var escalated = (ReplanResult.Escalated) result;
         assertTrue(escalated.reason().contains("corrupted"));
+    }
+
+    @Test
+    void replan_attributesOneRequestAsReplan() throws LlmException {
+        // PR A.2: attribution builder passed into replan() must receive one REPLAN entry per
+        // successful LLM call. Pre-attempt escalation (max-attempts short-circuit) records
+        // nothing because no LLM call was made.
+        var client = new ReplanMockLlmClient();
+        client.setNextResponse("""
+                {"action": "escalate", "reason": "test"}
+                """);
+        var replanner = new AdaptiveReplanner(client, "mock-model");
+        var attribution = RequestAttribution.builder();
+
+        replanner.replan(createTrigger(1), attribution);
+
+        var snapshot = attribution.build();
+        assertThat(snapshot.total()).isEqualTo(1);
+        assertThat(snapshot.count(RequestSource.REPLAN)).isEqualTo(1);
+    }
+
+    @Test
+    void replan_maxAttemptsShortCircuitRecordsNothing() throws LlmException {
+        var client = new ReplanMockLlmClient();
+        var replanner = new AdaptiveReplanner(client, "mock-model");
+        var attribution = RequestAttribution.builder();
+
+        // Over the cap — no LLM call issued, attribution stays empty.
+        replanner.replan(createTrigger(AdaptiveReplanner.MAX_REPLAN_ATTEMPTS + 1), attribution);
+
+        assertThat(attribution.build()).isEqualTo(RequestAttribution.empty());
     }
 
     @Test

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/planner/SequentialPlanExecutorTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/planner/SequentialPlanExecutorTest.java
@@ -149,6 +149,35 @@ class SequentialPlanExecutorTest {
     }
 
     @Test
+    void planExecutionAggregatesStepAttributionsAcrossSteps() throws LlmException {
+        // End-to-end attribution aggregation for the happy path: two successful steps produce
+        // two MAIN_TURN requests that sum up on PlanExecutionResult.requestAttribution().
+        // The planner request is NOT in this total — it's issued before the executor runs,
+        // and the caller (StreamingAgentHandler) merges its own planner count on top.
+        //
+        // The FALLBACK / REPLAN paths are covered by unit tests at AgentLoop / AdaptiveReplanner;
+        // duplicating them here would require reasoning about streaming retry semantics that
+        // aren't the concern of plan-level aggregation.
+        var client = new SimpleMockLlmClient();
+        client.enqueueTextResponse("step 1 ok");
+        client.enqueueTextResponse("step 2 ok");
+
+        var plan = createTestPlan(2);
+        var loop = createLoop(client);
+        var executor = new SequentialPlanExecutor();
+
+        var result = executor.execute(plan, loop, new ArrayList<>(), noOpHandler, null);
+
+        assertTrue(result.success());
+        var attribution = result.requestAttribution();
+        assertEquals(2, attribution.total());
+        assertEquals(2, attribution.count(dev.aceclaw.core.llm.RequestSource.MAIN_TURN));
+        // Invariant: plan total equals sum of step llmRequestCounts (plus replans, here 0).
+        int stepSum = result.stepResults().stream().mapToInt(StepResult::llmRequestCount).sum();
+        assertEquals(stepSum, attribution.total());
+    }
+
+    @Test
     void stepFailsNoFallback() throws LlmException {
         var client = new SimpleMockLlmClient();
         client.enqueueError(); // step 1 fails

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/planner/TaskPlannerAttributionTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/planner/TaskPlannerAttributionTest.java
@@ -1,0 +1,62 @@
+package dev.aceclaw.core.planner;
+
+import dev.aceclaw.core.llm.LlmException;
+import dev.aceclaw.core.llm.RequestAttribution;
+import dev.aceclaw.core.llm.RequestSource;
+import dev.aceclaw.core.llm.ToolDefinition;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Pins the {@link TaskPlanner} interface default method that records a single PLANNER
+ * request on success. The default implementation is correct for every planner in-tree
+ * today (each issues exactly one LLM call per invocation). A concrete planner that
+ * issued multiple calls would need to override this method.
+ */
+class TaskPlannerAttributionTest {
+
+    private static final TaskPlan STUB_PLAN = new TaskPlan(
+            "plan-1", "goal", List.of(),
+            new PlanStatus.Draft(), Instant.EPOCH);
+
+    @Test
+    void defaultPlanOverloadRecordsOnePlannerRequest() throws LlmException {
+        TaskPlanner planner = (goal, tools) -> STUB_PLAN;
+        var attribution = RequestAttribution.builder();
+
+        planner.plan("goal", List.of(), attribution);
+
+        var snapshot = attribution.build();
+        assertThat(snapshot.total()).isEqualTo(1);
+        assertThat(snapshot.count(RequestSource.PLANNER)).isEqualTo(1);
+    }
+
+    @Test
+    void defaultPlanOverloadToleratesNullAttribution() throws LlmException {
+        TaskPlanner planner = (goal, tools) -> STUB_PLAN;
+        // The null case covers callers that don't care about attribution (existing callers).
+        assertThat(planner.plan("goal", List.of(), null)).isSameAs(STUB_PLAN);
+    }
+
+    @Test
+    void defaultPlanOverloadDoesNotRecordWhenPlanThrows() {
+        TaskPlanner failing = new TaskPlanner() {
+            @Override
+            public TaskPlan plan(String goal, List<ToolDefinition> availableTools) throws LlmException {
+                throw new LlmException("boom");
+            }
+        };
+        var attribution = RequestAttribution.builder();
+
+        assertThatThrownBy(() -> failing.plan("goal", List.of(), attribution))
+                .isInstanceOf(LlmException.class);
+        // On failure, no successful LLM call happened — attribution stays empty so counts
+        // match actual billed requests.
+        assertThat(attribution.build()).isEqualTo(RequestAttribution.empty());
+    }
+}


### PR DESCRIPTION
## Summary

PR A of #419 (which is the first slice of epic #418). Adds per-source breakdown of LLM requests to every Turn, StepResult, and PlanExecutionResult the core agent produces, so follow-up slices can surface the data and tune Copilot premium-request behavior against a real baseline.

Originally split as PR A.1 (foundation, MAIN_TURN only) + PR A.2 (tag remaining sources). Both are now in this branch as sequential commits; merging them together keeps the wire complete — splitting would leave an intermediate state where the enum has five unused values, which is worse than either state alone.

## What's wired

| RequestSource | Where it's recorded | Tested |
|---|---|---|
| \`MAIN_TURN\` | default source on AgentLoop / StreamingAgentLoop iterations | ✅ turnAttributionMatches... |
| \`FALLBACK\` | runTurn overload called by SequentialPlanExecutor's fallback path | ✅ fallbackOverloadAttributes... |
| \`CONTINUATION\` | first LLM request after a compaction run, via a post-compaction flag on the streaming loop | inspection (see test-gap note) |
| \`COMPACTION_SUMMARY\` | populated on CompactionResult when phase==SUMMARIZED; streaming loop merges into the turn's builder | inspection |
| \`PLANNER\` | default plan(..., builder) method on TaskPlanner records once on success | ✅ TaskPlannerAttributionTest |
| \`REPLAN\` | AdaptiveReplanner.replan(trigger, builder) overload records once per successful call | ✅ AdaptiveReplannerTest.replan_attributes... |

## Notable behavioral fix as a side-effect

Before this PR the compaction summary LLM call happened invisibly — \`Turn.llmRequestCount\` did NOT include it, because MessageCompactor called LlmClient directly without going through the agent loop's \`llmRequestCount++\` site. That meant token usage reported from a compacted turn was one request short of the truth.

This PR fixes it: when the streaming loop merges compaction attribution into its builder, it also bumps \`llmRequestCount\` by the compaction's total. Invariant \`sum(attribution.bySource.values()) == llmRequestCount\` now holds end-to-end and matches actual API cost.

## Scope boundaries

- No protocol change. \`llmRequestsBySource\` on the JSON-RPC \`usage\` payload and the matching CLI read / display are **PR B** per the #419 split.
- No \`/status\` display change. Also PR B / C.
- Retries fold into their parent source per the #419 pre-implementation decision — no dedicated \`RETRY\` category on the enum.

## Test plan

- [x] \`./gradlew build\` — passes (53 tasks, BUILD SUCCESSFUL)
- [x] \`RequestAttributionTest\` — data model (record/builder/merge invariant/immutability/new merge helper)
- [x] \`AgentLoopIntegrationTest\`:
  - \`turnAttributionMatchesLlmRequestCountAsMainTurn\`
  - \`fallbackOverloadAttributesRequestsToFallback\`
- [x] \`StreamingAgentLoopRequestPruningTest.streamingTurnAttributesAllRequestsToMainTurn\`
- [x] \`AdaptiveReplannerTest\`:
  - \`replan_attributesOneRequestAsReplan\`
  - \`replan_maxAttemptsShortCircuitRecordsNothing\`
- [x] \`TaskPlannerAttributionTest\` — default method records PLANNER, null tolerated, no record on exception

### Test gap (intentional)

No end-to-end test yet asserts the CONTINUATION flag fires across compaction. Triggering compaction in a test requires a summarizing LlmClient stub, token-pressure config, and a message set large enough to cross the threshold — substantial infra that doesn't exist in the streaming test harness today. The flag's read-then-consume semantics are linear in the streaming loop (\`postCompaction\` is set in \`checkAndCompact\`, consumed exactly once at the next record site, cleared after the retry loop) and verifiable by inspection. Deferred to PR A.3 / PR B.

Refs #418, #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)