### PR TITLE
feat(metrics): tag runtime export with provider + model + Copilot multiplier

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/CopilotRequestMultipliers.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/CopilotRequestMultipliers.java
@@ -6,45 +6,74 @@ import java.util.Map;
 /**
  * Normalized cost multipliers for GitHub Copilot premium requests, keyed by model.
  *
- * <p>Copilot charges differ per underlying model — e.g. Claude Opus runs at 10x while
- * Claude Sonnet and GPT-4o run at 1x — so raw request counts across models aren't
+ * <p>Copilot charges differ per underlying model — e.g. Claude Opus runs at 3x while
+ * GPT-4o runs at 0x on paid plans — so raw request counts across models aren't
  * directly comparable. Exporting a multiplier alongside the per-source attribution
  * lets offline analysis translate request counts into normalized cost units for
  * apples-to-apples comparison.
  *
+ * <p>Keys follow the Copilot-native identifier form (dot notation for Claude, as-is
+ * for others). AceClaw's {@code LlmClientFactory} routes Anthropic-style hyphenated
+ * names through a translator before they reach Copilot, so by the time a model id
+ * arrives here via {@code LlmClient.defaultModel()} or the {@code /model} override,
+ * it is already in Copilot form. Hyphenated aliases for the same Claude models are
+ * included defensively for the edge case where a caller passes the pre-translation
+ * form.
+ *
  * <p>Values reflect the GitHub Copilot premium-request rate card current as of
- * {@value #RATE_CARD_DATE}. Rates change as GitHub tunes their pricing; this table
- * is intentionally small and named-literal rather than scraped — update via PR when
+ * {@value #RATE_CARD_DATE}. Rates change as GitHub tunes pricing; the table is
+ * intentionally small and named-literal rather than scraped — update via PR when
  * the rate card shifts.
  *
- * <p>Unknown Copilot model → {@code 1.0} (the common-case rate). Non-Copilot
- * provider → {@code null} (the multiplier concept doesn't apply to token-priced
- * providers like direct Anthropic or OpenAI).
+ * <p>Unknown Copilot model → {@link #DEFAULT_COPILOT_MULTIPLIER} (the common-case
+ * rate). Non-Copilot provider → {@code null} (the multiplier concept doesn't apply
+ * to token-priced providers like direct Anthropic or OpenAI).
  */
 final class CopilotRequestMultipliers {
 
     static final String RATE_CARD_DATE = "2026-04";
     static final double DEFAULT_COPILOT_MULTIPLIER = 1.0;
 
+    /**
+     * Copilot-canonical model id → premium-request multiplier.
+     * Dot-notation Claude ids match the form produced by
+     * {@code LlmClientFactory#ANTHROPIC_TO_COPILOT_MODEL}; non-Claude models are used as-is.
+     */
     private static final Map<String, Double> COPILOT = Map.ofEntries(
-            // Anthropic through Copilot
-            Map.entry("claude-sonnet-4-5", 1.0),
-            Map.entry("claude-sonnet-4-6", 1.0),
-            Map.entry("claude-opus-4", 5.0),
-            Map.entry("claude-opus-4-5", 5.0),
-            Map.entry("claude-opus-4-6", 10.0),
-            Map.entry("claude-opus-4-7", 10.0),
+            // Anthropic via Copilot (Copilot form: dot notation)
+            Map.entry("claude-sonnet-4.5", 1.0),
+            Map.entry("claude-sonnet-4.6", 1.0),
+            Map.entry("claude-opus-4.5", 3.0),
+            Map.entry("claude-opus-4.6", 3.0),
+            Map.entry("claude-haiku-4.5", 0.33),
             Map.entry("claude-3-5-sonnet", 1.0),
-            // OpenAI through Copilot
-            Map.entry("gpt-4o", 1.0),
+            // OpenAI via Copilot
+            Map.entry("gpt-4o", 0.0),
             Map.entry("gpt-4.1", 0.0),
             Map.entry("gpt-5", 1.0),
+            Map.entry("gpt-5.4-mini", 0.33),
             Map.entry("o1", 10.0),
             Map.entry("o1-preview", 10.0),
             Map.entry("o3-mini", 0.33),
-            // Gemini through Copilot
+            Map.entry("raptor-mini", 0.0),
+            // Google via Copilot
             Map.entry("gemini-2.0-flash", 0.25),
-            Map.entry("gemini-2.5-pro", 1.0)
+            Map.entry("gemini-2.5-pro", 1.0),
+            // xAI via Copilot
+            Map.entry("grok-code-fast-1", 0.25)
+    );
+
+    /**
+     * Hyphenated Anthropic-direct ids → their Copilot dot-notation equivalent. Covers the
+     * case where the pre-translation form leaks through (e.g. a caller reading the daemon
+     * config instead of the resolved Copilot model).
+     */
+    private static final Map<String, String> HYPHEN_TO_DOT_CLAUDE = Map.ofEntries(
+            Map.entry("claude-sonnet-4-5", "claude-sonnet-4.5"),
+            Map.entry("claude-sonnet-4-6", "claude-sonnet-4.6"),
+            Map.entry("claude-opus-4-5", "claude-opus-4.5"),
+            Map.entry("claude-opus-4-6", "claude-opus-4.6"),
+            Map.entry("claude-haiku-4-5", "claude-haiku-4.5")
     );
 
     private CopilotRequestMultipliers() {}
@@ -53,8 +82,14 @@ final class CopilotRequestMultipliers {
      * Returns the normalized premium-request multiplier for a given provider + model,
      * or {@code null} if the provider is not Copilot.
      *
-     * <p>Models with a trailing date suffix (e.g. {@code claude-opus-4-6-20250929})
-     * are normalized to their base identifier before lookup.
+     * <p>Normalization handles:
+     * <ol>
+     *   <li>Case: lowercases before lookup.</li>
+     *   <li>Date suffix: strips a trailing 8-digit suffix
+     *       ({@code claude-opus-4.6-20250929} → {@code claude-opus-4.6}).</li>
+     *   <li>Anthropic-style hyphens: maps {@code claude-opus-4-6} →
+     *       {@code claude-opus-4.6} before table lookup.</li>
+     * </ol>
      */
     static Double forProviderAndModel(String provider, String model) {
         if (provider == null || !"copilot".equalsIgnoreCase(provider)) {
@@ -63,8 +98,14 @@ final class CopilotRequestMultipliers {
         if (model == null || model.isBlank()) {
             return DEFAULT_COPILOT_MULTIPLIER;
         }
-        String normalized = model.toLowerCase(Locale.ROOT);
-        // Strip trailing 8-digit date suffix: "claude-opus-4-6-20250929" -> "claude-opus-4-6"
+        String normalized = normalizeModelId(model);
+        return COPILOT.getOrDefault(normalized, DEFAULT_COPILOT_MULTIPLIER);
+    }
+
+    /** Visible for test. */
+    static String normalizeModelId(String model) {
+        String normalized = model.toLowerCase(Locale.ROOT).trim();
+        // Strip trailing 8-digit date suffix: "claude-opus-4.6-20250929" -> "claude-opus-4.6"
         int dashDate = normalized.lastIndexOf('-');
         if (dashDate > 0 && dashDate < normalized.length() - 1) {
             String tail = normalized.substring(dashDate + 1);
@@ -72,6 +113,9 @@ final class CopilotRequestMultipliers {
                 normalized = normalized.substring(0, dashDate);
             }
         }
-        return COPILOT.getOrDefault(normalized, DEFAULT_COPILOT_MULTIPLIER);
+        // Anthropic hyphen form → Copilot dot form. Applied after date-suffix stripping so
+        // "claude-opus-4-6-20250929" first becomes "claude-opus-4-6" then "claude-opus-4.6".
+        String dotted = HYPHEN_TO_DOT_CLAUDE.get(normalized);
+        return dotted != null ? dotted : normalized;
     }
 }

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/CopilotRequestMultipliers.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/CopilotRequestMultipliers.java
@@ -1,0 +1,77 @@
+package dev.aceclaw.daemon;
+
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Normalized cost multipliers for GitHub Copilot premium requests, keyed by model.
+ *
+ * <p>Copilot charges differ per underlying model — e.g. Claude Opus runs at 10x while
+ * Claude Sonnet and GPT-4o run at 1x — so raw request counts across models aren't
+ * directly comparable. Exporting a multiplier alongside the per-source attribution
+ * lets offline analysis translate request counts into normalized cost units for
+ * apples-to-apples comparison.
+ *
+ * <p>Values reflect the GitHub Copilot premium-request rate card current as of
+ * {@value #RATE_CARD_DATE}. Rates change as GitHub tunes their pricing; this table
+ * is intentionally small and named-literal rather than scraped — update via PR when
+ * the rate card shifts.
+ *
+ * <p>Unknown Copilot model → {@code 1.0} (the common-case rate). Non-Copilot
+ * provider → {@code null} (the multiplier concept doesn't apply to token-priced
+ * providers like direct Anthropic or OpenAI).
+ */
+final class CopilotRequestMultipliers {
+
+    static final String RATE_CARD_DATE = "2026-04";
+    static final double DEFAULT_COPILOT_MULTIPLIER = 1.0;
+
+    private static final Map<String, Double> COPILOT = Map.ofEntries(
+            // Anthropic through Copilot
+            Map.entry("claude-sonnet-4-5", 1.0),
+            Map.entry("claude-sonnet-4-6", 1.0),
+            Map.entry("claude-opus-4", 5.0),
+            Map.entry("claude-opus-4-5", 5.0),
+            Map.entry("claude-opus-4-6", 10.0),
+            Map.entry("claude-opus-4-7", 10.0),
+            Map.entry("claude-3-5-sonnet", 1.0),
+            // OpenAI through Copilot
+            Map.entry("gpt-4o", 1.0),
+            Map.entry("gpt-4.1", 0.0),
+            Map.entry("gpt-5", 1.0),
+            Map.entry("o1", 10.0),
+            Map.entry("o1-preview", 10.0),
+            Map.entry("o3-mini", 0.33),
+            // Gemini through Copilot
+            Map.entry("gemini-2.0-flash", 0.25),
+            Map.entry("gemini-2.5-pro", 1.0)
+    );
+
+    private CopilotRequestMultipliers() {}
+
+    /**
+     * Returns the normalized premium-request multiplier for a given provider + model,
+     * or {@code null} if the provider is not Copilot.
+     *
+     * <p>Models with a trailing date suffix (e.g. {@code claude-opus-4-6-20250929})
+     * are normalized to their base identifier before lookup.
+     */
+    static Double forProviderAndModel(String provider, String model) {
+        if (provider == null || !"copilot".equalsIgnoreCase(provider)) {
+            return null;
+        }
+        if (model == null || model.isBlank()) {
+            return DEFAULT_COPILOT_MULTIPLIER;
+        }
+        String normalized = model.toLowerCase(Locale.ROOT);
+        // Strip trailing 8-digit date suffix: "claude-opus-4-6-20250929" -> "claude-opus-4-6"
+        int dashDate = normalized.lastIndexOf('-');
+        if (dashDate > 0 && dashDate < normalized.length() - 1) {
+            String tail = normalized.substring(dashDate + 1);
+            if (tail.length() == 8 && tail.chars().allMatch(Character::isDigit)) {
+                normalized = normalized.substring(0, dashDate);
+            }
+        }
+        return COPILOT.getOrDefault(normalized, DEFAULT_COPILOT_MULTIPLIER);
+    }
+}

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/RuntimeMetricsExporter.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/RuntimeMetricsExporter.java
@@ -1,6 +1,7 @@
 package dev.aceclaw.daemon;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import dev.aceclaw.core.agent.ToolMetrics;
 import dev.aceclaw.core.agent.ToolMetricsCollector;
@@ -14,6 +15,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -26,8 +28,11 @@ import java.util.concurrent.locks.ReentrantLock;
  *
  * <p>Output: {@code .aceclaw/metrics/continuous-learning/runtime-latest.json}
  *
- * <p>Counters are accumulated across daemon lifetime (reset on restart).
- * Each metric includes {@code value}, {@code sample_size}, and {@code status}.
+ * <p>Counters are accumulated across daemon lifetime (reset on restart). LLM
+ * request counts are additionally partitioned by {@code (provider, model)} so a
+ * mid-session {@code /model} switch doesn't misattribute prior history to the new
+ * model. Each per-(provider, model) bucket carries its own total + per-source
+ * breakdown + Copilot-normalised cost multiplier.
  *
  * <p>Thread-safety: all counter mutations and snapshot reads are protected
  * by a single lock to ensure consistent ratios (e.g., success &lt;= total).
@@ -55,12 +60,11 @@ public final class RuntimeMetricsExporter {
     private int turnTotal;
     private int timeoutCount;
 
-    // LLM request counters — guarded by lock. Total stays consistent with
-    // llmRequestsBySource — the sum of the map values always equals llmRequestsTotal.
-    // Insertion-ordered for deterministic JSON output; sources appear in the order the
-    // daemon first observed them during this lifetime.
-    private long llmRequestsTotal;
-    private final LinkedHashMap<String, Long> llmRequestsBySource = new LinkedHashMap<>();
+    // LLM request counters — guarded by lock. Keyed by (provider, model) so /model
+    // switches don't cross-contaminate the per-model baseline. Per-bucket totals +
+    // per-source breakdowns are self-consistent within their bucket; a grand total
+    // across all buckets is derived at export time for convenience.
+    private final LinkedHashMap<ModelKey, ModelCounts> llmRequestsByModel = new LinkedHashMap<>();
 
     public RuntimeMetricsExporter() {
         this.mapper = new ObjectMapper();
@@ -119,20 +123,30 @@ public final class RuntimeMetricsExporter {
     }
 
     /**
-     * Folds a turn or plan's {@link RequestAttribution} into cumulative per-source LLM
-     * request counters. Used by {@link StreamingAgentHandler} to persist baseline data
-     * for Copilot premium-request tuning (epic #418, issue #419). Silently accepts
-     * empty or null attribution — callers on older code paths don't have to thread
-     * attribution through to get the rest of the runtime metrics.
+     * Folds a turn or plan's {@link RequestAttribution} into the cumulative per-source
+     * LLM request counters for the given provider + model bucket. Each distinct
+     * {@code (provider, model)} observed during a daemon lifetime gets its own bucket,
+     * so a mid-session {@code /model} switch doesn't re-label history.
+     *
+     * <p>Silently accepts {@code null} or empty attribution — callers on older code paths
+     * don't have to thread attribution through to get the rest of the runtime metrics.
+     *
+     * @param attribution the per-source request counts from this turn or plan
+     * @param provider    the LLM provider identifier for these requests; may be {@code null}
+     *                    (recorded under an {@code unknown} provider bucket)
+     * @param model       the model identifier for these requests; may be {@code null}
+     *                    (recorded under an {@code unknown} model bucket)
      */
-    public void recordLlmRequests(RequestAttribution attribution) {
+    public void recordLlmRequests(RequestAttribution attribution, String provider, String model) {
         if (attribution == null || attribution.total() == 0) return;
         lock.lock();
         try {
-            llmRequestsTotal += attribution.total();
+            var key = ModelKey.of(provider, model);
+            var bucket = llmRequestsByModel.computeIfAbsent(key, k -> new ModelCounts());
             attribution.bySource().forEach((source, count) -> {
-                String key = source.name().toLowerCase(Locale.ROOT);
-                llmRequestsBySource.merge(key, (long) count, Long::sum);
+                String sourceKey = source.name().toLowerCase(Locale.ROOT);
+                bucket.bySource.merge(sourceKey, (long) count, Long::sum);
+                bucket.total += count;
             });
         } finally {
             lock.unlock();
@@ -158,64 +172,26 @@ public final class RuntimeMetricsExporter {
      * @param toolMetrics the session tool metrics collector (may be null)
      */
     public void export(Path projectRoot, ToolMetricsCollector toolMetrics) {
-        export(projectRoot, toolMetrics, null, null);
-    }
-
-    /**
-     * Exports all accumulated metrics to the runtime-latest.json file, tagging the
-     * snapshot with the current provider + model so downstream baseline analysis can
-     * segment Copilot data by pricing tier. When provider is Copilot, a normalized
-     * {@code model_multiplier} is derived from {@link CopilotRequestMultipliers} so
-     * raw request counts can be converted to cost units without a second lookup.
-     *
-     * @param projectRoot the project root directory (must not be null)
-     * @param toolMetrics the session tool metrics collector (may be null)
-     * @param provider    the LLM provider identifier (e.g. {@code "copilot"}, {@code "anthropic"});
-     *                    {@code null} omits the field
-     * @param model       the active model identifier; {@code null} omits the field
-     */
-    public void export(Path projectRoot, ToolMetricsCollector toolMetrics,
-                       String provider, String model) {
         Objects.requireNonNull(projectRoot, "projectRoot");
         try {
-            // Take a consistent snapshot under lock
             Snapshot snap = snapshot();
 
             ObjectNode root = mapper.createObjectNode();
             root.put("exported_at", Instant.now().toString());
-            if (provider != null && !provider.isBlank()) {
-                root.put("provider", provider);
-            }
-            if (model != null && !model.isBlank()) {
-                root.put("model", model);
-            }
-            Double multiplier = CopilotRequestMultipliers.forProviderAndModel(provider, model);
-            if (multiplier != null) {
-                // Only populated for Copilot. Non-Copilot providers charge per-token, not
-                // per-request, so a request multiplier is not meaningful and the field is
-                // omitted rather than set to a misleading 1.0.
-                root.put("model_multiplier", multiplier);
-                root.put("model_multiplier_rate_card_date", CopilotRequestMultipliers.RATE_CARD_DATE);
-            }
+            root.put("rate_card_date", CopilotRequestMultipliers.RATE_CARD_DATE);
 
             ObjectNode metrics = root.putObject("metrics");
 
-            // Task success rate
             addMetric(metrics, "task_success_rate",
                     snap.taskTotal > 0 ? (double) snap.taskSuccess / snap.taskTotal : Double.NaN,
                     snap.taskTotal);
-
-            // First try success rate
             addMetric(metrics, "first_try_success_rate",
                     snap.taskTotal > 0 ? (double) snap.taskFirstTrySuccess / snap.taskTotal : Double.NaN,
                     snap.taskTotal);
-
-            // Retry count per task (average)
             addMetric(metrics, "retry_count_per_task",
                     snap.taskTotal > 0 ? (double) snap.retryCountTotal / snap.taskTotal : Double.NaN,
                     snap.taskTotal);
 
-            // Tool execution metrics (from ToolMetricsCollector)
             if (toolMetrics != null) {
                 Map<String, ToolMetrics> allTools = toolMetrics.allMetrics();
                 int totalToolInvocations = 0;
@@ -237,27 +213,35 @@ public final class RuntimeMetricsExporter {
                 addMetric(metrics, "tool_error_rate", Double.NaN, 0);
             }
 
-            // Permission block rate
             addMetric(metrics, "permission_block_rate",
                     snap.permissionRequests > 0
                             ? (double) snap.permissionBlocks / snap.permissionRequests : Double.NaN,
                     snap.permissionRequests);
-
-            // Timeout rate
             addMetric(metrics, "timeout_rate",
                     snap.turnTotal > 0 ? (double) snap.timeoutCount / snap.turnTotal : Double.NaN,
                     snap.turnTotal);
 
-            // LLM request totals + per-source breakdown. Each emitted as an absolute count
-            // (value = count, sample_size = grand total so downstream scripts can derive
-            // ratios without re-summing). Sources with zero counts are omitted.
-            addRequestCountMetric(metrics, "llm_requests_total",
-                    snap.llmRequestsTotal, snap.llmRequestsTotal);
-            snap.llmRequestsBySource.forEach((source, count) ->
-                    addRequestCountMetric(metrics, "llm_requests_" + source,
-                            count, snap.llmRequestsTotal));
+            // Per-(provider, model) breakdown. Each bucket carries its own total + per-source
+            // distribution + Copilot multiplier so downstream analysis can compute normalized
+            // cost units without re-labeling history after a /model switch.
+            long grandTotal = snap.llmRequestsByModel.values().stream()
+                    .mapToLong(ModelCounts::total).sum();
+            ArrayNode perModel = root.putArray("llm_requests_by_model");
+            snap.llmRequestsByModel.forEach((key, counts) -> {
+                ObjectNode bucket = perModel.addObject();
+                bucket.put("provider", key.provider());
+                bucket.put("model", key.model());
+                Double multiplier = CopilotRequestMultipliers.forProviderAndModel(
+                        key.provider(), key.model());
+                if (multiplier != null) {
+                    bucket.put("multiplier", multiplier);
+                }
+                bucket.put("total", counts.total());
+                ObjectNode bySource = bucket.putObject("by_source");
+                counts.bySource().forEach(bySource::put);
+            });
+            addRequestCountMetric(metrics, "llm_requests_total", grandTotal, grandTotal);
 
-            // Write atomically
             Path metricsDir = projectRoot.resolve(METRICS_DIR);
             Files.createDirectories(metricsDir);
             Path target = metricsDir.resolve(RUNTIME_FILE);
@@ -309,30 +293,60 @@ public final class RuntimeMetricsExporter {
     public Snapshot snapshot() {
         lock.lock();
         try {
+            var copied = new LinkedHashMap<ModelKey, ModelCounts>();
+            llmRequestsByModel.forEach((k, v) -> copied.put(k, v.copy()));
             return new Snapshot(
                     taskTotal, taskSuccess, taskFirstTrySuccess,
                     retryCountTotal, permissionRequests, permissionBlocks,
                     turnTotal, timeoutCount,
-                    llmRequestsTotal, new LinkedHashMap<>(llmRequestsBySource));
+                    copied);
         } finally {
             lock.unlock();
         }
+    }
+
+    /** Identifies a distinct {@code (provider, model)} pair for bucketing request counts. */
+    public record ModelKey(String provider, String model) {
+        public ModelKey {
+            provider = (provider == null || provider.isBlank()) ? "unknown" : provider;
+            model = (model == null || model.isBlank()) ? "unknown" : model;
+        }
+
+        static ModelKey of(String provider, String model) {
+            return new ModelKey(provider, model);
+        }
+    }
+
+    /** Mutable per-bucket counters. Copied on snapshot; never leaked outside the lock. */
+    static final class ModelCounts {
+        long total;
+        final LinkedHashMap<String, Long> bySource = new LinkedHashMap<>();
+
+        ModelCounts copy() {
+            var c = new ModelCounts();
+            c.total = this.total;
+            c.bySource.putAll(this.bySource);
+            return c;
+        }
+
+        long total() { return total; }
+        Map<String, Long> bySource() { return Collections.unmodifiableMap(bySource); }
     }
 
     public record Snapshot(
             int taskTotal, int taskSuccess, int taskFirstTrySuccess,
             long retryCountTotal, int permissionRequests, int permissionBlocks,
             int turnTotal, int timeoutCount,
-            long llmRequestsTotal, Map<String, Long> llmRequestsBySource
+            Map<ModelKey, ModelCounts> llmRequestsByModel
     ) {
         public Snapshot {
-            // Preserve insertion order so JSON output lists sources in a stable sequence
+            // Preserve insertion order so JSON output lists models in a stable sequence
             // (Map.copyOf offers no order guarantee; LinkedHashMap via unmodifiableMap does).
-            if (llmRequestsBySource == null) {
-                llmRequestsBySource = Map.of();
+            if (llmRequestsByModel == null) {
+                llmRequestsByModel = Map.of();
             } else {
-                llmRequestsBySource = java.util.Collections.unmodifiableMap(
-                        new LinkedHashMap<>(llmRequestsBySource));
+                llmRequestsByModel = Collections.unmodifiableMap(
+                        new LinkedHashMap<>(llmRequestsByModel));
             }
         }
     }

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/RuntimeMetricsExporter.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/RuntimeMetricsExporter.java
@@ -158,6 +158,24 @@ public final class RuntimeMetricsExporter {
      * @param toolMetrics the session tool metrics collector (may be null)
      */
     public void export(Path projectRoot, ToolMetricsCollector toolMetrics) {
+        export(projectRoot, toolMetrics, null, null);
+    }
+
+    /**
+     * Exports all accumulated metrics to the runtime-latest.json file, tagging the
+     * snapshot with the current provider + model so downstream baseline analysis can
+     * segment Copilot data by pricing tier. When provider is Copilot, a normalized
+     * {@code model_multiplier} is derived from {@link CopilotRequestMultipliers} so
+     * raw request counts can be converted to cost units without a second lookup.
+     *
+     * @param projectRoot the project root directory (must not be null)
+     * @param toolMetrics the session tool metrics collector (may be null)
+     * @param provider    the LLM provider identifier (e.g. {@code "copilot"}, {@code "anthropic"});
+     *                    {@code null} omits the field
+     * @param model       the active model identifier; {@code null} omits the field
+     */
+    public void export(Path projectRoot, ToolMetricsCollector toolMetrics,
+                       String provider, String model) {
         Objects.requireNonNull(projectRoot, "projectRoot");
         try {
             // Take a consistent snapshot under lock
@@ -165,6 +183,20 @@ public final class RuntimeMetricsExporter {
 
             ObjectNode root = mapper.createObjectNode();
             root.put("exported_at", Instant.now().toString());
+            if (provider != null && !provider.isBlank()) {
+                root.put("provider", provider);
+            }
+            if (model != null && !model.isBlank()) {
+                root.put("model", model);
+            }
+            Double multiplier = CopilotRequestMultipliers.forProviderAndModel(provider, model);
+            if (multiplier != null) {
+                // Only populated for Copilot. Non-Copilot providers charge per-token, not
+                // per-request, so a request multiplier is not meaningful and the field is
+                // omitted rather than set to a misleading 1.0.
+                root.put("model_multiplier", multiplier);
+                root.put("model_multiplier_rate_card_date", CopilotRequestMultipliers.RATE_CARD_DATE);
+            }
 
             ObjectNode metrics = root.putObject("metrics");
 

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -2089,14 +2089,18 @@ public final class StreamingAgentHandler {
         try {
             exporter.recordTaskOutcome(success, firstTry, retryCount);
             exporter.recordTurn();
-            exporter.recordLlmRequests(requestAttribution);
+            // Provider + model live at the level of the INDIVIDUAL request batch, not the
+            // daemon-lifetime aggregate, so they flow into the counter here rather than at
+            // export time. A /model switch mid-session produces new (provider, model)
+            // buckets for subsequent turns while leaving earlier history correctly tagged.
+            String provider = getLlmClient() != null ? getLlmClient().provider() : null;
+            String model = getModelForSession(sessionId);
+            exporter.recordLlmRequests(requestAttribution, provider, model);
             if (stopReason == StopReason.MAX_TOKENS) {
                 exporter.recordTimeout();
             }
             if (projectPath != null) {
-                String provider = getLlmClient() != null ? getLlmClient().provider() : null;
-                String model = getModelForSession(sessionId);
-                exporter.export(projectPath, metricsCollector, provider, model);
+                exporter.export(projectPath, metricsCollector);
             }
         } catch (Exception e) {
             log.debug("Runtime metrics recording failed: {}", e.getMessage());

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -2094,7 +2094,9 @@ public final class StreamingAgentHandler {
                 exporter.recordTimeout();
             }
             if (projectPath != null) {
-                exporter.export(projectPath, metricsCollector);
+                String provider = getLlmClient() != null ? getLlmClient().provider() : null;
+                String model = getModelForSession(sessionId);
+                exporter.export(projectPath, metricsCollector, provider, model);
             }
         } catch (Exception e) {
             log.debug("Runtime metrics recording failed: {}", e.getMessage());

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/CopilotRequestMultipliersTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/CopilotRequestMultipliersTest.java
@@ -1,0 +1,71 @@
+package dev.aceclaw.daemon;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CopilotRequestMultipliersTest {
+
+    @Test
+    void returnsNullForNonCopilotProvider() {
+        assertThat(CopilotRequestMultipliers.forProviderAndModel("anthropic", "claude-opus-4-6"))
+                .isNull();
+        assertThat(CopilotRequestMultipliers.forProviderAndModel("openai", "gpt-4o"))
+                .isNull();
+        assertThat(CopilotRequestMultipliers.forProviderAndModel(null, "claude-opus-4-6"))
+                .isNull();
+    }
+
+    @Test
+    void returnsKnownMultipliersForCopilotModels() {
+        // Exact model identifier hits the map directly.
+        assertThat(CopilotRequestMultipliers.forProviderAndModel("copilot", "claude-opus-4-6"))
+                .isEqualTo(10.0);
+        assertThat(CopilotRequestMultipliers.forProviderAndModel("copilot", "claude-sonnet-4-5"))
+                .isEqualTo(1.0);
+        assertThat(CopilotRequestMultipliers.forProviderAndModel("copilot", "o3-mini"))
+                .isEqualTo(0.33);
+        assertThat(CopilotRequestMultipliers.forProviderAndModel("copilot", "gpt-4.1"))
+                .isEqualTo(0.0);
+    }
+
+    @Test
+    void stripsTrailingDateSuffixBeforeLookup() {
+        // Anthropic model ids in this repo carry a date suffix — the lookup should strip
+        // it before hitting the table so "claude-opus-4-6-20250929" maps to the same
+        // multiplier as "claude-opus-4-6".
+        assertThat(CopilotRequestMultipliers.forProviderAndModel("copilot", "claude-opus-4-6-20250929"))
+                .isEqualTo(10.0);
+        assertThat(CopilotRequestMultipliers.forProviderAndModel("copilot", "claude-sonnet-4-5-20260101"))
+                .isEqualTo(1.0);
+    }
+
+    @Test
+    void unknownCopilotModelFallsBackToDefault() {
+        // Unknown Copilot model (newly released, or a typo in config) falls back to 1.0 —
+        // the common-case rate. Logged offline data still has "model" so analysts can spot
+        // the fallback and update the table.
+        assertThat(CopilotRequestMultipliers.forProviderAndModel("copilot", "future-model-9000"))
+                .isEqualTo(CopilotRequestMultipliers.DEFAULT_COPILOT_MULTIPLIER);
+    }
+
+    @Test
+    void caseInsensitiveProviderAndModel() {
+        assertThat(CopilotRequestMultipliers.forProviderAndModel("COPILOT", "CLAUDE-OPUS-4-6"))
+                .isEqualTo(10.0);
+        assertThat(CopilotRequestMultipliers.forProviderAndModel("Copilot", "Claude-Sonnet-4-5"))
+                .isEqualTo(1.0);
+    }
+
+    @Test
+    void blankOrNullModelYieldsDefault() {
+        // Copilot with no model yields the default — caller knows the provider but can't
+        // distinguish the tier; 1.0 is the safe assumption for projection.
+        assertThat(CopilotRequestMultipliers.forProviderAndModel("copilot", null))
+                .isEqualTo(CopilotRequestMultipliers.DEFAULT_COPILOT_MULTIPLIER);
+        assertThat(CopilotRequestMultipliers.forProviderAndModel("copilot", ""))
+                .isEqualTo(CopilotRequestMultipliers.DEFAULT_COPILOT_MULTIPLIER);
+        assertThat(CopilotRequestMultipliers.forProviderAndModel("copilot", "   "))
+                .isEqualTo(CopilotRequestMultipliers.DEFAULT_COPILOT_MULTIPLIER);
+    }
+}

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/CopilotRequestMultipliersTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/CopilotRequestMultipliersTest.java
@@ -17,50 +17,62 @@ class CopilotRequestMultipliersTest {
     }
 
     @Test
-    void returnsKnownMultipliersForCopilotModels() {
-        // Exact model identifier hits the map directly.
-        assertThat(CopilotRequestMultipliers.forProviderAndModel("copilot", "claude-opus-4-6"))
-                .isEqualTo(10.0);
-        assertThat(CopilotRequestMultipliers.forProviderAndModel("copilot", "claude-sonnet-4-5"))
+    void returnsKnownMultipliersForCopilotCanonicalModelIds() {
+        // Copilot uses dot notation for Claude — matches the form LlmClientFactory's
+        // ANTHROPIC_TO_COPILOT_MODEL translator emits. Values reflect the 2026-04 rate card.
+        assertThat(CopilotRequestMultipliers.forProviderAndModel("copilot", "claude-opus-4.6"))
+                .isEqualTo(3.0);
+        assertThat(CopilotRequestMultipliers.forProviderAndModel("copilot", "claude-sonnet-4.5"))
                 .isEqualTo(1.0);
+        assertThat(CopilotRequestMultipliers.forProviderAndModel("copilot", "claude-haiku-4.5"))
+                .isEqualTo(0.33);
+        assertThat(CopilotRequestMultipliers.forProviderAndModel("copilot", "gpt-4o"))
+                .isEqualTo(0.0);
         assertThat(CopilotRequestMultipliers.forProviderAndModel("copilot", "o3-mini"))
                 .isEqualTo(0.33);
-        assertThat(CopilotRequestMultipliers.forProviderAndModel("copilot", "gpt-4.1"))
-                .isEqualTo(0.0);
+        assertThat(CopilotRequestMultipliers.forProviderAndModel("copilot", "grok-code-fast-1"))
+                .isEqualTo(0.25);
     }
 
     @Test
-    void stripsTrailingDateSuffixBeforeLookup() {
-        // Anthropic model ids in this repo carry a date suffix — the lookup should strip
-        // it before hitting the table so "claude-opus-4-6-20250929" maps to the same
-        // multiplier as "claude-opus-4-6".
+    void hyphenatedClaudeIdNormalizesToDotNotation() {
+        // Regression guard for the reviewer-found dot-notation bug (#424): Anthropic-style
+        // hyphenated Claude ids must map to the Copilot dot form before table lookup, so
+        // a caller passing pre-translation names still gets the right multiplier.
+        assertThat(CopilotRequestMultipliers.forProviderAndModel("copilot", "claude-opus-4-6"))
+                .isEqualTo(3.0);
+        assertThat(CopilotRequestMultipliers.forProviderAndModel("copilot", "claude-sonnet-4-5"))
+                .isEqualTo(1.0);
+        assertThat(CopilotRequestMultipliers.forProviderAndModel("copilot", "claude-haiku-4-5"))
+                .isEqualTo(0.33);
+    }
+
+    @Test
+    void dateSuffixStrippedBeforeHyphenToDotNormalization() {
+        // "claude-opus-4-6-20250929" must normalize first to "claude-opus-4-6" (date strip)
+        // and then to "claude-opus-4.6" (hyphen→dot) to hit the table.
         assertThat(CopilotRequestMultipliers.forProviderAndModel("copilot", "claude-opus-4-6-20250929"))
-                .isEqualTo(10.0);
+                .isEqualTo(3.0);
         assertThat(CopilotRequestMultipliers.forProviderAndModel("copilot", "claude-sonnet-4-5-20260101"))
                 .isEqualTo(1.0);
     }
 
     @Test
     void unknownCopilotModelFallsBackToDefault() {
-        // Unknown Copilot model (newly released, or a typo in config) falls back to 1.0 —
-        // the common-case rate. Logged offline data still has "model" so analysts can spot
-        // the fallback and update the table.
         assertThat(CopilotRequestMultipliers.forProviderAndModel("copilot", "future-model-9000"))
                 .isEqualTo(CopilotRequestMultipliers.DEFAULT_COPILOT_MULTIPLIER);
     }
 
     @Test
     void caseInsensitiveProviderAndModel() {
-        assertThat(CopilotRequestMultipliers.forProviderAndModel("COPILOT", "CLAUDE-OPUS-4-6"))
-                .isEqualTo(10.0);
-        assertThat(CopilotRequestMultipliers.forProviderAndModel("Copilot", "Claude-Sonnet-4-5"))
+        assertThat(CopilotRequestMultipliers.forProviderAndModel("COPILOT", "CLAUDE-OPUS-4.6"))
+                .isEqualTo(3.0);
+        assertThat(CopilotRequestMultipliers.forProviderAndModel("Copilot", "Claude-Sonnet-4.5"))
                 .isEqualTo(1.0);
     }
 
     @Test
     void blankOrNullModelYieldsDefault() {
-        // Copilot with no model yields the default — caller knows the provider but can't
-        // distinguish the tier; 1.0 is the safe assumption for projection.
         assertThat(CopilotRequestMultipliers.forProviderAndModel("copilot", null))
                 .isEqualTo(CopilotRequestMultipliers.DEFAULT_COPILOT_MULTIPLIER);
         assertThat(CopilotRequestMultipliers.forProviderAndModel("copilot", ""))

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/RuntimeMetricsExporterTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/RuntimeMetricsExporterTest.java
@@ -140,6 +140,57 @@ class RuntimeMetricsExporterTest {
     }
 
     @Test
+    void export_includesProviderModelAndMultiplierForCopilot() throws Exception {
+        // Copilot path: the export carries a multiplier so offline analysis can translate
+        // raw request counts into normalized cost units.
+        var exporter = new RuntimeMetricsExporter();
+        exporter.recordTurn();
+
+        exporter.export(tempDir, null, "copilot", "claude-opus-4-6");
+
+        Path output = tempDir.resolve(".aceclaw/metrics/continuous-learning/runtime-latest.json");
+        JsonNode root = new ObjectMapper().readTree(output.toFile());
+        assertThat(root.get("provider").asText()).isEqualTo("copilot");
+        assertThat(root.get("model").asText()).isEqualTo("claude-opus-4-6");
+        assertThat(root.get("model_multiplier").asDouble()).isEqualTo(10.0);
+        assertThat(root.has("model_multiplier_rate_card_date")).isTrue();
+    }
+
+    @Test
+    void export_omitsMultiplierForNonCopilotProvider() throws Exception {
+        // Direct Anthropic / OpenAI are token-priced; a request multiplier doesn't apply.
+        // Field is omitted rather than set to 1.0 so baseline scripts can tell "unknown"
+        // from "equivalent to the base rate".
+        var exporter = new RuntimeMetricsExporter();
+        exporter.recordTurn();
+
+        exporter.export(tempDir, null, "anthropic", "claude-opus-4-6");
+
+        Path output = tempDir.resolve(".aceclaw/metrics/continuous-learning/runtime-latest.json");
+        JsonNode root = new ObjectMapper().readTree(output.toFile());
+        assertThat(root.get("provider").asText()).isEqualTo("anthropic");
+        assertThat(root.get("model").asText()).isEqualTo("claude-opus-4-6");
+        assertThat(root.has("model_multiplier")).isFalse();
+        assertThat(root.has("model_multiplier_rate_card_date")).isFalse();
+    }
+
+    @Test
+    void export_backwardCompatibleWhenProviderModelNotSupplied() throws Exception {
+        // The single-arg export variant stays — callers on older code paths still work,
+        // and they just don't tag the snapshot with provider/model.
+        var exporter = new RuntimeMetricsExporter();
+        exporter.recordTurn();
+
+        exporter.export(tempDir, null);
+
+        Path output = tempDir.resolve(".aceclaw/metrics/continuous-learning/runtime-latest.json");
+        JsonNode root = new ObjectMapper().readTree(output.toFile());
+        assertThat(root.has("provider")).isFalse();
+        assertThat(root.has("model")).isFalse();
+        assertThat(root.has("model_multiplier")).isFalse();
+    }
+
+    @Test
     void export_withNoData_marksPendingInstrumentation() throws Exception {
         var exporter = new RuntimeMetricsExporter();
         exporter.export(tempDir, null);

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/RuntimeMetricsExporterTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/RuntimeMetricsExporterTest.java
@@ -84,110 +84,111 @@ class RuntimeMetricsExporterTest {
     }
 
     @Test
-    void recordLlmRequests_accumulatesTotalAndPerSource() throws Exception {
-        // PR C: runtime-latest.json gains absolute-count metrics for LLM requests by source
-        // so offline tools can build a Copilot-usage baseline. Each per-source count lands
-        // in a metric named llm_requests_<source>; the grand total lands in llm_requests_total.
+    void recordLlmRequests_bucketsByProviderAndModel() throws Exception {
+        // Per-(provider, model) partitioning: a mid-session /model switch must not cross-
+        // contaminate the per-model baseline. Two recordings against different buckets
+        // produce two entries in llm_requests_by_model, each carrying its own total +
+        // by_source breakdown.
         var exporter = new RuntimeMetricsExporter();
 
-        // Turn 1: two main-turn + one planner.
         exporter.recordLlmRequests(dev.aceclaw.core.llm.RequestAttribution.builder()
                 .record(dev.aceclaw.core.llm.RequestSource.MAIN_TURN, 2)
                 .record(dev.aceclaw.core.llm.RequestSource.PLANNER, 1)
-                .build());
-        // Turn 2: one main-turn + one continuation.
+                .build(), "copilot", "claude-opus-4.6");
         exporter.recordLlmRequests(dev.aceclaw.core.llm.RequestAttribution.builder()
                 .record(dev.aceclaw.core.llm.RequestSource.MAIN_TURN)
-                .record(dev.aceclaw.core.llm.RequestSource.CONTINUATION)
-                .build());
-        // Empty / null are ignored.
-        exporter.recordLlmRequests(null);
-        exporter.recordLlmRequests(dev.aceclaw.core.llm.RequestAttribution.empty());
+                .build(), "copilot", "claude-sonnet-4.5");
+        // Null / empty attribution is ignored on every path.
+        exporter.recordLlmRequests(null, "copilot", "claude-opus-4.6");
+        exporter.recordLlmRequests(dev.aceclaw.core.llm.RequestAttribution.empty(),
+                "copilot", "claude-opus-4.6");
 
         exporter.export(tempDir, null);
 
         Path output = tempDir.resolve(".aceclaw/metrics/continuous-learning/runtime-latest.json");
-        JsonNode metrics = new ObjectMapper().readTree(output.toFile()).get("metrics");
+        JsonNode root = new ObjectMapper().readTree(output.toFile());
+        assertThat(root.get("rate_card_date").asText()).isEqualTo(CopilotRequestMultipliers.RATE_CARD_DATE);
 
-        assertThat(metrics.get("llm_requests_total").get("value").asLong()).isEqualTo(5);
-        assertThat(metrics.get("llm_requests_total").get("status").asText()).isEqualTo("measured");
-        assertThat(metrics.get("llm_requests_main_turn").get("value").asLong()).isEqualTo(3);
-        assertThat(metrics.get("llm_requests_planner").get("value").asLong()).isEqualTo(1);
-        assertThat(metrics.get("llm_requests_continuation").get("value").asLong()).isEqualTo(1);
-        // Sample size is the grand total so downstream scripts can compute ratios
-        // without having to re-sum every per-source metric.
-        assertThat(metrics.get("llm_requests_main_turn").get("sample_size").asLong()).isEqualTo(5);
-        // Sources that never fired are NOT emitted — keeps the metrics file compact.
-        assertThat(metrics.has("llm_requests_replan")).isFalse();
-        assertThat(metrics.has("llm_requests_fallback")).isFalse();
+        JsonNode byModel = root.get("llm_requests_by_model");
+        assertThat(byModel.isArray()).isTrue();
+        assertThat(byModel.size()).isEqualTo(2);
+
+        JsonNode opus = byModel.get(0);
+        assertThat(opus.get("provider").asText()).isEqualTo("copilot");
+        assertThat(opus.get("model").asText()).isEqualTo("claude-opus-4.6");
+        assertThat(opus.get("multiplier").asDouble()).isEqualTo(3.0);
+        assertThat(opus.get("total").asLong()).isEqualTo(3);
+        assertThat(opus.get("by_source").get("main_turn").asLong()).isEqualTo(2);
+        assertThat(opus.get("by_source").get("planner").asLong()).isEqualTo(1);
+
+        JsonNode sonnet = byModel.get(1);
+        assertThat(sonnet.get("model").asText()).isEqualTo("claude-sonnet-4.5");
+        assertThat(sonnet.get("multiplier").asDouble()).isEqualTo(1.0);
+        assertThat(sonnet.get("total").asLong()).isEqualTo(1);
+
+        // Grand total is the sum across buckets.
+        assertThat(root.get("metrics").get("llm_requests_total").get("value").asLong())
+                .isEqualTo(4);
     }
 
     @Test
-    void export_withNoLlmRequests_omitsPerSourceMetrics() throws Exception {
-        // A daemon lifetime with no LLM requests at all (only task or tool metrics) should
-        // emit the total metric with pending_instrumentation status but no per-source
-        // clutter — otherwise fresh baselines look noisy.
+    void recordLlmRequests_preservesHistoryAcrossModelSwitch() throws Exception {
+        // The bug the reviewer called out: /model mid-session used to relabel prior history
+        // as the new model. Now an Opus-then-Sonnet sequence keeps both buckets intact and
+        // no count is misattributed.
+        var exporter = new RuntimeMetricsExporter();
+        exporter.recordLlmRequests(dev.aceclaw.core.llm.RequestAttribution.builder()
+                .record(dev.aceclaw.core.llm.RequestSource.MAIN_TURN, 10).build(),
+                "copilot", "claude-opus-4.6");
+        exporter.recordLlmRequests(dev.aceclaw.core.llm.RequestAttribution.builder()
+                .record(dev.aceclaw.core.llm.RequestSource.MAIN_TURN, 5).build(),
+                "copilot", "claude-sonnet-4.5");
+
+        exporter.export(tempDir, null);
+        JsonNode root = new ObjectMapper().readTree(
+                tempDir.resolve(".aceclaw/metrics/continuous-learning/runtime-latest.json").toFile());
+
+        JsonNode byModel = root.get("llm_requests_by_model");
+        // Opus bucket kept its 10, Sonnet bucket has 5. No cross-contamination.
+        assertThat(byModel.get(0).get("model").asText()).isEqualTo("claude-opus-4.6");
+        assertThat(byModel.get(0).get("total").asLong()).isEqualTo(10);
+        assertThat(byModel.get(1).get("model").asText()).isEqualTo("claude-sonnet-4.5");
+        assertThat(byModel.get(1).get("total").asLong()).isEqualTo(5);
+    }
+
+    @Test
+    void recordLlmRequests_omitsMultiplierForNonCopilotProvider() throws Exception {
+        // Token-priced providers don't carry a request multiplier — the field is absent
+        // from the bucket, and analysts can tell "not applicable" from "1.0".
+        var exporter = new RuntimeMetricsExporter();
+        exporter.recordLlmRequests(dev.aceclaw.core.llm.RequestAttribution.builder()
+                .record(dev.aceclaw.core.llm.RequestSource.MAIN_TURN).build(),
+                "anthropic", "claude-opus-4-6");
+
+        exporter.export(tempDir, null);
+        JsonNode root = new ObjectMapper().readTree(
+                tempDir.resolve(".aceclaw/metrics/continuous-learning/runtime-latest.json").toFile());
+
+        JsonNode bucket = root.get("llm_requests_by_model").get(0);
+        assertThat(bucket.get("provider").asText()).isEqualTo("anthropic");
+        assertThat(bucket.has("multiplier")).isFalse();
+    }
+
+    @Test
+    void export_withNoLlmRequests_emitsEmptyBuckets() throws Exception {
+        // Fresh baseline: no LLM requests at all. Top-level array is empty; scalar total
+        // metric is pending_instrumentation.
         var exporter = new RuntimeMetricsExporter();
         exporter.recordTurn();
         exporter.export(tempDir, null);
 
-        Path output = tempDir.resolve(".aceclaw/metrics/continuous-learning/runtime-latest.json");
-        JsonNode metrics = new ObjectMapper().readTree(output.toFile()).get("metrics");
+        JsonNode root = new ObjectMapper().readTree(
+                tempDir.resolve(".aceclaw/metrics/continuous-learning/runtime-latest.json").toFile());
 
-        assertThat(metrics.get("llm_requests_total").get("status").asText())
+        assertThat(root.get("llm_requests_by_model").isArray()).isTrue();
+        assertThat(root.get("llm_requests_by_model").size()).isZero();
+        assertThat(root.get("metrics").get("llm_requests_total").get("status").asText())
                 .isEqualTo("pending_instrumentation");
-        assertThat(metrics.has("llm_requests_main_turn")).isFalse();
-    }
-
-    @Test
-    void export_includesProviderModelAndMultiplierForCopilot() throws Exception {
-        // Copilot path: the export carries a multiplier so offline analysis can translate
-        // raw request counts into normalized cost units.
-        var exporter = new RuntimeMetricsExporter();
-        exporter.recordTurn();
-
-        exporter.export(tempDir, null, "copilot", "claude-opus-4-6");
-
-        Path output = tempDir.resolve(".aceclaw/metrics/continuous-learning/runtime-latest.json");
-        JsonNode root = new ObjectMapper().readTree(output.toFile());
-        assertThat(root.get("provider").asText()).isEqualTo("copilot");
-        assertThat(root.get("model").asText()).isEqualTo("claude-opus-4-6");
-        assertThat(root.get("model_multiplier").asDouble()).isEqualTo(10.0);
-        assertThat(root.has("model_multiplier_rate_card_date")).isTrue();
-    }
-
-    @Test
-    void export_omitsMultiplierForNonCopilotProvider() throws Exception {
-        // Direct Anthropic / OpenAI are token-priced; a request multiplier doesn't apply.
-        // Field is omitted rather than set to 1.0 so baseline scripts can tell "unknown"
-        // from "equivalent to the base rate".
-        var exporter = new RuntimeMetricsExporter();
-        exporter.recordTurn();
-
-        exporter.export(tempDir, null, "anthropic", "claude-opus-4-6");
-
-        Path output = tempDir.resolve(".aceclaw/metrics/continuous-learning/runtime-latest.json");
-        JsonNode root = new ObjectMapper().readTree(output.toFile());
-        assertThat(root.get("provider").asText()).isEqualTo("anthropic");
-        assertThat(root.get("model").asText()).isEqualTo("claude-opus-4-6");
-        assertThat(root.has("model_multiplier")).isFalse();
-        assertThat(root.has("model_multiplier_rate_card_date")).isFalse();
-    }
-
-    @Test
-    void export_backwardCompatibleWhenProviderModelNotSupplied() throws Exception {
-        // The single-arg export variant stays — callers on older code paths still work,
-        // and they just don't tag the snapshot with provider/model.
-        var exporter = new RuntimeMetricsExporter();
-        exporter.recordTurn();
-
-        exporter.export(tempDir, null);
-
-        Path output = tempDir.resolve(".aceclaw/metrics/continuous-learning/runtime-latest.json");
-        JsonNode root = new ObjectMapper().readTree(output.toFile());
-        assertThat(root.has("provider")).isFalse();
-        assertThat(root.has("model")).isFalse();
-        assertThat(root.has("model_multiplier")).isFalse();
     }
 
     @Test


### PR DESCRIPTION
## Summary

Small follow-up to the #419 attribution epic. PR C (#423) gave \`runtime-latest.json\` per-source request counts; this extends the export so offline baseline analysis can segment by \`(provider, model)\` and translate Copilot request counts into normalized cost units.

Restructured in review to address three reviewer findings — see the \"Review follow-ups\" section below for the log of what changed after the initial push.

## Motivation

Copilot premium requests are priced per model. Without a per-model breakdown in the export, baseline data is uncomparable across model switches or across users on different default models. The next step in the #418 plan is the first Copilot optimization PR (\`ProviderCostPolicyResolver\` skeleton + Copilot planner gate); that work should tune against normalized cost units, not raw counts.

## Wire format

Each distinct \`(provider, model)\` observed during the daemon lifetime gets its own bucket — so a mid-session \`/model\` switch cannot cross-contaminate the per-model baseline.

\`\`\`json
{
  \"exported_at\": \"2026-04-18T00:30:00Z\",
  \"rate_card_date\": \"2026-04\",
  \"metrics\": {
    \"llm_requests_total\": {\"value\": 15, \"sample_size\": 15, \"status\": \"measured\"},
    ...
  },
  \"llm_requests_by_model\": [
    {
      \"provider\": \"copilot\",
      \"model\": \"claude-opus-4.6\",
      \"multiplier\": 3.0,
      \"total\": 10,
      \"by_source\": {\"main_turn\": 8, \"planner\": 2}
    },
    {
      \"provider\": \"copilot\",
      \"model\": \"claude-sonnet-4.5\",
      \"multiplier\": 1.0,
      \"total\": 5,
      \"by_source\": {\"main_turn\": 5}
    }
  ]
}
\`\`\`

For non-Copilot providers (direct Anthropic, OpenAI, etc.) the bucket omits \`multiplier\` — those providers are token-priced, and \"not applicable\" is more honest than \"equivalent to the base rate\". The top-level \`rate_card_date\` stamps when the Copilot multiplier table was last reconciled against GitHub's docs.

## Lookup & normalization

\`CopilotRequestMultipliers\` holds a small curated table keyed on Copilot-canonical model ids, dated to the 2026-04 rate card in the Javadoc. Values after review:

| Model | Multiplier |
|---|---|
| claude-opus-4.6, claude-opus-4.5 | 3.0 |
| claude-sonnet-4.5, claude-sonnet-4.6 | 1.0 |
| claude-haiku-4.5 | 0.33 |
| gpt-4o, gpt-4.1 | 0.0 |
| gpt-5 | 1.0 |
| gpt-5.4-mini | 0.33 |
| o1, o1-preview | 10.0 |
| o3-mini | 0.33 |
| raptor-mini | 0.0 |
| gemini-2.0-flash | 0.25 |
| gemini-2.5-pro | 1.0 |
| grok-code-fast-1 | 0.25 |

Model-id normalization handles:

1. Case (lowercase)
2. Trailing 8-digit date suffix (\`claude-opus-4-6-20250929\` → \`claude-opus-4-6\`)
3. Anthropic hyphen → Copilot dot (\`claude-opus-4-6\` → \`claude-opus-4.6\`) — important because \`LlmClientFactory\` already translates hyphen-form ids when dispatching to Copilot; this step catches callers reading the pre-translation form defensively

Unknown Copilot models fall back to 1.0 with the original model id still logged, so new releases show up in baseline data as \"default tier, investigate\" rather than disappearing.

## API compatibility

\`export(Path, ToolMetricsCollector)\` signature is preserved. Internal behavior change:

- \`recordLlmRequests\` now takes \`(attribution, provider, model)\` — the (provider, model) decision is made at record time so model switches partition correctly, not at export time.
- \`StreamingAgentHandler.recordRuntimeMetrics\` threads provider via \`getLlmClient().provider()\` and model via \`getModelForSession(sessionId)\`.

## Review follow-ups addressed in-branch

- **[P1]** Dot-notation Copilot model ids previously missed the table — table now keyed on dot form with hyphen→dot normalization.
- **[P1]** Multiplier values refreshed to the 2026-04 Copilot rate card (Claude Opus → 3x, GPT-4o → 0x on paid plans, plus new entries for GPT-5.4 mini, Raptor mini, Grok Code Fast 1).
- **[P2]** Dropped the top-level single-current-model tag that would have mislabeled daemon-lifetime aggregates after a \`/model\` switch. Per-(provider, model) buckets take its place — regression test \`preservesHistoryAcrossModelSwitch\` locks the scenario.

## Known follow-up (non-blocking)

The Copilot multiplier table is materially correct but not exhaustive against the current public rate card — a few non-1x/0x entries (e.g. GPT-5 mini, Gemini 3 Flash) are not in the table yet, so if AceClaw's Copilot defaults shift to one of them later, the fallback-to-1.0 could overstate normalized cost. A small follow-up PR to complete the table is cheap and separately reviewable.

## Test plan

- [x] \`./gradlew build\` — passes (53 tasks)
- [x] \`CopilotRequestMultipliersTest\` — 7 cases: non-Copilot returns null, known Copilot-canonical ids, hyphenated-id normalization, date-suffix + hyphen-to-dot chained normalization, unknown-model fallback, case insensitivity, blank/null model
- [x] \`RuntimeMetricsExporterTest\`:
  - \`recordLlmRequests_bucketsByProviderAndModel\` — two buckets in \`llm_requests_by_model\`, grand total sums across
  - \`recordLlmRequests_preservesHistoryAcrossModelSwitch\` — regression for reviewer finding #3
  - \`recordLlmRequests_omitsMultiplierForNonCopilotProvider\`
  - \`export_withNoLlmRequests_emitsEmptyBuckets\`
- [x] Existing task / tool / permission / timeout metric tests still pass (no ratio-metric changes)

## Next up (not in this PR)

1. Collect a few days of real Copilot baseline with this richer export.
2. Small follow-up PR to complete the Copilot multiplier table against the current rate card.
3. First optimization PR — \`ProviderCostPolicyResolver\` skeleton + Copilot planner gate.

Refs #418, #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)