### PR TITLE
feat(cli): show active profile in startup banner and /status

### DIFF
--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/AceClawMain.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/AceClawMain.java
@@ -51,10 +51,17 @@ public final class AceClawMain implements Runnable {
             // Fetch health status to get model info and context window size
             String model = "unknown";
             int contextWindowTokens = 0;
+            String profile = null;
             try {
                 JsonNode health = client.sendRequest("health.status", null);
                 model = health.path("model").asText("unknown");
                 contextWindowTokens = health.path("contextWindowTokens").asInt(0);
+                if (health.hasNonNull("profile")) {
+                    String p = health.path("profile").asText("");
+                    if (!p.isBlank()) {
+                        profile = p;
+                    }
+                }
             } catch (Exception e) {
                 // Non-fatal; banner will show "unknown" model
             }
@@ -83,7 +90,7 @@ public final class AceClawMain implements Runnable {
 
             // Enter REPL with session info
             var sessionInfo = new TerminalRepl.SessionInfo(
-                    VERSION, model, effectiveProject, contextWindowTokens, gitBranch, benchMode);
+                    VERSION, model, effectiveProject, contextWindowTokens, gitBranch, benchMode, profile);
             var repl = new TerminalRepl(client, sessionId, sessionInfo);
             repl.run();
 

--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
@@ -314,15 +314,21 @@ public final class TerminalRepl {
      */
     public record SessionInfo(String version, String model, String project,
                               int contextWindowTokens, String gitBranch,
-                              String benchMode) {
+                              String benchMode, String profile) {
+        public SessionInfo(String version, String model, String project,
+                           int contextWindowTokens, String gitBranch,
+                           String benchMode) {
+            this(version, model, project, contextWindowTokens, gitBranch, benchMode, null);
+        }
+
         public SessionInfo(String version, String model, String project,
                            int contextWindowTokens, String gitBranch) {
-            this(version, model, project, contextWindowTokens, gitBranch, null);
+            this(version, model, project, contextWindowTokens, gitBranch, null, null);
         }
 
         public SessionInfo(String version, String model, String project,
                            int contextWindowTokens) {
-            this(version, model, project, contextWindowTokens, null, null);
+            this(version, model, project, contextWindowTokens, null, null, null);
         }
     }
 
@@ -1720,11 +1726,18 @@ public final class TerminalRepl {
         String modelLine = "  Model: " + modelDisplay;
         String projectLine = "  Project: " + projectDisplay;
         String sessionLine = "  Session: " + sessionShort;
+        String profile = sessionInfo.profile();
+        String profileLine = (profile != null && !profile.isBlank())
+                ? "  Profile: " + fitWidth(profile, innerWidth - 14)
+                : null;
 
         out.println();
         out.println(ACCENT + BOX_TOP_LEFT + hline(innerWidth) + BOX_TOP_RIGHT + RESET);
         out.println(ACCENT + BOX_VERTICAL + RESET + BOLD + padRight(titleLine, innerWidth) + ACCENT + BOX_VERTICAL + RESET);
         out.println(ACCENT + BOX_VERTICAL + RESET + MUTED + padRight(modelLine, innerWidth) + ACCENT + BOX_VERTICAL + RESET);
+        if (profileLine != null) {
+            out.println(ACCENT + BOX_VERTICAL + RESET + MUTED + padRight(profileLine, innerWidth) + ACCENT + BOX_VERTICAL + RESET);
+        }
         out.println(ACCENT + BOX_VERTICAL + RESET + MUTED + padRight(projectLine, innerWidth) + ACCENT + BOX_VERTICAL + RESET);
         out.println(ACCENT + BOX_VERTICAL + RESET + MUTED + padRight(sessionLine, innerWidth) + ACCENT + BOX_VERTICAL + RESET);
         out.println(ACCENT + BOX_BOTTOM_LEFT + hline(innerWidth) + BOX_BOTTOM_RIGHT + RESET);
@@ -3083,6 +3096,9 @@ public final class TerminalRepl {
                 out.println();
                 out.println(BOLD + "Session Status" + RESET);
                 out.printf("  %sModel:%s       %s%n", MUTED, RESET, effectiveModel);
+                if (sessionInfo.profile() != null && !sessionInfo.profile().isBlank()) {
+                    out.printf("  %sProfile:%s     %s%n", MUTED, RESET, sessionInfo.profile());
+                }
                 out.printf("  %sProject:%s     %s%n", MUTED, RESET, sessionInfo.project());
                 String statusBranch = currentGitBranch();
                 if (statusBranch != null) {

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -847,6 +847,7 @@ public final class AceClawDaemon {
         // Expose model name, provider info, and health monitor to status endpoint
         router.setModelName(effectiveModel);
         router.setProviderInfo(config.provider(), contextWindow);
+        router.setActiveProfile(config.activeProfileName());
         router.setHealthMonitor(healthMonitor);
         router.setMcpStatusSupplier(() -> {
             var node = objectMapper.createObjectNode();

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/RequestRouter.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/RequestRouter.java
@@ -57,6 +57,7 @@ public final class RequestRouter {
 
     private volatile String modelName;
     private volatile String providerName;
+    private volatile String activeProfile;
     private volatile int contextWindowTokens;
     private volatile HealthMonitor healthMonitor;
     private volatile Supplier<JsonNode> mcpStatusSupplier;
@@ -96,6 +97,14 @@ public final class RequestRouter {
     public void setProviderInfo(String provider, int contextWindowTokens) {
         this.providerName = provider;
         this.contextWindowTokens = contextWindowTokens;
+    }
+
+    /**
+     * Sets the active config profile name reported by the health status endpoint.
+     * May be null when no profile is applied.
+     */
+    public void setActiveProfile(String activeProfile) {
+        this.activeProfile = activeProfile;
     }
 
     /**
@@ -406,6 +415,10 @@ public final class RequestRouter {
         var p = providerName;
         if (p != null) {
             result.put("provider", p);
+        }
+        var profile = activeProfile;
+        if (profile != null && !profile.isBlank()) {
+            result.put("profile", profile);
         }
         if (contextWindowTokens > 0) {
             result.put("contextWindowTokens", contextWindowTokens);


### PR DESCRIPTION
## Summary
- Surface `AceClawConfig.activeProfileName()` through `health.status` as a new `profile` field so the CLI can display which credential profile the session is using.
- Add `profile` to `TerminalRepl.SessionInfo`, render it as an extra banner line between `Model` and `Project`, and add a `Profile:` entry to `/status`.
- Line/entry is skipped when no profile is active — banner layout is unchanged for users who do not use profiles.

## Motivation
Previously the startup banner only showed version, model, project, and session id. When a user has multiple profiles configured (e.g. a work `claude-acn` account and a personal `claude` account), there was no way to tell which one the daemon picked up without running a separate check. This PR makes the active profile visible at a glance.

## Test plan
- [x] `./gradlew :aceclaw-daemon:test :aceclaw-cli:test` — green
- [x] `./gradlew build` (sans native-image) — green
- [ ] Manual: start daemon with `ACECLAW_PROFILE=<name>` and confirm the banner shows `Profile: <name>` and `/status` lists it
- [ ] Manual: start daemon with no profile configured and confirm the banner omits the Profile line (4-line layout preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile information is now displayed in the terminal session banner and status output when available, providing greater visibility into the active configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->