### PR TITLE
feat(attribution): per-turn breakdown on turn summary + runtime metrics export (PR C, #419)

### DIFF
--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
@@ -1230,11 +1230,11 @@ public final class TerminalRepl {
      * unmapped key is shown as-is so a daemon that adds a new source ships through the
      * upgrade gracefully.
      */
-    static String formatLlmRequestsBreakdown(Map<String, Long> bySource) {
+    static String formatLlmRequestsBreakdown(Map<String, ? extends Number> bySource) {
         if (bySource == null || bySource.isEmpty()) return "";
         var parts = new ArrayList<String>();
         for (var entry : bySource.entrySet()) {
-            long count = entry.getValue() == null ? 0 : entry.getValue();
+            long count = entry.getValue() == null ? 0L : entry.getValue().longValue();
             if (count <= 0) continue;
             String raw = LLM_REQUEST_SOURCE_DISPLAY.getOrDefault(entry.getKey(), entry.getKey());
             // Sanitize before interpolating: an unknown source falls through from the wire,
@@ -1309,7 +1309,14 @@ public final class TerminalRepl {
             String elapsed = elapsedMs >= 1000
                     ? String.format("%.1fs", elapsedMs / 1000.0)
                     : elapsedMs + "ms";
-            String llmRequestText = llmRequests > 0 ? "  " + llmRequests + " LLM req" : "";
+            // Per-turn breakdown inline when the daemon provided a map (PR C). Falls back
+            // to the scalar-only form for older daemons or turns the daemon didn't decompose.
+            String llmRequestBreakdown = llmRequests > 0
+                    ? formatLlmRequestsBreakdown(parseLlmRequestsBySource(usage))
+                    : "";
+            String llmRequestText = llmRequests > 0
+                    ? "  " + llmRequests + " LLM req" + llmRequestBreakdown
+                    : "";
 
             out.println();
             out.printf("%s%s%s  %d in / %d out  %s%s%n",

--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
@@ -1291,13 +1291,17 @@ public final class TerminalRepl {
             // NOT the per-call value — using it would cause erratic usage % jumps.
             // If no streaming usage was received, keep the monitor's existing per-call value (0 means "no update").
             long perCallContext = handle.liveInputTokens();
+            // Parse once; this parsed map is fed to the session monitor below (on the first
+            // render only, via markUsageAccounted) AND to the per-turn display formatter
+            // below (on every render, since display is idempotent across re-renders).
+            Map<String, Integer> bySource = parseLlmRequestsBySource(usage);
             // Guarded: same handle can reach renderTaskCompletion through multiple paths
             // (foreground completion, /fg rendezvous, fallback notify). Only the first render
             // should feed session totals or the user-visible counters double-count.
             if (handle.markUsageAccounted()) {
                 contextMonitor.recordTurnComplete(turnIn, turnOut, perCallContext);
                 contextMonitor.recordLlmRequests(llmRequests);
-                contextMonitor.recordLlmRequestsBySource(parseLlmRequestsBySource(usage));
+                contextMonitor.recordLlmRequestsBySource(bySource);
                 contextMonitor.checkThresholds(log);
             }
 
@@ -1312,7 +1316,7 @@ public final class TerminalRepl {
             // Per-turn breakdown inline when the daemon provided a map (PR C). Falls back
             // to the scalar-only form for older daemons or turns the daemon didn't decompose.
             String llmRequestBreakdown = llmRequests > 0
-                    ? formatLlmRequestsBreakdown(parseLlmRequestsBySource(usage))
+                    ? formatLlmRequestsBreakdown(bySource)
                     : "";
             String llmRequestText = llmRequests > 0
                     ? "  " + llmRequests + " LLM req" + llmRequestBreakdown

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/RuntimeMetricsExporter.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/RuntimeMetricsExporter.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import dev.aceclaw.core.agent.ToolMetrics;
 import dev.aceclaw.core.agent.ToolMetricsCollector;
+import dev.aceclaw.core.llm.RequestAttribution;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,6 +14,8 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.locks.ReentrantLock;
@@ -51,6 +54,13 @@ public final class RuntimeMetricsExporter {
     // Timeout counters — guarded by lock
     private int turnTotal;
     private int timeoutCount;
+
+    // LLM request counters — guarded by lock. Total stays consistent with
+    // llmRequestsBySource — the sum of the map values always equals llmRequestsTotal.
+    // Insertion-ordered for deterministic JSON output; sources appear in the order the
+    // daemon first observed them during this lifetime.
+    private long llmRequestsTotal;
+    private final LinkedHashMap<String, Long> llmRequestsBySource = new LinkedHashMap<>();
 
     public RuntimeMetricsExporter() {
         this.mapper = new ObjectMapper();
@@ -103,6 +113,27 @@ public final class RuntimeMetricsExporter {
         lock.lock();
         try {
             timeoutCount++;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Folds a turn or plan's {@link RequestAttribution} into cumulative per-source LLM
+     * request counters. Used by {@link StreamingAgentHandler} to persist baseline data
+     * for Copilot premium-request tuning (epic #418, issue #419). Silently accepts
+     * empty or null attribution — callers on older code paths don't have to thread
+     * attribution through to get the rest of the runtime metrics.
+     */
+    public void recordLlmRequests(RequestAttribution attribution) {
+        if (attribution == null || attribution.total() == 0) return;
+        lock.lock();
+        try {
+            llmRequestsTotal += attribution.total();
+            attribution.bySource().forEach((source, count) -> {
+                String key = source.name().toLowerCase(Locale.ROOT);
+                llmRequestsBySource.merge(key, (long) count, Long::sum);
+            });
         } finally {
             lock.unlock();
         }
@@ -185,6 +216,15 @@ public final class RuntimeMetricsExporter {
                     snap.turnTotal > 0 ? (double) snap.timeoutCount / snap.turnTotal : Double.NaN,
                     snap.turnTotal);
 
+            // LLM request totals + per-source breakdown. Each emitted as an absolute count
+            // (value = count, sample_size = grand total so downstream scripts can derive
+            // ratios without re-summing). Sources with zero counts are omitted.
+            addRequestCountMetric(metrics, "llm_requests_total",
+                    snap.llmRequestsTotal, snap.llmRequestsTotal);
+            snap.llmRequestsBySource.forEach((source, count) ->
+                    addRequestCountMetric(metrics, "llm_requests_" + source,
+                            count, snap.llmRequestsTotal));
+
             // Write atomically
             Path metricsDir = projectRoot.resolve(METRICS_DIR);
             Files.createDirectories(metricsDir);
@@ -197,6 +237,24 @@ public final class RuntimeMetricsExporter {
             log.debug("Exported runtime metrics to {}", target);
         } catch (IOException e) {
             log.warn("Failed to export runtime metrics: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Variant of {@link #addMetric} for absolute counts (not ratios). Emits the raw value
+     * as an integer so downstream parsers don't see a trailing {@code .0} from double
+     * rounding, and marks the metric measured as long as the sample size is non-zero.
+     */
+    private void addRequestCountMetric(ObjectNode parent, String name, long value, long sampleSize) {
+        ObjectNode metric = parent.putObject(name);
+        if (sampleSize <= 0) {
+            metric.putNull("value");
+            metric.put("sample_size", 0);
+            metric.put("status", "pending_instrumentation");
+        } else {
+            metric.put("value", value);
+            metric.put("sample_size", sampleSize);
+            metric.put("status", "measured");
         }
     }
 
@@ -222,7 +280,8 @@ public final class RuntimeMetricsExporter {
             return new Snapshot(
                     taskTotal, taskSuccess, taskFirstTrySuccess,
                     retryCountTotal, permissionRequests, permissionBlocks,
-                    turnTotal, timeoutCount);
+                    turnTotal, timeoutCount,
+                    llmRequestsTotal, new LinkedHashMap<>(llmRequestsBySource));
         } finally {
             lock.unlock();
         }
@@ -231,6 +290,18 @@ public final class RuntimeMetricsExporter {
     public record Snapshot(
             int taskTotal, int taskSuccess, int taskFirstTrySuccess,
             long retryCountTotal, int permissionRequests, int permissionBlocks,
-            int turnTotal, int timeoutCount
-    ) {}
+            int turnTotal, int timeoutCount,
+            long llmRequestsTotal, Map<String, Long> llmRequestsBySource
+    ) {
+        public Snapshot {
+            // Preserve insertion order so JSON output lists sources in a stable sequence
+            // (Map.copyOf offers no order guarantee; LinkedHashMap via unmodifiableMap does).
+            if (llmRequestsBySource == null) {
+                llmRequestsBySource = Map.of();
+            } else {
+                llmRequestsBySource = java.util.Collections.unmodifiableMap(
+                        new LinkedHashMap<>(llmRequestsBySource));
+            }
+        }
+    }
 }

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -546,8 +546,17 @@ public final class StreamingAgentHandler {
                 null);
         int failedSteps = (int) planResult.stepResults().stream().filter(s -> !s.success()).count();
         boolean planFirstTry = planResult.success() && failedSteps == 0;
+        // Fold the upfront PLANNER request into the plan's aggregated attribution before
+        // reporting: planResult.requestAttribution() covers step turns + REPLAN calls; the
+        // initial planner call happens above and must be merged in here so the per-source
+        // map, the llmRequests scalar, and runtime metrics all stay consistent.
+        var planUsage = RequestAttribution.builder()
+                .merge(planResult.requestAttribution())
+                .merge(plannerAttribution.build())
+                .build();
         recordRuntimeMetrics(sessionId, planResult.success(), planFirstTry,
-                failedSteps, plannedStopReason, metricsCollector, session.projectPath());
+                failedSteps, plannedStopReason, metricsCollector, session.projectPath(),
+                planUsage);
 
         // 6. Build result
         var result = objectMapper.createObjectNode();
@@ -565,14 +574,6 @@ public final class StreamingAgentHandler {
 
         int totalInput = planResult.stepResults().stream().mapToInt(StepResult::inputTokens).sum();
         int totalOutput = planResult.stepResults().stream().mapToInt(StepResult::outputTokens).sum();
-        // Fold the upfront PLANNER request into the plan's aggregated attribution before
-        // reporting: planResult.requestAttribution() covers step turns + REPLAN calls; the
-        // initial planner call happens above and must be merged in here so the per-source
-        // map and the llmRequests scalar stay consistent.
-        var planUsage = RequestAttribution.builder()
-                .merge(planResult.requestAttribution())
-                .merge(plannerAttribution.build())
-                .build();
         var usageNode = objectMapper.createObjectNode();
         usageNode.put("inputTokens", totalInput);
         usageNode.put("outputTokens", totalOutput);
@@ -653,7 +654,8 @@ public final class StreamingAgentHandler {
         boolean directFirstTry = turnSuccess && (adaptive == null || adaptive.continuationCount() == 0);
         int directRetryCount = adaptive != null ? adaptive.continuationCount() : 0;
         recordRuntimeMetrics(sessionId, turnSuccess, directFirstTry,
-                directRetryCount, turn.finalStopReason(), metricsCollector, session.projectPath());
+                directRetryCount, turn.finalStopReason(), metricsCollector, session.projectPath(),
+                turn.requestAttribution());
 
         // Build result
         var result = objectMapper.createObjectNode();
@@ -2080,12 +2082,14 @@ public final class StreamingAgentHandler {
      */
     private void recordRuntimeMetrics(String sessionId, boolean success, boolean firstTry,
                                        int retryCount, StopReason stopReason,
-                                       ToolMetricsCollector metricsCollector, Path projectPath) {
+                                       ToolMetricsCollector metricsCollector, Path projectPath,
+                                       RequestAttribution requestAttribution) {
         var exporter = this.runtimeMetricsExporter;
         if (exporter == null) return;
         try {
             exporter.recordTaskOutcome(success, firstTry, retryCount);
             exporter.recordTurn();
+            exporter.recordLlmRequests(requestAttribution);
             if (stopReason == StopReason.MAX_TOKENS) {
                 exporter.recordTimeout();
             }
@@ -2644,8 +2648,13 @@ public final class StreamingAgentHandler {
                 null);
         int resumeFailedSteps = (int) planResult.stepResults().stream().filter(s -> !s.success()).count();
         boolean resumeFirstTry = planResult.success() && resumeFailedSteps == 0;
+        // Resumed plans don't re-run the planner (plan was already generated + checkpointed),
+        // so planResult.requestAttribution() is the full picture: step turns + any replans
+        // during resumption. Same attribution goes to both runtime metrics and the payload.
+        var resumedUsage = planResult.requestAttribution();
         recordRuntimeMetrics(sessionId, planResult.success(), resumeFirstTry,
-                resumeFailedSteps, plannedStopReason, metricsCollector, session.projectPath());
+                resumeFailedSteps, plannedStopReason, metricsCollector, session.projectPath(),
+                resumedUsage);
 
         var result = objectMapper.createObjectNode();
         result.put("sessionId", sessionId);
@@ -2664,10 +2673,6 @@ public final class StreamingAgentHandler {
 
         int totalInput = planResult.stepResults().stream().mapToInt(StepResult::inputTokens).sum();
         int totalOutput = planResult.stepResults().stream().mapToInt(StepResult::outputTokens).sum();
-        // Resumed plans don't re-run the planner (plan was already generated + checkpointed),
-        // so planResult.requestAttribution() is the full picture: step turns + any replans
-        // during resumption.
-        var resumedUsage = planResult.requestAttribution();
         var usageNode = objectMapper.createObjectNode();
         usageNode.put("inputTokens", totalInput);
         usageNode.put("outputTokens", totalOutput);

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/RuntimeMetricsExporterTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/RuntimeMetricsExporterTest.java
@@ -84,6 +84,62 @@ class RuntimeMetricsExporterTest {
     }
 
     @Test
+    void recordLlmRequests_accumulatesTotalAndPerSource() throws Exception {
+        // PR C: runtime-latest.json gains absolute-count metrics for LLM requests by source
+        // so offline tools can build a Copilot-usage baseline. Each per-source count lands
+        // in a metric named llm_requests_<source>; the grand total lands in llm_requests_total.
+        var exporter = new RuntimeMetricsExporter();
+
+        // Turn 1: two main-turn + one planner.
+        exporter.recordLlmRequests(dev.aceclaw.core.llm.RequestAttribution.builder()
+                .record(dev.aceclaw.core.llm.RequestSource.MAIN_TURN, 2)
+                .record(dev.aceclaw.core.llm.RequestSource.PLANNER, 1)
+                .build());
+        // Turn 2: one main-turn + one continuation.
+        exporter.recordLlmRequests(dev.aceclaw.core.llm.RequestAttribution.builder()
+                .record(dev.aceclaw.core.llm.RequestSource.MAIN_TURN)
+                .record(dev.aceclaw.core.llm.RequestSource.CONTINUATION)
+                .build());
+        // Empty / null are ignored.
+        exporter.recordLlmRequests(null);
+        exporter.recordLlmRequests(dev.aceclaw.core.llm.RequestAttribution.empty());
+
+        exporter.export(tempDir, null);
+
+        Path output = tempDir.resolve(".aceclaw/metrics/continuous-learning/runtime-latest.json");
+        JsonNode metrics = new ObjectMapper().readTree(output.toFile()).get("metrics");
+
+        assertThat(metrics.get("llm_requests_total").get("value").asLong()).isEqualTo(5);
+        assertThat(metrics.get("llm_requests_total").get("status").asText()).isEqualTo("measured");
+        assertThat(metrics.get("llm_requests_main_turn").get("value").asLong()).isEqualTo(3);
+        assertThat(metrics.get("llm_requests_planner").get("value").asLong()).isEqualTo(1);
+        assertThat(metrics.get("llm_requests_continuation").get("value").asLong()).isEqualTo(1);
+        // Sample size is the grand total so downstream scripts can compute ratios
+        // without having to re-sum every per-source metric.
+        assertThat(metrics.get("llm_requests_main_turn").get("sample_size").asLong()).isEqualTo(5);
+        // Sources that never fired are NOT emitted — keeps the metrics file compact.
+        assertThat(metrics.has("llm_requests_replan")).isFalse();
+        assertThat(metrics.has("llm_requests_fallback")).isFalse();
+    }
+
+    @Test
+    void export_withNoLlmRequests_omitsPerSourceMetrics() throws Exception {
+        // A daemon lifetime with no LLM requests at all (only task or tool metrics) should
+        // emit the total metric with pending_instrumentation status but no per-source
+        // clutter — otherwise fresh baselines look noisy.
+        var exporter = new RuntimeMetricsExporter();
+        exporter.recordTurn();
+        exporter.export(tempDir, null);
+
+        Path output = tempDir.resolve(".aceclaw/metrics/continuous-learning/runtime-latest.json");
+        JsonNode metrics = new ObjectMapper().readTree(output.toFile()).get("metrics");
+
+        assertThat(metrics.get("llm_requests_total").get("status").asText())
+                .isEqualTo("pending_instrumentation");
+        assertThat(metrics.has("llm_requests_main_turn")).isFalse();
+    }
+
+    @Test
     void export_withNoData_marksPendingInstrumentation() throws Exception {
         var exporter = new RuntimeMetricsExporter();
         exporter.export(tempDir, null);


### PR DESCRIPTION
## Summary

Last slice of #419 (epic #418). Two separate but related user-visible surfaces land together because both consume the per-source attribution that PR B (#421) shipped on the wire; splitting would leave one half without the other.

### 1. Per-turn breakdown on the turn summary line

The turn summary already shows \`N LLM req\` inline. When the daemon's \`usage\` includes \`llmRequestsBySource\` (PR B), the CLI now appends a parenthetical breakdown matching the \`/status\` format:

Before (direct turn with 3 LLM calls including compaction summary):
\`\`\`
4.0s  3 LLM req  3 in / 17 out  context 78K/1000K
\`\`\`

After:
\`\`\`
4.0s  3 LLM req (main=2 compact=1)  3 in / 17 out  context 78K/1000K
\`\`\`

Backward compatible — older daemons or turns with no attribution show the scalar form unchanged (the breakdown helper returns \`\"\"\` on empty maps). \`formatLlmRequestsBreakdown\` was widened to \`Map<String, ? extends Number>\` so the per-turn Integer map and the session-level Long map share one formatter.

### 2. runtime-latest.json export

\`RuntimeMetricsExporter\` gains a \`recordLlmRequests(RequestAttribution)\` method and a per-source counter on its \`Snapshot\`. The existing \`export()\` emits them as absolute-count metrics:

\`\`\`json
\"llm_requests_total\":     {\"value\": 42, \"sample_size\": 42, \"status\": \"measured\"},
\"llm_requests_main_turn\": {\"value\": 30, \"sample_size\": 42, \"status\": \"measured\"},
\"llm_requests_planner\":   {\"value\":  6, \"sample_size\": 42, \"status\": \"measured\"},
\"llm_requests_continuation\":{\"value\":  4, \"sample_size\": 42, \"status\": \"measured\"},
\"llm_requests_compaction_summary\":{\"value\": 2, \"sample_size\": 42, \"status\": \"measured\"}
\`\`\`

Each per-source metric's \`sample_size\` equals the grand total so offline tools computing Copilot-spend ratios don't have to re-sum. Sources with zero counts are omitted. When no LLM requests have been recorded at all, only \`llm_requests_total\` appears with \`pending_instrumentation\` status — matches existing convention.

### 3. Wiring

\`StreamingAgentHandler.recordRuntimeMetrics\` now takes \`RequestAttribution\` and forwards it to the exporter. The three call sites pass:

| Path | Attribution source |
|---|---|
| Planned task | plan-level = `planner` + `planResult` (same value already used for the JSON-RPC payload) |
| Direct turn | \`turn.requestAttribution()\` |
| Resumed plan | \`planResult.requestAttribution()\` (no planner re-run on resume) |

Planned path now dedups the attribution computation — one build, two consumers (runtime metrics + wire payload).

## Scope boundaries

- No new protocol changes (wire fields are exactly what PR B shipped).
- No behavior changes to when/how requests are counted.

## Test plan

- [x] \`./gradlew build\` — passes (53 tasks)
- [x] \`RuntimeMetricsExporterTest.recordLlmRequests_accumulatesTotalAndPerSource\` — three recordings (one empty) aggregate correctly; \`sample_size\` matches grand total; sources that never fired are absent from the output.
- [x] \`RuntimeMetricsExporterTest.export_withNoLlmRequests_omitsPerSourceMetrics\` — fresh baseline shows only \`llm_requests_total\` with \`pending_instrumentation\`, no per-source clutter.
- [x] All existing exporter tests still pass (new counter additive, no ratio-metric changes).

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)