### PR TITLE
feat(dashboard): execution event schema for browser clients (#439)

### DIFF
--- a/PRD-Frontend.md
+++ b/PRD-Frontend.md
@@ -1,0 +1,1143 @@
+# AceClaw Execution Dashboard — Frontend PRD
+
+## Real-Time Execution Tree Visualization for All Three Tiers
+
+**Version**: 1.0
+**Date**: 2026-04-28
+**Status**: Draft
+**Parent PRD**: PRD.md (AceClaw v1.2)
+**Author**: AceClaw PRD Team
+**Scope**: Standalone web frontend that visualizes AceClaw agent execution in real-time as a live, interactive tree.
+
+---
+
+> **Relationship to Main PRD**: The main PRD (§4.9.5) describes a "Swarm Dashboard" for Tier 3 only. This PRD **supersedes and extends** that concept — the Execution Dashboard covers **all three tiers** (ReAct, Plan, Swarm) with a single recursive tree component. The Swarm Dashboard becomes a special case (Tier 3 view) within this unified frontend.
+
+---
+
+## Table of Contents
+
+1. [Problem Statement](#1-problem-statement)
+2. [Design Philosophy: Runtime-UI Separation](#2-design-philosophy-runtime-ui-separation)
+3. [Product Vision](#3-product-vision)
+4. [Core Concept: The Execution Tree](#4-core-concept-the-execution-tree)
+5. [Architecture](#5-architecture)
+6. [Event System (Backend → Frontend)](#6-event-system-backend--frontend)
+7. [Frontend Technical Design](#7-frontend-technical-design)
+8. [Interaction Model](#8-interaction-model)
+9. [Visual Design](#9-visual-design)
+10. [Implementation Phases](#10-implementation-phases)
+11. [Technology Stack](#11-technology-stack)
+12. [Performance Requirements](#12-performance-requirements)
+13. [Open Questions](#13-open-questions)
+
+---
+
+## 1. Problem Statement
+
+### Current State
+
+AceClaw's CLI renders agent execution as **flat text stream** — tool invocations, text output, and plan steps are interleaved sequentially in the terminal. This works for simple tasks but breaks down as complexity increases:
+
+| Tier | Current Experience | Problem |
+|------|-------------------|---------|
+| **Tier 1 (ReAct)** | Tool calls shown inline, parallel tools appear sequential | User cannot see parallel execution; no structural overview |
+| **Tier 2 (Plan)** | Step names shown before execution, results inline | User cannot see remaining steps, progress, or replan events clearly |
+| **Tier 3 (Swarm)** | Not yet implemented | Multiple workers in one console = unreadable interleaved output |
+
+### Root Cause
+
+The terminal is a **one-dimensional** output channel. Agent execution is a **tree** (turns contain tools, plans contain steps, steps contain turns, swarms contain workers containing plans). Projecting a tree onto a line loses structure.
+
+### Impact
+
+- Users cannot understand **what is happening** during complex executions
+- Users cannot see **what will happen** (plan steps, DAG dependencies)
+- Users cannot **control** execution (pause, approve, cancel) without CLI commands
+- Users cannot distinguish **parallel** from **sequential** execution
+- Users lose context when execution takes > 30 seconds
+
+---
+
+## 2. Design Philosophy: Runtime-UI Separation
+
+> **AceClaw's original intent is not "CLI only" — it is "runtime and UI separation".**
+
+The daemon is the **kernel**. The CLI is merely the **first client**. This PRD adds the **second client** (web browser) without disturbing the first.
+
+### The Stable Path
+
+```
+                     ┌───────────────────────────────────────────────────┐
+                     │              AceClaw Daemon (Kernel)               │
+                     │                                                   │
+                     │  AgentLoop ─→ Plan Executor ─→ (future) Swarm    │
+                     │                      │                            │
+                     │              JSON-RPC / Streaming Events          │
+                     │              (unchanged — this is the contract)   │
+                     │                      │                            │
+                     │           ┌──────────┴──────────┐                 │
+                     │           │                     │                 │
+                     │      Unix Socket           Web Bridge             │
+                     │      (existing)            (new — thin layer)     │
+                     │           │                     │                 │
+                     └───────────│─────────────────────│─────────────────┘
+                                 │                     │
+                                 ▼                     ▼
+                     ┌───────────────────┐  ┌────────────────────────┐
+                     │    CLI (Terminal)  │  │   Web UI (Browser)     │
+                     │    ✅ unchanged    │  │   ✅ new               │
+                     │                   │  │                        │
+                     │  Text rendering   │  │  Tree visualization    │
+                     │  Permission TTY   │  │  Permission buttons    │
+                     │  Keyboard input   │  │  Pause/Resume/Cancel   │
+                     └───────────────────┘  └────────────────────────┘
+                                 │                     │
+                                 └──────────┬──────────┘
+                                            │
+                                  Future: more clients
+                                  - VS Code extension
+                                  - Mobile app
+                                  - Slack/Teams bot
+                                  - Remote daemon access
+```
+
+### What This Means
+
+| Principle | Implication |
+|-----------|-------------|
+| **Daemon = kernel** | All intelligence, execution, memory, tool routing stays in the daemon. Zero logic moves to the frontend. |
+| **JSON-RPC = contract** | The existing event protocol (`stream.text`, `stream.tool_use`, `permission.request`, etc.) is the **stable API**. The web bridge does not invent new semantics — it translates existing ones to WebSocket. |
+| **CLI does not die** | The terminal remains the primary input channel. The dashboard is an **observer + secondary controller**, not a replacement. If the browser disconnects, execution continues. |
+| **Web bridge = thin** | The bridge is a ~200-line adapter: receive JSON-RPC notifications from daemon's `EventMultiplexer`, convert to WebSocket frames, forward to browser. No business logic. |
+| **Frontend = display + interaction only** | React renders the tree. Buttons send commands. That's it. No execution logic, no LLM calls, no tool routing. |
+| **Multi-client ready** | Any future client (VS Code, mobile, Slack bot) connects via the same protocol — WebSocket for push events, REST for commands. The daemon doesn't care who's listening. |
+
+### What We Get
+
+1. **CLI continues to work** — zero regression, zero migration
+2. **Web visualization** — real-time execution tree across all three tiers
+3. **Full observability** — ReAct turns, tool use, plan steps, permission requests, swarm workers — all visible
+4. **Interactive control** — permissions, pause, resume, cancel — from the browser
+5. **Extensibility** — the web bridge pattern is the same pattern for any future UI client
+
+> **One kernel. Many windows. The daemon owns the brain; clients own the eyes.**
+
+---
+
+## 3. Product Vision
+
+A **real-time web dashboard** that renders AceClaw agent execution as a **live, interactive tree** — growing in real-time as the agent works, with drill-down from swarm → worker → plan → step → turn → tool.
+
+### Design Principles
+
+1. **Tree-first** — Execution is always a tree, never flat text
+2. **Real-time** — Nodes appear and update as events arrive (< 100ms latency)
+3. **Fractal** — The same `<ExecutionNode>` component renders all levels; Tier 3 is just deeper nesting
+4. **Pre-visualization** — Plans and DAGs are shown **before** execution starts (AceClaw pre-plans)
+5. **Interactive** — Permission requests, pause/resume, cancel — all from the browser
+6. **Non-blocking** — The dashboard is a **read/control** overlay; the CLI remains the primary input channel
+7. **Zero-config** — `aceclaw dashboard` opens the browser; no setup required
+
+---
+
+## 4. Core Concept: The Execution Tree
+
+### 4.1 Tree Structure (Fractal / Self-Similar)
+
+```
+Tier 3: Swarm Node
+  ├── Meta-Agent Node
+  │   └── Planning Turn
+  │       └── 🟢 LLM call [320ms]
+  ├── Worker-1 Node (role: Coder, model: Haiku)
+  │   └── Plan Node (linear steps)
+  │       ├── ✅ Step 1: "Read source files"
+  │       │   └── Turn 1
+  │       │       ├── 🟢 read_file(auth.java) [45ms]
+  │       │       ├── 🟢 read_file(config.java) [38ms]    ← parallel
+  │       │       └── 🟢 grep("@Auth") [120ms]             ← parallel
+  │       ├── 🔄 Step 2: "Modify handler" [running]
+  │       │   └── Turn 1
+  │       │       └── 🟡 edit_file(handler.java) [running]
+  │       ├── ⬚ Step 3: "Add tests" [pending]
+  │       └── ⬚ Step 4: "Run tests" [pending]
+  ├── Worker-2 Node (role: Coder, model: Haiku)           ← parallel with W1
+  │   └── Plan Node
+  │       ├── 🔄 Step 1: "Refactor middleware" [running]
+  │       │   └── Turn 1
+  │       │       └── 🟡 read_file(middleware.java) [running]
+  │       └── ⬚ Step 2: "Update routes" [pending]
+  └── Worker-3 Node (role: Tester, model: Sonnet)          ← DAG dep on W1+W2
+      └── ⬚ [waiting for Worker-1 and Worker-2]
+```
+
+### 4.2 Node Types
+
+Every node in the tree is one of these types, rendered by the **same recursive component**:
+
+| Node Type | Parent | Children | Created By Event |
+|-----------|--------|----------|-----------------|
+| **Session** | (root) | Turn \| Plan \| Swarm | Session start |
+| **Swarm** | Session | Meta-Agent, Worker[] | `stream.swarm_created` |
+| **Worker** | Swarm | Plan \| Turn | `stream.worker_started` |
+| **Plan** | Session \| Worker | Step[] | `stream.plan_created` |
+| **Step** | Plan | Turn[] | `stream.plan_created` (all steps listed) |
+| **Turn** | Session \| Step \| Worker | Tool[] | `stream.turn_started` *(new event)* |
+| **Tool** | Turn | (leaf) | `stream.tool_use` |
+| **Permission** | Turn | (leaf, interactive) | `permission.request` |
+| **Text** | Turn | (leaf, collapsible) | `stream.text` |
+
+### 4.3 Node State Machine
+
+Every node follows the same lifecycle:
+
+```
+pending ──→ running ──→ completed
+                    ──→ failed
+                    ──→ cancelled
+pending ──→ skipped (replan removed it)
+running ──→ paused ──→ running (resume)
+running ──→ awaiting_input ──→ running (user responds)
+```
+
+### 4.4 Unified Node Data Model
+
+```typescript
+interface ExecutionNode {
+  id: string;
+  type: 'session' | 'swarm' | 'worker' | 'plan' | 'step' | 'turn' | 'tool' | 'permission' | 'text';
+  status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled' | 'skipped' | 'paused' | 'awaiting_input';
+  label: string;
+  
+  // Timing
+  startTime?: number;        // epoch ms
+  endTime?: number;
+  duration?: number;         // ms (computed or from event)
+  
+  // Hierarchy
+  children: ExecutionNode[];
+  parallel?: boolean;        // true if children execute concurrently
+  
+  // Type-specific metadata
+  meta?: {
+    // Tool nodes
+    toolName?: string;
+    isError?: boolean;
+    errorPreview?: string;
+    
+    // Worker nodes
+    role?: string;           // 'coder' | 'reviewer' | 'tester' | 'researcher'
+    model?: string;          // 'haiku' | 'sonnet' | 'opus'
+    
+    // Step nodes
+    stepIndex?: number;
+    totalSteps?: number;
+    fallbackApproach?: string;
+    
+    // Plan nodes
+    replanCount?: number;
+    
+    // Permission nodes
+    permissionPrompt?: string;
+    permissionTool?: string;
+    
+    // Swarm nodes
+    dagDependencies?: Record<string, string[]>;  // taskId → depIds
+    
+    // Cost tracking
+    tokens?: { input: number; output: number };
+    cost?: number;
+  };
+  
+  // Collapsible content
+  textContent?: string;      // For text nodes — full LLM output (collapsed by default)
+}
+```
+
+---
+
+## 5. Architecture
+
+### 5.1 System Overview
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                         AceClaw Daemon (Java 21)                     │
+│                                                                      │
+│  StreamingAgentLoop ───→ StreamingNotificationHandler                │
+│  SequentialPlanExecutor ─→ PlanEventListener                         │
+│  (future) SwarmExecutor ──→ SwarmEventListener                       │
+│                                │                                     │
+│                          JSON-RPC events                             │
+│                                │                                     │
+│                     ┌──────────┴──────────┐                          │
+│                     │    EventMultiplexer  │  ← NEW (§4.2)           │
+│                     └──────┬────────┬─────┘                          │
+│                            │        │                                │
+│                     Unix Socket   WebSocket                          │
+│                     (→ CLI)       (→ Browser)  ← NEW                 │
+│                                      │                               │
+│                          ┌───────────┤                               │
+│                          │   Javalin │  (embedded, ~100KB)           │
+│                          │  :3141    │                               │
+│                          │  GET /    │  → serve SPA                  │
+│                          │  WS /ws   │  → event stream              │
+│                          │  POST /api│  → control (pause/cancel)    │
+│                          └───────────┘                               │
+└──────────────────────────────────────────────────────────────────────┘
+                                   │
+                            ws://localhost:3141/ws
+                                   │
+┌──────────────────────────────────│───────────────────────────────────┐
+│                        React SPA (Browser)                           │
+│                                                                      │
+│  WebSocket ──→ EventReducer (useReducer) ──→ ExecutionTree           │
+│                                                                      │
+│  ┌────────────────────────────────────────────────────────────────┐  │
+│  │  Header: session info | tokens | cost | elapsed | controls     │  │
+│  ├────────────────────────────────────────────────────────────────┤  │
+│  │                                                                │  │
+│  │   ExecutionTree (react-window virtualized)                     │  │
+│  │                                                                │  │
+│  │   ▼ Session: "Refactor auth module + add tests"               │  │
+│  │     ▼ Plan (5 steps, 1 replan)                                │  │
+│  │       ✅ Step 1: Read source files                            │  │
+│  │         ▸ Turn 1 (3 tools, 203ms)        ← collapsed          │  │
+│  │       🔄 Step 2: Modify handler                               │  │
+│  │         ▼ Turn 1                          ← expanded (active) │  │
+│  │           🟡 edit_file(handler.java)  [2.1s running]          │  │
+│  │       ⬚ Step 3: Add tests                                     │  │
+│  │       ⬚ Step 4: Run tests                                     │  │
+│  │       ⬚ Step 5: Verify                                        │  │
+│  │                                                                │  │
+│  ├────────────────────────────────────────────────────────────────┤  │
+│  │  Event Log (tail -f style)                                     │  │
+│  └────────────────────────────────────────────────────────────────┘  │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+### 5.2 EventMultiplexer (New Daemon Component)
+
+The daemon currently sends events to **one** `StreamContext` (the CLI connection). The EventMultiplexer fans out to **N** listeners:
+
+```java
+// New class in aceclaw-daemon
+public final class EventMultiplexer implements StreamContext {
+    
+    private final StreamContext primary;                     // CLI (Unix socket)
+    private final List<StreamContext> secondaries;           // WebSocket sessions
+    
+    @Override
+    public void sendNotification(String method, Object params) throws IOException {
+        // Always send to CLI (primary)
+        primary.sendNotification(method, params);
+        
+        // Best-effort fan-out to dashboard(s)
+        for (var ctx : secondaries) {
+            try {
+                ctx.sendNotification(method, params);
+            } catch (IOException e) {
+                // Dashboard disconnect is non-fatal; log and remove
+                secondaries.remove(ctx);
+            }
+        }
+    }
+    
+    public void addDashboard(StreamContext wsContext) { secondaries.add(wsContext); }
+    public void removeDashboard(StreamContext wsContext) { secondaries.remove(wsContext); }
+}
+```
+
+**Key design choice**: The CLI remains the **primary** channel. The dashboard is a **secondary observer**. If the dashboard disconnects, execution continues uninterrupted.
+
+### 5.3 WebSocket Endpoint
+
+```java
+// Javalin embedded in daemon — started on demand by `aceclaw dashboard`
+var app = Javalin.create(config -> {
+    config.staticFiles.add("/dashboard", Location.CLASSPATH);  // serve SPA
+}).start(3141);
+
+app.ws("/ws", ws -> {
+    ws.onConnect(ctx -> {
+        var wsContext = new JavalinWebSocketStreamContext(ctx);
+        multiplexer.addDashboard(wsContext);
+        
+        // Send current state snapshot (for late-join / page refresh)
+        ctx.send(objectMapper.writeValueAsString(
+            Map.of("method", "snapshot", "params", getCurrentExecutionTree())
+        ));
+    });
+    
+    ws.onMessage(ctx -> {
+        // Handle permission responses, pause/cancel commands from browser
+        var msg = objectMapper.readTree(ctx.message());
+        switch (msg.get("method").asText()) {
+            case "permission.response" -> handlePermissionResponse(msg);
+            case "swarm.pause"         -> handleSwarmPause();
+            case "swarm.cancel"        -> handleSwarmCancel();
+        }
+    });
+    
+    ws.onClose(ctx -> multiplexer.removeDashboard(...));
+});
+```
+
+### 5.4 Launch Flow
+
+```bash
+# User types in terminal:
+$ aceclaw dashboard
+
+# This:
+# 1. Sends "dashboard.start" notification to daemon
+# 2. Daemon starts Javalin on :3141 (if not already running)
+# 3. Opens browser to http://localhost:3141
+# 4. Browser connects WebSocket, receives state snapshot
+# 5. Real-time events start flowing
+
+# Or auto-open on plan/swarm:
+$ aceclaw --dashboard "refactor the auth module"
+# Automatically opens dashboard when plan/swarm mode triggers
+```
+
+---
+
+## 6. Event System (Backend → Frontend)
+
+### 6.1 Existing Events (Already Implemented in Daemon)
+
+These events are already sent by `StreamingNotificationHandler` and `PlanEventListener` in `StreamingAgentHandler.java`:
+
+| Event | Source | Payload | Tree Action |
+|-------|--------|---------|-------------|
+| `stream.text` | `StreamingNotificationHandler` | `{text}` | Append text to current Turn's text node |
+| `stream.thinking` | `StreamingNotificationHandler` | `{text}` | Append to thinking indicator (collapsible) |
+| `stream.tool_use` | `StreamingNotificationHandler` | `{toolUseId, name, input}` | Add Tool child to current Turn (status: running) |
+| `stream.tool_completed` | `StreamingNotificationHandler` | `{toolUseId, name, durationMs, isError, errorPreview}` | Update Tool node (status: completed/failed) |
+| `stream.heartbeat` | `StreamingNotificationHandler` | `{phase}` | Pulse animation on current running node |
+| `stream.error` | `StreamingNotificationHandler` | `{message}` | Mark current node as failed |
+| `stream.compaction` | `StreamingNotificationHandler` | `{before, after}` | Show compaction indicator on session |
+| `stream.subagent.start` | `StreamingNotificationHandler` | `{agentId, prompt}` | Add SubAgent child node (status: running) |
+| `stream.subagent.end` | `StreamingNotificationHandler` | `{agentId}` | Mark SubAgent node completed |
+| `stream.usage` | `StreamingNotificationHandler` | `{input, output, cacheRead, cacheCreation}` | Update header cost/token counters |
+| `stream.plan_created` | `StreamingAgentHandler` | `{planId, goal, steps[]}` | Add Plan node + all Step children (pending) |
+| `stream.plan_step_started` | `StreamingAgentHandler` | `{planId, stepName, stepIndex, totalSteps}` | Activate Step node (status: running) |
+| `stream.plan_step_completed` | `StreamingAgentHandler` | `{planId, stepName, stepIndex, success}` | Complete Step node (status: completed/failed) |
+| `stream.plan_completed` | `StreamingAgentHandler` | `{planId, success, durationMs}` | Complete Plan node |
+| `stream.plan_replanned` | `StreamingAgentHandler` | `{planId, attempt, rationale, newSteps[]}` | Replace pending Steps; add replan indicator |
+| `stream.plan_escalated` | `StreamingAgentHandler` | `{planId, reason}` | Mark Plan failed; show escalation reason |
+| `permission.request` | `PermissionGate` | `{requestId, tool, input, message}` | Add Permission node (status: awaiting_input) |
+| `stream.gate` | `StreamingAgentHandler` | `{tool, action}` | Show permission gate decision |
+| `stream.cancelled` | `StreamingAgentHandler` | `{sessionId}` | Mark session cancelled |
+| `stream.budget_exhausted` | `StreamingAgentHandler` | `{sessionId, reason}` | Mark session budget-exceeded |
+
+### 6.2 New Events Required
+
+| Event | When | Payload | Tree Action |
+|-------|------|---------|-------------|
+| `stream.turn_started` | AgentLoop begins new iteration | `{turnNumber, parentStepId?}` | Add Turn child to current Step or Session |
+| `stream.turn_completed` | AgentLoop iteration done | `{turnNumber, durationMs}` | Complete Turn node |
+| `stream.swarm_created` | Meta-Agent generates DAG | `{swarmId, goal, tasks[], deps{}}` | Add Swarm node + Worker placeholders with DAG edges |
+| `stream.worker_started` | Worker virtual thread begins | `{swarmId, workerId, role, model, taskDescription}` | Activate Worker node |
+| `stream.worker_completed` | Worker finishes | `{swarmId, workerId, success, durationMs}` | Complete Worker node |
+| `stream.swarm_replanned` | Meta-Agent modifies DAG | `{swarmId, attempt, rationale, newTasks[], newDeps{}}` | Update DAG structure with animation |
+| `stream.swarm_completed` | All workers done | `{swarmId, success, totalDurationMs, totalCost}` | Complete Swarm node |
+| `snapshot` | Dashboard connects (late-join) | `{tree: ExecutionNode}` | Replace entire tree state |
+
+### 6.3 Event Implementation Priority
+
+| Priority | Events | Effort | Enables |
+|----------|--------|--------|---------|
+| **P0** | Use all existing events as-is | 0h (already implemented) | Tier 1 tree |
+| **P1** | `stream.turn_started`, `stream.turn_completed` | ~2h (add to `StreamingAgentLoop`) | Turn-level grouping |
+| **P2** | `snapshot` | ~3h (serialize current execution state) | Page refresh / late join |
+| **P3** | `stream.swarm_*` (6 events) | Part of Swarm implementation | Tier 3 tree |
+
+---
+
+## 7. Frontend Technical Design
+
+### 7.1 State Management: Event Reducer
+
+```typescript
+// All state lives in a single useReducer — no external state library needed.
+// Each WebSocket message dispatches to the reducer.
+
+type TreeAction =
+  | { type: 'SNAPSHOT'; tree: ExecutionNode }
+  | { type: 'TURN_STARTED'; turnNumber: number; parentStepId?: string }
+  | { type: 'TURN_COMPLETED'; turnNumber: number; durationMs: number }
+  | { type: 'TOOL_USE'; toolUseId: string; name: string }
+  | { type: 'TOOL_COMPLETED'; toolUseId: string; name: string; durationMs: number; isError: boolean; errorPreview?: string }
+  | { type: 'TEXT_DELTA'; text: string }
+  | { type: 'PLAN_CREATED'; planId: string; goal: string; steps: StepInfo[] }
+  | { type: 'PLAN_STEP_STARTED'; planId: string; stepIndex: number }
+  | { type: 'PLAN_STEP_COMPLETED'; planId: string; stepIndex: number; success: boolean }
+  | { type: 'PLAN_REPLANNED'; planId: string; attempt: number; rationale: string; newSteps: StepInfo[] }
+  | { type: 'PLAN_COMPLETED'; planId: string; success: boolean; durationMs: number }
+  | { type: 'PLAN_ESCALATED'; planId: string; reason: string }
+  | { type: 'SUBAGENT_START'; agentId: string; prompt: string }
+  | { type: 'SUBAGENT_END'; agentId: string }
+  | { type: 'PERMISSION_REQUEST'; requestId: string; tool: string; message: string }
+  | { type: 'USAGE_UPDATE'; input: number; output: number }
+  | { type: 'SWARM_CREATED'; swarmId: string; goal: string; tasks: TaskInfo[]; deps: Record<string, string[]> }
+  | { type: 'WORKER_STARTED'; swarmId: string; workerId: string; role: string; model: string }
+  | { type: 'WORKER_COMPLETED'; swarmId: string; workerId: string; success: boolean }
+  | { type: 'SWARM_COMPLETED'; swarmId: string; success: boolean; totalCost: number };
+
+function executionTreeReducer(state: ExecutionNode, action: TreeAction): ExecutionNode {
+  switch (action.type) {
+    case 'SNAPSHOT':
+      return action.tree;
+
+    case 'TOOL_USE':
+      return addChildToActiveLeaf(state, {
+        id: action.toolUseId,
+        type: 'tool',
+        status: 'running',
+        label: action.name,
+        children: [],
+        meta: { toolName: action.name },
+        startTime: Date.now(),
+      });
+
+    case 'TOOL_COMPLETED':
+      return updateNode(state, action.toolUseId, {
+        status: action.isError ? 'failed' : 'completed',
+        duration: action.durationMs,
+        meta: { isError: action.isError, errorPreview: action.errorPreview },
+      });
+
+    case 'PLAN_CREATED':
+      return addPlanWithPendingSteps(state, action);
+
+    case 'PLAN_STEP_STARTED':
+      return activateStep(state, action.planId, action.stepIndex);
+
+    case 'PLAN_REPLANNED':
+      return replaceRemainingSteps(state, action);
+
+    case 'PERMISSION_REQUEST':
+      return addChildToActiveLeaf(state, {
+        id: action.requestId,
+        type: 'permission',
+        status: 'awaiting_input',
+        label: `Permission: ${action.tool}`,
+        children: [],
+        meta: { permissionPrompt: action.message, permissionTool: action.tool },
+      });
+
+    // ... other cases follow the same pattern
+  }
+}
+```
+
+### 7.2 WebSocket Hook
+
+```typescript
+function useExecutionStream(wsUrl: string) {
+  const [tree, dispatch] = useReducer(executionTreeReducer, createRootNode());
+  const [connected, setConnected] = useState(false);
+  const wsRef = useRef<WebSocket | null>(null);
+
+  useEffect(() => {
+    const ws = new WebSocket(wsUrl);
+    wsRef.current = ws;
+
+    ws.onopen = () => setConnected(true);
+    ws.onclose = () => {
+      setConnected(false);
+      // Auto-reconnect after 2s
+      setTimeout(() => wsRef.current = new WebSocket(wsUrl), 2000);
+    };
+
+    ws.onmessage = (e) => {
+      const event = JSON.parse(e.data);
+      const action = mapEventToAction(event);  // JSON-RPC → TreeAction
+      if (action) dispatch(action);
+    };
+
+    return () => ws.close();
+  }, [wsUrl]);
+
+  // Expose send for permission responses and control commands
+  const send = useCallback((method: string, params: object) => {
+    wsRef.current?.send(JSON.stringify({ method, params }));
+  }, []);
+
+  return { tree, connected, send };
+}
+```
+
+### 7.3 Tree Renderer (Virtualized)
+
+```tsx
+// Using react-window VariableSizeList for virtualization.
+// The tree is flattened into a list with indentation levels.
+
+interface FlatNode {
+  node: ExecutionNode;
+  depth: number;
+  isExpanded: boolean;
+  isLast: boolean;          // last sibling (for tree-line drawing)
+  parentIsLast: boolean[];  // for tree-line continuation
+}
+
+function flattenTree(root: ExecutionNode, expandedIds: Set<string>): FlatNode[] {
+  const result: FlatNode[] = [];
+  
+  function walk(node: ExecutionNode, depth: number, isLast: boolean, parentIsLast: boolean[]) {
+    result.push({ node, depth, isExpanded: expandedIds.has(node.id), isLast, parentIsLast });
+    
+    if (expandedIds.has(node.id)) {
+      node.children.forEach((child, i) => {
+        walk(child, depth + 1, i === node.children.length - 1, [...parentIsLast, isLast]);
+      });
+    }
+  }
+  
+  walk(root, 0, true, []);
+  return result;
+}
+
+// Auto-expand active (running) nodes, collapse completed ones
+function useAutoExpand(tree: ExecutionNode): Set<string> {
+  return useMemo(() => {
+    const expanded = new Set<string>();
+    
+    function walk(node: ExecutionNode) {
+      // Always expand running, awaiting_input nodes and their ancestors
+      if (node.status === 'running' || node.status === 'awaiting_input') {
+        expanded.add(node.id);
+      }
+      // Expand completed nodes only if they have < 5 children (readable)
+      if (node.status === 'completed' && node.children.length < 5) {
+        expanded.add(node.id);
+      }
+      node.children.forEach(walk);
+    }
+    
+    walk(tree);
+    return expanded;
+  }, [tree]);
+}
+```
+
+### 7.4 ExecutionNodeRow Component
+
+```tsx
+function ExecutionNodeRow({ flatNode, send }: { flatNode: FlatNode; send: SendFn }) {
+  const { node, depth, isExpanded } = flatNode;
+  
+  return (
+    <div className="node-row" style={{ paddingLeft: depth * 20 }}>
+      {/* Tree lines */}
+      <TreeLines parentIsLast={flatNode.parentIsLast} isLast={flatNode.isLast} />
+      
+      {/* Expand/collapse toggle */}
+      {node.children.length > 0 && (
+        <button className="toggle" onClick={() => toggleExpand(node.id)}>
+          {isExpanded ? '▼' : '▸'}
+        </button>
+      )}
+      
+      {/* Status icon */}
+      <StatusIcon status={node.status} type={node.type} />
+      
+      {/* Label */}
+      <span className="label">
+        {node.label}
+        {node.meta?.role && <Badge>{node.meta.role}</Badge>}
+        {node.meta?.model && <Badge variant="outline">{node.meta.model}</Badge>}
+      </span>
+      
+      {/* Duration */}
+      {node.status === 'running' && <LiveTimer startTime={node.startTime!} />}
+      {node.duration && <span className="duration">{formatDuration(node.duration)}</span>}
+      
+      {/* Parallel indicator */}
+      {node.parallel && <Badge variant="parallel">parallel</Badge>}
+      
+      {/* Error preview */}
+      {node.meta?.isError && node.meta?.errorPreview && (
+        <span className="error-preview">{node.meta.errorPreview}</span>
+      )}
+      
+      {/* Permission input */}
+      {node.type === 'permission' && node.status === 'awaiting_input' && (
+        <PermissionPrompt
+          message={node.meta!.permissionPrompt!}
+          tool={node.meta!.permissionTool!}
+          onRespond={(allowed) => send('permission.response', {
+            requestId: node.id,
+            allowed,
+          })}
+        />
+      )}
+    </div>
+  );
+}
+```
+
+### 7.5 Parallel Tool Detection
+
+The frontend infers parallel execution from **event timing**:
+
+```typescript
+// When multiple stream.tool_use events arrive for the same Turn
+// before any stream.tool_completed — they are parallel.
+
+case 'TOOL_USE': {
+  const currentTurn = findActiveTurn(state);
+  if (!currentTurn) return state;
+  
+  // If the turn already has running tools, this is a parallel sibling
+  const hasRunningTools = currentTurn.children.some(
+    c => c.type === 'tool' && c.status === 'running'
+  );
+  
+  if (hasRunningTools) {
+    currentTurn.parallel = true;  // Mark the turn as parallel
+  }
+  
+  return addChild(currentTurn, newToolNode(action));
+}
+```
+
+Visual result:
+```
+▼ Turn 1                           ← parallel = true
+  ├── 🟢 read_file(a.java) [45ms]  ┐
+  ├── 🟢 read_file(b.java) [38ms]  ├ shown side-by-side or with ║ indicator
+  └── 🟢 grep("@Auth") [120ms]     ┘
+```
+
+---
+
+## 8. Interaction Model
+
+### 8.1 Permission Handling (Bidirectional)
+
+```
+Daemon ──→ permission.request ──→ WebSocket ──→ Browser
+                                                  │
+                                          User clicks [Allow] / [Deny]
+                                                  │
+Browser ──→ permission.response ──→ WebSocket ──→ Daemon
+
+Simultaneously:
+Daemon ──→ permission.request ──→ Unix Socket ──→ CLI
+                                                   │
+                                           User types y/n
+                                                   │
+CLI ──→ permission.response ──→ Unix Socket ──→ Daemon
+
+First response wins. Daemon ignores the second.
+```
+
+The tree shows a `⏸ Awaiting input` node with inline buttons:
+
+```
+  🔄 Step 2: Modify handler
+    ▼ Turn 1
+      ⏸ Permission: edit_file(src/auth/handler.java)
+         "Allow editing src/auth/handler.java?"
+         [✅ Allow]  [❌ Deny]  [🔓 Always Allow]
+```
+
+### 8.2 Controls (Header Bar)
+
+| Control | Action | Implementation |
+|---------|--------|---------------|
+| **⏸ Pause** | Pause execution after current tool completes | `send('execution.pause')` → Daemon sets `CancellationToken.pause()` |
+| **▶ Resume** | Resume paused execution | `send('execution.resume')` |
+| **⏹ Stop** | Cancel execution gracefully | `send('execution.cancel')` → Daemon triggers `CancellationToken.cancel()` |
+| **🔇 Auto-approve** | Approve all permissions for this session | `send('permission.auto_approve', { scope: 'session' })` |
+
+### 8.3 Node Interactions
+
+| Interaction | Behavior |
+|-------------|----------|
+| **Click expand/collapse** | Toggle children visibility |
+| **Click completed tool** | Show full tool input/output in side panel |
+| **Click failed tool** | Show error details in side panel |
+| **Click text node** | Show full LLM text output (usually collapsed) |
+| **Click pending step** | Show step description and dependencies |
+| **Hover on worker** | Highlight DAG dependencies (for Tier 3) |
+| **Click replan indicator** | Show replan rationale |
+
+### 8.4 Auto-Scroll and Focus
+
+```typescript
+// The tree auto-scrolls to keep the active (running) node visible.
+// User scrolling pauses auto-scroll; a "Follow execution" button resumes it.
+
+function useAutoScroll(listRef: RefObject<VariableSizeList>, tree: ExecutionNode) {
+  const [following, setFollowing] = useState(true);
+  
+  useEffect(() => {
+    if (!following) return;
+    
+    const activeIndex = findFirstActiveNodeIndex(tree);
+    if (activeIndex >= 0) {
+      listRef.current?.scrollToItem(activeIndex, 'center');
+    }
+  }, [tree, following]);
+  
+  // On user scroll, disable following; show "Follow" button
+  const onScroll = useCallback(() => setFollowing(false), []);
+  
+  return { following, setFollowing, onScroll };
+}
+```
+
+---
+
+## 9. Visual Design
+
+### 9.1 Status Icons
+
+| Status | Icon | Color | Animation |
+|--------|------|-------|-----------|
+| `pending` | `○` | Gray (#9CA3AF) | None |
+| `running` | `●` | Blue (#3B82F6) | Pulse animation (opacity 0.5→1→0.5) |
+| `completed` | `✓` | Green (#10B981) | None |
+| `failed` | `✗` | Red (#EF4444) | None |
+| `cancelled` | `⊘` | Gray (#6B7280) | None |
+| `skipped` | `⊘` | Gray (#6B7280) | Strikethrough on label |
+| `paused` | `⏸` | Yellow (#F59E0B) | None |
+| `awaiting_input` | `⏸` | Yellow (#F59E0B) | Pulse + input UI shown |
+
+### 9.2 Node Type Indicators
+
+| Node Type | Prefix | Example |
+|-----------|--------|---------|
+| Session | (none) | `"Refactor auth module + add tests"` |
+| Swarm | 🐝 | `🐝 Swarm: "Full system refactor"` |
+| Worker | 🤖 | `🤖 Worker-1 (Coder, Haiku)` |
+| Plan | 📋 | `📋 Plan (5 steps)` |
+| Step | Number | `1. Read source files` |
+| Turn | 🔄 | `🔄 Turn 1` |
+| Tool | 🔧 | `🔧 read_file(auth.java)` |
+| Permission | 🔒 | `🔒 Permission: edit_file(...)` |
+| Text | 💬 | `💬 Response (243 chars)` — collapsed |
+
+### 9.3 Color Themes
+
+Support dark (default) and light themes, following system preference:
+
+```css
+:root {
+  /* Dark theme (default) */
+  --bg-primary: #0F172A;
+  --bg-secondary: #1E293B;
+  --bg-node-active: #1E3A5F;
+  --text-primary: #F1F5F9;
+  --text-secondary: #94A3B8;
+  --border: #334155;
+  --accent: #3B82F6;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg-primary: #FFFFFF;
+    --bg-secondary: #F8FAFC;
+    --bg-node-active: #EFF6FF;
+    --text-primary: #0F172A;
+    --text-secondary: #64748B;
+    --border: #E2E8F0;
+    --accent: #2563EB;
+  }
+}
+```
+
+### 9.4 Layout
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  AceClaw Dashboard    ● Connected    [⏸ Pause] [⏹ Stop]        │
+│  Session: abc123 | Tokens: 24.3k | Cost: $0.12 | Elapsed: 1m32s │
+├───────────────────────────────────────────────┬──────────────────┤
+│                                               │                  │
+│  Execution Tree (70% width)                   │ Detail Panel     │
+│                                               │ (30% width)      │
+│  ▼ "Refactor auth module + add tests"         │                  │
+│    ▼ 📋 Plan (5 steps, replan: 1)            │ ┌──────────────┐ │
+│      ✓ 1. Read source files [2.1s]           │ │ Tool Detail   │ │
+│        ▸ 🔄 Turn 1 (3 tools, 2.1s)          │ │               │ │
+│      ● 2. Modify handler                      │ │ read_file     │ │
+│        ▼ 🔄 Turn 1                           │ │ Input: ...    │ │
+│          ● 🔧 edit_file(handler.java) 2.1s   │ │ Output: ...   │ │
+│      ○ 3. Add tests                           │ │ Duration: 45ms│ │
+│      ○ 4. Run tests                           │ └──────────────┘ │
+│      ○ 5. Verify                              │                  │
+│                                               │                  │
+├───────────────────────────────────────────────┴──────────────────┤
+│  Event Log                                          [Auto-scroll]│
+│  19:23:15  🔧 edit_file(handler.java) started                    │
+│  19:23:14  ✓ read_file(config.java) completed [38ms]             │
+│  19:23:14  ✓ read_file(auth.java) completed [45ms]               │
+│  19:23:14  ✓ grep("@Auth") completed [120ms]                     │
+│  19:23:12  📋 Plan created: 5 steps                              │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### 9.5 DAG View (Tier 3 Swarm)
+
+When a Swarm is active, the tree panel gains a **DAG toggle**:
+
+```
+[🌳 Tree View]  [🕸 DAG View]    ← toggle between tree and graph
+
+DAG View (D3.js force-directed or dagre layout):
+
+  ┌──────────────┐     ┌──────────────────┐
+  │ 🤖 W1:Coder  │     │ 🤖 W2:Coder      │
+  │ ● Running    ├──┐  │ ● Running        ├──┐
+  │ auth module  │  │  │ payment module   │  │
+  └──────────────┘  │  └──────────────────┘  │
+                    │                         │
+                    └────────┬────────────────┘
+                             │ (both must complete)
+                             ▼
+                    ┌──────────────────┐
+                    │ 🤖 W3:Tester     │
+                    │ ○ Waiting        │
+                    │ integration tests│
+                    └──────────────────┘
+```
+
+---
+
+## 10. Implementation Phases
+
+### Phase 1: Tier 1 Visualization (MVP) — ~2 weeks
+
+**Goal**: Real-time tree for basic ReAct execution.
+
+| Task | Effort | Description |
+|------|--------|-------------|
+| Javalin WebSocket endpoint in daemon | 3h | `/ws` endpoint, `EventMultiplexer` |
+| `stream.turn_started/completed` events | 2h | Add to `StreamingAgentLoop` |
+| `aceclaw dashboard` CLI command | 2h | Start Javalin, open browser |
+| React SPA scaffold | 2h | Vite + React + TypeScript |
+| `useExecutionStream` hook | 3h | WebSocket + reducer |
+| `ExecutionNodeRow` component | 4h | Recursive tree with status icons, timers |
+| Virtualized tree (`react-window`) | 3h | Flatten tree + `VariableSizeList` |
+| Auto-expand/collapse + auto-scroll | 2h | Follow active node |
+| Header bar (session info, tokens, cost) | 2h | `stream.usage` events |
+| Dark/light theme | 1h | CSS variables + system preference |
+| **Total** | **~24h** | |
+
+**Delivers**: Live tree showing turns and tools for every ReAct execution. Parallel tools shown as siblings.
+
+### Phase 2: Tier 2 Plan Visualization — ~1 week
+
+**Goal**: Plan steps shown as a tree with pre-visualization.
+
+| Task | Effort | Description |
+|------|--------|-------------|
+| Plan node + Step children rendering | 3h | `plan_created` → show all steps (pending) |
+| Step activation and completion | 2h | `plan_step_started/completed` |
+| Replan animation | 3h | Old steps strikethrough, new steps slide in |
+| Plan escalation indicator | 1h | `plan_escalated` |
+| Nested turns inside steps | 2h | Step → Turn → Tool (already built in Phase 1) |
+| **Total** | **~11h** | |
+
+**Delivers**: Full plan tree. User sees all steps before execution. Replan events animate.
+
+### Phase 3: Interactivity — ~1 week
+
+**Goal**: Permission handling, pause/resume, detail panel.
+
+| Task | Effort | Description |
+|------|--------|-------------|
+| Permission request → inline buttons | 3h | `permission.request` → [Allow]/[Deny] |
+| Permission response → WebSocket → daemon | 2h | Bidirectional, first-response-wins |
+| Pause/Resume/Stop controls | 3h | Header buttons → daemon `CancellationToken` |
+| Detail panel (tool input/output) | 4h | Click node → show details on right |
+| Event log panel (bottom) | 2h | Tail-style log of all events |
+| **Total** | **~14h** | |
+
+**Delivers**: Fully interactive dashboard. Permissions answered from browser. Execution controllable.
+
+### Phase 4: Tier 3 Swarm Visualization — ~2 weeks
+
+**Goal**: Swarm DAG with worker nodes (depends on Swarm backend from PRD.md Phase 5).
+
+| Task | Effort | Description |
+|------|--------|-------------|
+| Swarm node + Worker children | 4h | `swarm_created` → DAG topology |
+| Worker → Plan nesting (reuse Phase 2) | 2h | Each Worker contains a Plan tree |
+| DAG view toggle (D3.js dagre) | 8h | Graph layout for Swarm dependencies |
+| Worker status badges (role, model) | 2h | Metadata display |
+| Swarm cost tracking | 2h | Per-worker + total cost counters |
+| Swarm replan animation | 3h | DAG restructure |
+| **Total** | **~21h** | |
+
+**Delivers**: Full swarm visualization with DAG view and nested worker trees.
+
+### Phase 5: Polish — ~1 week
+
+| Task | Effort | Description |
+|------|--------|-------------|
+| Snapshot/late-join (page refresh) | 4h | Daemon serializes current tree state |
+| Keyboard shortcuts | 2h | j/k navigate, Enter expand, Esc collapse |
+| Search/filter nodes | 3h | Find by tool name, step name, error text |
+| Export execution log (JSON) | 1h | Download button |
+| Responsive layout (mobile) | 2h | Side panel → bottom panel on narrow screens |
+| **Total** | **~12h** | |
+
+### Summary Timeline
+
+| Phase | Duration | Cumulative | Delivers |
+|-------|----------|------------|----------|
+| Phase 1 (Tier 1 MVP) | 2 weeks | 2 weeks | Live ReAct tree |
+| Phase 2 (Tier 2 Plan) | 1 week | 3 weeks | Plan visualization |
+| Phase 3 (Interactive) | 1 week | 4 weeks | Permissions + controls |
+| Phase 4 (Tier 3 Swarm) | 2 weeks | 6 weeks | Swarm DAG |
+| Phase 5 (Polish) | 1 week | 7 weeks | Production-ready |
+
+---
+
+## 11. Technology Stack
+
+| Layer | Technology | Rationale |
+|-------|-----------|-----------|
+| **Backend WebSocket** | Javalin 6 (embedded) | ~100KB, virtual-thread native, already in PRD.md tech stack |
+| **Frontend Framework** | React 19 + TypeScript | Mature ecosystem, `useReducer` perfect for event-driven state |
+| **Build Tool** | Vite | Fast dev server, instant HMR, small bundle |
+| **Virtualization** | `react-window` | Proven for large lists; tree flattened to list |
+| **DAG Rendering** | D3.js + dagre (Phase 4 only) | Standard for directed graph layout |
+| **Styling** | Tailwind CSS | Utility-first, dark/light theme, no runtime cost |
+| **Icons** | Lucide React | Tree-shakeable, consistent style |
+| **Bundle Deployment** | Embedded in daemon JAR as static resources | `aceclaw dashboard` serves from classpath — zero external dependencies |
+| **Package Manager** | pnpm | Fast, strict, disk-efficient |
+| **Testing** | Vitest + React Testing Library | Unit tests for reducer + component tests |
+
+### Why React, Not "Vanilla HTML/JS + D3.js" (as in PRD.md §4.9.5)?
+
+The main PRD specifies "Vanilla HTML/JS + D3.js" for the Swarm Dashboard. This Frontend PRD **changes that decision** for these reasons:
+
+| Factor | Vanilla JS | React |
+|--------|-----------|-------|
+| **Tree state management** | Manual DOM diffing — error-prone for deeply nested, rapidly updating trees | `useReducer` + immutable state → predictable, testable |
+| **Virtualization** | Must build from scratch | `react-window` off-the-shelf |
+| **Component reuse** | Copy-paste | `<ExecutionNodeRow>` recursive composition |
+| **Event-driven updates** | Manual `getElementById` + DOM mutation | Reducer dispatch → automatic re-render |
+| **Build step** | None (PRD benefit) | Required (Vite) — **but**: output is static HTML/JS bundled into daemon JAR at build time |
+| **Bundle size** | ~10KB | ~80KB (React + react-window + Tailwind) — acceptable |
+
+The "no build step" benefit of Vanilla JS is **irrelevant** because the dashboard is bundled into the daemon JAR at compile time, not served from a CDN. The user never runs `npm install` — they run `aceclaw dashboard` and it just works.
+
+---
+
+## 12. Performance Requirements
+
+| Metric | Target | Rationale |
+|--------|--------|-----------|
+| **WebSocket → tree render** | < 100ms | Events should feel instant |
+| **Tree with 1000 nodes** | 60fps scroll | `react-window` virtualizes — only visible rows render |
+| **Tree with 5000 nodes** | 60fps scroll | Long swarm runs with many tools |
+| **Initial page load** | < 500ms | SPA served from localhost, bundled in JAR |
+| **Memory (browser)** | < 100MB for 5000-node tree | Flat node objects, no DOM for off-screen nodes |
+| **WebSocket bandwidth** | < 10KB/s typical | JSON events are small (< 500 bytes each) |
+| **Reconnect after disconnect** | < 3s (auto-reconnect + snapshot) | Dashboard must survive network blips |
+| **Bundle size** | < 200KB gzipped | Embedded in daemon JAR |
+
+---
+
+## 13. Open Questions
+
+| # | Question | Options | Recommendation |
+|---|----------|---------|----------------|
+| 1 | **Multi-session support?** | (a) Dashboard shows one session (b) Tab per session (c) Session switcher | (a) for v1 — one session. CLI handles session switching. |
+| 2 | **Dashboard auto-open?** | (a) Always open on `aceclaw start` (b) Only on `aceclaw dashboard` (c) Auto-open when plan/swarm triggers | (c) — auto-open on plan/swarm, manual for ReAct |
+| 3 | **CLI + Dashboard simultaneous permission?** | (a) CLI only (b) Dashboard only (c) First-response-wins | (c) — both can respond, first wins |
+| 4 | **Historical execution replay?** | (a) Not in v1 (b) Save event log + replay | (a) for v1 — focus on live. Export JSON for debugging. |
+| 5 | **Remote access?** | (a) localhost only (b) Optional TLS + auth for remote | (a) for v1 — `localhost:3141` only. Remote is Phase 4 of main PRD. |
+| 6 | **Port configuration?** | (a) Fixed 3141 (b) Configurable in `config.json` | (b) — configurable, default 3141 |
+| 7 | **Separate npm project or monorepo?** | (a) `aceclaw-dashboard/` sibling module (b) Embedded in `aceclaw-daemon/src/main/resources` | (a) — separate module, built by Gradle, output copied to daemon resources |
+
+---
+
+## Appendix A: Event-to-Tree Mapping Quick Reference
+
+```
+Daemon Event                    → Frontend Tree Action
+──────────────────────────────────────────────────────────────
+stream.turn_started             → Add Turn node (running)
+stream.tool_use                 → Add Tool child to active Turn (running)
+stream.tool_completed           → Update Tool node (completed/failed)
+stream.text                     → Append text to active Turn's text child
+stream.thinking                 → Update thinking indicator (collapsible)
+stream.heartbeat                → Pulse animation on active node
+stream.error                    → Mark active node failed
+stream.usage                    → Update header counters
+stream.subagent.start           → Add SubAgent node (running)
+stream.subagent.end             → Complete SubAgent node
+stream.compaction               → Show compaction badge on session
+stream.plan_created             → Add Plan + pending Step children
+stream.plan_step_started        → Activate Step node (running)
+stream.plan_step_completed      → Complete Step node (completed/failed)
+stream.plan_completed           → Complete Plan node
+stream.plan_replanned           → Strikethrough old steps, add new ones
+stream.plan_escalated           → Mark Plan failed with reason
+permission.request              → Add Permission node (awaiting_input)
+stream.gate                     → Update Permission node (auto-decision)
+stream.cancelled                → Mark session cancelled
+stream.budget_exhausted         → Mark session budget-exceeded
+stream.swarm_created            → Add Swarm + Worker placeholders + DAG
+stream.worker_started           → Activate Worker node (running)
+stream.worker_completed         → Complete Worker node
+stream.swarm_replanned          → Restructure DAG with animation
+stream.swarm_completed          → Complete Swarm node
+snapshot                        → Replace entire tree (late-join)
+```
+
+## Appendix B: File Structure
+
+```
+aceclaw-dashboard/              ← new Gradle module
+├── package.json
+├── pnpm-lock.yaml
+├── vite.config.ts
+├── tsconfig.json
+├── index.html
+├── src/
+│   ├── main.tsx                       # Entry point
+│   ├── App.tsx                        # Root component
+│   ├── hooks/
+│   │   ├── useExecutionStream.ts      # WebSocket + reducer
+│   │   └── useAutoScroll.ts           # Follow active node
+│   ├── state/
+│   │   ├── types.ts                   # ExecutionNode, TreeAction, etc.
+│   │   ├── reducer.ts                 # executionTreeReducer
+│   │   ├── eventMapper.ts            # JSON-RPC event → TreeAction
+│   │   └── treeUtils.ts              # findActiveNode, flattenTree, etc.
+│   ├── components/
+│   │   ├── Header.tsx                 # Session info, cost, controls
+│   │   ├── ExecutionTree.tsx          # Virtualized tree (react-window)
+│   │   ├── ExecutionNodeRow.tsx       # Single node row (recursive visual)
+│   │   ├── StatusIcon.tsx             # Status → icon/color mapping
+│   │   ├── LiveTimer.tsx              # Running duration counter
+│   │   ├── PermissionPrompt.tsx       # Inline [Allow]/[Deny] buttons
+│   │   ├── DetailPanel.tsx            # Tool input/output side panel
+│   │   ├── EventLog.tsx               # Bottom event log
+│   │   ├── DagView.tsx                # D3.js DAG for Swarm (Phase 4)
+│   │   └── TreeLines.tsx              # Unicode tree-drawing lines
+│   ├── styles/
+│   │   └── globals.css                # Tailwind + theme variables
+│   └── __tests__/
+│       ├── reducer.test.ts            # Pure function tests for reducer
+│       ├── eventMapper.test.ts        # Event → Action mapping tests
+│       └── treeUtils.test.ts          # flattenTree, findActive, etc.
+├── build.gradle.kts                   # Gradle build: pnpm build → copy to daemon resources
+└── README.md
+```
+
+---
+
+*This PRD defines the AceClaw Execution Dashboard as a standalone frontend that unifies observability across all three execution tiers. It reuses 100% of existing daemon events (Tier 1 + Tier 2) and defines 7 new events for Tier 3 (Swarm). The fractal tree model means building Tier 1 visualization automatically provides the rendering primitives for Tier 2 and Tier 3.*

--- a/PRD.md
+++ b/PRD.md
@@ -2,10 +2,14 @@
 
 ## A High-Performance, Secure, Self-Learning AI Coding Agent for Java
 
-**Version**: 1.0
-**Date**: 2026-02-16
+**Version**: 1.2
+**Date**: 2026-04-28
 **Status**: Draft
 **Team**: AceClaw PRD Team (Architect, OpenClaw Expert, PO, Security Expert, Engineer, Frontend Developer)
+**Change Log**:
+- v1.2 (2026-04-28): Explicit swarm trigger (`/swarm`, `/team`), DAG-only-at-swarm-tier architecture decision, three-tier execution model (§4.9.3), auto-escalation from Plan to Swarm
+- v1.1 (2026-04-28): Added research-backed Multi-Agent Swarm Architecture (§4.9.2–4.9.6), Meta-Agent concept, Worker lifecycle, real-time Swarm Dashboard, updated Roadmap Phase 4–5
+- v1.0 (2026-02-16): Initial PRD
 
 ---
 
@@ -29,6 +33,7 @@
 11. [MVP Scope](#11-mvp-scope)
 12. [Success Metrics](#12-success-metrics)
 13. [Risks and Mitigations](#13-risks-and-mitigations)
+14. [Research Foundation — Multi-Agent Swarm](#14-research-foundation--multi-agent-swarm)
 
 ---
 
@@ -333,6 +338,384 @@ Agent Teams enable multiple AceClaw agent instances to work collaboratively on c
 
 **Coordination Patterns**: Delegate mode, plan approval, self-claiming, quality gates (hooks), parallel specialists, pipeline, competing hypotheses
 
+### 4.9.2 Multi-Agent Swarm Architecture (Research-Backed)
+
+> Based on synthesis of 7 core papers on Multi-Agent Systems (2025-2026): Multi-Agent Collaboration Survey (arXiv:2501.06322), SwarmAgentic (arXiv:2506.15672), LLM Swarm Intelligence (arXiv:2503.03800), SwarmSys (arXiv:2510.10047), Beyond Frameworks — ACL 2025 (arXiv:2505.12467), LLM-based MAS Survey (arXiv:2412.17481), IEEE SMC MAS×LLM (June 2025).
+
+The current Agent Teams design (§4.9.1) covers in-process collaborative execution. This section extends it with **research-validated swarm intelligence patterns** for large-scale, observable, self-organizing multi-agent systems.
+
+**Core Research Findings Driving This Design**:
+
+| # | Finding | Confidence | Source | Design Impact |
+|---|---------|------------|--------|---------------|
+| 1 | Collaboration > Model Capability | 7/7 consensus | All papers | Invest in coordination architecture, not larger models |
+| 2 | Architecture is task-dependent | 7/7 consensus | P1, P4, P5 | Hybrid: centralized planning + decentralized execution |
+| 3 | Agent count saturates at 8-14 for reasoning | Strong | P4 (SwarmSys) | Cap worker count; parallelize I/O tasks, not reasoning |
+| 4 | Fully automated agent team design is possible | Emerging | P2 (SwarmAgentic) | Meta-Agent auto-designs teams from goals |
+| 5 | Centralized + instructor summarization = best cost/quality | Strong | P5 (ACL 2025) | Meta-Agent as instructor/summarizer |
+| 6 | Adaptive profiles (memory units) enable specialization | Strong | P4 (SwarmSys) | Workers evolve profiles through task history |
+
+### 4.9.3 Meta-Agent Architecture
+
+The **Meta-Agent** is the central coordination intelligence that replaces static orchestration with **dynamic, research-informed swarm management**. It operates within the existing daemon process.
+
+**Key Distinction**: Traditional Agent Teams (§4.9.1) use a Team Lead that is itself an agent running a ReAct loop. The Meta-Agent is a **coordination-only controller** — it does not execute tools directly; it plans, delegates, monitors, and adapts.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        AceClaw Daemon                           │
+│                                                                 │
+│  ┌──────────────────────────────────────────────────────────┐  │
+│  │                     Meta-Agent                            │  │
+│  │                                                           │  │
+│  │  ┌─────────────┐  ┌──────────────┐  ┌────────────────┐  │  │
+│  │  │ Goal Decomp  │  │ Team Designer │  │ Cost Optimizer │  │  │
+│  │  │ (Task DAG)   │  │ (SwarmAgentic │  │ (P5 patterns)  │  │  │
+│  │  │              │  │  inspired)    │  │                │  │  │
+│  │  └──────────────┘  └──────────────┘  └────────────────┘  │  │
+│  │  ┌─────────────┐  ┌──────────────┐  ┌────────────────┐  │  │
+│  │  │ Worker Pool  │  │ Progress     │  │ Replan Engine  │  │  │
+│  │  │ Manager      │  │ Monitor      │  │                │  │  │
+│  │  └──────────────┘  └──────────────┘  └────────────────┘  │  │
+│  └──────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐      │
+│  │ Worker 1 │  │ Worker 2 │  │ Worker 3 │  │ Worker N │      │
+│  │ (VThread)│  │ (VThread)│  │ (VThread)│  │ (VThread)│      │
+│  └──────────┘  └──────────┘  └──────────┘  └──────────┘      │
+│       │              │              │              │            │
+│  ┌─────────────────────────────────────────────────────────┐  │
+│  │               Shared State (JSON on Filesystem)          │  │
+│  │  swarm-state.json:  worker profiles, task assignments,   │  │
+│  │                     progress, metrics                    │  │
+│  └─────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────┘
+         │
+         ▼ WebSocket (localhost:PORT)
+┌─────────────────────────────────────────────────────────────────┐
+│                    Swarm Dashboard (Web)                         │
+│  Real-time: Task DAG → Progress → Worker Status → Cost          │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Meta-Agent Responsibilities**:
+
+| Responsibility | Implementation | Research Basis |
+|----------------|----------------|----------------|
+| **Goal Decomposition** | Parse user goal → generate Task DAG with dependencies | P1: structured decomposition |
+| **Team Design** | Auto-select worker count, roles, and models based on task complexity | P2: SwarmAgentic joint optimization |
+| **Cost Optimization** | Apply instructor-summarization pattern: Meta-Agent filters context for each worker, reducing tokens by up to 93% | P5: ACL 2025 pattern |
+| **Worker Dispatch** | Spawn virtual-thread workers, assign tasks, manage lifecycle | P4: embedding-based matching |
+| **Progress Monitoring** | Track task status, detect stalls, trigger replanning | P4: pheromone reinforcement |
+| **Adaptive Replanning** | When workers fail, reassign or decompose further; max 3 replans | P4: Explorer/Worker/Validator cycle |
+
+**Decision Flow — Three-Tier Execution Model**:
+
+> **Architecture Decision**: DAG parallel execution is **only** implemented at the Swarm tier (Tier 3). The Plan tier (Tier 2) remains strictly linear. This is a deliberate design choice — see §4.9.7 for rationale.
+
+```
+User Input
+  │
+  ├── Explicit swarm trigger? ────────────────────────────→ Tier 3: Swarm Mode
+  │   (/swarm, /team prefix, or                                │
+  │    "agent team"/"agent swarm" in text)                     ▼
+  │                                                    Meta-Agent (§4.9.3)
+  │                                                    DAG parallel execution
+  │
+  ├── plannerEnabled && score ≥ 5? ───────────────────→ Tier 2: Plan Mode
+  │   (ComplexityEstimator regex heuristic)                    │
+  │                                                            ▼
+  │                                                    SequentialPlanExecutor
+  │                                                    Linear steps + fallback + replan
+  │                                                            │
+  │                                                    Plan fails 2+ times?
+  │                                                    ──→ Auto-escalate to Tier 3 ↑
+  │
+  └── Default ────────────────────────────────────────→ Tier 1: ReAct Mode
+                                                               │
+                                                               ▼
+                                                       AgentLoop (single agent)
+                                                       Tool-level parallel only
+```
+
+**Explicit Swarm Trigger**:
+
+The primary entry to Swarm Mode is **user-initiated**, not automatic score-based routing. This is a deliberate UX decision:
+
+| Trigger | Syntax | Example |
+|---------|--------|---------|
+| **Slash command** (primary) | `/swarm <goal>` or `/team <goal>` | `/swarm refactor the auth module, add tests, deploy` |
+| **Natural language** (fallback) | Include "agent team" or "agent swarm" in prompt | `用 agent team 帮我重构 auth 模块` |
+| **Auto-escalation** | Plan Mode fails 2+ consecutive replans | *(automatic, notifies user)* |
+
+Why explicit > automatic:
+- `ComplexityEstimator` is English-only regex — **Chinese prompts always score 0**, making automatic triggering impossible for CJK users
+- Short prompts for complex tasks (e.g., "重构整个项目") get low scores despite high actual complexity
+- User intent is **transparent** — you know exactly which execution tier you're in
+- Zero false positives — no accidental swarm spawning on simple tasks
+
+**Swarm command options** (v1 = minimal, future = extended):
+
+```bash
+# v1 (Phase 5 launch)
+/swarm <goal>              # Meta-Agent decides workers, roles, DAG
+/team <goal>               # Alias for /swarm
+
+# Future extensions
+/swarm --workers=3 <goal>          # Hint: max 3 workers
+/swarm --strategy=parallel <goal>  # Hint: prefer parallel branches
+/swarm --model=haiku <goal>        # Force cheap model for workers
+/swarm --dry-run <goal>            # Show plan without executing
+```
+
+**Routing implementation** (in `StreamingAgentHandler`):
+
+```java
+// Priority-ordered routing
+if (SwarmCommandParser.isSwarmTrigger(prompt)) {        // /swarm, /team, "agent team"
+    String goal = SwarmCommandParser.extractGoal(prompt);
+    return swarmMode(goal, session);
+    
+} else if (plannerEnabled) {
+    var score = complexityEstimator.estimate(prompt);
+    if (score.shouldPlan()) {                            // score ≥ 5
+        return planMode(prompt, session);                // linear, may auto-escalate
+    }
+}
+return reactMode(prompt, session);                       // default
+```
+
+### 4.9.4 Worker Lifecycle and Spawning
+
+**Critical Design Decision**: Workers are **in-process virtual threads** within the daemon JVM, not separate terminal sessions or processes. This directly addresses the observability problem — all workers share the daemon's event bus, state, and monitoring infrastructure.
+
+```java
+// Worker spawning — all within the same daemon JVM
+try (var scope = StructuredTaskScope.open()) {
+    for (PlannedTask task : readyTasks) {
+        scope.fork(() -> {
+            var worker = WorkerAgent.create(task, workerProfile, llmClient);
+            worker.execute();  // Runs ReAct loop on virtual thread
+            return worker.result();
+        });
+    }
+    scope.join();
+}
+```
+
+**Worker Profile Evolution** (inspired by P4 SwarmSys Adaptive Profiles):
+
+| Profile Field | Description | Update Trigger |
+|---------------|-------------|----------------|
+| `role` | Specialized role (coder, reviewer, researcher, tester) | Assigned by Meta-Agent |
+| `capabilities` | Tool/language/framework strengths | Updated after task outcomes |
+| `performance` | Success rate, avg completion time, token efficiency | Updated per task |
+| `workload` | Current task count, estimated remaining work | Real-time |
+| `history` | Recent task IDs + outcomes | Append per task |
+
+Over time, Worker Profiles enable **intelligent task assignment**: the Meta-Agent routes code generation tasks to workers with high coding success rates, and review tasks to workers with strong validation track records.
+
+**Worker Communication**:
+- Workers communicate **only through shared state** (JSON files or in-memory `ConcurrentHashMap`)
+- No direct worker-to-worker messaging (avoids N² communication complexity)
+- Meta-Agent summarizes and distributes relevant context to each worker (instructor pattern, P5)
+- Workers emit structured events via the daemon's EventBus for real-time monitoring
+
+### 4.9.5 Swarm Dashboard (Real-Time Observability)
+
+**Problem Statement**: Agent swarms are opaque — the user has one console but N workers executing in parallel. Without observability, the user cannot understand, control, or trust the swarm.
+
+**Solution**: A lightweight web-based dashboard served by the daemon, rendering the Task DAG and worker status in real-time.
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  AceClaw Swarm Dashboard                    [Stop] [Pause]   │
+├──────────────────────────────────────────────────────────────┤
+│                                                              │
+│  Goal: "Refactor auth module to use OAuth2 + add tests"      │
+│                                                              │
+│  ┌─────────────────── Task DAG ───────────────────┐         │
+│  │                                                 │         │
+│  │  [✅ Research OAuth2 libs]                       │         │
+│  │       │                                         │         │
+│  │       ├── [🔄 Implement OAuth2 client] W1       │         │
+│  │       │         │                               │         │
+│  │       │         ├── [⏳ Write unit tests] W3     │         │
+│  │       │         └── [⏳ Update API routes] W4    │         │
+│  │       │                                         │         │
+│  │       └── [🔄 Refactor auth middleware] W2      │         │
+│  │                 │                               │         │
+│  │                 └── [⏳ Integration tests] W5    │         │
+│  │                                                 │         │
+│  └─────────────────────────────────────────────────┘         │
+│                                                              │
+│  Workers                                                     │
+│  ┌──────────┬──────────┬───────────┬──────────┬──────────┐  │
+│  │ W1:Coder │ W2:Coder │ W3:Tester │ W4:Coder │ W5:Test  │  │
+│  │ Haiku    │ Haiku    │ Haiku     │ Haiku    │ Sonnet   │  │
+│  │ ●Active  │ ●Active  │ ○Waiting  │ ○Waiting │ ○Waiting │  │
+│  │ 12/15tok │ 8/15tok  │ —         │ —        │ —        │  │
+│  └──────────┴──────────┴───────────┴──────────┴──────────┘  │
+│                                                              │
+│  Cost: $0.12 | Tokens: 24.3k | Elapsed: 1m 32s | ETA: ~2m   │
+│                                                              │
+├──────────────────────────────────────────────────────────────┤
+│  Event Log                                                   │
+│  19:23:15  W1  Edit: src/auth/oauth2-client.java (+142 -0)   │
+│  19:23:08  W2  Read: src/middleware/auth.java                 │
+│  19:22:54  META Spawned W1(Coder), W2(Coder)                 │
+│  19:22:51  META Plan approved (5 tasks, 2 parallel branches)  │
+└──────────────────────────────────────────────────────────────┘
+```
+
+**Dashboard Technical Design**:
+
+| Component | Technology | Rationale |
+|-----------|-----------|-----------|
+| Server | Javalin (embedded in daemon) | Lightweight, virtual-thread native, ~100KB |
+| Protocol | WebSocket (Server-Sent Events fallback) | Real-time push, low overhead |
+| Frontend | Vanilla HTML/JS + D3.js (for DAG rendering) | No build step, no framework dependency |
+| State Source | Daemon EventBus → WebSocket bridge | Workers emit events, dashboard renders |
+
+**Dashboard Endpoints**:
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `GET /dashboard` | HTTP | Serve the single-page dashboard HTML |
+| `WS /ws/swarm` | WebSocket | Real-time event stream (task status, worker events, cost) |
+| `POST /api/swarm/pause` | HTTP | Pause all workers |
+| `POST /api/swarm/stop` | HTTP | Graceful stop of swarm execution |
+| `POST /api/swarm/approve/{taskId}` | HTTP | Approve a pending task |
+| `GET /api/swarm/state` | HTTP | Current swarm state snapshot (JSON) |
+
+**Key Feature**: The plan is shown **before execution** — since AceClaw pre-plans via the Task Planner (§4.5.2), the full Task DAG is visible in the dashboard the moment it's created, before any worker starts. The user sees the complete workflow upfront and can approve, modify, or reject it.
+
+### 4.9.6 Swarm Cost Model and Scaling Rules
+
+Based on research findings, AceClaw enforces the following swarm scaling rules:
+
+| Rule | Value | Source | Rationale |
+|------|-------|--------|-----------|
+| Max reasoning workers | 14 | P4 SwarmSys | Performance saturates beyond this for reasoning tasks |
+| Max parallel I/O workers | 50 | P6 survey | I/O tasks (file search, web fetch) scale linearly |
+| Default worker model | Haiku (fast) | Cost | Workers use cheapest model; Meta-Agent uses Sonnet/Opus for planning |
+| Token budget per worker | Configurable | P5 | Instructor-summarization reduces per-worker context |
+| Cost guard | Configurable $/swarm | Safety | Auto-pause if total swarm cost exceeds threshold |
+| Replan limit | 3 per swarm | P4 | Avoid infinite replan loops |
+
+**Cost Optimization via Instructor-Summarization (P5 Pattern)**:
+
+```
+Traditional approach:
+  Each worker gets full context → N × full_context_tokens → expensive
+
+Meta-Agent as Instructor (P5 pattern):
+  Meta-Agent reads full context once
+  → Summarizes relevant subset for each worker
+  → Each worker gets only its task-relevant context
+  → Up to 93% token reduction (measured by P5)
+```
+
+This is AceClaw's **primary competitive advantage** over naive multi-agent systems: the Meta-Agent acts as an intelligent context filter, not just a task router.
+
+### 4.9.7 Architecture Decision: DAG Only at Swarm Tier
+
+> **Decision**: DAG parallel execution is implemented **exclusively** at the Swarm tier (Tier 3). The Plan tier (Tier 2, `SequentialPlanExecutor`) remains strictly **linear**. This is a deliberate architectural choice, not a missing feature.
+
+**Rationale — why DAG at Plan tier is the wrong abstraction**:
+
+| Issue | Plan Tier (Tier 2) | Swarm Tier (Tier 3) |
+|-------|-------------------|---------------------|
+| **Context model** | All steps share one `allMessages` conversation history. Parallel branches would require merging two divergent conversation streams — non-deterministic, high token cost | Each Worker has an **isolated** `AgentLoop` with independent conversation history. No merge needed |
+| **Failure propagation** | One step failure in a DAG branch affects the entire plan's shared context | One Worker failure is contained — Meta-Agent reassigns or decomposes |
+| **Replan complexity** | Replanning mid-DAG requires re-wiring dependency graph while preserving partial shared context | Meta-Agent simply re-decomposes remaining goals from scratch |
+| **Cost control** | Shared context accumulates across all branches — context window bloat | Instructor-summarization (P5) gives each Worker only its relevant subset — up to 93% token savings |
+| **Observability** | Parallel branches in a single console = interleaved output, unreadable | Swarm Dashboard renders DAG visually with per-Worker status |
+
+**What Tier 2 already provides without DAG**:
+
+```
+Scenario: "Read 3 files, fix each one, run tests"
+
+Tier 2 (Linear Plan):
+  Step 1: "Read and understand files a, b, c"
+    └─ AgentLoop turn: read_file(a) ┐
+                       read_file(b) ├─ StructuredTaskScope ← tool-level parallel!
+                       read_file(c) ┘
+  Step 2: "Fix file a"  → AgentLoop
+  Step 3: "Fix file b"  → AgentLoop
+  Step 4: "Fix file c"  → AgentLoop
+  Step 5: "Run tests"   → AgentLoop
+
+Steps 2-4 are sequential, but for score 3-6 tasks this is acceptable.
+Tool-level parallelism (Tier 1's StructuredTaskScope) already handles
+the most common "read multiple files" pattern within a single step.
+```
+
+**Only genuinely parallel workloads need Swarm**:
+
+```
+Scenario: "Refactor auth, add tests, update docs — all independently"
+
+Tier 3 (Swarm DAG):
+  Worker 1: Refactor auth  ─┐
+  Worker 2: Write tests     ├─ parallel, isolated AgentLoops
+  Worker 3: Update docs     ─┘
+                             │
+                    Meta-Agent joins results
+```
+
+**Three-tier summary**:
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                       AceClaw Execution Tiers                       │
+├──────────────┬────────────────────────┬─────────────────────────────┤
+│   Tier 1     │   Tier 2               │   Tier 3                    │
+│   ReAct      │   Linear Plan          │   Swarm (DAG)               │
+├──────────────┼────────────────────────┼─────────────────────────────┤
+│              │                        │                             │
+│  Trigger:    │  Trigger:              │  Trigger:                   │
+│  Default     │  score ≥ 5 (auto)      │  /swarm or /team (explicit) │
+│              │  or /plan (explicit)   │  or auto-escalation         │
+│              │                        │                             │
+│  Execution:  │  Execution:            │  Execution:                 │
+│  Single      │  Sequential steps      │  DAG with parallel branches │
+│  ReAct loop  │  Shared context        │  Isolated Workers           │
+│              │  fallback + replan     │  Meta-Agent coordination    │
+│              │                        │                             │
+│  Parallel:   │  Parallel:             │  Parallel:                  │
+│  Tool-level  │  Tool-level (per step) │  Task-level (Worker DAG)    │
+│  (same turn) │  Steps are linear      │  + tool-level (per Worker)  │
+│              │                        │                             │
+│  Context:    │  Context:              │  Context:                   │
+│  Shared      │  Shared (allMessages)  │  Isolated per Worker        │
+│  (cumulative)│  (cumulative)          │  (instructor-summarized)    │
+│              │                        │                             │
+│  Status: ✅   │  Status: ✅             │  Status: Phase 5            │
+└──────────────┴────────────────────────┴─────────────────────────────┘
+```
+
+**Auto-escalation** (Plan → Swarm):
+
+When the Plan tier fails repeatedly, the system can automatically escalate to Swarm mode:
+
+```java
+// In SequentialPlanExecutor — after replan also fails
+if (replanAttempt >= MAX_REPLAN_ATTEMPTS) {
+    var escalation = AdaptiveReplanner.Escalated("Plan exhausted 3 replans");
+    
+    if (swarmEnabled && SwarmEscalationPolicy.shouldEscalate(plan, failureHistory)) {
+        eventBus.publish(new PlanEvent.EscalatedToSwarm(plan.planId()));
+        notifyUser("Plan mode exhausted — escalating to swarm mode");
+        return swarmMode(plan.originalGoal(), session);  // hand off to Meta-Agent
+    }
+    return PlanResult.failed(escalation.reason());
+}
+```
+
+This creates a natural **safety net**: complex tasks that were misjudged as medium-complexity (score 3-6) will auto-recover by escalating to the more powerful Swarm tier.
+
 ### 4.10 Adaptive Skills and Slash Commands
 
 - **Skills**: Model-invoked capabilities auto-matched to user requests (`.aceclaw/skills/`), with **adaptive learning**:
@@ -504,6 +887,15 @@ aceclaw-cli ──> aceclaw-daemon (thin client connects via UDS)
 - `AgentTask`, `TaskStatus` (PENDING, IN_PROGRESS, COMPLETED, DELETED), `TaskStore`, `TaskUpdate`
 - `TeamConfig`, `TeamMember`, `TeammateConfig`, `TeammateBackend` (IN_PROCESS, EXTERNAL_PROCESS, TMUX)
 - `TeamContext` (ScopedValues: TEAM_NAME, AGENT_ID, AGENT_NAME, AGENT_TYPE, PLAN_MODE_REQUIRED)
+
+**Swarm interfaces** (aceclaw-core, Phase 5):
+- `SwarmCommandParser` (detects `/swarm`, `/team`, "agent team" triggers; extracts goal and options)
+- `SwarmEscalationPolicy` (decides when Plan tier auto-escalates to Swarm tier)
+- `MetaAgent`, `GoalDecomposer`, `TeamDesigner`, `CostOptimizer`, `ProgressMonitor`, `ReplanEngine`
+- `WorkerPool`, `WorkerAgent`, `WorkerProfile` (role, capabilities, performance, workload, history)
+- `SwarmState`, `SwarmConfig`, `SwarmCostGuard`
+- `SwarmEvent` (sealed: SwarmCreated, WorkerSpawned, TaskAssigned, TaskCompleted, TaskFailed, ReplanTriggered, SwarmCompleted, CostLimitReached, **EscalatedFromPlan**)
+- `SwarmDashboard`, `DashboardWebSocket`, `DashboardState`
 
 **Adaptive skills interfaces** (aceclaw-memory / aceclaw-core):
 - `SkillState` (sealed: Draft, Active, Deprecated, Disabled), `SkillDefinition`, `SkillMetadata`, `SkillMetrics`
@@ -887,6 +1279,9 @@ This ensures no insight is lost even if the agent did not actively call `memory 
 | Task Planner (basic, single-branch) | P1 | Autonomous planning for complex tasks |
 | Task Planner (full DAG, parallel execution) | P2 | Parallel branch execution + replanning |
 | Task Planner (Agent Teams bridge) | P3 | Auto-materialize plans into team TaskStore |
+| Swarm explicit trigger (`/swarm`, `/team`) | P3 | User-initiated swarm mode; language-agnostic routing |
+| Swarm auto-escalation (Plan → Swarm) | P3 | Safety net for misjudged complexity; SwarmEscalationPolicy |
+| DAG parallel execution (Swarm tier only) | P3 | Task-level parallelism via isolated Worker AgentLoops |
 | Skills system (basic) | P2 | Model-invoked extensibility |
 | Adaptive skills (learning loop, metrics) | P2 | Self-improving skill system |
 | Auto-generated skills | P3 | Pattern-based skill proposal |
@@ -904,9 +1299,10 @@ This ensures no insight is lost even if the agent did not actively call `memory 
 
 | Feature | Rationale |
 |---------|----------|
-| Multi-agent team orchestration | Phase 4 (Weeks 13-18); infrastructure (event bus, message queue, scheduler) laid in v1.0-v2.0; design faithfully ports Claude Code's agent team model (sealed TeamMessage, TaskStore, TeamMessageRouter with dual-mode transport) |
+| Multi-agent team orchestration | Phase 4 (Weeks 13-18); infrastructure ready in v1.0-v2.0 |
+| Multi-agent swarm intelligence | Phase 5 (Weeks 19-26); depends on Phase 4 Agent Teams |
 | Plugin distribution system | Needs stable core API |
-| Web dashboard | CLI-first approach |
+| Full web dashboard (project management) | CLI-first; Swarm Dashboard (Phase 5) is monitoring-only |
 | IDE plugins | Requires stable core API |
 | Enterprise SSO/RBAC | Needs organizational infrastructure |
 | MCP server mode | Client-first |
@@ -920,6 +1316,7 @@ This ensures no insight is lost even if the agent did not actively call `memory 
 | **Phase 2: Intelligence** | Weeks 5-8 | **Multi-session daemon, session persistence/resume, heartbeat runner (HEARTBEAT.md), cron scheduler, BOOT.md, background memory consolidation**, memory/compaction, OS-level sandbox, OpenAI/Ollama, hooks, health monitor, circuit breakers, LLM failover, Task Planner (ComplexityEstimator + basic single-branch plans) |
 | **Phase 3: Extensibility** | Weeks 9-12 | **WebSocket listener (IDE), JSON-RPC full method set, codebase indexing**, MCP client, plugin SPI, auto-memory, rich terminal UI, subagents, basic skills system, full event type hierarchy, message queue (point-to-point + pub/sub), adaptive skills (metrics tracking + learning loop), Task Planner (full DAG, parallel execution, replanning, PlanEvent) |
 | **Phase 4: Multi-Agent** | Weeks 13-18 | **`aceclaw daemon install` (launchd/systemd), Agent Teams persistence (survive client disconnect), file watchers, remote access (TLS + auth)**, agent teams (sealed TeamMessage, TeamManager, TaskStore, dual-mode transport, in-process/external teammates, plan approval), message queue (request-reply + DLQ + TTL), skill refinement engine, auto-generated skills, GraalVM native builds, Task Planner (Agent Teams bridge, adaptive plan templates) |
+| **Phase 5: Swarm Intelligence** | Weeks 19-26 | **Explicit swarm trigger (`/swarm`, `/team` commands + natural language detection), SwarmCommandParser, three-tier routing (ReAct → Plan → Swarm), auto-escalation from Plan to Swarm (SwarmEscalationPolicy)**, Meta-Agent controller, Worker Pool Manager, DAG-only-at-swarm-tier execution, Swarm Dashboard (Javalin + WebSocket + D3.js), Worker Profile evolution, instructor-summarization cost optimization, swarm cost guard, adaptive replanning, goal decomposition engine, swarm state persistence, dashboard controls (pause/stop/approve), multi-model worker assignment (Haiku workers + Sonnet/Opus planner), research-backed scaling rules (14-worker cap for reasoning) |
 
 ---
 
@@ -959,6 +1356,19 @@ This ensures no insight is lost even if the agent did not actively call `memory 
 | Resume binding accuracy (`continue`) | >= 95% (replay set) |
 | Cross-workspace auto-resume leakage | 0 |
 
+### Swarm (Phase 5)
+
+| Metric | Target |
+|--------|--------|
+| Meta-Agent plan generation | < 5 seconds |
+| Worker spawn latency | < 50ms per worker (virtual thread) |
+| Dashboard render latency | < 100ms (WebSocket push) |
+| Token cost reduction (vs naive broadcast) | > 80% (instructor-summarization) |
+| Swarm task completion rate | > 80% |
+| Adaptive replan success rate | > 60% (within 3 replans) |
+| Worker profile accuracy (task routing) | > 70% after 20 swarm runs |
+| Dashboard uptime during swarm | 100% |
+
 ### User Experience
 
 | Metric | Target |
@@ -996,6 +1406,11 @@ This ensures no insight is lost even if the agent did not actively call `memory 
 | **Auto-generated skill noise** | Medium | Low | Require 3+ matching patterns before proposing; user must approve all drafts; clear rejection path |
 | **Message queue ordering edge cases** | Low | Medium | FIFO guaranteed per queue; correlation IDs for request-reply; thorough testing with concurrent producers |
 | **Circuit breaker tuning** | Medium | Low | Conservative defaults (5 failures / 60s reset); configurable per provider; observability via event bus |
+| **Swarm cost explosion** | Medium | High | Cost guard with configurable $/swarm threshold; auto-pause on breach; instructor-summarization reduces baseline cost by ~93% |
+| **Worker coordination deadlock** | Low | High | Workers communicate only via shared state (no direct messaging); Meta-Agent detects stalls via progress monitoring; 5-minute timeout per task |
+| **Emergent deceptive coordination** | Low | Medium | All worker actions gated by existing permission system; Meta-Agent audits all state changes; replan limit of 3 prevents runaway loops |
+| **Dashboard as attack surface** | Low | Medium | Bind to localhost only; optional auth token; no external network access; read-only by default |
+| **Meta-Agent single point of failure** | Medium | High | Meta-Agent runs on daemon's main thread; daemon crash recovery preserves swarm state to disk; workers resume from last checkpoint |
 
 ---
 
@@ -1014,4 +1429,65 @@ All detailed research is available in the `research/` directory:
 
 ---
 
-*This PRD was compiled from research by the AceClaw PRD Team: Architect, OpenClaw Expert, Product Owner, Security Expert, Java Engineer, and Frontend Developer.*
+---
+
+## 14. Research Foundation — Multi-Agent Swarm
+
+The Swarm Architecture design (§4.9.2–4.9.6) is grounded in a systematic review of 7 core academic papers published between 2025-2026. This section maps each research finding to its corresponding AceClaw design decision.
+
+### 14.1 Source Papers
+
+| ID | Paper | Institution | Published | Key Contribution |
+|----|-------|-------------|-----------|------------------|
+| P1 | Multi-Agent Collaboration Mechanisms Survey | Univ. College Cork | arXiv:2501.06322 | 5-dimensional collaboration framework |
+| P2 | SwarmAgentic | LMU Munich | arXiv:2506.15672 | Fully automated agent system generation via PSO |
+| P3 | LLM-driven Swarm Intelligence | CY Cergy Paris | arXiv:2503.03800 | LLM replacing hard-coded swarm rules in NetLogo |
+| P4 | SwarmSys | HKUST-GZ, NYU | arXiv:2510.10047 | Decentralized pheromone-inspired reasoning (GPT-4o swarm → 70% of GPT-5) |
+| P5 | Beyond Frameworks (ACL 2025) | Harbin IT | arXiv:2505.12467 | Fine-grained collaboration experiments: centralized + instructor = 93% cost reduction |
+| P6 | LLM-based MAS Survey | Harbin IT | arXiv:2412.17481 | 125-paper application taxonomy |
+| P7 | IEEE SMC MAS×LLM | CNR Italy | June 2025 | Architecture fusion of MAS and LLM |
+
+### 14.2 Research → Design Mapping
+
+| Research Finding | Evidence | AceClaw Design Decision |
+|------------------|----------|-------------------------|
+| **Collaboration > Model Capability** (7/7 consensus) | P4: GPT-4o swarm closed 70% of gap to GPT-5 purely through coordination | Meta-Agent invests in coordination architecture; workers use cheap models (Haiku) |
+| **Centralized planning + decentralized execution = optimal hybrid** | P5: centralized + instructor → 93% token reduction; P4: decentralized execution → emergent specialization | Meta-Agent (centralized planning) + Worker Pool (decentralized execution) |
+| **Reasoning tasks saturate at 8-14 agents** | P4: SwarmSys ablation — gains plateau at 14 workers | `MAX_REASONING_WORKERS = 14` hard cap |
+| **Instructor-summarization is the best cost/quality pattern** | P5: ordered turns + instructor summarization = best token-to-accuracy ratio | Meta-Agent filters and summarizes context per worker (up to 93% token savings) |
+| **Adaptive profiles enable specialization** | P4: Worker profiles (role, capability, performance) evolve through task history | `WorkerProfile` with role, capabilities, performance, history fields |
+| **Automated agent team design is feasible** | P2: SwarmAgentic generates agents from scratch + self-optimizes | Meta-Agent Team Designer auto-selects worker count, roles, and models |
+| **Communication pattern matters more than message content** | P5: simultaneous broadcast = worst; sequential ordered = best quality | Workers communicate only through shared state; no direct worker-worker messaging |
+| **Memory must evolve from stateless to adaptive** | P4: stateless → three-layer → adaptive archive (frontier) | Worker Profiles are adaptive archives; Meta-Agent maintains swarm-level memory |
+
+### 14.3 Open Research Questions Tracked
+
+These unresolved questions from the literature will guide iterative improvements:
+
+| Question | Status | Action |
+|----------|--------|--------|
+| Optimal agent count given budget + task complexity | Unresolved | Meta-Agent uses heuristic; collect telemetry to build empirical model |
+| Standardized MAS benchmarks | Immature | Track SWE-bench, GAIA, TravelPlanner for swarm evaluation |
+| Safety in emergent coordination | Theoretical | Cost guard + replan limit + human approval gate |
+| Token cost prediction models | None exist | Instrument swarm runs; build regression model over time |
+| Human-in-the-loop optimal insertion points | Underexplored | Dashboard approval gates at plan creation + high-risk tasks |
+
+### 14.4 Competitive Positioning
+
+| Capability | Claude Code | OpenClaw | CrewAI | LangGraph | AceClaw (Phase 5) |
+|-----------|------------|---------|--------|-----------|-------------------|
+| Sub-agents | ✅ (basic) | ✅ | ❌ | ✅ | ✅ |
+| Multi-agent teams | ✅ (Team Lead) | ❌ | ✅ (static roles) | ✅ (graph) | ✅ (Meta-Agent + dynamic workers) |
+| **Explicit swarm trigger** | ❌ | ❌ | ❌ | ❌ | **✅ (`/swarm`, `/team`, natural language)** |
+| **Three-tier execution** | ❌ (ReAct only) | ❌ | ❌ | Partial | **✅ (ReAct → Plan → Swarm)** |
+| **Auto-escalation** | ❌ | ❌ | ❌ | ❌ | **✅ (Plan fails → Swarm)** |
+| Real-time dashboard | ❌ | ❌ | ❌ | ❌ | **✅ (Swarm Dashboard)** |
+| Pre-execution plan visibility | ❌ | ❌ | ❌ | Partial | **✅ (full DAG before execution)** |
+| Worker profile evolution | ❌ | ❌ | ❌ | ❌ | **✅ (adaptive profiles, P4)** |
+| Instructor-summarization | ❌ | ❌ | ❌ | ❌ | **✅ (93% token reduction, P5)** |
+| Automated team design | ❌ | ❌ | ❌ | ❌ | **✅ (SwarmAgentic-inspired, P2)** |
+| Research-backed scaling rules | ❌ | ❌ | ❌ | ❌ | **✅ (7-paper synthesis)** |
+
+---
+
+*This PRD was compiled from research by the AceClaw PRD Team: Architect, OpenClaw Expert, Product Owner, Security Expert, Java Engineer, and Frontend Developer. Swarm Architecture sections (§4.9.2–4.9.6, §14) are informed by systematic review of 7 academic papers (2025-2026).*

--- a/aceclaw-dashboard/.gitignore
+++ b/aceclaw-dashboard/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.log
+.DS_Store

--- a/aceclaw-dashboard/package.json
+++ b/aceclaw-dashboard/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@aceclaw/dashboard",
+  "version": "0.0.0",
+  "private": true,
+  "description": "AceClaw real-time execution dashboard (epic #430). Currently scaffolded for issue #439 — wire-format event schema only.",
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.0"
+  }
+}

--- a/aceclaw-dashboard/src/types/events.ts
+++ b/aceclaw-dashboard/src/types/events.ts
@@ -1,0 +1,392 @@
+// AceClaw — Web Event Schema (issue #439, epic #430)
+//
+// Canonical TypeScript wire format for browser clients consuming AceClaw
+// runtime state over the WebSocket bridge (#431).
+//
+// Architectural rule (decided in #439):
+//   Schema layer = flat wire format (this file).
+//   Reducer layer (#435) = builds the ExecutionNode tree.
+//
+// Therefore this file MUST NOT contain:
+//   - parentId, nodeType, children, depth
+//   - any tree / parallelism / nesting semantics
+//   - any presentation concerns (colors, icons, status enums for UI)
+//
+// All field names mirror the JSON-RPC notifications emitted by the daemon
+// (see aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java).
+// If a daemon emission site changes a field, this file must be updated in lockstep.
+
+// ---------------------------------------------------------------------------
+// Envelope
+// ---------------------------------------------------------------------------
+
+/**
+ * Monotonic event id assigned by the WebSocket bridge (#431) so that browser
+ * clients can de-duplicate after `snapshot + live stream` reconnect.
+ *
+ * Snapshot interop rule:
+ *   1. Browser fetches snapshot → receives `lastEventId` watermark.
+ *   2. Browser opens WebSocket → applies only events with `eventId > lastEventId`.
+ *   3. Within a session, eventId is strictly increasing.
+ *
+ * `eventId` is added by the bridge and is NOT part of the daemon's existing
+ * JSON-RPC notification payload. It lives on the envelope, not in `params`.
+ */
+export interface DaemonEventEnvelope<E extends DaemonEvent = DaemonEvent> {
+  eventId: number;
+  sessionId: string;
+  receivedAt: string; // ISO-8601, set by bridge
+  event: E;
+}
+
+// ---------------------------------------------------------------------------
+// Per-event params (flat, mirror daemon emission sites verbatim)
+// ---------------------------------------------------------------------------
+
+// --- Lifecycle (some new — see "Daemon must emit" below) ---
+
+/** stream.session_started — NEW (issue #439, daemon to add in #431). */
+export interface SessionStartedParams {
+  sessionId: string;
+  model: string;
+  timestamp: string; // ISO-8601
+}
+
+/** stream.turn_started — NEW (issue #439, daemon to add in #431). */
+export interface TurnStartedParams {
+  sessionId: string;
+  requestId: string;
+  turnNumber: number;
+  timestamp: string; // ISO-8601
+}
+
+/** stream.turn_completed — NEW (issue #439, daemon to add in #431). */
+export interface TurnCompletedParams {
+  sessionId: string;
+  requestId: string;
+  turnNumber: number;
+  durationMs: number;
+  toolCount: number;
+  timestamp: string; // ISO-8601
+}
+
+// --- Existing daemon stream events ---
+
+/** stream.thinking — extended thinking deltas. */
+export interface ThinkingDeltaParams {
+  delta: string;
+}
+
+/** stream.text — assistant text token deltas. */
+export interface TextDeltaParams {
+  delta: string;
+}
+
+/** stream.tool_use — emitted at tool-use block start (input may still be partial). */
+export interface ToolUseParams {
+  /** Tool use id (Anthropic block id, e.g. "toolu_..."). Unique per call. */
+  id: string;
+  /** Tool name (e.g. "read_file", "bash"). */
+  name: string;
+  /** Optional one-line summary of the input (path, command, etc.). */
+  summary?: string;
+}
+
+/** stream.tool_completed — terminal event for a tool call. */
+export interface ToolCompletedParams {
+  id: string;
+  name: string;
+  durationMs: number;
+  isError: boolean;
+  /** Truncated error message; only present when isError === true. */
+  error?: string;
+}
+
+/** stream.heartbeat — keepalive/progress beacon while a phase is in flight. */
+export interface HeartbeatParams {
+  phase: string;
+}
+
+/** stream.error — non-fatal stream-level error from the LLM transport. */
+export interface StreamErrorParams {
+  error: string;
+}
+
+/** stream.cancelled — emitted when a turn was cancelled mid-flight. */
+export interface CancelledParams {
+  sessionId: string;
+}
+
+/** stream.budget_exhausted — watchdog hit hard or soft-stall stop. */
+export interface BudgetExhaustedParams {
+  sessionId: string;
+  reason: string;
+  elapsedMs: number;
+  extensionCount: number;
+  softLimitReached: boolean;
+}
+
+/** stream.compaction — context compactor ran. */
+export interface CompactionParams {
+  originalTokens: number;
+  compactedTokens: number;
+  phase: string;
+}
+
+/** stream.subagent.start — a sub-agent (Task tool) began. */
+export interface SubAgentStartParams {
+  agentType: string;
+  prompt: string;
+}
+
+/** stream.subagent.end — sub-agent terminated. */
+export interface SubAgentEndParams {
+  agentType: string;
+}
+
+/** stream.usage — token usage update for the session. */
+export interface UsageParams {
+  /** Input tokens for the most recent LLM call. */
+  inputTokens: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+}
+
+/** stream.gate — anti-pattern pre-execution gate decision (BLOCK/PENALIZE/etc.). */
+export interface GateParams {
+  sessionId: string;
+  tool: string;
+  gate: string;
+  action: string;
+  ruleId?: string;
+  reason?: string;
+  fallback?: string;
+  override: boolean;
+  overrideTtlSeconds?: number;
+  overrideReason?: string;
+}
+
+// --- Plan events ---
+
+/** stream.plan_created — task planner produced a plan. */
+export interface PlanCreatedParams {
+  planId: string;
+  stepCount: number;
+  goal: string;
+  steps: PlanStepDescriptor[];
+}
+
+export interface PlanStepDescriptor {
+  /** 1-based. */
+  index: number;
+  name: string;
+  description: string;
+}
+
+/** stream.plan_step_started — sequential plan executor began a step. */
+export interface PlanStepStartedParams {
+  planId: string;
+  stepId: string;
+  /** 1-based. */
+  stepIndex: number;
+  totalSteps: number;
+  stepName: string;
+}
+
+/** stream.plan_step_completed — step terminated (success or failure). */
+export interface PlanStepCompletedParams {
+  planId: string;
+  stepId: string;
+  /** 1-based. */
+  stepIndex: number;
+  stepName: string;
+  success: boolean;
+  durationMs: number;
+  tokensUsed: number;
+}
+
+/** stream.plan_step_fallback — NEW (issue #439, daemon to add in #431). */
+export interface PlanStepFallbackParams {
+  sessionId: string;
+  planId: string;
+  stepId: string;
+  /** 1-based. */
+  stepIndex: number;
+  fallbackApproach: string;
+  attempt: number;
+}
+
+/** stream.plan_replanned — planner produced a revised plan mid-execution. */
+export interface PlanReplannedParams {
+  planId: string;
+  replanAttempt: number;
+  newStepCount: number;
+  rationale: string;
+}
+
+/** stream.plan_completed — entire plan finished (success or failure). */
+export interface PlanCompletedParams {
+  planId: string;
+  success: boolean;
+  totalDurationMs: number;
+  stepsCompleted: number;
+  totalSteps: number;
+}
+
+/** stream.plan_escalated — planner gave up; control returned to ReAct loop. */
+export interface PlanEscalatedParams {
+  planId: string;
+  reason: string;
+}
+
+// --- Permission (bidirectional) ---
+
+/**
+ * permission.request — daemon → client.
+ *
+ * The browser correlates request/response by `requestId`. With the WebSocket
+ * bridge enabled, both CLI and Browser may receive the same request; the
+ * daemon uses first-response-wins via CompletableFuture (#433).
+ */
+export interface PermissionRequestParams {
+  tool: string;
+  description: string;
+  requestId: string;
+}
+
+/**
+ * permission.response — client → daemon.
+ *
+ * Included here for completeness so reducers and bridge code share a single
+ * source of truth. Browsers send this back over WebSocket (#433).
+ */
+export interface PermissionResponseParams {
+  requestId: string;
+  approved: boolean;
+  /** When true, daemon grants session-level approval for this tool. */
+  remember?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Discriminated union — DaemonEvent
+// ---------------------------------------------------------------------------
+
+/**
+ * Wire-format union mirroring daemon JSON-RPC notifications exactly.
+ *
+ * Discriminator: `method`. The reducer (#435) switches on `event.method` and
+ * builds the ExecutionNode tree from the resulting `params`.
+ *
+ * This union is exhaustive over the events documented as required for Tier 1
+ * (epic #430). Forward-compatible additions go in `DaemonEventExtension` below.
+ */
+export type DaemonEvent =
+  // Lifecycle (NEW — daemon must add in #431)
+  | { method: 'stream.session_started'; params: SessionStartedParams }
+  | { method: 'stream.turn_started'; params: TurnStartedParams }
+  | { method: 'stream.turn_completed'; params: TurnCompletedParams }
+  // Streaming primitives
+  | { method: 'stream.thinking'; params: ThinkingDeltaParams }
+  | { method: 'stream.text'; params: TextDeltaParams }
+  | { method: 'stream.tool_use'; params: ToolUseParams }
+  | { method: 'stream.tool_completed'; params: ToolCompletedParams }
+  | { method: 'stream.heartbeat'; params: HeartbeatParams }
+  | { method: 'stream.error'; params: StreamErrorParams }
+  | { method: 'stream.cancelled'; params: CancelledParams }
+  | { method: 'stream.budget_exhausted'; params: BudgetExhaustedParams }
+  | { method: 'stream.compaction'; params: CompactionParams }
+  | { method: 'stream.subagent.start'; params: SubAgentStartParams }
+  | { method: 'stream.subagent.end'; params: SubAgentEndParams }
+  | { method: 'stream.usage'; params: UsageParams }
+  | { method: 'stream.gate'; params: GateParams }
+  // Plan events
+  | { method: 'stream.plan_created'; params: PlanCreatedParams }
+  | { method: 'stream.plan_step_started'; params: PlanStepStartedParams }
+  | { method: 'stream.plan_step_completed'; params: PlanStepCompletedParams }
+  | { method: 'stream.plan_step_fallback'; params: PlanStepFallbackParams }
+  | { method: 'stream.plan_replanned'; params: PlanReplannedParams }
+  | { method: 'stream.plan_completed'; params: PlanCompletedParams }
+  | { method: 'stream.plan_escalated'; params: PlanEscalatedParams }
+  // Permission (bidirectional)
+  | { method: 'permission.request'; params: PermissionRequestParams }
+  | { method: 'permission.response'; params: PermissionResponseParams };
+
+/** Extracts the params type for a given event method (compile-time helper). */
+export type EventParams<M extends DaemonEvent['method']> = Extract<
+  DaemonEvent,
+  { method: M }
+>['params'];
+
+// ---------------------------------------------------------------------------
+// Forward-compatibility hooks (Tier 2 / Tier 3 — out of scope for #439)
+// ---------------------------------------------------------------------------
+
+/**
+ * Reserved namespaces. The reducer (#435) MUST tolerate unknown methods
+ * (drop or stash under "unknown") so that new event kinds can ship without
+ * forcing schema bumps in lockstep.
+ *
+ * Reserved prefixes:
+ *   - `stream.swarm_*`     — Tier 3 swarm DAG events
+ *   - `stream.worker_*`    — Tier 3 worker session events
+ *   - `stream.skill_*`     — skill/agent invocation telemetry
+ *   - `stream.memory_*`    — memory subsystem events
+ *   - custom client namespaces: `x-<vendor>.<event>` (will not collide with daemon)
+ */
+export type ReservedMethodPrefix =
+  | 'stream.swarm_'
+  | 'stream.worker_'
+  | 'stream.skill_'
+  | 'stream.memory_';
+
+/**
+ * Loose escape hatch for events not yet in the canonical union. Reducers
+ * should branch on `method` first and only fall through to this shape.
+ */
+export interface UnknownDaemonEvent {
+  method: string;
+  params: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Daemon emission map — single source of truth for #431 implementers
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps each event method to its current daemon emission site. Updated whenever
+ * the daemon is changed; CI can grep this list against StreamingAgentHandler
+ * source to catch drift.
+ *
+ * `status: 'existing'` — already emitted today.
+ * `status: 'new'`      — must be added by #431 per issue #439.
+ */
+export const DAEMON_EMISSION_MAP = {
+  // NEW — to be added by #431
+  'stream.session_started': { status: 'new', emitter: 'StreamingAgentHandler#startSession' },
+  'stream.turn_started': { status: 'new', emitter: 'StreamingAgentHandler#beginTurn' },
+  'stream.turn_completed': { status: 'new', emitter: 'StreamingAgentHandler#endTurn' },
+  'stream.plan_step_fallback': { status: 'new', emitter: 'SequentialPlanExecutor#onStepFallback' },
+
+  // Existing — already emitted by daemon
+  'stream.thinking': { status: 'existing', emitter: 'StreamingNotificationHandler#onThinkingDelta' },
+  'stream.text': { status: 'existing', emitter: 'StreamingNotificationHandler#onTextDelta' },
+  'stream.tool_use': { status: 'existing', emitter: 'StreamingNotificationHandler#onContentBlockStart' },
+  'stream.tool_completed': { status: 'existing', emitter: 'StreamingNotificationHandler#onToolCompleted' },
+  'stream.heartbeat': { status: 'existing', emitter: 'StreamingNotificationHandler#onHeartbeat' },
+  'stream.error': { status: 'existing', emitter: 'StreamingNotificationHandler#onError' },
+  'stream.cancelled': { status: 'existing', emitter: 'StreamingAgentHandler#sendCancelledNotificationIfNeeded' },
+  'stream.budget_exhausted': { status: 'existing', emitter: 'StreamingAgentHandler#sendBudgetExhaustedNotificationIfNeeded' },
+  'stream.compaction': { status: 'existing', emitter: 'StreamingNotificationHandler#onCompaction' },
+  'stream.subagent.start': { status: 'existing', emitter: 'StreamingNotificationHandler#onSubAgentStart' },
+  'stream.subagent.end': { status: 'existing', emitter: 'StreamingNotificationHandler#onSubAgentEnd' },
+  'stream.usage': { status: 'existing', emitter: 'StreamingNotificationHandler#onUsageUpdate' },
+  'stream.gate': { status: 'existing', emitter: 'StreamingAgentHandler#emitGateNotification' },
+  'stream.plan_created': { status: 'existing', emitter: 'StreamingAgentHandler (plan executor wiring)' },
+  'stream.plan_step_started': { status: 'existing', emitter: 'PlanEventListener#onStepStarted' },
+  'stream.plan_step_completed': { status: 'existing', emitter: 'PlanEventListener#onStepCompleted' },
+  'stream.plan_replanned': { status: 'existing', emitter: 'PlanEventListener#onPlanReplanned' },
+  'stream.plan_completed': { status: 'existing', emitter: 'PlanEventListener#onPlanCompleted' },
+  'stream.plan_escalated': { status: 'existing', emitter: 'PlanEventListener#onPlanEscalated' },
+  'permission.request': { status: 'existing', emitter: 'StreamingAgentHandler permission gate' },
+  'permission.response': { status: 'existing', emitter: '(client → daemon)' },
+} as const satisfies Record<DaemonEvent['method'], { status: 'existing' | 'new'; emitter: string }>;

--- a/aceclaw-dashboard/src/types/events.ts
+++ b/aceclaw-dashboard/src/types/events.ts
@@ -31,8 +31,14 @@
  *
  * `eventId` is added by the bridge and is NOT part of the daemon's existing
  * JSON-RPC notification payload. It lives on the envelope, not in `params`.
+ *
+ * The `E` parameter accepts {@link UnknownDaemonEvent} as well as the canonical
+ * {@link DaemonEvent} union, so forward-compatible methods (e.g. Tier 3
+ * `stream.swarm_*`) can be wrapped by the bridge without unsafe casts.
  */
-export interface DaemonEventEnvelope<E extends DaemonEvent = DaemonEvent> {
+export interface DaemonEventEnvelope<
+  E extends DaemonEvent | UnknownDaemonEvent = DaemonEvent,
+> {
   eventId: number;
   sessionId: string;
   receivedAt: string; // ISO-8601, set by bridge

--- a/aceclaw-dashboard/src/types/events.ts
+++ b/aceclaw-dashboard/src/types/events.ts
@@ -174,6 +174,10 @@ export interface PlanCreatedParams {
   stepCount: number;
   goal: string;
   steps: PlanStepDescriptor[];
+  /** True when this plan was rebuilt from a resume checkpoint. Absent on fresh plans. */
+  resumed?: boolean;
+  /** 1-based index of the first remaining step, present iff `resumed === true`. */
+  resumedFromStep?: number;
 }
 
 export interface PlanStepDescriptor {
@@ -222,6 +226,8 @@ export interface PlanReplannedParams {
   replanAttempt: number;
   newStepCount: number;
   rationale: string;
+  /** True when emitted from a resume-path planner. Absent on fresh-plan replanning. */
+  resumed?: boolean;
 }
 
 /** stream.plan_completed — entire plan finished (success or failure). */
@@ -231,6 +237,8 @@ export interface PlanCompletedParams {
   totalDurationMs: number;
   stepsCompleted: number;
   totalSteps: number;
+  /** True when this completion belongs to a resumed plan. Absent on fresh plans. */
+  resumed?: boolean;
 }
 
 /** stream.plan_escalated — planner gave up; control returned to ReAct loop. */
@@ -239,10 +247,18 @@ export interface PlanEscalatedParams {
   reason: string;
 }
 
-// --- Permission (bidirectional) ---
+// --- Permission — split direction ---
+//
+// The protocol is bidirectional, but the schema is one-directional per side:
+//   permission.request  → inbound  (DaemonEvent)
+//   permission.response → outbound (ClientCommand, see below)
+//
+// Keeping these on different unions means DaemonEventEnvelope (with eventId /
+// receivedAt set by the bridge) only ever wraps messages the daemon actually
+// emits, and DAEMON_EMISSION_MAP stays a true daemon-emission source of truth.
 
 /**
- * permission.request — daemon → client.
+ * permission.request — daemon → client (inbound DaemonEvent).
  *
  * The browser correlates request/response by `requestId`. With the WebSocket
  * bridge enabled, both CLI and Browser may receive the same request; the
@@ -255,10 +271,12 @@ export interface PermissionRequestParams {
 }
 
 /**
- * permission.response — client → daemon.
+ * permission.response — client → daemon (outbound ClientCommand).
  *
- * Included here for completeness so reducers and bridge code share a single
- * source of truth. Browsers send this back over WebSocket (#433).
+ * Lives on the {@link ClientCommand} union, NOT {@link DaemonEvent}, because
+ * it is browser-originated and is never broadcast as a daemon notification.
+ * Therefore it is also absent from {@link DaemonEventEnvelope} and from
+ * {@link DAEMON_EMISSION_MAP}.
  */
 export interface PermissionResponseParams {
   requestId: string;
@@ -307,13 +325,33 @@ export type DaemonEvent =
   | { method: 'stream.plan_replanned'; params: PlanReplannedParams }
   | { method: 'stream.plan_completed'; params: PlanCompletedParams }
   | { method: 'stream.plan_escalated'; params: PlanEscalatedParams }
-  // Permission (bidirectional)
-  | { method: 'permission.request'; params: PermissionRequestParams }
-  | { method: 'permission.response'; params: PermissionResponseParams };
+  // Permission (inbound only — see ClientCommand for the response)
+  | { method: 'permission.request'; params: PermissionRequestParams };
 
 /** Extracts the params type for a given event method (compile-time helper). */
 export type EventParams<M extends DaemonEvent['method']> = Extract<
   DaemonEvent,
+  { method: M }
+>['params'];
+
+// ---------------------------------------------------------------------------
+// ClientCommand — outbound (browser → daemon)
+// ---------------------------------------------------------------------------
+
+/**
+ * Discriminated union of messages the browser sends back to the daemon over
+ * the WebSocket bridge (#433). Discriminator: `method`.
+ *
+ * These are never wrapped in {@link DaemonEventEnvelope}; the bridge does not
+ * assign `eventId` to outbound traffic. Tier 1 only ships permission.response;
+ * future client commands (cancel, resume.accept, etc.) extend this union.
+ */
+export type ClientCommand =
+  | { method: 'permission.response'; params: PermissionResponseParams };
+
+/** Extracts the params type for a given client command (compile-time helper). */
+export type CommandParams<M extends ClientCommand['method']> = Extract<
+  ClientCommand,
   { method: M }
 >['params'];
 
@@ -388,5 +426,5 @@ export const DAEMON_EMISSION_MAP = {
   'stream.plan_completed': { status: 'existing', emitter: 'PlanEventListener#onPlanCompleted' },
   'stream.plan_escalated': { status: 'existing', emitter: 'PlanEventListener#onPlanEscalated' },
   'permission.request': { status: 'existing', emitter: 'StreamingAgentHandler permission gate' },
-  'permission.response': { status: 'existing', emitter: '(client → daemon)' },
+  // permission.response is a ClientCommand (browser → daemon), not a daemon emission — intentionally absent.
 } as const satisfies Record<DaemonEvent['method'], { status: 'existing' | 'new'; emitter: string }>;

--- a/aceclaw-dashboard/tsconfig.json
+++ b/aceclaw-dashboard/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Protocol-first deliverable for epic #430 (Tier 1 real-time execution tree). Defines the canonical TypeScript wire format that the WebSocket bridge (#431) and React reducer (#435) will share, so both sides start with a frozen contract.

- `aceclaw-dashboard/src/types/events.ts` — `DaemonEvent` discriminated union + per-event `Params` interfaces, mirroring every emission site in `StreamingAgentHandler.java` verbatim. **Flat wire format only — zero tree semantics**, per the Reducer-builds-the-tree decision in #439.
- Specifies the four daemon-must-add events so #431 has a frozen contract:
  - `stream.session_started`
  - `stream.turn_started`
  - `stream.turn_completed`
  - `stream.plan_step_fallback`
- `DAEMON_EMISSION_MAP` records each method's `existing`/`new` status and emitter location as the single source of truth for #431 implementers.
- `DaemonEventEnvelope.eventId` carries a monotonic watermark for snapshot + live-stream reconnect de-duplication (rule documented inline).
- Reserves `stream.swarm_*` / `worker_*` / `skill_*` / `memory_*` for Tier 2/3; `UnknownDaemonEvent` keeps reducers tolerant of unknown methods.
- Minimal `package.json` + `tsconfig.json` (strict + `exactOptionalPropertyTypes`) so the schema typechecks standalone — `tsc --noEmit` clean.

## Non-goals (explicit)

- No `ExecutionNode`, no `parentId`, no `children`, no `nodeType` — all tree shaping lives in the reducer (#435).
- No daemon Java changes in this PR. Emission of the four new events is #431.
- No React components, no WebSocket client.

## Success criteria (from #439)

- [x] TypeScript types cover all 20+ daemon events (flat wire format)
- [x] New events (`turn_started`, `turn_completed`, `session_started`, `plan_step_fallback`) fully specified
- [x] Schema contains zero tree semantics (no `parentId`, no `nodeType`, no `children`)
- [x] Browser client can pass events directly to reducer without transformation
- [x] Permission `request`/`response` correlated by `requestId`
- [x] Snapshot + live stream semantics documented (`eventId` ordering)
- [x] Existing CLI protocol unchanged
- [x] Contract committed in-repo at `aceclaw-dashboard/src/types/events.ts`

## Test plan

- [x] `npm run typecheck` passes (`tsc --noEmit`, strict mode, no errors)
- [ ] Reviewer spot-checks each `Params` shape against `StreamingAgentHandler.java` emission sites
- [ ] Reviewer confirms reserved namespaces match Tier 2/3 plans in PRD-Frontend.md

Closes #439
Refs #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository-level version control configuration to exclude generated artifacts, build outputs, and system files.
  * Introduced event schema and type definitions for daemon-to-browser WebSocket communication supporting session lifecycle, real-time streaming, planning workflows, and permission management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->