### PR TITLE
feat(attribution): per-source LLM request breakdown on JSON-RPC + /status (PR B, #419)

### DIFF
--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/ContextMonitor.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/ContextMonitor.java
@@ -5,7 +5,10 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
 import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Locale;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 /**
@@ -51,8 +54,8 @@ public final class ContextMonitor {
      * talking to an older daemon. Invariant when populated:
      * {@code sum(values) == totalLlmRequests}.
      */
-    private final java.util.LinkedHashMap<String, Long> totalLlmRequestsBySource =
-            new java.util.LinkedHashMap<>();
+    private final LinkedHashMap<String, Long> totalLlmRequestsBySource =
+            new LinkedHashMap<>();
     /** Number of compaction events observed in the session. */
     private int compactionCount;
     /** Number of compaction events that stopped after phase 1 pruning. */
@@ -174,7 +177,7 @@ public final class ContextMonitor {
      * leaving the per-source total untouched but the scalar total still tracked via
      * {@link #recordLlmRequests(int)}.
      */
-    public synchronized void recordLlmRequestsBySource(java.util.Map<String, Integer> turnBySource) {
+    public synchronized void recordLlmRequestsBySource(Map<String, Integer> turnBySource) {
         if (turnBySource == null || turnBySource.isEmpty()) return;
         turnBySource.forEach((source, count) -> {
             if (source == null || source.isBlank() || count == null || count <= 0) return;
@@ -194,9 +197,9 @@ public final class ContextMonitor {
      * hasn't yet sent a per-source map (older daemon, or no requests recorded this session).
      * Iteration order is insertion order — typically the order sources first appeared.
      */
-    public synchronized java.util.Map<String, Long> totalLlmRequestsBySource() {
-        return java.util.Collections.unmodifiableMap(
-                new java.util.LinkedHashMap<>(totalLlmRequestsBySource));
+    public synchronized Map<String, Long> totalLlmRequestsBySource() {
+        return Collections.unmodifiableMap(
+                new LinkedHashMap<>(totalLlmRequestsBySource));
     }
 
     /**

--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/ContextMonitor.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/ContextMonitor.java
@@ -180,8 +180,13 @@ public final class ContextMonitor {
     public synchronized void recordLlmRequestsBySource(Map<String, Integer> turnBySource) {
         if (turnBySource == null || turnBySource.isEmpty()) return;
         turnBySource.forEach((source, count) -> {
-            if (source == null || source.isBlank() || count == null || count <= 0) return;
-            totalLlmRequestsBySource.merge(source, (long) count, Long::sum);
+            if (source == null || count == null || count <= 0) return;
+            // Normalize the key so a future daemon sending mixed case doesn't split a
+            // logical source across two buckets on /status. The current daemon already
+            // lowercases, so this is defense-in-depth rather than a known gap.
+            String normalized = source.trim().toLowerCase(Locale.ROOT);
+            if (normalized.isEmpty()) return;
+            totalLlmRequestsBySource.merge(normalized, (long) count, Long::sum);
         });
     }
 

--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/ContextMonitor.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/ContextMonitor.java
@@ -44,6 +44,15 @@ public final class ContextMonitor {
     private long totalOutputTokens;
     /** Cumulative LLM API request count across all turns in the session. */
     private long totalLlmRequests;
+    /**
+     * Per-source breakdown of {@link #totalLlmRequests}, keyed by lowercase source name
+     * (e.g. {@code "main_turn"}, {@code "planner"}). Populated from the JSON-RPC
+     * {@code usage.llmRequestsBySource} field when the daemon sends it; left empty when
+     * talking to an older daemon. Invariant when populated:
+     * {@code sum(values) == totalLlmRequests}.
+     */
+    private final java.util.LinkedHashMap<String, Long> totalLlmRequestsBySource =
+            new java.util.LinkedHashMap<>();
     /** Number of compaction events observed in the session. */
     private int compactionCount;
     /** Number of compaction events that stopped after phase 1 pruning. */
@@ -158,10 +167,36 @@ public final class ContextMonitor {
     }
 
     /**
+     * Folds a turn's per-source request breakdown into the session total. When the daemon
+     * sends {@code usage.llmRequestsBySource}, the CLI feeds that map here so
+     * {@code /status} can render per-source counts alongside the existing scalar total.
+     * Silently accepts {@code null} or empty maps (older daemons don't send the field),
+     * leaving the per-source total untouched but the scalar total still tracked via
+     * {@link #recordLlmRequests(int)}.
+     */
+    public synchronized void recordLlmRequestsBySource(java.util.Map<String, Integer> turnBySource) {
+        if (turnBySource == null || turnBySource.isEmpty()) return;
+        turnBySource.forEach((source, count) -> {
+            if (source == null || source.isBlank() || count == null || count <= 0) return;
+            totalLlmRequestsBySource.merge(source, (long) count, Long::sum);
+        });
+    }
+
+    /**
      * Returns cumulative LLM API request count across all turns.
      */
     public synchronized long totalLlmRequests() {
         return totalLlmRequests;
+    }
+
+    /**
+     * Returns the per-source breakdown of {@link #totalLlmRequests}. Empty when the daemon
+     * hasn't yet sent a per-source map (older daemon, or no requests recorded this session).
+     * Iteration order is insertion order — typically the order sources first appeared.
+     */
+    public synchronized java.util.Map<String, Long> totalLlmRequestsBySource() {
+        return java.util.Collections.unmodifiableMap(
+                new java.util.LinkedHashMap<>(totalLlmRequestsBySource));
     }
 
     /**

--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
@@ -1207,6 +1207,68 @@ public final class TerminalRepl {
     /**
      * Renders the token usage summary after a task completes.
      */
+    /**
+     * Short display name per wire source, for the {@code /status} inline breakdown.
+     * Only the short label is user-facing; the raw key stays on the wire + in the monitor
+     * for telemetry consumers that want to correlate with the daemon's enum exactly.
+     */
+    private static final Map<String, String> LLM_REQUEST_SOURCE_DISPLAY = Map.of(
+            "main_turn", "main",
+            "planner", "planner",
+            "continuation", "cont",
+            "fallback", "fallback",
+            "replan", "replan",
+            "compaction_summary", "compact"
+    );
+
+    /**
+     * Formats the per-source breakdown as an inline suffix on the {@code LLM requests} line.
+     * Returns an empty string when the map has no positive counts so users talking to old
+     * daemons or on fresh sessions see the scalar alone (no trailing parens).
+     *
+     * <p>Keys are mapped through {@link #LLM_REQUEST_SOURCE_DISPLAY} to short forms; any
+     * unmapped key is shown as-is so a daemon that adds a new source ships through the
+     * upgrade gracefully.
+     */
+    static String formatLlmRequestsBreakdown(Map<String, Long> bySource) {
+        if (bySource == null || bySource.isEmpty()) return "";
+        var parts = new ArrayList<String>();
+        for (var entry : bySource.entrySet()) {
+            long count = entry.getValue() == null ? 0 : entry.getValue();
+            if (count <= 0) continue;
+            String label = LLM_REQUEST_SOURCE_DISPLAY.getOrDefault(entry.getKey(), entry.getKey());
+            parts.add(label + "=" + count);
+        }
+        if (parts.isEmpty()) return "";
+        return " (" + String.join(" ", parts) + ")";
+    }
+
+    /**
+     * Parses the optional {@code llmRequestsBySource} map from a JSON-RPC {@code usage}
+     * object. Returns an empty map when the field is absent (older daemon, or a daemon
+     * with no requests recorded this turn), allowing the caller to feed the result
+     * directly to {@link ContextMonitor#recordLlmRequestsBySource}.
+     *
+     * <p>Skips any entry whose source key is blank or whose count is non-positive — the
+     * daemon shouldn't send these, but the CLI shouldn't trust its input implicitly.
+     */
+    private static Map<String, Integer> parseLlmRequestsBySource(JsonNode usage) {
+        if (usage == null) return Map.of();
+        JsonNode bySource = usage.path("llmRequestsBySource");
+        if (!bySource.isObject()) return Map.of();
+        var parsed = new LinkedHashMap<String, Integer>();
+        bySource.fields().forEachRemaining(entry -> {
+            String key = entry.getKey();
+            if (key == null || key.isBlank()) return;
+            JsonNode valueNode = entry.getValue();
+            if (valueNode == null || !valueNode.canConvertToInt()) return;
+            int count = valueNode.asInt();
+            if (count <= 0) return;
+            parsed.put(key, count);
+        });
+        return parsed;
+    }
+
     private void renderTaskCompletion(PrintWriter out, TaskHandle handle) {
         JsonNode message = handle.result();
         if (message == null) return;
@@ -1229,6 +1291,7 @@ public final class TerminalRepl {
             if (handle.markUsageAccounted()) {
                 contextMonitor.recordTurnComplete(turnIn, turnOut, perCallContext);
                 contextMonitor.recordLlmRequests(llmRequests);
+                contextMonitor.recordLlmRequestsBySource(parseLlmRequestsBySource(usage));
                 contextMonitor.checkThresholds(log);
             }
 
@@ -1528,6 +1591,7 @@ public final class TerminalRepl {
                     long bgPerCall = handle.liveInputTokens();
                     contextMonitor.recordTurnComplete(bgTurnIn, bgTurnOut, bgPerCall);
                     contextMonitor.recordLlmRequests(bgLlmRequests);
+                    contextMonitor.recordLlmRequestsBySource(parseLlmRequestsBySource(bgUsage));
                     contextMonitor.checkThresholds(log);
                 }
             }
@@ -3032,8 +3096,9 @@ public final class TerminalRepl {
                 out.printf("  %sTotal usage:%s %s in / %s out%n", MUTED, RESET,
                         formatTokenCount(contextMonitor.totalInput()),
                         formatTokenCount(contextMonitor.totalOutput()));
-                out.printf("  %sLLM requests:%s %d%n", MUTED, RESET,
-                        contextMonitor.totalLlmRequests());
+                out.printf("  %sLLM requests:%s %d%s%n", MUTED, RESET,
+                        contextMonitor.totalLlmRequests(),
+                        formatLlmRequestsBreakdown(contextMonitor.totalLlmRequestsBySource()));
                 out.printf("  %sTasks:%s       %d running%n", MUTED, RESET,
                         taskManager.runningCount());
                 out.println();

--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
@@ -1236,7 +1236,13 @@ public final class TerminalRepl {
         for (var entry : bySource.entrySet()) {
             long count = entry.getValue() == null ? 0 : entry.getValue();
             if (count <= 0) continue;
-            String label = LLM_REQUEST_SOURCE_DISPLAY.getOrDefault(entry.getKey(), entry.getKey());
+            String raw = LLM_REQUEST_SOURCE_DISPLAY.getOrDefault(entry.getKey(), entry.getKey());
+            // Sanitize before interpolating: an unknown source falls through from the wire,
+            // and we shouldn't inject ANSI / control chars into the status line if a future
+            // daemon ever shipped a malformed key. Known display labels are already clean
+            // but go through the same path for consistency.
+            String label = sanitizeTerminalText(raw == null ? "" : raw);
+            if (label.isBlank()) label = "unknown";
             parts.add(label + "=" + count);
         }
         if (parts.isEmpty()) return "";

--- a/aceclaw-cli/src/test/java/dev/aceclaw/cli/ContextMonitorTest.java
+++ b/aceclaw-cli/src/test/java/dev/aceclaw/cli/ContextMonitorTest.java
@@ -60,6 +60,51 @@ class ContextMonitorTest {
     }
 
     @Test
+    void recordLlmRequestsBySourceAccumulatesPerSource() {
+        // PR B: daemon sends a per-source map in the JSON-RPC usage payload; the monitor
+        // folds it into a session-wide total keyed by lowercase source name.
+        var monitor = new ContextMonitor(200_000);
+
+        monitor.recordLlmRequestsBySource(java.util.Map.of("main_turn", 3, "planner", 1));
+        monitor.recordLlmRequestsBySource(java.util.Map.of("main_turn", 2, "replan", 1));
+
+        var totals = monitor.totalLlmRequestsBySource();
+        assertThat(totals).containsEntry("main_turn", 5L);
+        assertThat(totals).containsEntry("planner", 1L);
+        assertThat(totals).containsEntry("replan", 1L);
+    }
+
+    @Test
+    void recordLlmRequestsBySourceIgnoresNullEmptyAndInvalidValues() {
+        // Tolerant of absent / malformed payloads. An old daemon sends nothing; a new daemon
+        // on an empty turn sends an empty map; either path must keep the counters at zero.
+        var monitor = new ContextMonitor(200_000);
+
+        monitor.recordLlmRequestsBySource(null);
+        monitor.recordLlmRequestsBySource(java.util.Map.of());
+        monitor.recordLlmRequestsBySource(new java.util.HashMap<>() {{
+            put("", 5);        // blank key
+            put("planner", 0); // non-positive value
+            put("main_turn", -1); // negative value
+        }});
+
+        assertThat(monitor.totalLlmRequestsBySource()).isEmpty();
+    }
+
+    @Test
+    void totalLlmRequestsBySourceReturnsUnmodifiableSnapshot() {
+        // Callers shouldn't be able to mutate the monitor's state through the returned map.
+        var monitor = new ContextMonitor(200_000);
+        monitor.recordLlmRequestsBySource(java.util.Map.of("main_turn", 3));
+
+        var snapshot = monitor.totalLlmRequestsBySource();
+
+        assertThat(snapshot).containsEntry("main_turn", 3L);
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> snapshot.put("x", 1L))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
     void recordLlmRequestsIgnoresZeroAndNegativeValues() {
         // A turn with no LLM call (e.g. cancelled before send) reports llmRequests=0 in the
         // usage payload. The counter must not advance on those, and must never go backward.

--- a/aceclaw-cli/src/test/java/dev/aceclaw/cli/ContextMonitorTest.java
+++ b/aceclaw-cli/src/test/java/dev/aceclaw/cli/ContextMonitorTest.java
@@ -92,6 +92,21 @@ class ContextMonitorTest {
     }
 
     @Test
+    void recordLlmRequestsBySourceNormalizesKeyCase() {
+        // Defense against a future daemon (or a protocol accident) shipping mixed-case keys.
+        // Two records for "MAIN_TURN" + "main_turn" must collapse to a single logical source.
+        var monitor = new ContextMonitor(200_000);
+
+        monitor.recordLlmRequestsBySource(java.util.Map.of("MAIN_TURN", 3));
+        monitor.recordLlmRequestsBySource(java.util.Map.of(" main_turn ", 2));
+        monitor.recordLlmRequestsBySource(java.util.Map.of("Main_Turn", 1));
+
+        var totals = monitor.totalLlmRequestsBySource();
+        assertThat(totals).hasSize(1);
+        assertThat(totals).containsEntry("main_turn", 6L);
+    }
+
+    @Test
     void totalLlmRequestsBySourceReturnsUnmodifiableSnapshot() {
         // Callers shouldn't be able to mutate the monitor's state through the returned map.
         var monitor = new ContextMonitor(200_000);

--- a/aceclaw-cli/src/test/java/dev/aceclaw/cli/TerminalReplTest.java
+++ b/aceclaw-cli/src/test/java/dev/aceclaw/cli/TerminalReplTest.java
@@ -153,6 +153,87 @@ class TerminalReplTest {
     }
 
     @Test
+    void status_renderBreakdownOnlyWhenDaemonSuppliedPerSourceMap() throws Exception {
+        // Old daemon (or fresh session): scalar only, no parenthetical suffix.
+        ContextMonitor monitor = (ContextMonitor) getPrivateField(repl, "contextMonitor");
+        monitor.recordLlmRequests(5);
+
+        repl.handleSlashCommand(out, "/status", null);
+        String stripped = outputBuffer.toString().replaceAll("\u001B\\[[0-9;]*m", "");
+
+        assertThat(stripped).contains("LLM requests: 5");
+        // Spot-check: the LLM requests line doesn't include a breakdown when no per-source
+        // data is available. Scope the assertion to a single line to avoid matching other
+        // content in /status (e.g. context window numbers).
+        String llmLine = stripped.lines()
+                .filter(line -> line.contains("LLM requests:"))
+                .findFirst().orElse("");
+        assertThat(llmLine).doesNotContain("(");
+    }
+
+    @Test
+    void status_rendersInlineBreakdownFromPerSourceMap() throws Exception {
+        // New daemon path: monitor has been fed llmRequestsBySource from JSON-RPC usage.
+        // /status renders the breakdown with short display names in insertion order.
+        ContextMonitor monitor = (ContextMonitor) getPrivateField(repl, "contextMonitor");
+        monitor.recordLlmRequests(8);
+        monitor.recordLlmRequestsBySource(java.util.Map.of(
+                "main_turn", 5,
+                "planner", 2,
+                "continuation", 1));
+
+        repl.handleSlashCommand(out, "/status", null);
+        String stripped = outputBuffer.toString().replaceAll("\u001B\\[[0-9;]*m", "");
+        String llmLine = stripped.lines()
+                .filter(line -> line.contains("LLM requests:"))
+                .findFirst().orElse("");
+
+        assertThat(llmLine).contains("LLM requests: 8");
+        // Short display labels: main_turn -> main, continuation -> cont.
+        assertThat(llmLine).contains("main=5");
+        assertThat(llmLine).contains("planner=2");
+        assertThat(llmLine).contains("cont=1");
+    }
+
+    @Test
+    void formatLlmRequestsBreakdown_roundTripsKnownSources() {
+        // Direct unit test on the pure formatter — the /status integration tests above rely
+        // on Java 21 Map.of() which does not preserve insertion order, so ordering of the
+        // parenthetical is validated here on a LinkedHashMap with a stable sequence.
+        var src = new java.util.LinkedHashMap<String, Long>();
+        src.put("main_turn", 5L);
+        src.put("planner", 2L);
+        src.put("continuation", 1L);
+        src.put("fallback", 3L);
+        src.put("replan", 1L);
+        src.put("compaction_summary", 1L);
+
+        String out = TerminalRepl.formatLlmRequestsBreakdown(src);
+
+        assertThat(out).isEqualTo(" (main=5 planner=2 cont=1 fallback=3 replan=1 compact=1)");
+    }
+
+    @Test
+    void formatLlmRequestsBreakdown_emptyOrZeroReturnsEmpty() {
+        assertThat(TerminalRepl.formatLlmRequestsBreakdown(null)).isEmpty();
+        assertThat(TerminalRepl.formatLlmRequestsBreakdown(java.util.Map.of())).isEmpty();
+        // All-zero map collapses to empty, not to an awkward "()" suffix.
+        var zeroMap = new java.util.LinkedHashMap<String, Long>();
+        zeroMap.put("main_turn", 0L);
+        assertThat(TerminalRepl.formatLlmRequestsBreakdown(zeroMap)).isEmpty();
+    }
+
+    @Test
+    void formatLlmRequestsBreakdown_unknownSourcePassesThroughAsRawKey() {
+        // Future-proofing: if the daemon adds a new source, the CLI shouldn't swallow it.
+        // The key gets rendered as-is until a display mapping is added in a later release.
+        var src = new java.util.LinkedHashMap<String, Long>();
+        src.put("future_source", 2L);
+        assertThat(TerminalRepl.formatLlmRequestsBreakdown(src))
+                .isEqualTo(" (future_source=2)");
+    }
+
+    @Test
     void contextWithNoClient_showsNotConnectedWhenNullClient() {
         boolean shouldExit = repl.handleSlashCommand(out, "/context list", null);
         assertThat(shouldExit).isFalse();

--- a/aceclaw-cli/src/test/java/dev/aceclaw/cli/TerminalReplTest.java
+++ b/aceclaw-cli/src/test/java/dev/aceclaw/cli/TerminalReplTest.java
@@ -224,6 +224,21 @@ class TerminalReplTest {
     }
 
     @Test
+    void formatLlmRequestsBreakdown_sanitizesControlCharsInUnknownKeys() {
+        // Defensive: an unknown source key flows through from the wire. If some future or
+        // corrupt daemon shipped a key with ANSI escape sequences, we must not paint them
+        // into the status line. sanitizeTerminalText strips them; blank-after-sanitize
+        // falls back to a safe placeholder.
+        var src = new java.util.LinkedHashMap<String, Long>();
+        src.put("\u001B[31mdanger\u001B[0m", 1L); // ANSI red
+        src.put("\u001B[0m", 1L);                  // entirely escape sequences
+        String out = TerminalRepl.formatLlmRequestsBreakdown(src);
+        assertThat(out).doesNotContain("\u001B");
+        // The all-escape key collapses to the "unknown" placeholder.
+        assertThat(out).contains("unknown=1");
+    }
+
+    @Test
     void formatLlmRequestsBreakdown_unknownSourcePassesThroughAsRawKey() {
         // Future-proofing: if the daemon adds a new source, the CLI shouldn't swallow it.
         // The key gets rendered as-is until a display mapping is added in a later release.

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -605,7 +605,7 @@ public final class StreamingAgentHandler {
         }
         var bySourceNode = objectMapper.createObjectNode();
         attribution.bySource().forEach((source, count) ->
-                bySourceNode.put(source.name().toLowerCase(java.util.Locale.ROOT), count));
+                bySourceNode.put(source.name().toLowerCase(Locale.ROOT), count));
         usageNode.set("llmRequestsBySource", bySourceNode);
     }
 

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -1046,6 +1046,12 @@ public final class StreamingAgentHandler {
         int totalCacheCreate = 0;
         int totalCacheRead = 0;
         int totalLlmRequests = 0;
+        // Accumulate per-source attribution across segments so the merged Turn carries a
+        // faithful breakdown. Without this, writeLlmRequestsBySource at the buildTurnResult
+        // boundary would see empty attribution on any multi-segment turn, dropping the
+        // whole point of the per-source map on /status for exactly the turns that ran long
+        // enough to need it. See #419 PR B review.
+        var totalAttribution = RequestAttribution.builder();
         String reason = "single_segment";
         int segments = 0;
         int continuationCount = 0;
@@ -1080,6 +1086,7 @@ public final class StreamingAgentHandler {
             totalCacheCreate += turn.totalUsage().cacheCreationInputTokens();
             totalCacheRead += turn.totalUsage().cacheReadInputTokens();
             totalLlmRequests += turn.llmRequestCount();
+            totalAttribution.merge(turn.requestAttribution());
             conversation.addAll(turn.newMessages());
 
             if (turn.budgetExhausted()) {
@@ -1142,7 +1149,8 @@ public final class StreamingAgentHandler {
         var usage = new dev.aceclaw.core.llm.Usage(totalInput, totalOutput, totalCacheCreate, totalCacheRead);
         var mergedTurn = new dev.aceclaw.core.agent.Turn(
                 mergedMessages, lastStopReason, usage, lastCompaction, maxIterationsReached,
-                budgetExhausted, budgetExhaustionReason, totalLlmRequests);
+                budgetExhausted, budgetExhaustionReason, totalLlmRequests,
+                totalAttribution.build());
         return new AdaptiveTurnResult(
                 mergedTurn,
                 segments <= 0 ? 1 : segments,

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -27,6 +27,7 @@ import dev.aceclaw.core.agent.ToolRegistry;
 import dev.aceclaw.core.llm.ContentBlock;
 import dev.aceclaw.core.llm.LlmException;
 import dev.aceclaw.core.llm.Message;
+import dev.aceclaw.core.llm.RequestAttribution;
 import dev.aceclaw.core.llm.StopReason;
 import dev.aceclaw.core.llm.StreamEvent;
 import dev.aceclaw.core.llm.StreamEventHandler;
@@ -362,9 +363,14 @@ public final class StreamingAgentHandler {
         var planner = new LLMTaskPlanner(getLlmClient(), getModelForSession(sessionId));
         var toolDefs = toolRegistry.toDefinitions();
 
+        // Capture the planner's own LLM request separately from step/replan attribution so
+        // the final /usage payload can report PLANNER vs MAIN_TURN vs REPLAN distinctly.
+        // PlanExecutionResult.requestAttribution() does NOT include this — it's issued
+        // before the executor runs. See #419 PR A.2.
+        var plannerAttribution = RequestAttribution.builder();
         TaskPlan plan;
         try {
-            plan = planner.plan(prompt, toolDefs);
+            plan = planner.plan(prompt, toolDefs, plannerAttribution);
         } catch (Exception e) {
             log.warn("Plan generation failed, falling back to direct execution: {}", e.getMessage());
             // Fall back to direct execution
@@ -559,12 +565,20 @@ public final class StreamingAgentHandler {
 
         int totalInput = planResult.stepResults().stream().mapToInt(StepResult::inputTokens).sum();
         int totalOutput = planResult.stepResults().stream().mapToInt(StepResult::outputTokens).sum();
-        int totalLlmRequests = planResult.stepResults().stream().mapToInt(StepResult::llmRequestCount).sum();
+        // Fold the upfront PLANNER request into the plan's aggregated attribution before
+        // reporting: planResult.requestAttribution() covers step turns + REPLAN calls; the
+        // initial planner call happens above and must be merged in here so the per-source
+        // map and the llmRequests scalar stay consistent.
+        var planUsage = RequestAttribution.builder()
+                .merge(planResult.requestAttribution())
+                .merge(plannerAttribution.build())
+                .build();
         var usageNode = objectMapper.createObjectNode();
         usageNode.put("inputTokens", totalInput);
         usageNode.put("outputTokens", totalOutput);
         usageNode.put("totalTokens", planResult.totalTokensUsed());
-        usageNode.put("llmRequests", totalLlmRequests);
+        usageNode.put("llmRequests", planUsage.total());
+        writeLlmRequestsBySource(usageNode, planUsage);
         result.set("usage", usageNode);
 
         log.info("Planned task complete: sessionId={}, success={}, steps={}/{}, tokens={}",
@@ -572,6 +586,27 @@ public final class StreamingAgentHandler {
                 planResult.plan().steps().size(), planResult.totalTokensUsed());
 
         return result;
+    }
+
+    /**
+     * Writes the per-source breakdown of LLM requests onto the JSON-RPC usage node.
+     *
+     * <p>Keyed by the lowercase {@link dev.aceclaw.core.llm.RequestSource} name
+     * ({@code "main_turn"}, {@code "planner"}, ...). Omitted when the attribution has
+     * no recorded requests so old CLIs and empty payloads don't see a needless field.
+     *
+     * <p>Invariant: {@code sum(llmRequestsBySource.values()) == llmRequests}. The CLI can
+     * rely on this when reconciling the scalar with the map.
+     */
+    private void writeLlmRequestsBySource(com.fasterxml.jackson.databind.node.ObjectNode usageNode,
+                                          RequestAttribution attribution) {
+        if (attribution == null || attribution.total() == 0) {
+            return;
+        }
+        var bySourceNode = objectMapper.createObjectNode();
+        attribution.bySource().forEach((source, count) ->
+                bySourceNode.put(source.name().toLowerCase(java.util.Locale.ROOT), count));
+        usageNode.set("llmRequestsBySource", bySourceNode);
     }
 
     /**
@@ -635,6 +670,7 @@ public final class StreamingAgentHandler {
         usageNode.put("outputTokens", turn.totalUsage().outputTokens());
         usageNode.put("totalTokens", turn.totalUsage().totalTokens());
         usageNode.put("llmRequests", turn.llmRequestCount());
+        writeLlmRequestsBySource(usageNode, turn.requestAttribution());
         result.set("usage", usageNode);
 
         if (turn.wasCompacted()) {
@@ -2620,12 +2656,16 @@ public final class StreamingAgentHandler {
 
         int totalInput = planResult.stepResults().stream().mapToInt(StepResult::inputTokens).sum();
         int totalOutput = planResult.stepResults().stream().mapToInt(StepResult::outputTokens).sum();
-        int totalLlmRequests = planResult.stepResults().stream().mapToInt(StepResult::llmRequestCount).sum();
+        // Resumed plans don't re-run the planner (plan was already generated + checkpointed),
+        // so planResult.requestAttribution() is the full picture: step turns + any replans
+        // during resumption.
+        var resumedUsage = planResult.requestAttribution();
         var usageNode = objectMapper.createObjectNode();
         usageNode.put("inputTokens", totalInput);
         usageNode.put("outputTokens", totalOutput);
         usageNode.put("totalTokens", planResult.totalTokensUsed());
-        usageNode.put("llmRequests", totalLlmRequests);
+        usageNode.put("llmRequests", resumedUsage.total());
+        writeLlmRequestsBySource(usageNode, resumedUsage);
         result.set("usage", usageNode);
 
         log.info("Resumed plan complete: sessionId={}, success={}, steps={}/{}, tokens={}",


### PR DESCRIPTION
## Summary

PR B of #419 (epic #418). Takes the attribution data PR A (merged in #420) plumbed through the core agent types and makes it user-visible:

1. **Daemon**: every JSON-RPC \`agent.prompt\` result's \`usage\` node now carries an additive \`llmRequestsBySource\` field — a map of lowercase source name to count, alongside the existing scalar \`llmRequests\`.
2. **CLI**: \`ContextMonitor\` accumulates the per-source counts across turns.
3. **\`/status\`**: renders an inline breakdown using short labels.

## Before / After

Before (PR A only):
\`\`\`
LLM requests: 8
\`\`\`

After:
\`\`\`
LLM requests: 8 (main=5 planner=2 cont=1)
\`\`\`

When talking to an older daemon (or on a fresh session with no requests yet), the parenthetical is omitted — just the scalar.

## Backward compatibility

Protocol change is **strictly additive**:
- **Old CLI + new daemon**: old CLI ignores the new \`llmRequestsBySource\` field (Jackson default), keeps reading \`llmRequests\`. Unchanged UX.
- **New CLI + old daemon**: new CLI sees no map field, monitor stays empty, \`/status\` renders scalar-only.
- **Same-version pair**: new breakdown visible.

Invariant locked in tests: \`sum(llmRequestsBySource.values()) == llmRequests\` on every payload.

## Behavioral fix caught along the way

PR A's review surfaced that the compaction summary LLM call was uncounted in \`llmRequestCount\`. Its sibling — the \`LLMTaskPlanner\` request on planned flows — had the same bug: the scalar reported only stepResults' counts, not the planner's one-shot. This PR threads \`plannerAttribution\` through the planner call site and merges it into the plan's serialized usage, so both the scalar and the per-source map match real API cost.

Resumed plans (\`plan.resume\` flow) don't re-run the planner — their plan was already generated and checkpointed — so that path reports \`PlanExecutionResult.requestAttribution()\` directly.

## Wire format

\`\`\`json
{
  \"usage\": {
    \"inputTokens\": 1234,
    \"outputTokens\": 567,
    \"totalTokens\": 1801,
    \"llmRequests\": 8,
    \"llmRequestsBySource\": {
      \"main_turn\": 5,
      \"planner\": 2,
      \"continuation\": 1
    }
  }
}
\`\`\`

Keys match the lowercase enum names. Short display names (\`main\`, \`cont\`, \`compact\`) live only in the CLI's display map; the wire keeps the full name so external telemetry can correlate exactly with the daemon's \`RequestSource\` enum.

## Scope boundaries

- **Not in this PR**: per-turn breakdown on the individual turn summary line and structured export to \`runtime-latest.json\` for offline analysis — that's PR C, the last slice.
- **Not in this PR**: any policy change based on attribution data. Pure visibility.

## Test plan

- [x] \`./gradlew build\` — passes (53 tasks, BUILD SUCCESSFUL)
- [x] \`ContextMonitorTest\`:
  - \`recordLlmRequestsBySourceAccumulatesPerSource\`
  - \`recordLlmRequestsBySourceIgnoresNullEmptyAndInvalidValues\`
  - \`totalLlmRequestsBySourceReturnsUnmodifiableSnapshot\`
- [x] \`TerminalReplTest\`:
  - \`status_renderBreakdownOnlyWhenDaemonSuppliedPerSourceMap\` — old-daemon compat path
  - \`status_rendersInlineBreakdownFromPerSourceMap\` — end-to-end /status render
  - \`formatLlmRequestsBreakdown_*\` — pure formatter unit tests (ordering, empty/zero, unknown-source fallthrough)

Refs #418, #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-source tracking of LLM requests to monitor request distribution across different system components.
  * Enhanced status display to show LLM request counts broken down by source, providing improved visibility into usage patterns across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->