### PR TITLE
feat(daemon): WebSocket bridge + EventMultiplexer + missing events (#431)

### DIFF
--- a/aceclaw-bom/build.gradle.kts
+++ b/aceclaw-bom/build.gradle.kts
@@ -32,6 +32,9 @@ dependencies {
         // MCP (Model Context Protocol)
         api("io.modelcontextprotocol.sdk:mcp:0.17.2")
 
+        // WebSocket bridge (Tier 1 dashboard, issue #431)
+        api("io.javalin:javalin:6.4.0")
+
         // HTML parsing
         api("org.jsoup:jsoup:1.18.3")
 

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/planner/SequentialPlanExecutor.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/planner/SequentialPlanExecutor.java
@@ -48,6 +48,19 @@ public final class SequentialPlanExecutor implements PlanExecutor {
 
         /** Called when replanning determines recovery is impossible. */
         default void onPlanEscalated(TaskPlan plan, String reason) {}
+
+        /**
+         * Called when a step's primary attempt failed and the executor is about
+         * to run its fallback approach. Surfaces the fallback as an explicit
+         * stream event for browser dashboards (issue #439, epic #430).
+         *
+         * @param step             the step whose primary attempt failed
+         * @param stepIndex        zero-based index of the step in the plan
+         * @param fallbackApproach the step's declared fallback approach text
+         * @param attempt          1-based fallback attempt counter
+         */
+        default void onStepFallback(PlannedStep step, int stepIndex,
+                                    String fallbackApproach, int attempt) {}
     }
 
     private final PlanEventListener listener;
@@ -246,6 +259,10 @@ public final class SequentialPlanExecutor implements PlanExecutor {
                 // Attempt fallback if available
                 if (step.fallbackApproach() != null) {
                     log.info("Attempting fallback for step {}: {}", i + 1, step.fallbackApproach());
+
+                    if (listener != null) {
+                        listener.onStepFallback(step, i, step.fallbackApproach(), 1);
+                    }
 
                     try {
                         String fallbackPrompt = buildFallbackPrompt(step, e.getMessage());

--- a/aceclaw-daemon/build.gradle.kts
+++ b/aceclaw-daemon/build.gradle.kts
@@ -12,5 +12,6 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     implementation("org.slf4j:slf4j-api")
+    implementation("io.javalin:javalin")
     runtimeOnly("ch.qos.logback:logback-classic")
 }

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
@@ -113,6 +113,11 @@ public final class AceClawConfig {
     private static final int DEFAULT_MAX_PLAN_TOTAL_WALL_TIME_SEC = 3600;
     private static final boolean DEFAULT_DEFERRED_ACTION_ENABLED = true;
     private static final int DEFAULT_DEFERRED_ACTION_TICK_SECONDS = 5;
+    /** WebSocket bridge for browser dashboard (issue #431). Disabled by default; opt-in. */
+    private static final boolean DEFAULT_WEBSOCKET_ENABLED = false;
+    private static final int DEFAULT_WEBSOCKET_PORT = 3141;
+    /** Bind only to localhost by default. Acceptance criterion of #431 (security). */
+    private static final String DEFAULT_WEBSOCKET_HOST = "localhost";
 
     /** Claude CLI credentials directory. */
     private static final Path CLAUDE_CLI_DIR = Path.of(System.getProperty("user.home"), ".claude");
@@ -193,6 +198,9 @@ public final class AceClawConfig {
     private int maxPlanTotalWallTimeSec;
     private boolean deferredActionEnabled;
     private int deferredActionTickSeconds;
+    private boolean webSocketEnabled;
+    private int webSocketPort;
+    private String webSocketHost;
     private List<String> subAgentAutoApproveTools;
     private Map<String, List<HookMatcherFormat>> hooks;
     private boolean context1m;
@@ -271,6 +279,9 @@ public final class AceClawConfig {
         this.maxPlanTotalWallTimeSec = DEFAULT_MAX_PLAN_TOTAL_WALL_TIME_SEC;
         this.deferredActionEnabled = DEFAULT_DEFERRED_ACTION_ENABLED;
         this.deferredActionTickSeconds = DEFAULT_DEFERRED_ACTION_TICK_SECONDS;
+        this.webSocketEnabled = DEFAULT_WEBSOCKET_ENABLED;
+        this.webSocketPort = DEFAULT_WEBSOCKET_PORT;
+        this.webSocketHost = DEFAULT_WEBSOCKET_HOST;
         this.subAgentAutoApproveTools = List.of();
         this.providerModels = new java.util.HashMap<>();
         this.context1m = DEFAULT_CONTEXT_1M;
@@ -1175,6 +1186,29 @@ public final class AceClawConfig {
     }
 
     /**
+     * Returns whether the browser-facing WebSocket bridge is enabled.
+     * Defaults to {@code false} — opt-in via {@code webSocket.enabled} in config.json.
+     */
+    public boolean webSocketEnabled() {
+        return webSocketEnabled;
+    }
+
+    /**
+     * Returns the port the WebSocket bridge binds to. Defaults to 3141.
+     */
+    public int webSocketPort() {
+        return webSocketPort;
+    }
+
+    /**
+     * Returns the host the WebSocket bridge binds to. Defaults to {@code localhost}
+     * for security; never expose without an authentication layer in front.
+     */
+    public String webSocketHost() {
+        return webSocketHost;
+    }
+
+    /**
      * Returns extra tool names to auto-approve for sub-agents, configured via
      * {@code subAgentAutoApproveTools} in config.json. These are merged with
      * the built-in read-only tool whitelist.
@@ -1675,6 +1709,17 @@ public final class AceClawConfig {
         if (fileConfig.deferredActionTickSeconds > 0) {
             this.deferredActionTickSeconds = fileConfig.deferredActionTickSeconds;
         }
+        if (fileConfig.webSocket != null) {
+            if (fileConfig.webSocket.enabled != null) {
+                this.webSocketEnabled = fileConfig.webSocket.enabled;
+            }
+            if (fileConfig.webSocket.port != null && fileConfig.webSocket.port > 0) {
+                this.webSocketPort = fileConfig.webSocket.port;
+            }
+            if (fileConfig.webSocket.host != null && !fileConfig.webSocket.host.isBlank()) {
+                this.webSocketHost = fileConfig.webSocket.host;
+            }
+        }
         if (fileConfig.context1m != null) {
             this.context1m = fileConfig.context1m;
         }
@@ -1777,6 +1822,7 @@ public final class AceClawConfig {
         public Integer maxPlanTotalWallTimeSec;
         public Boolean deferredActionEnabled;
         public int deferredActionTickSeconds;
+        public WebSocketConfigFormat webSocket;
         public List<String> subAgentAutoApproveTools;
         public String defaultProfile;
         public Map<String, ConfigFileFormat> profiles;
@@ -1796,6 +1842,16 @@ public final class AceClawConfig {
         public Long initialBackoffMs;
         public Long maxBackoffMs;
         public Double jitterFactor;
+    }
+
+    /**
+     * JSON structure for the WebSocket bridge section (issue #431).
+     * <pre>{ "enabled": true, "port": 3141, "host": "localhost" }</pre>
+     */
+    public static class WebSocketConfigFormat {
+        public Boolean enabled;
+        public Integer port;
+        public String host;
     }
 
     /**

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
@@ -1731,8 +1731,18 @@ public final class AceClawConfig {
             if (fileConfig.webSocket.enabled != null) {
                 this.webSocketEnabled = fileConfig.webSocket.enabled;
             }
-            if (fileConfig.webSocket.port != null && fileConfig.webSocket.port > 0) {
-                this.webSocketPort = fileConfig.webSocket.port;
+            if (fileConfig.webSocket.port != null) {
+                int p = fileConfig.webSocket.port;
+                // Reject out-of-range ports here so a misconfiguration surfaces
+                // at config-parsing time, not later when the bridge tries to
+                // bind. Port 0 ("ephemeral") is intentionally not allowed in
+                // user-facing config — production deployments need a stable
+                // port; tests construct WebSocketBridge directly with port=0.
+                if (p >= 1 && p <= 65_535) {
+                    this.webSocketPort = p;
+                } else {
+                    log.warn("Ignoring invalid webSocket.port {} (must be 1..65535)", p);
+                }
             }
             if (fileConfig.webSocket.host != null && !fileConfig.webSocket.host.isBlank()) {
                 this.webSocketHost = fileConfig.webSocket.host;

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
@@ -201,6 +201,14 @@ public final class AceClawConfig {
     private boolean webSocketEnabled;
     private int webSocketPort;
     private String webSocketHost;
+    /**
+     * Allowlist of {@code Origin} headers permitted to open a WebSocket.
+     * Default empty — browsers cannot connect until the user explicitly opts in
+     * by listing the dashboard's origin (e.g. {@code http://localhost:5173}).
+     * Tools that send no {@code Origin} (curl, Java HttpClient) are always
+     * allowed because cross-site browser attacks cannot suppress the header.
+     */
+    private List<String> webSocketAllowedOrigins;
     private List<String> subAgentAutoApproveTools;
     private Map<String, List<HookMatcherFormat>> hooks;
     private boolean context1m;
@@ -282,6 +290,7 @@ public final class AceClawConfig {
         this.webSocketEnabled = DEFAULT_WEBSOCKET_ENABLED;
         this.webSocketPort = DEFAULT_WEBSOCKET_PORT;
         this.webSocketHost = DEFAULT_WEBSOCKET_HOST;
+        this.webSocketAllowedOrigins = List.of();
         this.subAgentAutoApproveTools = List.of();
         this.providerModels = new java.util.HashMap<>();
         this.context1m = DEFAULT_CONTEXT_1M;
@@ -1209,6 +1218,15 @@ public final class AceClawConfig {
     }
 
     /**
+     * Returns the allowlist of browser {@code Origin} headers permitted to open
+     * a WebSocket connection. Empty list = no browser may connect; tools with
+     * no {@code Origin} header are always allowed.
+     */
+    public List<String> webSocketAllowedOrigins() {
+        return webSocketAllowedOrigins;
+    }
+
+    /**
      * Returns extra tool names to auto-approve for sub-agents, configured via
      * {@code subAgentAutoApproveTools} in config.json. These are merged with
      * the built-in read-only tool whitelist.
@@ -1719,6 +1737,11 @@ public final class AceClawConfig {
             if (fileConfig.webSocket.host != null && !fileConfig.webSocket.host.isBlank()) {
                 this.webSocketHost = fileConfig.webSocket.host;
             }
+            if (fileConfig.webSocket.allowedOrigins != null) {
+                this.webSocketAllowedOrigins = fileConfig.webSocket.allowedOrigins.stream()
+                        .filter(o -> o != null && !o.isBlank())
+                        .toList();
+            }
         }
         if (fileConfig.context1m != null) {
             this.context1m = fileConfig.context1m;
@@ -1846,12 +1869,18 @@ public final class AceClawConfig {
 
     /**
      * JSON structure for the WebSocket bridge section (issue #431).
-     * <pre>{ "enabled": true, "port": 3141, "host": "localhost" }</pre>
+     * <pre>{
+     *   "enabled": true,
+     *   "port": 3141,
+     *   "host": "localhost",
+     *   "allowedOrigins": ["http://localhost:5173"]
+     * }</pre>
      */
     public static class WebSocketConfigFormat {
         public Boolean enabled;
         public Integer port;
         public String host;
+        public List<String> allowedOrigins;
     }
 
     /**

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
@@ -1748,8 +1748,13 @@ public final class AceClawConfig {
                 this.webSocketHost = fileConfig.webSocket.host;
             }
             if (fileConfig.webSocket.allowedOrigins != null) {
+                // Trim before the blank check — WebSocketBridge does an exact
+                // Origin match, so " http://localhost:5173 " would otherwise
+                // survive the merge but never match a real browser header.
                 this.webSocketAllowedOrigins = fileConfig.webSocket.allowedOrigins.stream()
-                        .filter(o -> o != null && !o.isBlank())
+                        .filter(o -> o != null)
+                        .map(String::trim)
+                        .filter(o -> !o.isBlank())
                         .toList();
             }
         }

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -113,6 +113,8 @@ public final class AceClawDaemon {
     private DeferredActionScheduler deferredActionScheduler;
     private DeferredActionStore deferredActionStore;
     private DeferCheckTool deferCheckTool;
+    /** Browser dashboard bridge (issue #431); null when {@code webSocket.enabled=false}. */
+    private WebSocketBridge webSocketBridge;
 
     private volatile boolean running;
 
@@ -468,6 +470,16 @@ public final class AceClawDaemon {
         // 8. Streaming agent handler
         var agentHandler = new StreamingAgentHandler(
                 sessionManager, agentLoop, toolRegistry, permissionManager, objectMapper);
+        // 8a. WebSocket bridge for browser dashboard (issue #431). Disabled by default.
+        // Constructed but NOT started here; lifecycle binds to udsListener below so the
+        // port is held only while the daemon is accepting clients.
+        if (config.webSocketEnabled()) {
+            this.webSocketBridge = new WebSocketBridge(
+                    config.webSocketHost(), config.webSocketPort(), objectMapper);
+            agentHandler.setWebSocketBridge(this.webSocketBridge);
+            log.info("WebSocket bridge configured: {}:{}",
+                    config.webSocketHost(), config.webSocketPort());
+        }
         // Use config model for anthropic (user's choice), client's resolved model for other providers
         // (factory may translate or fall back, e.g. copilot ignores anthropic model names)
         String effectiveModel = "anthropic".equals(config.provider()) ? model : llmClient.defaultModel();
@@ -2029,6 +2041,17 @@ public final class AceClawDaemon {
             @Override public void onShutdown() { eventBus.stop(); }
         });
 
+        if (webSocketBridge != null) {
+            shutdownManager.register(new ShutdownManager.ShutdownParticipant() {
+                @Override public String name() { return "WebSocket Bridge"; }
+                // Stop AFTER UDS (priority 100) and Session Manager (90) so any
+                // in-flight prompt finishes its notification stream cleanly first;
+                // BEFORE Event Bus (15) since it has no dependency on the bus.
+                @Override public int priority() { return 25; }
+                @Override public void onShutdown() { webSocketBridge.stop(); }
+            });
+        }
+
         shutdownManager.register(new ShutdownManager.ShutdownParticipant() {
             @Override public String name() { return "Daemon Lock"; }
             @Override public int priority() { return 10; }
@@ -2059,6 +2082,18 @@ public final class AceClawDaemon {
             }
         } else {
             log.debug("Boot execution disabled via config");
+        }
+
+        // 3.9 Start WebSocket bridge (issue #431). Bound before UDS listener so a
+        // browser tab connecting in the same instant as the CLI does not race with
+        // the first agent.prompt event arrival.
+        if (webSocketBridge != null) {
+            try {
+                webSocketBridge.start();
+            } catch (Exception e) {
+                log.error("WebSocket bridge failed to start (continuing without it): {}",
+                        e.getMessage(), e);
+            }
         }
 
         // 4. Start UDS listener

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -475,10 +475,14 @@ public final class AceClawDaemon {
         // port is held only while the daemon is accepting clients.
         if (config.webSocketEnabled()) {
             this.webSocketBridge = new WebSocketBridge(
-                    config.webSocketHost(), config.webSocketPort(), objectMapper);
+                    config.webSocketHost(), config.webSocketPort(), objectMapper,
+                    config.webSocketAllowedOrigins());
             agentHandler.setWebSocketBridge(this.webSocketBridge);
-            log.info("WebSocket bridge configured: {}:{}",
-                    config.webSocketHost(), config.webSocketPort());
+            log.info("WebSocket bridge configured: {}:{} (allowed browser origins: {})",
+                    config.webSocketHost(), config.webSocketPort(),
+                    config.webSocketAllowedOrigins().isEmpty()
+                            ? "(none — browsers blocked)"
+                            : config.webSocketAllowedOrigins());
         }
         // Use config model for anthropic (user's choice), client's resolved model for other providers
         // (factory may translate or fall back, e.g. copilot ignores anthropic model names)

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -2104,6 +2104,20 @@ public final class AceClawDaemon {
         try {
             udsListener.start();
         } catch (Exception e) {
+            // Roll back the WS bridge we already started in step 3.9. Without
+            // this, a UDS bind failure (stale socket path, permission error,
+            // …) leaves the Javalin thread holding the WS port — blocking the
+            // operator's retry and presenting an unexpected local endpoint
+            // even though the daemon is considered failed to start. Best-
+            // effort: log but do not mask the original DaemonException.
+            if (webSocketBridge != null) {
+                try {
+                    webSocketBridge.stop();
+                } catch (Exception stopErr) {
+                    log.warn("Failed to stop WebSocket bridge during startup abort: {}",
+                            stopErr.getMessage());
+                }
+            }
             lock.release();
             throw new DaemonException("Failed to start UDS listener: " + e.getMessage(), e);
         }

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/EventMultiplexer.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/EventMultiplexer.java
@@ -1,0 +1,58 @@
+package dev.aceclaw.daemon;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Per-request {@link StreamContext} that tees outgoing JSON-RPC notifications
+ * to both the original CLI sink (Unix domain socket) and the
+ * {@link WebSocketBridge} fan-out for connected browser clients
+ * (issue #431, epic #430).
+ *
+ * <p>Architectural rule from #431:
+ * <ul>
+ *   <li>{@code sendNotification} → delegate (CLI) + bridge.broadcast (all WS)</li>
+ *   <li>{@code readMessage} → delegate only. Inbound from WS is browser→daemon
+ *       traffic and is wired separately via {@link WebSocketBridge#setInboundHandler}
+ *       in #433. Routing inbound WS messages into the per-request reader would
+ *       race with the CLI's permission flow.</li>
+ * </ul>
+ *
+ * <p>If the bridge is disabled (i.e. the daemon was started without the
+ * WebSocket section), construction is skipped at the call site and the raw
+ * {@link StreamContext} is used as before — zero overhead, zero behavioural
+ * change for the CLI path.
+ */
+public final class EventMultiplexer implements StreamContext {
+
+    private final StreamContext delegate;
+    private final WebSocketBridge bridge;
+
+    public EventMultiplexer(StreamContext delegate, WebSocketBridge bridge) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
+        this.bridge = Objects.requireNonNull(bridge, "bridge");
+    }
+
+    @Override
+    public void sendNotification(String method, Object params) throws IOException {
+        // CLI sink: must propagate IOException so the per-request handler
+        // can react to a broken Unix socket (cancel, cleanup, etc.).
+        delegate.sendNotification(method, params);
+        // WS sink: best-effort fan-out. A browser disconnect must NOT corrupt
+        // the CLI's request flow. WebSocketBridge#broadcast already swallows
+        // and logs per-client send failures.
+        bridge.broadcast(method, params);
+    }
+
+    @Override
+    public JsonNode readMessage() throws IOException {
+        return delegate.readMessage();
+    }
+
+    @Override
+    public JsonNode readMessage(long timeoutMs) throws IOException {
+        return delegate.readMessage(timeoutMs);
+    }
+}

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/EventMultiplexer.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/EventMultiplexer.java
@@ -13,12 +13,18 @@ import java.util.Objects;
  *
  * <p>Architectural rule from #431:
  * <ul>
- *   <li>{@code sendNotification} → delegate (CLI) + bridge.broadcast (all WS)</li>
+ *   <li>{@code sendNotification} → delegate (CLI, raw JSON-RPC) +
+ *       {@code bridge.broadcast(sessionId, method, params)} (WS, wrapped in the
+ *       {@code DaemonEventEnvelope} frozen by issue #439)</li>
  *   <li>{@code readMessage} → delegate only. Inbound from WS is browser→daemon
  *       traffic and is wired separately via {@link WebSocketBridge#setInboundHandler}
  *       in #433. Routing inbound WS messages into the per-request reader would
  *       race with the CLI's permission flow.</li>
  * </ul>
+ *
+ * <p>The CLI wire format (raw JSON-RPC over UDS) and the browser wire format
+ * (envelope-wrapped) intentionally diverge: each is the right shape for its
+ * consumer, and the multiplexer is the only place that sees both.
  *
  * <p>If the bridge is disabled (i.e. the daemon was started without the
  * WebSocket section), the call site uses the raw {@link StreamContext} directly
@@ -29,10 +35,12 @@ public final class EventMultiplexer implements StreamContext {
 
     private final StreamContext delegate;
     private final WebSocketBridge bridge;
+    private final String sessionId;
 
-    public EventMultiplexer(StreamContext delegate, WebSocketBridge bridge) {
+    public EventMultiplexer(StreamContext delegate, WebSocketBridge bridge, String sessionId) {
         this.delegate = Objects.requireNonNull(delegate, "delegate");
         this.bridge = Objects.requireNonNull(bridge, "bridge");
+        this.sessionId = Objects.requireNonNull(sessionId, "sessionId");
     }
 
     @Override
@@ -40,10 +48,13 @@ public final class EventMultiplexer implements StreamContext {
         // CLI sink: must propagate IOException so the per-request handler
         // can react to a broken Unix socket (cancel, cleanup, etc.).
         delegate.sendNotification(method, params);
-        // WS sink: best-effort fan-out. A browser disconnect must NOT corrupt
-        // the CLI's request flow. WebSocketBridge#broadcast already swallows
-        // and logs per-client send failures.
-        bridge.broadcast(method, params);
+        // WS sink: best-effort fan-out wrapped in the #439 envelope. The
+        // sessionId stamped on every envelope lets the reducer recover session
+        // identity for events whose params don't carry it (text deltas,
+        // tool_use, tool_completed, etc.). WebSocketBridge#broadcast already
+        // swallows and logs per-client send failures so a browser disconnect
+        // never corrupts the CLI's request flow.
+        bridge.broadcast(sessionId, method, params);
     }
 
     @Override

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/EventMultiplexer.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/EventMultiplexer.java
@@ -21,9 +21,9 @@ import java.util.Objects;
  * </ul>
  *
  * <p>If the bridge is disabled (i.e. the daemon was started without the
- * WebSocket section), construction is skipped at the call site and the raw
- * {@link StreamContext} is used as before — zero overhead, zero behavioural
- * change for the CLI path.
+ * WebSocket section), the call site uses the raw {@link StreamContext} directly
+ * and does not instantiate this class — zero overhead, zero behavioural change
+ * for the CLI path.
  */
 public final class EventMultiplexer implements StreamContext {
 

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -228,13 +228,15 @@ public final class StreamingAgentHandler {
         // Set workspace context for tools (e.g. CronTool) that need to know the current workspace.
         // Cleared in the finally block below to cover all exit paths (success, plan, resume, error).
         //
-        // Lifecycle-notification state (issue #431) is declared HERE — outside the
-        // try block — so the outer finally is the single source of truth for
-        // emitting stream.turn_completed: it pairs every turn_started with
-        // exactly one turn_completed regardless of which exit path the request
-        // takes. Both emissions are gated by requestId != null, which is only
-        // assigned once the per-session turnLock is held (preventing the
-        // turnNumber race when two clients hit the same session concurrently).
+        // Lifecycle-notification state (issue #431): turn_started + turn_completed
+        // both fire INSIDE the per-session turnLock (so concurrent prompts on
+        // the same session see correctly ordered events and no interleaving).
+        // requestId / turnNumber / turnStartMillis are declared here only because
+        // turn_completed lives in the inner finally and Java needs the variables
+        // in scope across the try/finally pair; the actual assignment happens
+        // under the lock and the inner-finally emission is gated by
+        // requestId != null so a throw before reaching the assignment (e.g. a
+        // startMonitor failure) emits neither side.
         CronTool.setWorkspaceContext(session.projectPath().toString());
         CancelAwareStreamContext cancelContext = null;
         String requestId = null;
@@ -411,27 +413,18 @@ public final class StreamingAgentHandler {
             String userMessage = formatLlmError(e);
             throw new IllegalStateException(userMessage);
         } finally {
-            if (watchdog != null) {
-                watchdog.close();
-            }
-            cancelContext.stopMonitor();
-            turnLock.unlock();
-
-        }
-
-        } finally {
-            // Emit stream.turn_completed in the OUTER finally so every code path
-            // through the request pairs a turn_started with exactly one
-            // turn_completed: success returns, the LlmException catch+rethrow,
-            // and any unexpected throw inside the inner turnLock block all run
-            // through here. Guarded by requestId != null so we never emit a
-            // closer for a Turn we never opened — assignment happens inside the
-            // turnLock try, so any exception before reaching it leaves requestId
-            // null and no notification fires. stopMonitor in the inner finally
-            // only stops the read pump; the underlying channel remains writable
-            // until the request response is dispatched, so this late notification
-            // still reaches the client.
-            if (cancelContext != null && requestId != null) {
+            // Emit stream.turn_completed BEFORE releasing the lock so the
+            // start→end window is fully serialised against other prompts on
+            // the same session. If we unlocked first, a concurrent agent.prompt
+            // on the same session could grab the lock and emit its own
+            // turn_started between this request's unlock and turn_completed,
+            // garbling event ordering on the browser dashboard.
+            //
+            // Guarded by requestId != null so we never emit a closer for a Turn
+            // we never opened — the assignment lives inside this try block,
+            // so anything thrown before reaching it (e.g. startMonitor failure)
+            // leaves requestId null and no notification fires.
+            if (requestId != null) {
                 try {
                     var tcp = objectMapper.createObjectNode();
                     tcp.put("sessionId", sessionId);
@@ -445,6 +438,15 @@ public final class StreamingAgentHandler {
                     log.debug("Failed to send stream.turn_completed: {}", e.getMessage());
                 }
             }
+            if (watchdog != null) {
+                watchdog.close();
+            }
+            cancelContext.stopMonitor();
+            turnLock.unlock();
+
+        }
+
+        } finally {
             CronTool.clearWorkspaceContext();
         }
     }

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -229,9 +229,12 @@ public final class StreamingAgentHandler {
         // Cleared in the finally block below to cover all exit paths (success, plan, resume, error).
         //
         // Lifecycle-notification state (issue #431) is declared HERE — outside the
-        // try block — so the outer finally can emit stream.turn_completed even
-        // when one of the ~60 lines of setup work below throws between the
-        // turn_started emission and the inner turnLock try.
+        // try block — so the outer finally is the single source of truth for
+        // emitting stream.turn_completed: it pairs every turn_started with
+        // exactly one turn_completed regardless of which exit path the request
+        // takes. Both emissions are gated by requestId != null, which is only
+        // assigned once the per-session turnLock is held (preventing the
+        // turnNumber race when two clients hit the same session concurrently).
         CronTool.setWorkspaceContext(session.projectPath().toString());
         CancelAwareStreamContext cancelContext = null;
         String requestId = null;
@@ -260,38 +263,6 @@ public final class StreamingAgentHandler {
                         context, new EventMultiplexer(context, bridge),
                         cancellationToken, objectMapper)
                 : new CancelAwareStreamContext(context, cancellationToken, objectMapper);
-
-        // ---- Lifecycle notifications (issue #439 + #431) ----------------------
-        // These three events fire per agent.prompt request; they let browser
-        // dashboards anchor a Turn-level node and render session boundaries
-        // without inferring them from text-delta gaps. The CLI ignores them.
-        turnStartMillis = System.currentTimeMillis();
-        requestId = "turn-" + UUID.randomUUID();
-        // turnNumber = Nth user message in this session, matching the existing
-        // AgentEvent.TurnStarted semantics in StreamingAgentLoop.
-        turnNumber = (int) session.messages().stream()
-                .filter(m -> m instanceof AgentSession.ConversationMessage.User).count() + 1;
-        if (sessionsStartedSignaled.add(sessionId)) {
-            try {
-                var p = objectMapper.createObjectNode();
-                p.put("sessionId", sessionId);
-                p.put("model", getModelForSession(sessionId));
-                p.put("timestamp", Instant.now().toString());
-                cancelContext.sendNotification("stream.session_started", p);
-            } catch (IOException e) {
-                log.debug("Failed to send stream.session_started: {}", e.getMessage());
-            }
-        }
-        try {
-            var p = objectMapper.createObjectNode();
-            p.put("sessionId", sessionId);
-            p.put("requestId", requestId);
-            p.put("turnNumber", turnNumber);
-            p.put("timestamp", Instant.now().toString());
-            cancelContext.sendNotification("stream.turn_started", p);
-        } catch (IOException e) {
-            log.debug("Failed to send stream.turn_started: {}", e.getMessage());
-        }
 
         // Create a StreamEventHandler that forwards events via the cancel-aware context
         var eventHandler = new StreamingNotificationHandler(cancelContext, objectMapper);
@@ -354,6 +325,45 @@ public final class StreamingAgentHandler {
             // Start the cancel monitor thread to read from the socket
             cancelContext.startMonitor();
 
+            // ---- Lifecycle notifications (issue #439 + #431) ------------------
+            // These fire per agent.prompt request and let browser dashboards
+            // anchor a Turn-level node + render session boundaries without
+            // inferring them from text-delta gaps. The CLI ignores them.
+            //
+            // Computed UNDER turnLock so concurrent agent.prompt calls on the
+            // same session (e.g. two attached clients) see correctly ordered
+            // turnNumbers — the lock serialises both the read of
+            // session.messages() and the resulting emission. session_started
+            // could safely emit outside (atomic CHM gate), but is kept here
+            // for symmetry — there is one place that opens the turn.
+            turnStartMillis = System.currentTimeMillis();
+            requestId = "turn-" + UUID.randomUUID();
+            // turnNumber = Nth user message in this session, matching the existing
+            // AgentEvent.TurnStarted semantics in StreamingAgentLoop.
+            turnNumber = (int) session.messages().stream()
+                    .filter(m -> m instanceof AgentSession.ConversationMessage.User).count() + 1;
+            if (sessionsStartedSignaled.add(sessionId)) {
+                try {
+                    var p = objectMapper.createObjectNode();
+                    p.put("sessionId", sessionId);
+                    p.put("model", getModelForSession(sessionId));
+                    p.put("timestamp", Instant.now().toString());
+                    cancelContext.sendNotification("stream.session_started", p);
+                } catch (IOException e) {
+                    log.debug("Failed to send stream.session_started: {}", e.getMessage());
+                }
+            }
+            try {
+                var p = objectMapper.createObjectNode();
+                p.put("sessionId", sessionId);
+                p.put("requestId", requestId);
+                p.put("turnNumber", turnNumber);
+                p.put("timestamp", Instant.now().toString());
+                cancelContext.sendNotification("stream.turn_started", p);
+            } catch (IOException e) {
+                log.debug("Failed to send stream.turn_started: {}", e.getMessage());
+            }
+
             // Check for resumable plan checkpoint before planning or execution
             if (planCheckpointStore != null) {
                 var resumeResult = tryResumeFromCheckpoint(
@@ -410,15 +420,17 @@ public final class StreamingAgentHandler {
         }
 
         } finally {
-            // Emit stream.turn_completed in the OUTER finally so it fires on every
-            // exit path — including exceptions thrown by the ~60 lines of setup
-            // between the turn_started emission and the inner turnLock try.
-            // Guard with requestId != null so we never emit a closer for a Turn
-            // we never opened (e.g. CancelAwareStreamContext construction itself
-            // threw, or we exited before reaching the turn_started block).
-            // stopMonitor (above) only stops the read pump; the underlying channel
-            // remains writable until the request response is dispatched, so this
-            // late notification still reaches the client.
+            // Emit stream.turn_completed in the OUTER finally so every code path
+            // through the request pairs a turn_started with exactly one
+            // turn_completed: success returns, the LlmException catch+rethrow,
+            // and any unexpected throw inside the inner turnLock block all run
+            // through here. Guarded by requestId != null so we never emit a
+            // closer for a Turn we never opened — assignment happens inside the
+            // turnLock try, so any exception before reaching it leaves requestId
+            // null and no notification fires. stopMonitor in the inner finally
+            // only stops the read pump; the underlying channel remains writable
+            // until the request response is dispatched, so this late notification
+            // still reaches the client.
             if (cancelContext != null && requestId != null) {
                 try {
                     var tcp = objectMapper.createObjectNode();

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -213,6 +213,33 @@ public final class StreamingAgentHandler {
         this.webSocketBridge = bridge;
     }
 
+    /**
+     * Emits a notification that should reach BROWSER clients only — never the
+     * CLI's Unix-domain socket protocol. Used for the lifecycle events added in
+     * #431 ({@code stream.session_started}, {@code stream.turn_started},
+     * {@code stream.turn_completed}, {@code stream.plan_step_fallback}) which
+     * the existing CLI does not consume and should not have to tolerate.
+     *
+     * <p>The boundary lives at the emission site rather than in
+     * {@link EventMultiplexer}: that keeps {@code sendNotification()} faithful
+     * to the original CLI protocol and {@code broadcast()} the browser
+     * projection, instead of pushing per-method routing policy into transport.
+     *
+     * <p>No-op when the bridge is disabled — these events are not emitted at
+     * all in that case, so the CLI never sees them and there is no CLI
+     * compatibility concern.
+     *
+     * <p>Package-private for unit tests; production callers are inside this
+     * class.
+     */
+    void emitBrowserOnly(String sessionId, String method, Object params) {
+        var bridge = this.webSocketBridge;
+        if (bridge == null) {
+            return;
+        }
+        bridge.broadcast(sessionId, method, params);
+    }
+
     private Object handlePrompt(JsonNode params, StreamContext context) throws Exception {
         var sessionId = requireString(params, "sessionId");
         var prompt = requireString(params, "prompt");
@@ -344,27 +371,22 @@ public final class StreamingAgentHandler {
             // AgentEvent.TurnStarted semantics in StreamingAgentLoop.
             turnNumber = (int) session.messages().stream()
                     .filter(m -> m instanceof AgentSession.ConversationMessage.User).count() + 1;
+            // Browser-only: bypass cancelContext entirely so the CLI's UDS
+            // protocol stays unchanged. emitBrowserOnly is a no-op when the
+            // bridge is off, so disabled deployments emit nothing at all.
             if (sessionsStartedSignaled.add(sessionId)) {
-                try {
-                    var p = objectMapper.createObjectNode();
-                    p.put("sessionId", sessionId);
-                    p.put("model", getModelForSession(sessionId));
-                    p.put("timestamp", Instant.now().toString());
-                    cancelContext.sendNotification("stream.session_started", p);
-                } catch (IOException e) {
-                    log.debug("Failed to send stream.session_started: {}", e.getMessage());
-                }
-            }
-            try {
                 var p = objectMapper.createObjectNode();
                 p.put("sessionId", sessionId);
-                p.put("requestId", requestId);
-                p.put("turnNumber", turnNumber);
+                p.put("model", getModelForSession(sessionId));
                 p.put("timestamp", Instant.now().toString());
-                cancelContext.sendNotification("stream.turn_started", p);
-            } catch (IOException e) {
-                log.debug("Failed to send stream.turn_started: {}", e.getMessage());
+                emitBrowserOnly(sessionId, "stream.session_started", p);
             }
+            var ts = objectMapper.createObjectNode();
+            ts.put("sessionId", sessionId);
+            ts.put("requestId", requestId);
+            ts.put("turnNumber", turnNumber);
+            ts.put("timestamp", Instant.now().toString());
+            emitBrowserOnly(sessionId, "stream.turn_started", ts);
 
             // Check for resumable plan checkpoint before planning or execution
             if (planCheckpointStore != null) {
@@ -420,23 +442,21 @@ public final class StreamingAgentHandler {
             // turn_started between this request's unlock and turn_completed,
             // garbling event ordering on the browser dashboard.
             //
-            // Guarded by requestId != null so we never emit a closer for a Turn
-            // we never opened — the assignment lives inside this try block,
-            // so anything thrown before reaching it (e.g. startMonitor failure)
-            // leaves requestId null and no notification fires.
+            // Browser-only: bypasses cancelContext, so the CLI never sees
+            // turn_completed. Guarded by requestId != null so we never emit a
+            // closer for a Turn we never opened — the assignment lives inside
+            // this try block, so anything thrown before reaching it (e.g.
+            // startMonitor failure) leaves requestId null and no notification
+            // fires.
             if (requestId != null) {
-                try {
-                    var tcp = objectMapper.createObjectNode();
-                    tcp.put("sessionId", sessionId);
-                    tcp.put("requestId", requestId);
-                    tcp.put("turnNumber", turnNumber);
-                    tcp.put("durationMs", System.currentTimeMillis() - turnStartMillis);
-                    tcp.put("toolCount", cancelContext.toolUseCount());
-                    tcp.put("timestamp", Instant.now().toString());
-                    cancelContext.sendNotification("stream.turn_completed", tcp);
-                } catch (Exception e) {
-                    log.debug("Failed to send stream.turn_completed: {}", e.getMessage());
-                }
+                var tcp = objectMapper.createObjectNode();
+                tcp.put("sessionId", sessionId);
+                tcp.put("requestId", requestId);
+                tcp.put("turnNumber", turnNumber);
+                tcp.put("durationMs", System.currentTimeMillis() - turnStartMillis);
+                tcp.put("toolCount", cancelContext.toolUseCount());
+                tcp.put("timestamp", Instant.now().toString());
+                emitBrowserOnly(sessionId, "stream.turn_completed", tcp);
             }
             if (watchdog != null) {
                 watchdog.close();
@@ -588,18 +608,17 @@ public final class StreamingAgentHandler {
             @Override
             public void onStepFallback(PlannedStep step, int stepIndex,
                                        String fallbackApproach, int attempt) {
-                try {
-                    var p = objectMapper.createObjectNode();
-                    p.put("sessionId", sessionId);
-                    p.put("planId", plan.planId());
-                    p.put("stepId", step.stepId());
-                    p.put("stepIndex", stepIndex + 1);
-                    p.put("fallbackApproach", fallbackApproach);
-                    p.put("attempt", attempt);
-                    cancelContext.sendNotification("stream.plan_step_fallback", p);
-                } catch (IOException e) {
-                    log.warn("Failed to send plan_step_fallback notification: {}", e.getMessage());
-                }
+                // Browser-only: CLI does not consume plan_step_fallback today,
+                // so route directly to the WS bridge instead of through
+                // cancelContext.sendNotification.
+                var p = objectMapper.createObjectNode();
+                p.put("sessionId", sessionId);
+                p.put("planId", plan.planId());
+                p.put("stepId", step.stepId());
+                p.put("stepIndex", stepIndex + 1);
+                p.put("fallbackApproach", fallbackApproach);
+                p.put("attempt", attempt);
+                emitBrowserOnly(sessionId, "stream.plan_step_fallback", p);
             }
         };
 
@@ -2715,20 +2734,17 @@ public final class StreamingAgentHandler {
             @Override
             public void onStepFallback(PlannedStep step, int stepIndex,
                                        String fallbackApproach, int attempt) {
-                try {
-                    var p = objectMapper.createObjectNode();
-                    p.put("sessionId", sessionId);
-                    p.put("planId", resumedPlanId);
-                    p.put("stepId", step.stepId());
-                    // Resume path: stepIndex is local to the remaining-steps slice,
-                    // so offset by cp.nextStepIndex() to match the original plan's 1-based index.
-                    p.put("stepIndex", cp.nextStepIndex() + stepIndex + 1);
-                    p.put("fallbackApproach", fallbackApproach);
-                    p.put("attempt", attempt);
-                    cancelContext.sendNotification("stream.plan_step_fallback", p);
-                } catch (IOException e) {
-                    log.warn("Failed to send plan_step_fallback notification: {}", e.getMessage());
-                }
+                // Browser-only — see planned-prompt path above for rationale.
+                var p = objectMapper.createObjectNode();
+                p.put("sessionId", sessionId);
+                p.put("planId", resumedPlanId);
+                p.put("stepId", step.stepId());
+                // Resume path: stepIndex is local to the remaining-steps slice,
+                // so offset by cp.nextStepIndex() to match the original plan's 1-based index.
+                p.put("stepIndex", cp.nextStepIndex() + stepIndex + 1);
+                p.put("fallbackApproach", fallbackApproach);
+                p.put("attempt", attempt);
+                emitBrowserOnly(sessionId, "stream.plan_step_fallback", p);
             }
         };
 

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -260,7 +260,7 @@ public final class StreamingAgentHandler {
         var bridge = this.webSocketBridge;
         cancelContext = bridge != null
                 ? new CancelAwareStreamContext(
-                        context, new EventMultiplexer(context, bridge),
+                        context, new EventMultiplexer(context, bridge, sessionId),
                         cancellationToken, objectMapper)
                 : new CancelAwareStreamContext(context, cancellationToken, objectMapper);
 

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -227,7 +227,16 @@ public final class StreamingAgentHandler {
 
         // Set workspace context for tools (e.g. CronTool) that need to know the current workspace.
         // Cleared in the finally block below to cover all exit paths (success, plan, resume, error).
+        //
+        // Lifecycle-notification state (issue #431) is declared HERE — outside the
+        // try block — so the outer finally can emit stream.turn_completed even
+        // when one of the ~60 lines of setup work below throws between the
+        // turn_started emission and the inner turnLock try.
         CronTool.setWorkspaceContext(session.projectPath().toString());
+        CancelAwareStreamContext cancelContext = null;
+        String requestId = null;
+        int turnNumber = 0;
+        long turnStartMillis = 0L;
         try {
 
         log.info("Streaming agent prompt: sessionId={}, promptLength={}", sessionId, prompt.length());
@@ -246,7 +255,7 @@ public final class StreamingAgentHandler {
         // connected browser clients in addition to the per-request CLI socket.
         var cancellationToken = new CancellationToken();
         var bridge = this.webSocketBridge;
-        var cancelContext = bridge != null
+        cancelContext = bridge != null
                 ? new CancelAwareStreamContext(
                         context, new EventMultiplexer(context, bridge),
                         cancellationToken, objectMapper)
@@ -256,11 +265,11 @@ public final class StreamingAgentHandler {
         // These three events fire per agent.prompt request; they let browser
         // dashboards anchor a Turn-level node and render session boundaries
         // without inferring them from text-delta gaps. The CLI ignores them.
-        long turnStartMillis = System.currentTimeMillis();
-        String requestId = "turn-" + UUID.randomUUID();
+        turnStartMillis = System.currentTimeMillis();
+        requestId = "turn-" + UUID.randomUUID();
         // turnNumber = Nth user message in this session, matching the existing
         // AgentEvent.TurnStarted semantics in StreamingAgentLoop.
-        int turnNumber = (int) session.messages().stream()
+        turnNumber = (int) session.messages().stream()
                 .filter(m -> m instanceof AgentSession.ConversationMessage.User).count() + 1;
         if (sessionsStartedSignaled.add(sessionId)) {
             try {
@@ -392,22 +401,6 @@ public final class StreamingAgentHandler {
             String userMessage = formatLlmError(e);
             throw new IllegalStateException(userMessage);
         } finally {
-            // Emit stream.turn_completed BEFORE stopMonitor so the channel still
-            // accepts writes. Fires on all exit paths (success returns, exception
-            // catch+rethrow, unexpected throws) so the browser tree always closes
-            // its Turn node.
-            try {
-                var tcp = objectMapper.createObjectNode();
-                tcp.put("sessionId", sessionId);
-                tcp.put("requestId", requestId);
-                tcp.put("turnNumber", turnNumber);
-                tcp.put("durationMs", System.currentTimeMillis() - turnStartMillis);
-                tcp.put("toolCount", cancelContext.toolUseCount());
-                tcp.put("timestamp", Instant.now().toString());
-                cancelContext.sendNotification("stream.turn_completed", tcp);
-            } catch (Exception e) {
-                log.debug("Failed to send stream.turn_completed: {}", e.getMessage());
-            }
             if (watchdog != null) {
                 watchdog.close();
             }
@@ -417,6 +410,29 @@ public final class StreamingAgentHandler {
         }
 
         } finally {
+            // Emit stream.turn_completed in the OUTER finally so it fires on every
+            // exit path — including exceptions thrown by the ~60 lines of setup
+            // between the turn_started emission and the inner turnLock try.
+            // Guard with requestId != null so we never emit a closer for a Turn
+            // we never opened (e.g. CancelAwareStreamContext construction itself
+            // threw, or we exited before reaching the turn_started block).
+            // stopMonitor (above) only stops the read pump; the underlying channel
+            // remains writable until the request response is dispatched, so this
+            // late notification still reaches the client.
+            if (cancelContext != null && requestId != null) {
+                try {
+                    var tcp = objectMapper.createObjectNode();
+                    tcp.put("sessionId", sessionId);
+                    tcp.put("requestId", requestId);
+                    tcp.put("turnNumber", turnNumber);
+                    tcp.put("durationMs", System.currentTimeMillis() - turnStartMillis);
+                    tcp.put("toolCount", cancelContext.toolUseCount());
+                    tcp.put("timestamp", Instant.now().toString());
+                    cancelContext.sendNotification("stream.turn_completed", tcp);
+                } catch (Exception e) {
+                    log.debug("Failed to send stream.turn_completed: {}", e.getMessage());
+                }
+            }
             CronTool.clearWorkspaceContext();
         }
     }
@@ -1846,6 +1862,7 @@ public final class StreamingAgentHandler {
         sessionProgressDetectors.remove(sessionId);
         sessionPostProcessing.remove(sessionId);
         sessionRuntimePruneScheduled.remove(sessionId);
+        sessionsStartedSignaled.remove(sessionId);
     }
 
     public void awaitSessionPostProcessing(String sessionId) {

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -162,6 +162,13 @@ public final class StreamingAgentHandler {
     private final SkillMetricsStore skillMetricsStore = new SkillMetricsStore();
     private volatile RuntimeMetricsExporter runtimeMetricsExporter;
     private volatile dev.aceclaw.memory.InjectionAuditLog injectionAuditLog;
+    /**
+     * WebSocket bridge for browser dashboard (issue #431). Null when disabled —
+     * the per-request context falls back to direct CLI delivery in that case.
+     */
+    private volatile WebSocketBridge webSocketBridge;
+    /** Sessions for which {@code stream.session_started} has already been emitted. */
+    private final Set<String> sessionsStartedSignaled = ConcurrentHashMap.newKeySet();
 
     /** Per-session turn locks for serializing main turns within a session. */
     private final ConcurrentHashMap<String, ReentrantLock> sessionTurnLocks =
@@ -197,6 +204,15 @@ public final class StreamingAgentHandler {
         router.registerStreaming("agent.prompt", this::handlePrompt);
     }
 
+    /**
+     * Wires the WebSocket bridge for browser-facing event fan-out (issue #431).
+     * Pass {@code null} to disable; once set, every JSON-RPC notification emitted
+     * during {@code agent.prompt} is also broadcast to all connected WS clients.
+     */
+    public void setWebSocketBridge(WebSocketBridge bridge) {
+        this.webSocketBridge = bridge;
+    }
+
     private Object handlePrompt(JsonNode params, StreamContext context) throws Exception {
         var sessionId = requireString(params, "sessionId");
         var prompt = requireString(params, "prompt");
@@ -224,8 +240,49 @@ public final class StreamingAgentHandler {
         // Set up cancellation support: the CancelAwareStreamContext runs a monitor
         // thread that reads from the socket and dispatches agent.cancel and
         // permission.response messages accordingly.
+        //
+        // When the WebSocket bridge is enabled (issue #431), wrap the raw context
+        // with an EventMultiplexer so every JSON-RPC notification fans out to all
+        // connected browser clients in addition to the per-request CLI socket.
         var cancellationToken = new CancellationToken();
-        var cancelContext = new CancelAwareStreamContext(context, cancellationToken, objectMapper);
+        var bridge = this.webSocketBridge;
+        var cancelContext = bridge != null
+                ? new CancelAwareStreamContext(
+                        context, new EventMultiplexer(context, bridge),
+                        cancellationToken, objectMapper)
+                : new CancelAwareStreamContext(context, cancellationToken, objectMapper);
+
+        // ---- Lifecycle notifications (issue #439 + #431) ----------------------
+        // These three events fire per agent.prompt request; they let browser
+        // dashboards anchor a Turn-level node and render session boundaries
+        // without inferring them from text-delta gaps. The CLI ignores them.
+        long turnStartMillis = System.currentTimeMillis();
+        String requestId = "turn-" + UUID.randomUUID();
+        // turnNumber = Nth user message in this session, matching the existing
+        // AgentEvent.TurnStarted semantics in StreamingAgentLoop.
+        int turnNumber = (int) session.messages().stream()
+                .filter(m -> m instanceof AgentSession.ConversationMessage.User).count() + 1;
+        if (sessionsStartedSignaled.add(sessionId)) {
+            try {
+                var p = objectMapper.createObjectNode();
+                p.put("sessionId", sessionId);
+                p.put("model", getModelForSession(sessionId));
+                p.put("timestamp", Instant.now().toString());
+                cancelContext.sendNotification("stream.session_started", p);
+            } catch (IOException e) {
+                log.debug("Failed to send stream.session_started: {}", e.getMessage());
+            }
+        }
+        try {
+            var p = objectMapper.createObjectNode();
+            p.put("sessionId", sessionId);
+            p.put("requestId", requestId);
+            p.put("turnNumber", turnNumber);
+            p.put("timestamp", Instant.now().toString());
+            cancelContext.sendNotification("stream.turn_started", p);
+        } catch (IOException e) {
+            log.debug("Failed to send stream.turn_started: {}", e.getMessage());
+        }
 
         // Create a StreamEventHandler that forwards events via the cancel-aware context
         var eventHandler = new StreamingNotificationHandler(cancelContext, objectMapper);
@@ -335,6 +392,22 @@ public final class StreamingAgentHandler {
             String userMessage = formatLlmError(e);
             throw new IllegalStateException(userMessage);
         } finally {
+            // Emit stream.turn_completed BEFORE stopMonitor so the channel still
+            // accepts writes. Fires on all exit paths (success returns, exception
+            // catch+rethrow, unexpected throws) so the browser tree always closes
+            // its Turn node.
+            try {
+                var tcp = objectMapper.createObjectNode();
+                tcp.put("sessionId", sessionId);
+                tcp.put("requestId", requestId);
+                tcp.put("turnNumber", turnNumber);
+                tcp.put("durationMs", System.currentTimeMillis() - turnStartMillis);
+                tcp.put("toolCount", cancelContext.toolUseCount());
+                tcp.put("timestamp", Instant.now().toString());
+                cancelContext.sendNotification("stream.turn_completed", tcp);
+            } catch (Exception e) {
+                log.debug("Failed to send stream.turn_completed: {}", e.getMessage());
+            }
             if (watchdog != null) {
                 watchdog.close();
             }
@@ -479,6 +552,23 @@ public final class StreamingAgentHandler {
                     cancelContext.sendNotification("stream.plan_escalated", p);
                 } catch (IOException e) {
                     log.warn("Failed to send plan_escalated notification: {}", e.getMessage());
+                }
+            }
+
+            @Override
+            public void onStepFallback(PlannedStep step, int stepIndex,
+                                       String fallbackApproach, int attempt) {
+                try {
+                    var p = objectMapper.createObjectNode();
+                    p.put("sessionId", sessionId);
+                    p.put("planId", plan.planId());
+                    p.put("stepId", step.stepId());
+                    p.put("stepIndex", stepIndex + 1);
+                    p.put("fallbackApproach", fallbackApproach);
+                    p.put("attempt", attempt);
+                    cancelContext.sendNotification("stream.plan_step_fallback", p);
+                } catch (IOException e) {
+                    log.warn("Failed to send plan_step_fallback notification: {}", e.getMessage());
                 }
             }
         };
@@ -2590,6 +2680,25 @@ public final class StreamingAgentHandler {
                     log.warn("Failed to send plan_escalated notification: {}", e.getMessage());
                 }
             }
+
+            @Override
+            public void onStepFallback(PlannedStep step, int stepIndex,
+                                       String fallbackApproach, int attempt) {
+                try {
+                    var p = objectMapper.createObjectNode();
+                    p.put("sessionId", sessionId);
+                    p.put("planId", resumedPlanId);
+                    p.put("stepId", step.stepId());
+                    // Resume path: stepIndex is local to the remaining-steps slice,
+                    // so offset by cp.nextStepIndex() to match the original plan's 1-based index.
+                    p.put("stepIndex", cp.nextStepIndex() + stepIndex + 1);
+                    p.put("fallbackApproach", fallbackApproach);
+                    p.put("attempt", attempt);
+                    cancelContext.sendNotification("stream.plan_step_fallback", p);
+                } catch (IOException e) {
+                    log.warn("Failed to send plan_step_fallback notification: {}", e.getMessage());
+                }
+            }
         };
 
         // 9. Wrap with checkpointing listener
@@ -2853,6 +2962,12 @@ public final class StreamingAgentHandler {
             }
         }
 
+        @Override
+        public void onStepFallback(PlannedStep step, int stepIndex,
+                                   String fallbackApproach, int attempt) {
+            delegate.onStepFallback(step, stepIndex, fallbackApproach, attempt);
+        }
+
         private static List<String> serializeSessionMessages(AgentSession session) {
             // Simple serialization: role:content for each message
             var result = new ArrayList<String>();
@@ -3102,24 +3217,42 @@ public final class StreamingAgentHandler {
         private final ConcurrentHashMap<String, CompletableFuture<JsonNode>> pendingPermissions = new ConcurrentHashMap<>();
         private final BlockingQueue<JsonNode> unmatchedResponses = new LinkedBlockingQueue<>();
         private final Object permissionLifecycleLock = new Object();
+        private final java.util.concurrent.atomic.AtomicInteger toolUseCount =
+                new java.util.concurrent.atomic.AtomicInteger();
         private volatile boolean stopped = false;
         private volatile Thread monitorThread;
         private volatile Selector selector;
 
         CancelAwareStreamContext(StreamContext delegate, CancellationToken cancellationToken,
                                  ObjectMapper objectMapper) {
-            this.delegate = delegate;
+            this(delegate, delegate, cancellationToken, objectMapper);
+        }
+
+        /**
+         * Two-context overload: {@code rawContext} is the original socket-backed
+         * context used for cancel-monitor channel extraction; {@code outboundContext}
+         * is what {@link #sendNotification} delegates to and is typically an
+         * {@link EventMultiplexer} that tees to the WebSocket bridge.
+         */
+        CancelAwareStreamContext(StreamContext rawContext, StreamContext outboundContext,
+                                 CancellationToken cancellationToken, ObjectMapper objectMapper) {
+            this.delegate = outboundContext;
             this.cancellationToken = cancellationToken;
             this.objectMapper = objectMapper;
 
             // Extract the channel and lineBuilder from the underlying ChannelStreamContext
-            if (delegate instanceof ConnectionBridge.ChannelStreamContext channelCtx) {
+            if (rawContext instanceof ConnectionBridge.ChannelStreamContext channelCtx) {
                 this.channel = channelCtx.channel();
                 this.lineBuilder = channelCtx.lineBuilder();
             } else {
                 this.channel = null;
                 this.lineBuilder = null;
             }
+        }
+
+        /** Number of {@code stream.tool_use} notifications observed during this request. */
+        int toolUseCount() {
+            return toolUseCount.get();
         }
 
         /**
@@ -3292,6 +3425,9 @@ public final class StreamingAgentHandler {
 
         @Override
         public void sendNotification(String method, Object params) throws IOException {
+            if ("stream.tool_use".equals(method)) {
+                toolUseCount.incrementAndGet();
+            }
             delegate.sendNotification(method, params);
         }
 

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/WebSocketBridge.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/WebSocketBridge.java
@@ -133,9 +133,19 @@ public final class WebSocketBridge {
                 fire(connectListeners, ctx);
             });
             ws.onClose(ctx -> {
-                clients.remove(ctx);
-                log.info("WS client closed: {} (total={})", ctx.sessionId(), clients.size());
-                fire(disconnectListeners, ctx);
+                // Gate listener notification on whether this client was ever
+                // an active member: disallowed-origin handshakes are closed in
+                // onConnect BEFORE clients.add, and onError may have already
+                // removed-and-notified the same socket. Either case would
+                // otherwise corrupt listener state (underflowed counts, double
+                // cleanup) for any consumer maintaining connect/disconnect
+                // parity.
+                boolean removed = clients.remove(ctx);
+                log.info("WS client closed: {} (total={}, wasActive={})",
+                        ctx.sessionId(), clients.size(), removed);
+                if (removed) {
+                    fire(disconnectListeners, ctx);
+                }
             });
             ws.onError(ctx -> {
                 boolean removed = clients.remove(ctx);

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/WebSocketBridge.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/WebSocketBridge.java
@@ -83,7 +83,9 @@ public final class WebSocketBridge {
                     var node = objectMapper.readTree(ctx.message());
                     inboundHandler.handle(ctx, node);
                 } catch (Exception e) {
-                    log.warn("WS inbound parse failed: {}", e.getMessage());
+                    // Log full stack — debugging #433's permission-routing handler
+                    // is painful without it.
+                    log.warn("WS inbound parse failed", e);
                 }
             });
         });
@@ -114,8 +116,11 @@ public final class WebSocketBridge {
     /**
      * Broadcasts a JSON-RPC 2.0 notification to all connected clients.
      *
-     * <p>Failed sends to a single client are logged and that client is dropped;
-     * a slow/dead browser tab cannot block notifications to others.
+     * <p>{@link WsContext#send(String)} is non-blocking — Jetty queues the frame
+     * and reports send failures asynchronously via {@code onError}, which is
+     * already wired to remove the client. The synchronous {@code try/catch}
+     * here is a fallback for the rare case where {@code send} throws inline
+     * (e.g. session already closed); it does not catch async failures.
      *
      * @param method JSON-RPC method (e.g. {@code "stream.text"})
      * @param params notification parameters; serialised via Jackson
@@ -139,6 +144,8 @@ public final class WebSocketBridge {
             try {
                 client.send(message);
             } catch (Exception e) {
+                // Synchronous failure (e.g. session closed mid-iteration). Async
+                // failures land on onError above, which also removes the client.
                 log.warn("WS send failed for {}: {}", client.sessionId(), e.getMessage());
                 clients.remove(client);
             }
@@ -147,11 +154,11 @@ public final class WebSocketBridge {
 
     /**
      * Installs a handler for inbound client messages (e.g. permission.response).
-     * Default handler drops messages so issue #431 stays one-way; #433 will
+     * The default handler drops messages so issue #431 stays one-way; #433 will
      * register a real handler that routes into the permission flow.
      */
     public void setInboundHandler(InboundHandler handler) {
-        this.inboundHandler = handler != null ? handler : (ctx, message) -> { };
+        this.inboundHandler = Objects.requireNonNull(handler, "handler");
     }
 
     /** Returns the number of currently connected browser clients. */

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/WebSocketBridge.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/WebSocketBridge.java
@@ -6,11 +6,13 @@ import io.javalin.websocket.WsContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
 /**
@@ -28,11 +30,24 @@ import java.util.function.Consumer;
  * </pre>
  *
  * <p>The bridge is intentionally one-way fan-out for Tier 1: every
- * {@link #broadcast(String, Object)} call serialises a JSON-RPC notification
- * and sends it to every connected {@link WsContext}. Inbound messages from
- * browsers (e.g. {@code permission.response}) are accepted and parked on
+ * {@link #broadcast(String, String, Object)} call wraps the daemon event in the
+ * {@code DaemonEventEnvelope} contract frozen by issue #439 and sends it to
+ * every connected {@link WsContext}. Inbound messages from browsers (e.g.
+ * {@code permission.response}) are accepted and parked on
  * {@link #setInboundHandler(InboundHandler)} so issue #433 can wire them
  * into the permission flow without touching this class again.
+ *
+ * <p>Wire format (matches {@code aceclaw-dashboard/src/types/events.ts}):
+ * <pre>{@code
+ * {
+ *   "eventId":    <monotonic long>,        // bridge-assigned, used by #432 snapshot dedup
+ *   "sessionId":  <string>,                // session this event belongs to
+ *   "receivedAt": <ISO-8601>,              // bridge-assigned timestamp
+ *   "event":      { method, params }       // mirrors DaemonEvent union
+ * }
+ * }</pre>
+ * The {@code eventId} counter is monotonic per bridge instance and resets on
+ * bridge restart — re-connecting clients fetch a fresh snapshot watermark.
  *
  * <p>Security: always binds to {@code localhost} by default. Acceptance
  * criterion from #431.
@@ -52,6 +67,13 @@ public final class WebSocketBridge {
      */
     private final List<Consumer<WsContext>> connectListeners = new CopyOnWriteArrayList<>();
     private final List<Consumer<WsContext>> disconnectListeners = new CopyOnWriteArrayList<>();
+    /**
+     * Monotonic envelope id (issue #439). Pre-incremented on each broadcast so
+     * the first event gets {@code eventId = 1}; {@link #currentEventId()}
+     * returns the last id assigned, which #432's snapshot endpoint will use as
+     * the {@code lastEventId} watermark.
+     */
+    private final AtomicLong eventIdCounter = new AtomicLong();
 
     private volatile Javalin app;
     private volatile InboundHandler inboundHandler = (ctx, message) -> { /* default: drop */ };
@@ -129,7 +151,8 @@ public final class WebSocketBridge {
     }
 
     /**
-     * Broadcasts a JSON-RPC 2.0 notification to all connected clients.
+     * Broadcasts a daemon event to all connected clients, wrapped in the
+     * {@code DaemonEventEnvelope} shape frozen by issue #439.
      *
      * <p>{@link WsContext#send(String)} is non-blocking — Jetty queues the frame
      * and reports send failures asynchronously via {@code onError}, which is
@@ -137,19 +160,34 @@ public final class WebSocketBridge {
      * here is a fallback for the rare case where {@code send} throws inline
      * (e.g. session already closed); it does not catch async failures.
      *
-     * @param method JSON-RPC method (e.g. {@code "stream.text"})
-     * @param params notification parameters; serialised via Jackson
+     * <p>{@code sessionId} is required so the reducer can recover session
+     * identity for events whose {@code params} do not carry it (e.g.
+     * {@code stream.text}, {@code stream.tool_use}, {@code stream.tool_completed}).
+     *
+     * @param sessionId session this event belongs to (must not be null)
+     * @param method    daemon event method (e.g. {@code "stream.text"})
+     * @param params    event parameters; serialised via Jackson
      */
-    public void broadcast(String method, Object params) {
+    public void broadcast(String sessionId, String method, Object params) {
+        Objects.requireNonNull(sessionId, "sessionId");
         if (clients.isEmpty() || app == null) {
             return;
         }
+        // Always assign an envelope id even with no live clients so the counter
+        // remains a faithful monotonic record. The early-return above is purely
+        // an optimisation; if it is removed in future work the eventId stream
+        // still has no gaps.
+        long eventId = eventIdCounter.incrementAndGet();
         String message;
         try {
             var envelope = objectMapper.createObjectNode();
-            envelope.put("jsonrpc", "2.0");
-            envelope.put("method", method);
-            envelope.set("params", objectMapper.valueToTree(params));
+            envelope.put("eventId", eventId);
+            envelope.put("sessionId", sessionId);
+            envelope.put("receivedAt", Instant.now().toString());
+            var event = objectMapper.createObjectNode();
+            event.put("method", method);
+            event.set("params", objectMapper.valueToTree(params));
+            envelope.set("event", event);
             message = objectMapper.writeValueAsString(envelope);
         } catch (Exception e) {
             log.warn("Failed to serialise WS broadcast for {}: {}", method, e.getMessage());
@@ -165,6 +203,16 @@ public final class WebSocketBridge {
                 clients.remove(client);
             }
         }
+    }
+
+    /**
+     * Returns the last envelope id assigned by {@link #broadcast}; zero if no
+     * event has ever been broadcast on this bridge instance. Used by #432's
+     * snapshot endpoint as the {@code lastEventId} watermark a freshly-loaded
+     * browser sends back to deduplicate the live stream against the snapshot.
+     */
+    public long currentEventId() {
+        return eventIdCounter.get();
     }
 
     /**

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/WebSocketBridge.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/WebSocketBridge.java
@@ -57,7 +57,12 @@ public final class WebSocketBridge {
     private static final Logger log = LoggerFactory.getLogger(WebSocketBridge.class);
 
     private final String host;
-    private final int port;
+    /**
+     * Configured port. {@code 0} means "let Jetty pick an ephemeral port"; in
+     * that case {@link #start()} replaces this with the actually-bound port so
+     * {@link #port()} is always correct after the bridge is running.
+     */
+    private volatile int port;
     private final ObjectMapper objectMapper;
     /**
      * Browser {@code Origin} headers allowed to open a WS handshake. Empty =
@@ -91,6 +96,10 @@ public final class WebSocketBridge {
 
     public WebSocketBridge(String host, int port, ObjectMapper objectMapper,
                            List<String> allowedOrigins) {
+        if (port < 0 || port > 65_535) {
+            throw new IllegalArgumentException(
+                    "port must be in [0, 65535] (0 = ephemeral); got " + port);
+        }
         this.host = Objects.requireNonNull(host, "host");
         this.port = port;
         this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
@@ -149,8 +158,15 @@ public final class WebSocketBridge {
             });
         });
         instance.start(port);
+        // Replace a 0 (ephemeral) port with the port Jetty actually bound. Tests
+        // rely on this to avoid the TOCTOU race that {@code ServerSocket(0)} +
+        // close-and-rebind would otherwise expose: another process can grab the
+        // port between probe and bridge bind.
+        if (this.port == 0) {
+            this.port = instance.port();
+        }
         this.app = instance;
-        log.info("WebSocket bridge listening on ws://{}:{}/ws", host, port);
+        log.info("WebSocket bridge listening on ws://{}:{}/ws", host, this.port);
     }
 
     /**
@@ -307,7 +323,11 @@ public final class WebSocketBridge {
         return app != null;
     }
 
-    /** Returns the port the bridge was configured to bind to. */
+    /**
+     * Returns the bridge's port. Before {@link #start()} this is the configured
+     * port (which may be {@code 0} when the caller asked for an ephemeral
+     * port); after {@code start()} it is always the actually-bound port.
+     */
     public int port() {
         return port;
     }

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/WebSocketBridge.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/WebSocketBridge.java
@@ -6,9 +6,12 @@ import io.javalin.websocket.WsContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
 
 /**
  * WebSocket bridge that fans out daemon JSON-RPC notifications to browser
@@ -42,6 +45,13 @@ public final class WebSocketBridge {
     private final int port;
     private final ObjectMapper objectMapper;
     private final Set<WsContext> clients = ConcurrentHashMap.newKeySet();
+    /**
+     * Connection listeners. Snapshot pushers (#432) and per-client routers (#433)
+     * subscribe here; tests use them to wait on a {@link java.util.concurrent.CountDownLatch}
+     * instead of polling {@link #clientCount()}.
+     */
+    private final List<Consumer<WsContext>> connectListeners = new CopyOnWriteArrayList<>();
+    private final List<Consumer<WsContext>> disconnectListeners = new CopyOnWriteArrayList<>();
 
     private volatile Javalin app;
     private volatile InboundHandler inboundHandler = (ctx, message) -> { /* default: drop */ };
@@ -67,16 +77,21 @@ public final class WebSocketBridge {
             ws.onConnect(ctx -> {
                 clients.add(ctx);
                 log.info("WS client connected: {} (total={})", ctx.sessionId(), clients.size());
+                fire(connectListeners, ctx);
             });
             ws.onClose(ctx -> {
                 clients.remove(ctx);
                 log.info("WS client closed: {} (total={})", ctx.sessionId(), clients.size());
+                fire(disconnectListeners, ctx);
             });
             ws.onError(ctx -> {
-                clients.remove(ctx);
+                boolean removed = clients.remove(ctx);
                 Throwable err = ctx.error();
                 log.warn("WS client error: {} ({})", ctx.sessionId(),
                         err != null ? err.getMessage() : "unknown");
+                if (removed) {
+                    fire(disconnectListeners, ctx);
+                }
             });
             ws.onMessage(ctx -> {
                 try {
@@ -159,6 +174,35 @@ public final class WebSocketBridge {
      */
     public void setInboundHandler(InboundHandler handler) {
         this.inboundHandler = Objects.requireNonNull(handler, "handler");
+    }
+
+    /**
+     * Registers a listener invoked synchronously on Jetty's WS thread when a new
+     * client establishes a connection. Useful for #432 (push the latest snapshot
+     * to a freshly-connected tab) and for tests waiting on a {@link
+     * java.util.concurrent.CountDownLatch} rather than polling {@link #clientCount()}.
+     */
+    public void addConnectionListener(Consumer<WsContext> listener) {
+        connectListeners.add(Objects.requireNonNull(listener, "listener"));
+    }
+
+    /**
+     * Registers a listener invoked when a client disconnects (clean close OR
+     * error after the client was added to the active set). Mirrors
+     * {@link #addConnectionListener} for cleanup symmetry.
+     */
+    public void addDisconnectionListener(Consumer<WsContext> listener) {
+        disconnectListeners.add(Objects.requireNonNull(listener, "listener"));
+    }
+
+    private static void fire(List<Consumer<WsContext>> listeners, WsContext ctx) {
+        for (var l : listeners) {
+            try {
+                l.accept(ctx);
+            } catch (Exception e) {
+                log.warn("WS listener threw: {}", e.toString(), e);
+            }
+        }
     }
 
     /** Returns the number of currently connected browser clients. */

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/WebSocketBridge.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/WebSocketBridge.java
@@ -1,0 +1,185 @@
+package dev.aceclaw.daemon;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.javalin.Javalin;
+import io.javalin.websocket.WsContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * WebSocket bridge that fans out daemon JSON-RPC notifications to browser
+ * clients (issue #431, epic #430).
+ *
+ * <p>Lifecycle:
+ * <pre>
+ *   bridge = new WebSocketBridge(host, port, mapper);
+ *   bridge.start();        // opens ws://{host}:{port}/ws
+ *   ...
+ *   bridge.broadcast("stream.text", paramsJson);   // → all connected clients
+ *   ...
+ *   bridge.stop();
+ * </pre>
+ *
+ * <p>The bridge is intentionally one-way fan-out for Tier 1: every
+ * {@link #broadcast(String, Object)} call serialises a JSON-RPC notification
+ * and sends it to every connected {@link WsContext}. Inbound messages from
+ * browsers (e.g. {@code permission.response}) are accepted and parked on
+ * {@link #setInboundHandler(InboundHandler)} so issue #433 can wire them
+ * into the permission flow without touching this class again.
+ *
+ * <p>Security: always binds to {@code localhost} by default. Acceptance
+ * criterion from #431.
+ */
+public final class WebSocketBridge {
+
+    private static final Logger log = LoggerFactory.getLogger(WebSocketBridge.class);
+
+    private final String host;
+    private final int port;
+    private final ObjectMapper objectMapper;
+    private final Set<WsContext> clients = ConcurrentHashMap.newKeySet();
+
+    private volatile Javalin app;
+    private volatile InboundHandler inboundHandler = (ctx, message) -> { /* default: drop */ };
+
+    public WebSocketBridge(String host, int port, ObjectMapper objectMapper) {
+        this.host = Objects.requireNonNull(host, "host");
+        this.port = port;
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
+    }
+
+    /**
+     * Starts the embedded Javalin server. Idempotent.
+     */
+    public synchronized void start() {
+        if (app != null) {
+            return;
+        }
+        var instance = Javalin.create(cfg -> {
+            cfg.showJavalinBanner = false;
+            // Bind only to the configured host (localhost by default).
+            cfg.jetty.defaultHost = host;
+        }).ws("/ws", ws -> {
+            ws.onConnect(ctx -> {
+                clients.add(ctx);
+                log.info("WS client connected: {} (total={})", ctx.sessionId(), clients.size());
+            });
+            ws.onClose(ctx -> {
+                clients.remove(ctx);
+                log.info("WS client closed: {} (total={})", ctx.sessionId(), clients.size());
+            });
+            ws.onError(ctx -> {
+                clients.remove(ctx);
+                Throwable err = ctx.error();
+                log.warn("WS client error: {} ({})", ctx.sessionId(),
+                        err != null ? err.getMessage() : "unknown");
+            });
+            ws.onMessage(ctx -> {
+                try {
+                    var node = objectMapper.readTree(ctx.message());
+                    inboundHandler.handle(ctx, node);
+                } catch (Exception e) {
+                    log.warn("WS inbound parse failed: {}", e.getMessage());
+                }
+            });
+        });
+        instance.start(port);
+        this.app = instance;
+        log.info("WebSocket bridge listening on ws://{}:{}/ws", host, port);
+    }
+
+    /**
+     * Stops the embedded server. Idempotent.
+     */
+    public synchronized void stop() {
+        var instance = app;
+        if (instance == null) {
+            return;
+        }
+        try {
+            instance.stop();
+        } catch (Exception e) {
+            log.warn("WebSocket bridge stop failed: {}", e.getMessage());
+        } finally {
+            clients.clear();
+            app = null;
+            log.info("WebSocket bridge stopped");
+        }
+    }
+
+    /**
+     * Broadcasts a JSON-RPC 2.0 notification to all connected clients.
+     *
+     * <p>Failed sends to a single client are logged and that client is dropped;
+     * a slow/dead browser tab cannot block notifications to others.
+     *
+     * @param method JSON-RPC method (e.g. {@code "stream.text"})
+     * @param params notification parameters; serialised via Jackson
+     */
+    public void broadcast(String method, Object params) {
+        if (clients.isEmpty() || app == null) {
+            return;
+        }
+        String message;
+        try {
+            var envelope = objectMapper.createObjectNode();
+            envelope.put("jsonrpc", "2.0");
+            envelope.put("method", method);
+            envelope.set("params", objectMapper.valueToTree(params));
+            message = objectMapper.writeValueAsString(envelope);
+        } catch (Exception e) {
+            log.warn("Failed to serialise WS broadcast for {}: {}", method, e.getMessage());
+            return;
+        }
+        for (var client : clients) {
+            try {
+                client.send(message);
+            } catch (Exception e) {
+                log.warn("WS send failed for {}: {}", client.sessionId(), e.getMessage());
+                clients.remove(client);
+            }
+        }
+    }
+
+    /**
+     * Installs a handler for inbound client messages (e.g. permission.response).
+     * Default handler drops messages so issue #431 stays one-way; #433 will
+     * register a real handler that routes into the permission flow.
+     */
+    public void setInboundHandler(InboundHandler handler) {
+        this.inboundHandler = handler != null ? handler : (ctx, message) -> { };
+    }
+
+    /** Returns the number of currently connected browser clients. */
+    public int clientCount() {
+        return clients.size();
+    }
+
+    /** Returns true once {@link #start()} has bound the listener. */
+    public boolean isRunning() {
+        return app != null;
+    }
+
+    /** Returns the port the bridge was configured to bind to. */
+    public int port() {
+        return port;
+    }
+
+    /** Returns the host the bridge was configured to bind to. */
+    public String host() {
+        return host;
+    }
+
+    /**
+     * Inbound message callback. Receives the raw {@link WsContext} so that
+     * #433 can correlate per-client state if needed.
+     */
+    @FunctionalInterface
+    public interface InboundHandler {
+        void handle(WsContext ctx, com.fasterxml.jackson.databind.JsonNode message) throws Exception;
+    }
+}

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/WebSocketBridge.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/WebSocketBridge.java
@@ -133,28 +133,22 @@ public final class WebSocketBridge {
                 fire(connectListeners, ctx);
             });
             ws.onClose(ctx -> {
-                // Gate listener notification on whether this client was ever
-                // an active member: disallowed-origin handshakes are closed in
-                // onConnect BEFORE clients.add, and onError may have already
-                // removed-and-notified the same socket. Either case would
-                // otherwise corrupt listener state (underflowed counts, double
-                // cleanup) for any consumer maintaining connect/disconnect
-                // parity.
-                boolean removed = clients.remove(ctx);
-                log.info("WS client closed: {} (total={}, wasActive={})",
-                        ctx.sessionId(), clients.size(), removed);
-                if (removed) {
-                    fire(disconnectListeners, ctx);
-                }
+                // dropClient gates listener notification on whether the client
+                // was an active member. Disallowed-origin handshakes are closed
+                // in onConnect BEFORE clients.add; onError or broadcast() may
+                // have already removed-and-notified the same socket; or send()
+                // may have failed synchronously inside broadcast. In every
+                // case the helper makes "remove + notify" exactly-once.
+                int beforeSize = clients.size();
+                boolean wasActive = dropClient(ctx);
+                log.info("WS client closed: {} (size {} -> {}, wasActive={})",
+                        ctx.sessionId(), beforeSize, clients.size(), wasActive);
             });
             ws.onError(ctx -> {
-                boolean removed = clients.remove(ctx);
                 Throwable err = ctx.error();
                 log.warn("WS client error: {} ({})", ctx.sessionId(),
                         err != null ? err.getMessage() : "unknown");
-                if (removed) {
-                    fire(disconnectListeners, ctx);
-                }
+                dropClient(ctx);
             });
             ws.onMessage(ctx -> {
                 try {
@@ -246,11 +240,31 @@ public final class WebSocketBridge {
                 client.send(message);
             } catch (Exception e) {
                 // Synchronous failure (e.g. session closed mid-iteration). Async
-                // failures land on onError above, which also removes the client.
+                // failures land on onError above. Either path goes through
+                // dropClient so disconnectListeners fire exactly once for the
+                // first observer that wins the remove — listeners that track
+                // connect/disconnect parity never lose a cleanup callback even
+                // if Jetty's onClose runs late or never.
                 log.warn("WS send failed for {}: {}", client.sessionId(), e.getMessage());
-                clients.remove(client);
+                dropClient(client);
             }
         }
+    }
+
+    /**
+     * Removes {@code ctx} from the active set and fires disconnect listeners
+     * iff this call won the remove. Idempotent: a second invocation for the
+     * same context returns {@code false} and notifies nobody. The unified path
+     * for every "this client is gone" observer (onClose, onError, broadcast
+     * synchronous send failure) — listeners that track connect/disconnect
+     * parity see exactly one disconnect per active client.
+     */
+    private boolean dropClient(WsContext ctx) {
+        if (clients.remove(ctx)) {
+            fire(disconnectListeners, ctx);
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/WebSocketBridge.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/WebSocketBridge.java
@@ -186,7 +186,14 @@ public final class WebSocketBridge {
         } catch (Exception e) {
             log.warn("WebSocket bridge stop failed: {}", e.getMessage());
         } finally {
-            clients.clear();
+            // Drain via dropClient so disconnectListeners observe shutdown
+            // drops, not just live-traffic drops. List.copyOf gives a stable
+            // snapshot that's safe to iterate even if Jetty's onClose runs
+            // concurrently from another thread; dropClient is idempotent so
+            // a late onClose for the same socket simply no-ops.
+            for (var client : List.copyOf(clients)) {
+                dropClient(client);
+            }
             app = null;
             log.info("WebSocket bridge stopped");
         }
@@ -212,14 +219,19 @@ public final class WebSocketBridge {
      */
     public void broadcast(String sessionId, String method, Object params) {
         Objects.requireNonNull(sessionId, "sessionId");
-        if (clients.isEmpty() || app == null) {
+        if (app == null) {
             return;
         }
-        // Always assign an envelope id even with no live clients so the counter
-        // remains a faithful monotonic record. The early-return above is purely
-        // an optimisation; if it is removed in future work the eventId stream
-        // still has no gaps.
+        // Increment BEFORE the no-clients short-circuit so eventId stays
+        // monotonic and gap-free across zero-client periods. #432's snapshot
+        // endpoint exposes currentEventId() as the reconnect watermark; the
+        // browser uses it to deduplicate the live stream against the snapshot,
+        // and that contract requires an unbroken sequence regardless of
+        // whether any tab was connected when each event was produced.
         long eventId = eventIdCounter.incrementAndGet();
+        if (clients.isEmpty()) {
+            return;
+        }
         String message;
         try {
             var envelope = objectMapper.createObjectNode();

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/WebSocketBridge.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/WebSocketBridge.java
@@ -59,6 +59,13 @@ public final class WebSocketBridge {
     private final String host;
     private final int port;
     private final ObjectMapper objectMapper;
+    /**
+     * Browser {@code Origin} headers allowed to open a WS handshake. Empty =
+     * reject any browser connection; tools that send no {@code Origin} (curl,
+     * Java {@code HttpClient} default) are always accepted because cross-site
+     * browser attacks cannot suppress the header.
+     */
+    private final List<String> allowedOrigins;
     private final Set<WsContext> clients = ConcurrentHashMap.newKeySet();
     /**
      * Connection listeners. Snapshot pushers (#432) and per-client routers (#433)
@@ -79,9 +86,15 @@ public final class WebSocketBridge {
     private volatile InboundHandler inboundHandler = (ctx, message) -> { /* default: drop */ };
 
     public WebSocketBridge(String host, int port, ObjectMapper objectMapper) {
+        this(host, port, objectMapper, List.of());
+    }
+
+    public WebSocketBridge(String host, int port, ObjectMapper objectMapper,
+                           List<String> allowedOrigins) {
         this.host = Objects.requireNonNull(host, "host");
         this.port = port;
         this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
+        this.allowedOrigins = List.copyOf(Objects.requireNonNull(allowedOrigins, "allowedOrigins"));
     }
 
     /**
@@ -97,6 +110,15 @@ public final class WebSocketBridge {
             cfg.jetty.defaultHost = host;
         }).ws("/ws", ws -> {
             ws.onConnect(ctx -> {
+                if (!isOriginAllowed(ctx)) {
+                    log.warn("WS: rejecting connection from disallowed origin '{}' (sessionId={})",
+                            ctx.header("Origin"), ctx.sessionId());
+                    // 1008 = Policy Violation. Closing here aborts the WS upgrade
+                    // before the client is added to {@link #clients}, so it never
+                    // receives any broadcast.
+                    ctx.closeSession(1008, "origin not allowed");
+                    return;
+                }
                 clients.add(ctx);
                 log.info("WS client connected: {} (total={})", ctx.sessionId(), clients.size());
                 fire(connectListeners, ctx);
@@ -251,6 +273,28 @@ public final class WebSocketBridge {
                 log.warn("WS listener threw: {}", e.toString(), e);
             }
         }
+    }
+
+    /**
+     * Origin policy:
+     * <ul>
+     *   <li>No {@code Origin} header (curl, Java {@code HttpClient} default,
+     *       native Jetty client): always allowed. Browsers cannot suppress the
+     *       header, so absence means a non-browser caller and there is no
+     *       cross-site exposure.</li>
+     *   <li>{@code Origin} present and listed in {@link #allowedOrigins}: allowed.</li>
+     *   <li>{@code Origin} present but not listed (or list is empty): rejected.
+     *       This closes the cross-site exfiltration vector that any malicious
+     *       webpage could otherwise exploit by opening
+     *       {@code new WebSocket('ws://localhost:...')}.</li>
+     * </ul>
+     */
+    private boolean isOriginAllowed(WsContext ctx) {
+        String origin = ctx.header("Origin");
+        if (origin == null) {
+            return true;
+        }
+        return allowedOrigins.contains(origin);
     }
 
     /** Returns the number of currently connected browser clients. */

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/BrowserOnlyEventsBoundaryTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/BrowserOnlyEventsBoundaryTest.java
@@ -1,0 +1,158 @@
+package dev.aceclaw.daemon;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.WebSocket;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies the architectural boundary that lifecycle events introduced by
+ * #431 ({@code stream.session_started}, {@code stream.turn_started},
+ * {@code stream.turn_completed}, {@code stream.plan_step_fallback}) reach
+ * browser clients only and never the CLI's UDS protocol.
+ *
+ * <p>The boundary is enforced at the emission site:
+ * {@link StreamingAgentHandler#emitBrowserOnly} routes directly to
+ * {@link WebSocketBridge#broadcast} without ever touching
+ * {@code cancelContext.sendNotification} (the CLI sink). This is structural —
+ * the helper's signature does not even take a {@link StreamContext} — so
+ * "CLI cannot see browser-only events" is impossible to violate by construction.
+ *
+ * <p>These tests cover the two policy outcomes the user can observe:
+ * <ul>
+ *   <li>WS disabled (bridge null) ⇒ the helper is a no-op, so neither the CLI
+ *       nor any future WS client receives anything.</li>
+ *   <li>WS enabled ⇒ the helper publishes only to the bridge; a real browser
+ *       client receives the {@code DaemonEventEnvelope}.</li>
+ * </ul>
+ */
+final class BrowserOnlyEventsBoundaryTest {
+
+    private static final long AWAIT_TIMEOUT_MS = 5_000;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private WebSocketBridge bridge;
+
+    @AfterEach
+    void tearDown() {
+        if (bridge != null) {
+            bridge.stop();
+        }
+    }
+
+    @Test
+    void emitBrowserOnly_isNoOpWhenBridgeIsDisabled() throws Exception {
+        // Two browser-side listeners — one would observe a broadcast on a real
+        // bridge instance, the other would observe a connect attempt on a
+        // bound port. With the bridge null we should see neither.
+        bridge = new WebSocketBridge("127.0.0.1", 0, objectMapper);
+        bridge.start();
+        var broadcasts = new AtomicInteger();
+        bridge.addConnectionListener(_ -> broadcasts.incrementAndGet());
+
+        var handler = new StreamingAgentHandler(
+                null, null, null, null, objectMapper);
+        // Explicit null = WS disabled. emitBrowserOnly must early-return.
+        handler.setWebSocketBridge(null);
+
+        handler.emitBrowserOnly("sess-1", "stream.session_started", Map.of());
+        handler.emitBrowserOnly("sess-1", "stream.turn_started", Map.of());
+        handler.emitBrowserOnly("sess-1", "stream.turn_completed", Map.of());
+        handler.emitBrowserOnly("sess-1", "stream.plan_step_fallback", Map.of());
+
+        // No clients connected ⇒ broadcasts go nowhere either way; the real
+        // assertion is that the helper does not even touch the bridge —
+        // verified by clientCount staying zero and currentEventId never
+        // incrementing on the live bridge instance below.
+        assertThat(bridge.currentEventId())
+                .as("no eventId should be assigned when bridge is disabled at the emission site")
+                .isZero();
+    }
+
+    @Test
+    void emitBrowserOnly_routesToWebSocketOnly() throws Exception {
+        bridge = new WebSocketBridge("127.0.0.1", 0, objectMapper);
+        bridge.start();
+
+        var handler = new StreamingAgentHandler(
+                null, null, null, null, objectMapper);
+        handler.setWebSocketBridge(bridge);
+
+        // Connect a real browser client; Java HttpClient sends no Origin so
+        // the no-Origin policy lets it through without an explicit allowlist.
+        var connected = new CountDownLatch(1);
+        bridge.addConnectionListener(_ -> connected.countDown());
+        var queue = new LinkedBlockingQueue<String>();
+        var ws = HttpClient.newHttpClient().newWebSocketBuilder()
+                .buildAsync(URI.create("ws://127.0.0.1:" + bridge.port() + "/ws"),
+                        new BufferingListener(queue::add))
+                .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertThat(connected.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS)).isTrue();
+
+        // Emit each of the four browser-only lifecycle events.
+        handler.emitBrowserOnly("sess-1", "stream.session_started",
+                Map.of("model", "test"));
+        handler.emitBrowserOnly("sess-1", "stream.turn_started",
+                Map.of("requestId", "r1", "turnNumber", 1));
+        handler.emitBrowserOnly("sess-1", "stream.turn_completed",
+                Map.of("requestId", "r1", "turnNumber", 1, "durationMs", 5L, "toolCount", 0));
+        handler.emitBrowserOnly("sess-1", "stream.plan_step_fallback",
+                Map.of("planId", "p1", "stepIndex", 1));
+
+        // Browser receives all four, in #439 envelope shape.
+        assertEnvelope(queue.poll(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS),
+                "stream.session_started");
+        assertEnvelope(queue.poll(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS),
+                "stream.turn_started");
+        assertEnvelope(queue.poll(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS),
+                "stream.turn_completed");
+        assertEnvelope(queue.poll(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS),
+                "stream.plan_step_fallback");
+        assertThat(bridge.currentEventId()).isEqualTo(4L);
+
+        ws.sendClose(WebSocket.NORMAL_CLOSURE, "bye")
+                .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    }
+
+    private void assertEnvelope(String json, String expectedMethod) throws Exception {
+        assertThat(json).isNotNull();
+        var node = objectMapper.readTree(json);
+        assertThat(node.has("eventId")).isTrue();
+        assertThat(node.get("sessionId").asText()).isEqualTo("sess-1");
+        assertThat(node.get("event").get("method").asText()).isEqualTo(expectedMethod);
+        // Critical: this is the #439 envelope, NOT the JSON-RPC frame the CLI
+        // would receive on UDS. The boundary holds.
+        assertThat(node.has("jsonrpc")).isFalse();
+    }
+
+    private static final class BufferingListener implements WebSocket.Listener {
+        private final java.util.function.Consumer<String> onText;
+        private final StringBuilder partial = new StringBuilder();
+
+        BufferingListener(java.util.function.Consumer<String> onText) {
+            this.onText = onText;
+        }
+
+        @Override
+        public CompletableFuture<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
+            partial.append(data);
+            if (last) {
+                onText.accept(partial.toString());
+                partial.setLength(0);
+            }
+            webSocket.request(1);
+            return null;
+        }
+    }
+}

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/WebSocketBridgeTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/WebSocketBridgeTest.java
@@ -145,6 +145,12 @@ final class WebSocketBridgeTest {
         // Empty allowedOrigins (the secure default) ⇒ any browser Origin is rejected.
         bridge = startOnRandomPort(List.of());
 
+        // Wire a disconnect listener; it MUST NOT fire for connections that
+        // were never added to the active set — otherwise consumers tracking
+        // connect/disconnect parity would underflow on rejected handshakes.
+        var disconnectFires = new java.util.concurrent.atomic.AtomicInteger();
+        bridge.addDisconnectionListener(_ -> disconnectFires.incrementAndGet());
+
         var queue = new LinkedBlockingQueue<String>();
         var listener = new BufferingListener(queue::add);
         // Java HttpClient lets us forge an Origin header — same surface a malicious
@@ -166,6 +172,9 @@ final class WebSocketBridgeTest {
         bridge.broadcast("sess-1", "stream.text", Map.of("delta", "should-not-arrive"));
         // poll(short) returns null because the client never received anything.
         assertThat(queue.poll(200, TimeUnit.MILLISECONDS)).isNull();
+        assertThat(disconnectFires.get())
+                .as("disconnect listener must NOT fire for handshakes that never joined")
+                .isZero();
     }
 
     @Test

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/WebSocketBridgeTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/WebSocketBridgeTest.java
@@ -120,6 +120,55 @@ final class WebSocketBridgeTest {
     }
 
     @Test
+    void eventIdAdvancesAcrossZeroClientGaps() throws Exception {
+        // The currentEventId watermark feeds #432's snapshot/reconnect dedup,
+        // so the counter must advance even when no tab is connected — gaps in
+        // the id stream would let the live stream alias against the snapshot
+        // and resurrect events the browser already saw.
+        bridge = startOnRandomPort();
+        assertThat(bridge.currentEventId()).isZero();
+
+        bridge.broadcast("sess-1", "stream.text", Map.of("delta", "a"));
+        bridge.broadcast("sess-1", "stream.text", Map.of("delta", "b"));
+        bridge.broadcast("sess-1", "stream.text", Map.of("delta", "c"));
+
+        assertThat(bridge.currentEventId())
+                .as("eventId must increment for every broadcast, even with no clients")
+                .isEqualTo(3L);
+    }
+
+    @Test
+    void stopFiresDisconnectListenersForActiveClients() throws Exception {
+        bridge = startOnRandomPort();
+        var connected = new CountDownLatch(1);
+        var disconnected = new CountDownLatch(1);
+        var disconnectFires = new java.util.concurrent.atomic.AtomicInteger();
+        bridge.addConnectionListener(_ -> connected.countDown());
+        bridge.addDisconnectionListener(_ -> {
+            disconnectFires.incrementAndGet();
+            disconnected.countDown();
+        });
+
+        var queue = new LinkedBlockingQueue<String>();
+        var ws = connect(queue::add);
+        assertThat(connected.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS)).isTrue();
+        assertThat(bridge.clientCount()).isEqualTo(1);
+
+        bridge.stop();
+
+        // dropClient drained the active set during stop; the listener observes
+        // the cleanup. Idempotent: a later async onClose for the same socket
+        // simply no-ops, so the count stays at exactly 1.
+        assertThat(disconnected.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS)).isTrue();
+        assertThat(disconnectFires.get())
+                .as("stop() must fire disconnect listener exactly once per active client")
+                .isEqualTo(1);
+        assertThat(bridge.isRunning()).isFalse();
+
+        ws.abort();
+    }
+
+    @Test
     void clientDisconnectDoesNotBlockSubsequentBroadcasts() throws Exception {
         bridge = startOnRandomPort();
         var connected = new CountDownLatch(1);

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/WebSocketBridgeTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/WebSocketBridgeTest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
-import java.net.ServerSocket;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.WebSocket;
@@ -216,8 +215,15 @@ final class WebSocketBridgeTest {
         return startOnRandomPort(List.of());
     }
 
+    /**
+     * Asks Jetty to bind an ephemeral port (port=0) and lets the bridge read
+     * back the actually-bound port via {@link WebSocketBridge#port()}. This
+     * avoids the TOCTOU race that {@code ServerSocket(0).close()} +
+     * later-rebind would expose: another process can grab the port in the
+     * window between probe and bind.
+     */
     private WebSocketBridge startOnRandomPort(List<String> allowedOrigins) throws Exception {
-        var b = new WebSocketBridge("127.0.0.1", freePort(), objectMapper, allowedOrigins);
+        var b = new WebSocketBridge("127.0.0.1", 0, objectMapper, allowedOrigins);
         b.start();
         return b;
     }
@@ -227,12 +233,6 @@ final class WebSocketBridgeTest {
                 .buildAsync(URI.create("ws://127.0.0.1:" + bridge.port() + "/ws"),
                         new BufferingListener(onText))
                 .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-    }
-
-    private static int freePort() throws Exception {
-        try (var s = new ServerSocket(0)) {
-            return s.getLocalPort();
-        }
     }
 
     private static final class BufferingListener implements WebSocket.Listener {

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/WebSocketBridgeTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/WebSocketBridgeTest.java
@@ -8,21 +8,29 @@ import java.net.ServerSocket;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.WebSocket;
-import java.util.ArrayList;
 import java.util.Map;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
-import java.util.function.BooleanSupplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Smoke tests for {@link WebSocketBridge} — issue #431 acceptance criteria
  * (port binds, multiple clients, broadcast fan-out, clean disconnect).
+ *
+ * <p>All synchronisation is done with proper wait/notify primitives —
+ * {@link BlockingQueue#poll(long, TimeUnit)} for messages and
+ * {@link CountDownLatch#await(long, TimeUnit)} for connect / disconnect events
+ * (via {@link WebSocketBridge#addConnectionListener}). No spin-polling, no
+ * {@code Thread.sleep}: every wait blocks until either the event fires or the
+ * 5-second timeout expires.
  */
 final class WebSocketBridgeTest {
 
-    private static final long POLL_TIMEOUT_MS = 5_000;
+    private static final long AWAIT_TIMEOUT_MS = 5_000;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     private WebSocketBridge bridge;
@@ -38,25 +46,35 @@ final class WebSocketBridgeTest {
     void broadcastsJsonRpcNotificationToAllConnectedClients() throws Exception {
         bridge = startOnRandomPort();
 
-        var received1 = new ArrayList<String>();
-        var received2 = new ArrayList<String>();
-        var ws1 = connect(received1::add);
-        var ws2 = connect(received2::add);
+        var connected = new CountDownLatch(2);
+        bridge.addConnectionListener(_ -> connected.countDown());
 
-        pollUntil(() -> bridge.clientCount() == 2);
+        var queue1 = new LinkedBlockingQueue<String>();
+        var queue2 = new LinkedBlockingQueue<String>();
+        var ws1 = connect(queue1::add);
+        var ws2 = connect(queue2::add);
+
+        // Block until both server-side onConnect callbacks have fired.
+        assertThat(connected.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+                .as("both clients must connect within %dms", AWAIT_TIMEOUT_MS)
+                .isTrue();
+        assertThat(bridge.clientCount()).isEqualTo(2);
 
         bridge.broadcast("stream.text", Map.of("delta", "hello"));
 
-        pollUntil(() -> received1.size() == 1 && received2.size() == 1);
+        var msg1 = queue1.poll(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        var msg2 = queue2.poll(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertThat(msg1).isNotNull();
+        assertThat(msg2).isNotNull();
 
-        var node = objectMapper.readTree(received1.get(0));
+        var node = objectMapper.readTree(msg1);
         assertThat(node.get("jsonrpc").asText()).isEqualTo("2.0");
         assertThat(node.get("method").asText()).isEqualTo("stream.text");
         assertThat(node.get("params").get("delta").asText()).isEqualTo("hello");
-        assertThat(received2.get(0)).isEqualTo(received1.get(0));
+        assertThat(msg2).isEqualTo(msg1);
 
-        ws1.sendClose(WebSocket.NORMAL_CLOSURE, "bye").get(POLL_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-        ws2.sendClose(WebSocket.NORMAL_CLOSURE, "bye").get(POLL_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        ws1.sendClose(WebSocket.NORMAL_CLOSURE, "bye").get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        ws2.sendClose(WebSocket.NORMAL_CLOSURE, "bye").get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
     }
 
     @Test
@@ -69,11 +87,18 @@ final class WebSocketBridgeTest {
     @Test
     void clientDisconnectDoesNotBlockSubsequentBroadcasts() throws Exception {
         bridge = startOnRandomPort();
-        var ws = connect(_ -> { });
-        pollUntil(() -> bridge.clientCount() == 1);
+        var connected = new CountDownLatch(1);
+        var disconnected = new CountDownLatch(1);
+        bridge.addConnectionListener(_ -> connected.countDown());
+        bridge.addDisconnectionListener(_ -> disconnected.countDown());
 
-        ws.sendClose(WebSocket.NORMAL_CLOSURE, "bye").get(POLL_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-        pollUntil(() -> bridge.clientCount() == 0);
+        var queue = new LinkedBlockingQueue<String>();
+        var ws = connect(queue::add);
+        assertThat(connected.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS)).isTrue();
+
+        ws.sendClose(WebSocket.NORMAL_CLOSURE, "bye").get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertThat(disconnected.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS)).isTrue();
+        assertThat(bridge.clientCount()).isZero();
 
         // The daemon must not crash or hang when broadcasting after a disconnect.
         bridge.broadcast("stream.text", Map.of("delta", "after-close"));
@@ -86,16 +111,20 @@ final class WebSocketBridgeTest {
         var inbound = new CompletableFuture<String>();
         bridge.setInboundHandler((ctx, message) -> inbound.complete(message.toString()));
 
-        var ws = connect(_ -> { });
-        pollUntil(() -> bridge.clientCount() == 1);
+        var connected = new CountDownLatch(1);
+        bridge.addConnectionListener(_ -> connected.countDown());
+
+        var queue = new LinkedBlockingQueue<String>();
+        var ws = connect(queue::add);
+        assertThat(connected.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS)).isTrue();
 
         ws.sendText("{\"method\":\"permission.response\",\"params\":{\"requestId\":\"r1\",\"approved\":true}}", true)
-                .get(POLL_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+                .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
 
-        var payload = inbound.get(POLL_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        var payload = inbound.get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
         assertThat(payload).contains("permission.response").contains("\"r1\"");
 
-        ws.sendClose(WebSocket.NORMAL_CLOSURE, "bye").get(POLL_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        ws.sendClose(WebSocket.NORMAL_CLOSURE, "bye").get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
     }
 
     private WebSocketBridge startOnRandomPort() throws Exception {
@@ -108,22 +137,13 @@ final class WebSocketBridgeTest {
         return HttpClient.newHttpClient().newWebSocketBuilder()
                 .buildAsync(URI.create("ws://127.0.0.1:" + bridge.port() + "/ws"),
                         new BufferingListener(onText))
-                .get(POLL_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+                .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
     }
 
     private static int freePort() throws Exception {
         try (var s = new ServerSocket(0)) {
             return s.getLocalPort();
         }
-    }
-
-    private static void pollUntil(BooleanSupplier condition) throws InterruptedException {
-        long deadline = System.currentTimeMillis() + POLL_TIMEOUT_MS;
-        while (System.currentTimeMillis() < deadline) {
-            if (condition.getAsBoolean()) return;
-            Thread.sleep(20);
-        }
-        throw new AssertionError("Timed out waiting for condition");
     }
 
     private static final class BufferingListener implements WebSocket.Listener {

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/WebSocketBridgeTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/WebSocketBridgeTest.java
@@ -1,0 +1,148 @@
+package dev.aceclaw.daemon;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.ServerSocket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.WebSocket;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Smoke tests for {@link WebSocketBridge} — issue #431 acceptance criteria
+ * (port binds, multiple clients, broadcast fan-out, clean disconnect).
+ */
+final class WebSocketBridgeTest {
+
+    private static final long POLL_TIMEOUT_MS = 5_000;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private WebSocketBridge bridge;
+
+    @AfterEach
+    void tearDown() {
+        if (bridge != null) {
+            bridge.stop();
+        }
+    }
+
+    @Test
+    void broadcastsJsonRpcNotificationToAllConnectedClients() throws Exception {
+        bridge = startOnRandomPort();
+
+        var received1 = new ArrayList<String>();
+        var received2 = new ArrayList<String>();
+        var ws1 = connect(received1::add);
+        var ws2 = connect(received2::add);
+
+        pollUntil(() -> bridge.clientCount() == 2);
+
+        bridge.broadcast("stream.text", Map.of("delta", "hello"));
+
+        pollUntil(() -> received1.size() == 1 && received2.size() == 1);
+
+        var node = objectMapper.readTree(received1.get(0));
+        assertThat(node.get("jsonrpc").asText()).isEqualTo("2.0");
+        assertThat(node.get("method").asText()).isEqualTo("stream.text");
+        assertThat(node.get("params").get("delta").asText()).isEqualTo("hello");
+        assertThat(received2.get(0)).isEqualTo(received1.get(0));
+
+        ws1.sendClose(WebSocket.NORMAL_CLOSURE, "bye").get(POLL_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        ws2.sendClose(WebSocket.NORMAL_CLOSURE, "bye").get(POLL_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    void broadcastBeforeAnyClientIsANoOp() throws Exception {
+        bridge = startOnRandomPort();
+        bridge.broadcast("stream.heartbeat", Map.of("phase", "warmup"));
+        assertThat(bridge.clientCount()).isZero();
+    }
+
+    @Test
+    void clientDisconnectDoesNotBlockSubsequentBroadcasts() throws Exception {
+        bridge = startOnRandomPort();
+        var ws = connect(_ -> { });
+        pollUntil(() -> bridge.clientCount() == 1);
+
+        ws.sendClose(WebSocket.NORMAL_CLOSURE, "bye").get(POLL_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        pollUntil(() -> bridge.clientCount() == 0);
+
+        // The daemon must not crash or hang when broadcasting after a disconnect.
+        bridge.broadcast("stream.text", Map.of("delta", "after-close"));
+        assertThat(bridge.isRunning()).isTrue();
+    }
+
+    @Test
+    void inboundHandlerReceivesParsedClientMessages() throws Exception {
+        bridge = startOnRandomPort();
+        var inbound = new CompletableFuture<String>();
+        bridge.setInboundHandler((ctx, message) -> inbound.complete(message.toString()));
+
+        var ws = connect(_ -> { });
+        pollUntil(() -> bridge.clientCount() == 1);
+
+        ws.sendText("{\"method\":\"permission.response\",\"params\":{\"requestId\":\"r1\",\"approved\":true}}", true)
+                .get(POLL_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
+        var payload = inbound.get(POLL_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertThat(payload).contains("permission.response").contains("\"r1\"");
+
+        ws.sendClose(WebSocket.NORMAL_CLOSURE, "bye").get(POLL_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    }
+
+    private WebSocketBridge startOnRandomPort() throws Exception {
+        var b = new WebSocketBridge("127.0.0.1", freePort(), objectMapper);
+        b.start();
+        return b;
+    }
+
+    private WebSocket connect(java.util.function.Consumer<String> onText) throws Exception {
+        return HttpClient.newHttpClient().newWebSocketBuilder()
+                .buildAsync(URI.create("ws://127.0.0.1:" + bridge.port() + "/ws"),
+                        new BufferingListener(onText))
+                .get(POLL_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    }
+
+    private static int freePort() throws Exception {
+        try (var s = new ServerSocket(0)) {
+            return s.getLocalPort();
+        }
+    }
+
+    private static void pollUntil(BooleanSupplier condition) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + POLL_TIMEOUT_MS;
+        while (System.currentTimeMillis() < deadline) {
+            if (condition.getAsBoolean()) return;
+            Thread.sleep(20);
+        }
+        throw new AssertionError("Timed out waiting for condition");
+    }
+
+    private static final class BufferingListener implements WebSocket.Listener {
+        private final java.util.function.Consumer<String> onText;
+        private final StringBuilder partial = new StringBuilder();
+
+        BufferingListener(java.util.function.Consumer<String> onText) {
+            this.onText = onText;
+        }
+
+        @Override
+        public CompletableFuture<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
+            partial.append(data);
+            if (last) {
+                onText.accept(partial.toString());
+                partial.setLength(0);
+            }
+            webSocket.request(1);
+            return null;
+        }
+    }
+}

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/WebSocketBridgeTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/WebSocketBridgeTest.java
@@ -43,7 +43,7 @@ final class WebSocketBridgeTest {
     }
 
     @Test
-    void broadcastsJsonRpcNotificationToAllConnectedClients() throws Exception {
+    void broadcastsDaemonEventEnvelopeToAllConnectedClients() throws Exception {
         bridge = startOnRandomPort();
 
         var connected = new CountDownLatch(2);
@@ -59,28 +59,63 @@ final class WebSocketBridgeTest {
                 .as("both clients must connect within %dms", AWAIT_TIMEOUT_MS)
                 .isTrue();
         assertThat(bridge.clientCount()).isEqualTo(2);
+        assertThat(bridge.currentEventId()).isZero();
 
-        bridge.broadcast("stream.text", Map.of("delta", "hello"));
+        bridge.broadcast("sess-1", "stream.text", Map.of("delta", "hello"));
 
         var msg1 = queue1.poll(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
         var msg2 = queue2.poll(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
         assertThat(msg1).isNotNull();
         assertThat(msg2).isNotNull();
 
+        // Wire format must match aceclaw-dashboard/src/types/events.ts
+        // DaemonEventEnvelope { eventId, sessionId, receivedAt, event:{method, params} }.
         var node = objectMapper.readTree(msg1);
-        assertThat(node.get("jsonrpc").asText()).isEqualTo("2.0");
-        assertThat(node.get("method").asText()).isEqualTo("stream.text");
-        assertThat(node.get("params").get("delta").asText()).isEqualTo("hello");
+        assertThat(node.get("eventId").asLong()).isEqualTo(1L);
+        assertThat(node.get("sessionId").asText()).isEqualTo("sess-1");
+        assertThat(node.get("receivedAt").asText()).isNotBlank();
+        assertThat(node.has("jsonrpc")).as("envelope must NOT be JSON-RPC framed").isFalse();
+        var event = node.get("event");
+        assertThat(event.get("method").asText()).isEqualTo("stream.text");
+        assertThat(event.get("params").get("delta").asText()).isEqualTo("hello");
         assertThat(msg2).isEqualTo(msg1);
+        assertThat(bridge.currentEventId()).isEqualTo(1L);
 
         ws1.sendClose(WebSocket.NORMAL_CLOSURE, "bye").get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
         ws2.sendClose(WebSocket.NORMAL_CLOSURE, "bye").get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
     }
 
     @Test
+    void eventIdIsMonotonicAcrossSuccessiveBroadcasts() throws Exception {
+        bridge = startOnRandomPort();
+        var connected = new CountDownLatch(1);
+        bridge.addConnectionListener(_ -> connected.countDown());
+        var queue = new LinkedBlockingQueue<String>();
+        var ws = connect(queue::add);
+        assertThat(connected.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS)).isTrue();
+
+        bridge.broadcast("sess-A", "stream.text", Map.of("delta", "1"));
+        bridge.broadcast("sess-A", "stream.text", Map.of("delta", "2"));
+        bridge.broadcast("sess-B", "stream.text", Map.of("delta", "3"));
+
+        long id1 = objectMapper.readTree(queue.poll(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+                .get("eventId").asLong();
+        long id2 = objectMapper.readTree(queue.poll(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+                .get("eventId").asLong();
+        long id3 = objectMapper.readTree(queue.poll(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+                .get("eventId").asLong();
+        assertThat(id1).isEqualTo(1L);
+        assertThat(id2).isEqualTo(2L);
+        assertThat(id3).isEqualTo(3L);
+        assertThat(bridge.currentEventId()).isEqualTo(3L);
+
+        ws.sendClose(WebSocket.NORMAL_CLOSURE, "bye").get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
     void broadcastBeforeAnyClientIsANoOp() throws Exception {
         bridge = startOnRandomPort();
-        bridge.broadcast("stream.heartbeat", Map.of("phase", "warmup"));
+        bridge.broadcast("sess-1", "stream.heartbeat", Map.of("phase", "warmup"));
         assertThat(bridge.clientCount()).isZero();
     }
 
@@ -101,7 +136,7 @@ final class WebSocketBridgeTest {
         assertThat(bridge.clientCount()).isZero();
 
         // The daemon must not crash or hang when broadcasting after a disconnect.
-        bridge.broadcast("stream.text", Map.of("delta", "after-close"));
+        bridge.broadcast("sess-1", "stream.text", Map.of("delta", "after-close"));
         assertThat(bridge.isRunning()).isTrue();
     }
 

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/WebSocketBridgeTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/WebSocketBridgeTest.java
@@ -124,8 +124,15 @@ final class WebSocketBridgeTest {
         bridge = startOnRandomPort();
         var connected = new CountDownLatch(1);
         var disconnected = new CountDownLatch(1);
+        // Disconnect parity contract: the listener must fire EXACTLY ONCE per
+        // client lifecycle, regardless of which observer path (onClose,
+        // onError, broadcast synchronous send-failure) drops the client first.
+        var disconnectFires = new java.util.concurrent.atomic.AtomicInteger();
         bridge.addConnectionListener(_ -> connected.countDown());
-        bridge.addDisconnectionListener(_ -> disconnected.countDown());
+        bridge.addDisconnectionListener(_ -> {
+            disconnectFires.incrementAndGet();
+            disconnected.countDown();
+        });
 
         var queue = new LinkedBlockingQueue<String>();
         var ws = connect(queue::add);
@@ -136,8 +143,15 @@ final class WebSocketBridgeTest {
         assertThat(bridge.clientCount()).isZero();
 
         // The daemon must not crash or hang when broadcasting after a disconnect.
-        bridge.broadcast("sess-1", "stream.text", Map.of("delta", "after-close"));
+        // Multiple post-close broadcasts must NOT re-fire disconnect — the
+        // helper that drops clients is idempotent (CHM.remove + conditional
+        // fire), so the listener observes one disconnect per client.
+        bridge.broadcast("sess-1", "stream.text", Map.of("delta", "after-close-1"));
+        bridge.broadcast("sess-1", "stream.text", Map.of("delta", "after-close-2"));
         assertThat(bridge.isRunning()).isTrue();
+        assertThat(disconnectFires.get())
+                .as("disconnect listener must fire exactly once per client lifecycle")
+                .isEqualTo(1);
     }
 
     @Test

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/WebSocketBridgeTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/WebSocketBridgeTest.java
@@ -8,6 +8,7 @@ import java.net.ServerSocket;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.WebSocket;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
@@ -141,6 +142,55 @@ final class WebSocketBridgeTest {
     }
 
     @Test
+    void rejectsHandshakeWithDisallowedOrigin() throws Exception {
+        // Empty allowedOrigins (the secure default) ⇒ any browser Origin is rejected.
+        bridge = startOnRandomPort(List.of());
+
+        var queue = new LinkedBlockingQueue<String>();
+        var listener = new BufferingListener(queue::add);
+        // Java HttpClient lets us forge an Origin header — same surface a malicious
+        // page would see when calling new WebSocket('ws://localhost:3141/ws').
+        HttpClient.newHttpClient().newWebSocketBuilder()
+                .header("Origin", "https://evil.example")
+                .buildAsync(URI.create("ws://127.0.0.1:" + bridge.port() + "/ws"), listener)
+                .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
+        // Server closes immediately with 1008 (policy violation). The client-side
+        // onClose latch is the proper signal; no polling.
+        assertThat(listener.closed.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+                .as("server should close handshake from disallowed origin")
+                .isTrue();
+        assertThat(listener.closeStatusCode).isEqualTo(1008);
+        assertThat(bridge.clientCount()).as("rejected client must NOT enter the active set").isZero();
+
+        // Subsequent broadcast must not be visible to the rejected client.
+        bridge.broadcast("sess-1", "stream.text", Map.of("delta", "should-not-arrive"));
+        // poll(short) returns null because the client never received anything.
+        assertThat(queue.poll(200, TimeUnit.MILLISECONDS)).isNull();
+    }
+
+    @Test
+    void acceptsHandshakeWithAllowedOrigin() throws Exception {
+        bridge = startOnRandomPort(List.of("https://dashboard.local"));
+
+        var connected = new CountDownLatch(1);
+        bridge.addConnectionListener(_ -> connected.countDown());
+
+        var queue = new LinkedBlockingQueue<String>();
+        var listener = new BufferingListener(queue::add);
+        var ws = HttpClient.newHttpClient().newWebSocketBuilder()
+                .header("Origin", "https://dashboard.local")
+                .buildAsync(URI.create("ws://127.0.0.1:" + bridge.port() + "/ws"), listener)
+                .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
+        assertThat(connected.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS)).isTrue();
+        bridge.broadcast("sess-1", "stream.text", Map.of("delta", "hello"));
+        assertThat(queue.poll(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS)).isNotNull();
+
+        ws.sendClose(WebSocket.NORMAL_CLOSURE, "bye").get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
     void inboundHandlerReceivesParsedClientMessages() throws Exception {
         bridge = startOnRandomPort();
         var inbound = new CompletableFuture<String>();
@@ -163,7 +213,11 @@ final class WebSocketBridgeTest {
     }
 
     private WebSocketBridge startOnRandomPort() throws Exception {
-        var b = new WebSocketBridge("127.0.0.1", freePort(), objectMapper);
+        return startOnRandomPort(List.of());
+    }
+
+    private WebSocketBridge startOnRandomPort(List<String> allowedOrigins) throws Exception {
+        var b = new WebSocketBridge("127.0.0.1", freePort(), objectMapper, allowedOrigins);
         b.start();
         return b;
     }
@@ -184,6 +238,9 @@ final class WebSocketBridgeTest {
     private static final class BufferingListener implements WebSocket.Listener {
         private final java.util.function.Consumer<String> onText;
         private final StringBuilder partial = new StringBuilder();
+        /** Counts down on onClose, letting tests await close without polling. */
+        final CountDownLatch closed = new CountDownLatch(1);
+        volatile int closeStatusCode = -1;
 
         BufferingListener(java.util.function.Consumer<String> onText) {
             this.onText = onText;
@@ -197,6 +254,13 @@ final class WebSocketBridgeTest {
                 partial.setLength(0);
             }
             webSocket.request(1);
+            return null;
+        }
+
+        @Override
+        public CompletableFuture<?> onClose(WebSocket webSocket, int statusCode, String reason) {
+            closeStatusCode = statusCode;
+            closed.countDown();
             return null;
         }
     }


### PR DESCRIPTION
## Summary

Implements **issue #431** end-to-end (epic #430, Tier 1 dashboard). Adds a localhost-only WebSocket endpoint that fans out the daemon's existing JSON-RPC notifications to browser clients, plus the four lifecycle events the dashboard reducer (#435) needs to anchor its tree.

**Disabled by default** (\`webSocket.enabled\` in config.json). When off, the codepaths are byte-identical to today — UDS protocol, stream semantics, and runtime authority are unchanged.

## What's in the PR

### New classes
- **\`WebSocketBridge\`** — Javalin 6 \`/ws\` endpoint. \`ConcurrentHashMap.newKeySet\` of \`WsContext\`. \`broadcast(method, params)\` serialises a JSON-RPC 2.0 notification and fans out; per-client send failures drop just that client without blocking others.
- **\`EventMultiplexer\`** — per-request \`StreamContext\` that tees outgoing notifications to both the CLI's UDS sink and the bridge. \`readMessage\` stays one-way (delegate-only) because browser→daemon traffic (\`permission.response\`) is **#433's** scope and would race with the CLI permission flow.

### Daemon plumbing
- \`CancelAwareStreamContext\` gains a two-context overload so the multiplexer sits on the outbound path while channel-extraction for the cancel monitor still works on the original socket-backed context.
- \`StreamingAgentHandler.setWebSocketBridge\` wires the bridge in. Null-safe — when off, the multiplexer is skipped.
- \`AceClawDaemon\` starts the bridge **before** the UDS listener (so a tab connecting at the same instant doesn't race the first event) and stops it at shutdown priority 25 — after Session Manager (90) and UDS (100), so in-flight prompts finish their notification stream cleanly.
- \`AceClawConfig\` gains \`webSocketEnabled\` / \`webSocketPort\` (3141) / \`webSocketHost\` (localhost). New \`WebSocketConfigFormat\` for \`{ \"enabled\": true, \"port\": 3141, \"host\": \"localhost\" }\`.

### Missing-event emissions (issue #439 contract)
| Event | Where | Notes |
|---|---|---|
| \`stream.session_started\` | first \`agent.prompt\` per session | gated by per-session \`Set\` flag; carries \`sessionId\`, \`model\`, \`timestamp\` |
| \`stream.turn_started\` | top of \`handlePrompt\` | fresh request UUID + \`turnNumber\` (Nth user message) |
| \`stream.turn_completed\` | inner \`finally\` | fires on success, LlmException catch+rethrow, and unexpected throws; \`durationMs\` + \`toolCount\` from a per-request counter on the cancel context |
| \`stream.plan_step_fallback\` | \`SequentialPlanExecutor\` fallback path | new \`onStepFallback\` on \`PlanEventListener\`; both planned-prompt and resume-path listeners emit the JSON-RPC, resume path adds the step-index offset |

## Acceptance criteria (#431)

- [x] \`ws://localhost:3141/ws\` accepts connections — covered by \`WebSocketBridgeTest\`
- [x] All existing stream events arrive on WebSocket in JSON-RPC format — every \`cancelContext.sendNotification(...)\` site now tees through \`EventMultiplexer\`
- [x] \`stream.turn_started\` / \`turn_completed\` emitted as JSON-RPC notifications (CLI **and** WS) — implemented at lifecycle points
- [x] \`stream.session_started\` emitted when a session begins — first-prompt gate
- [x] Multiple browser tabs can connect simultaneously — covered by \`broadcastsJsonRpcNotificationToAllConnectedClients\`
- [x] CLI continues to work unchanged — no existing \`sendNotification\` call sites changed; full \`./gradlew build\` clean
- [x] Graceful WS disconnect — covered by \`clientDisconnectDoesNotBlockSubsequentBroadcasts\`
- [x] WebSocket can be disabled via config — \`webSocketEnabled\` defaults to \`false\`
- [x] Bind only to localhost by default — \`DEFAULT_WEBSOCKET_HOST = \"localhost\"\` + \`Javalin.cfg.jetty.defaultHost\`

## Out of scope (separate issues)
- \`permission.response\` from browser → daemon: **#433**
- Snapshot API for late-join: **#432**
- Browser-side WS client + reducer + tree: **#435**, **#436**

## Test plan
- [x] \`./gradlew :aceclaw-daemon:test :aceclaw-core:test\` — all pass
- [x] \`./gradlew build\` (full project, 53 tasks) — clean
- [x] \`WebSocketBridgeTest\` — 4 cases: broadcast fan-out / no-client no-op / disconnect resilience / inbound handler
- [ ] Manual smoke: enable \`webSocket.enabled\`, run a CLI prompt, observe events on \`wscat -c ws://localhost:3141/ws\`
- [ ] Reviewer: confirm shutdown ordering won't drop notifications mid-flight

Closes #431
Refs #430, #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WebSocket bridge for real-time dashboard connectivity with configurable host, port, and origin allowlist.
  * New configuration options to enable/disable the WebSocket bridge and customize connection parameters.
  * Emitted per-session and per-turn lifecycle events for streaming, plus explicit notifications when a plan step fallback is attempted.

* **Tests**
  * Added end-to-end tests covering WebSocket connectivity, broadcasting, origin controls, and inbound message handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->