### PR TITLE
feat(dashboard,daemon): multi-session discovery — sessions.list + sidebar (#445)

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -501,6 +501,11 @@ public final class AceClawDaemon {
                         sNode.put("projectPath", session.projectPath().toString());
                         sNode.put("createdAt", session.createdAt().toString());
                         sNode.put("active", session.isActive());
+                        // Mirror the model carried by stream.session_started so the
+                        // sidebar can show the active model without waiting for the
+                        // next session start. getModelForSession falls back to the
+                        // daemon default when there's no per-session override.
+                        sNode.put("model", agentHandler.getModelForSession(session.id()));
                         sessionsArray.add(sNode);
                     }
                     response.set("sessions", sessionsArray);
@@ -791,6 +796,33 @@ public final class AceClawDaemon {
         }
         final var runtimeSkillGeneratorForSessionEnd = dynamicSkillGenerator;
         sessionManager.setSessionEndCallback(session -> {
+            // Notify dashboard FIRST so the sidebar transitions immediately —
+            // the rest of this callback (memory extraction, history flush,
+            // learning analysis, runtime-skill-draft persistence, …) can take
+            // multiple seconds and the user shouldn't watch a stale "active"
+            // dot the whole time. SessionManager has already removed the
+            // session from its map by the time this runs, so the broadcast is
+            // honest about the daemon's view of state.
+            //
+            // reason carries the daemon's lifecycle context: the running flag
+            // is true for normal session.destroy calls and false during
+            // shutdownManager.executeShutdown(), so the dashboard can
+            // distinguish "user closed this one session" from "daemon is
+            // going down" without an extra round-trip.
+            var bridge = this.webSocketBridge;
+            if (bridge != null) {
+                try {
+                    var params = objectMapper.createObjectNode();
+                    params.put("sessionId", session.id());
+                    params.put("timestamp", java.time.Instant.now().toString());
+                    params.put("reason", running ? "destroyed" : "shutdown");
+                    bridge.broadcast(session.id(), "stream.session_ended", params);
+                } catch (Exception e) {
+                    log.warn("Failed to broadcast stream.session_ended for {}: {}",
+                            session.id(), e.getMessage());
+                }
+            }
+
             if (memoryStore != null) {
                 var sessionWorkingDir = session.projectPath().toAbsolutePath().normalize();
                 var sessionWorkspaceHash = WorkspacePaths.workspaceHash(sessionWorkingDir);
@@ -890,23 +922,6 @@ public final class AceClawDaemon {
             // Clean up session-scoped resources in the agent handler
             agentHandlerForCleanup.clearSessionOverride(session.id());
             agentHandlerForCleanup.clearSessionMetrics(session.id());
-
-            // Notify dashboard sidebar (#445) that a session is gone — without
-            // this, the sidebar would have to poll sessions.list to detect
-            // closures. Bridge-disabled deployments skip this entirely.
-            var bridge = this.webSocketBridge;
-            if (bridge != null) {
-                try {
-                    var params = objectMapper.createObjectNode();
-                    params.put("sessionId", session.id());
-                    params.put("timestamp", java.time.Instant.now().toString());
-                    params.put("reason", "destroyed");
-                    bridge.broadcast(session.id(), "stream.session_ended", params);
-                } catch (Exception e) {
-                    log.warn("Failed to broadcast stream.session_ended for {}: {}",
-                            session.id(), e.getMessage());
-                }
-            }
         });
 
         // Expose model name, provider info, and health monitor to status endpoint

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -478,6 +478,38 @@ public final class AceClawDaemon {
                     config.webSocketHost(), config.webSocketPort(), objectMapper,
                     config.webSocketAllowedOrigins());
             agentHandler.setWebSocketBridge(this.webSocketBridge);
+
+            // Issue #445: respond to sessions.list requests from the dashboard
+            // sidebar. The reply is a one-shot point-to-point message rather
+            // than a broadcast envelope — semantically a request-response,
+            // not a stream event, so we ctx.send the JSON directly to the
+            // requesting client and skip the EventMultiplexer fan-out path.
+            final var sessionsRef = sessionManager;
+            final var mapperRef = objectMapper;
+            this.webSocketBridge.setInboundHandler((ctx, message) -> {
+                var methodNode = message.get("method");
+                if (methodNode == null) return;
+                var method = methodNode.asText("");
+                if (!"sessions.list".equals(method)) return;
+                try {
+                    var response = mapperRef.createObjectNode();
+                    response.put("method", "sessions.list.result");
+                    var sessionsArray = mapperRef.createArrayNode();
+                    for (var session : sessionsRef.activeSessions()) {
+                        var sNode = mapperRef.createObjectNode();
+                        sNode.put("sessionId", session.id());
+                        sNode.put("projectPath", session.projectPath().toString());
+                        sNode.put("createdAt", session.createdAt().toString());
+                        sNode.put("active", session.isActive());
+                        sessionsArray.add(sNode);
+                    }
+                    response.set("sessions", sessionsArray);
+                    ctx.send(mapperRef.writeValueAsString(response));
+                } catch (Exception e) {
+                    log.warn("Failed to send sessions.list reply: {}", e.getMessage());
+                }
+            });
+
             log.info("WebSocket bridge configured: {}:{} (allowed browser origins: {})",
                     config.webSocketHost(), config.webSocketPort(),
                     config.webSocketAllowedOrigins().isEmpty()
@@ -858,6 +890,23 @@ public final class AceClawDaemon {
             // Clean up session-scoped resources in the agent handler
             agentHandlerForCleanup.clearSessionOverride(session.id());
             agentHandlerForCleanup.clearSessionMetrics(session.id());
+
+            // Notify dashboard sidebar (#445) that a session is gone — without
+            // this, the sidebar would have to poll sessions.list to detect
+            // closures. Bridge-disabled deployments skip this entirely.
+            var bridge = this.webSocketBridge;
+            if (bridge != null) {
+                try {
+                    var params = objectMapper.createObjectNode();
+                    params.put("sessionId", session.id());
+                    params.put("timestamp", java.time.Instant.now().toString());
+                    params.put("reason", "destroyed");
+                    bridge.broadcast(session.id(), "stream.session_ended", params);
+                } catch (Exception e) {
+                    log.warn("Failed to broadcast stream.session_ended for {}: {}",
+                            session.id(), e.getMessage());
+                }
+            }
         });
 
         // Expose model name, provider info, and health monitor to status endpoint

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/WebSocketBridgeTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/WebSocketBridgeTest.java
@@ -283,6 +283,46 @@ final class WebSocketBridgeTest {
         ws.sendClose(WebSocket.NORMAL_CLOSURE, "bye").get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
     }
 
+    @Test
+    void inboundHandlerCanReplyPointToPoint() throws Exception {
+        // Pins the contract that #445's sessions.list relies on: an inbound
+        // handler can call ctx.send to reply to the requester only, without
+        // routing through bridge.broadcast (which would fan the response out
+        // to every other connected client too). Without this, the sessions
+        // list would leak into every browser tab — wrong shape for a
+        // request-response.
+        bridge = startOnRandomPort();
+        bridge.setInboundHandler((ctx, message) -> {
+            // Echo a control-style reply, unwrapped (no DaemonEventEnvelope).
+            // sessions.list does the same thing in production.
+            if (message.has("method") && "ping".equals(message.get("method").asText())) {
+                ctx.send("{\"method\":\"pong\",\"correlationId\":\""
+                        + message.get("id").asText() + "\"}");
+            }
+        });
+
+        var connected = new CountDownLatch(1);
+        bridge.addConnectionListener(_ -> connected.countDown());
+
+        var queue = new LinkedBlockingQueue<String>();
+        var ws = connect(queue::add);
+        assertThat(connected.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS)).isTrue();
+
+        ws.sendText("{\"method\":\"ping\",\"id\":\"r-42\"}", true)
+                .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
+        // Reply lands on the requesting client's queue. Crucially, this is
+        // NOT envelope-wrapped — no eventId / sessionId / receivedAt.
+        var reply = queue.poll(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertThat(reply).isNotNull();
+        var node = objectMapper.readTree(reply);
+        assertThat(node.get("method").asText()).isEqualTo("pong");
+        assertThat(node.get("correlationId").asText()).isEqualTo("r-42");
+        assertThat(node.has("eventId")).as("control replies must NOT carry an envelope").isFalse();
+
+        ws.sendClose(WebSocket.NORMAL_CLOSURE, "bye").get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    }
+
     private WebSocketBridge startOnRandomPort() throws Exception {
         return startOnRandomPort(List.of());
     }

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/WebSocketBridgeTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/WebSocketBridgeTest.java
@@ -301,11 +301,17 @@ final class WebSocketBridgeTest {
             }
         });
 
-        var connected = new CountDownLatch(1);
+        // Two clients connected: a single-client test would still pass even
+        // if the bridge fanned the reply out via broadcast (the requester
+        // would receive its own reply either way). The second client lets
+        // us prove the reply is requester-only.
+        var connected = new CountDownLatch(2);
         bridge.addConnectionListener(_ -> connected.countDown());
 
-        var queue = new LinkedBlockingQueue<String>();
-        var ws = connect(queue::add);
+        var requesterQueue = new LinkedBlockingQueue<String>();
+        var otherQueue = new LinkedBlockingQueue<String>();
+        var ws = connect(requesterQueue::add);
+        var wsOther = connect(otherQueue::add);
         assertThat(connected.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS)).isTrue();
 
         ws.sendText("{\"method\":\"ping\",\"id\":\"r-42\"}", true)
@@ -313,14 +319,24 @@ final class WebSocketBridgeTest {
 
         // Reply lands on the requesting client's queue. Crucially, this is
         // NOT envelope-wrapped — no eventId / sessionId / receivedAt.
-        var reply = queue.poll(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        var reply = requesterQueue.poll(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
         assertThat(reply).isNotNull();
         var node = objectMapper.readTree(reply);
         assertThat(node.get("method").asText()).isEqualTo("pong");
         assertThat(node.get("correlationId").asText()).isEqualTo("r-42");
         assertThat(node.has("eventId")).as("control replies must NOT carry an envelope").isFalse();
 
+        // The non-requesting client must not see the reply: this is what
+        // makes ctx.send semantically distinct from bridge.broadcast.
+        // Use a short bounded poll — the message either arrived by now
+        // (Jetty would have delivered it on the same network turn as the
+        // requester's frame) or it never will. 200ms is plenty in-process.
+        assertThat(otherQueue.poll(200, TimeUnit.MILLISECONDS))
+                .as("non-requesting clients must not receive point-to-point replies")
+                .isNull();
+
         ws.sendClose(WebSocket.NORMAL_CLOSURE, "bye").get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        wsOther.sendClose(WebSocket.NORMAL_CLOSURE, "bye").get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
     }
 
     private WebSocketBridge startOnRandomPort() throws Exception {

--- a/aceclaw-dashboard/src/App.tsx
+++ b/aceclaw-dashboard/src/App.tsx
@@ -1,22 +1,30 @@
 import { useState } from 'react';
 import { ExecutionTree } from './components/ExecutionTree';
+import { SessionList } from './components/SessionList';
 import { useExecutionTree } from './hooks/useExecutionTree';
+import { useSessions } from './hooks/useSessions';
 
 /**
- * Tier 1 dashboard root (issues #434 → #436). Wires three pieces:
+ * Tier 1 dashboard root (issues #434 → #436, sidebar from #445).
  *
- *   1. {@link useExecutionTree} — opens a WebSocket to the daemon's bridge
- *      (#431) and exposes a reactive {@link ExecutionTreeState}.
- *   2. {@link ExecutionTree} — SVG tree with dagre layout + Framer Motion
- *      animations (#436).
- *   3. A small status bar with the connection state, session id, and live
- *      stats from the reducer.
+ * Layout:
+ *   ┌──────────────┬──────────────────────────────────────┐
+ *   │ SessionList  │ StatusBar                            │
+ *   │   sidebar    ├──────────────────────────────────────┤
+ *   │  (#445)      │ ExecutionTree (#436)                 │
+ *   │              │                                      │
+ *   └──────────────┴──────────────────────────────────────┘
  *
- * Reading WS URL + session from query params keeps this Tier 1 friendly:
- * a developer can hit
- *   http://localhost:5173/?session=&ws=ws://localhost:3141/ws
- * once the daemon is running with webSocket.enabled and an allowlisted
- * origin, and see live trees without rebuilding.
+ * Two independent WebSockets (one per hook). The sidebar's
+ * {@link useSessions} sends {@code sessions.list} once on connect and then
+ * tails {@code stream.session_started} / {@code stream.session_ended} for
+ * live deltas. The tree's {@link useExecutionTree} filters by sessionId so
+ * only the selected session's events drive the rendered tree.
+ *
+ * Reading WS URL + session from query params keeps Tier 1 friendly:
+ *   http://localhost:5173/?session=<id>&ws=ws://localhost:3141/ws
+ * once the daemon is running. Selecting a session in the sidebar updates
+ * the URL in place so reloads remember the selection.
  */
 
 const DEFAULT_WS_URL = 'ws://localhost:3141/ws';
@@ -51,20 +59,49 @@ export function App() {
   const initialWs = sanitiseWsUrl(readQueryParam('ws')) ?? DEFAULT_WS_URL;
   const [sessionId, setSessionId] = useState(initialSession);
   const [wsUrl] = useState(initialWs);
+  const sessions = useSessions(wsUrl);
 
-  if (!sessionId.trim()) {
-    return <SessionPrompt onSubmit={setSessionId} defaultWsUrl={initialWs} />;
-  }
+  // Selecting a session in the sidebar replaces the URL so reload preserves
+  // the selection — replaceState rather than pushState so the back button
+  // doesn't treat session-switching as navigation history.
+  const selectSession = (newSessionId: string): void => {
+    setSessionId(newSessionId);
+    if (typeof window !== 'undefined') {
+      const url = new URL(window.location.href);
+      url.searchParams.set('session', newSessionId);
+      window.history.replaceState(null, '', url.toString());
+    }
+  };
 
-  return <DashboardConnected sessionId={sessionId.trim()} wsUrl={wsUrl} />;
+  return (
+    <div className="flex h-full">
+      <SessionList
+        sessions={sessions}
+        selectedSessionId={sessionId || null}
+        onSelect={selectSession}
+      />
+      <div className="flex flex-1 flex-col overflow-hidden">
+        {sessionId ? (
+          <DashboardConnected sessionId={sessionId.trim()} wsUrl={wsUrl} />
+        ) : (
+          <SessionPrompt
+            onSubmit={selectSession}
+            defaultWsUrl={initialWs}
+            hasSessions={sessions.length > 0}
+          />
+        )}
+      </div>
+    </div>
+  );
 }
 
 interface SessionPromptProps {
   onSubmit: (sessionId: string) => void;
   defaultWsUrl: string;
+  hasSessions: boolean;
 }
 
-function SessionPrompt({ onSubmit, defaultWsUrl }: SessionPromptProps) {
+function SessionPrompt({ onSubmit, defaultWsUrl, hasSessions }: SessionPromptProps) {
   const [draft, setDraft] = useState('');
   return (
     <main className="flex h-full flex-col items-center justify-center gap-6 p-8">
@@ -76,6 +113,11 @@ function SessionPrompt({ onSubmit, defaultWsUrl }: SessionPromptProps) {
           if (draft.trim()) onSubmit(draft);
         }}
       >
+        <p className="text-sm text-zinc-400">
+          {hasSessions
+            ? 'Pick a session from the sidebar, or paste an ID below.'
+            : 'No sessions yet — start one with the CLI, or paste an ID below.'}
+        </p>
         <label className="flex flex-col gap-1 text-sm text-zinc-400">
           Session ID
           <input
@@ -111,12 +153,12 @@ interface DashboardConnectedProps {
 function DashboardConnected({ sessionId, wsUrl }: DashboardConnectedProps) {
   const { tree, status } = useExecutionTree(wsUrl, sessionId);
   return (
-    <div className="flex h-full flex-col">
+    <>
       <StatusBar sessionId={sessionId} status={status} stats={tree.stats} />
       <div className="flex-1">
         <ExecutionTree tree={tree} />
       </div>
-    </div>
+    </>
   );
 }
 

--- a/aceclaw-dashboard/src/components/SessionList.tsx
+++ b/aceclaw-dashboard/src/components/SessionList.tsx
@@ -1,0 +1,112 @@
+/**
+ * SessionList sidebar (issue #445).
+ *
+ * Lists every active (and recently-closed) session the daemon knows about,
+ * sourced from {@link useSessions}. Click an entry → switch the dashboard's
+ * focus to that session via the {@code onSelect} callback (App keeps the
+ * actual sessionId state).
+ *
+ * Visual contract:
+ *   - Currently-selected session is highlighted (left border + lighter bg)
+ *   - Active sessions get a green pulse dot, closed sessions a grey dot
+ *   - Project path is shown tail-truncated (only the last 2 segments) so the
+ *     sidebar stays narrow while still distinguishing repos
+ *   - "started Xm ago" relative timestamp, computed at render time (no
+ *     ticking — the dashboard isn't a stopwatch)
+ */
+
+import type { SessionInfo } from '../hooks/useSessions';
+
+interface SessionListProps {
+  sessions: SessionInfo[];
+  selectedSessionId: string | null;
+  onSelect: (sessionId: string) => void;
+}
+
+export function SessionList({ sessions, selectedSessionId, onSelect }: SessionListProps) {
+  return (
+    <aside className="flex h-full w-60 shrink-0 flex-col border-r border-zinc-800 bg-zinc-900/40">
+      <header className="flex items-center justify-between border-b border-zinc-800 px-3 py-2 text-[11px] uppercase tracking-wider text-zinc-500">
+        <span>Sessions</span>
+        <span className="font-mono text-zinc-600">{sessions.length}</span>
+      </header>
+      {sessions.length === 0 ? (
+        <p className="px-3 py-4 text-xs text-zinc-500">
+          No active sessions.{' '}
+          <span className="text-zinc-600">Start one with the CLI.</span>
+        </p>
+      ) : (
+        <ul className="flex-1 overflow-y-auto">
+          {sessions.map((s) => (
+            <SessionRow
+              key={s.sessionId}
+              session={s}
+              selected={s.sessionId === selectedSessionId}
+              onSelect={onSelect}
+            />
+          ))}
+        </ul>
+      )}
+    </aside>
+  );
+}
+
+interface SessionRowProps {
+  session: SessionInfo;
+  selected: boolean;
+  onSelect: (sessionId: string) => void;
+}
+
+function SessionRow({ session, selected, onSelect }: SessionRowProps) {
+  const dot = session.active ? 'bg-emerald-500' : 'bg-zinc-600';
+  const baseBg = selected ? 'bg-zinc-800/60' : 'hover:bg-zinc-800/40';
+  const accent = selected ? 'border-l-2 border-blue-500' : 'border-l-2 border-transparent';
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={() => onSelect(session.sessionId)}
+        className={`flex w-full items-start gap-2 px-3 py-2 text-left text-xs transition-colors ${baseBg} ${accent}`}
+      >
+        <span className={`mt-1 h-2 w-2 shrink-0 rounded-full ${dot}`} />
+        <div className="min-w-0 flex-1">
+          <div className="truncate font-mono text-zinc-200" title={session.projectPath}>
+            {tailPath(session.projectPath)}
+          </div>
+          <div className="flex items-center gap-2 text-[10px] text-zinc-500">
+            <span className="font-mono">{shortId(session.sessionId)}</span>
+            <span>·</span>
+            <span>{relativeTime(session.createdAt)}</span>
+          </div>
+        </div>
+      </button>
+    </li>
+  );
+}
+
+/** Last two path segments — keeps the sidebar narrow but still informative. */
+function tailPath(path: string): string {
+  if (!path) return '(unknown)';
+  const parts = path.split(/[/\\]/).filter(Boolean);
+  if (parts.length <= 2) return path;
+  return `…/${parts.slice(-2).join('/')}`;
+}
+
+/** First eight chars of the sessionId — enough to disambiguate in practice. */
+function shortId(id: string): string {
+  return id.slice(0, 8);
+}
+
+/** Coarse human-friendly elapsed time. Rendered once per repaint, no ticking. */
+function relativeTime(iso: string): string {
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return '—';
+  const seconds = Math.max(0, Math.floor((Date.now() - t) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}

--- a/aceclaw-dashboard/src/hooks/useExecutionTree.ts
+++ b/aceclaw-dashboard/src/hooks/useExecutionTree.ts
@@ -53,6 +53,7 @@ export interface UseExecutionTreeResult {
  */
 const KNOWN_METHODS = new Set<DaemonEvent['method']>([
   'stream.session_started',
+  'stream.session_ended',
   'stream.turn_started',
   'stream.turn_completed',
   'stream.thinking',
@@ -104,6 +105,8 @@ const VALIDATORS: Partial<Record<DaemonEvent['method'], ParamGuard>> = {
   'stream.turn_completed': (p) =>
     isString(p['requestId']) && isNumber(p['turnNumber']) && isNumber(p['durationMs']),
   'stream.session_started': (p) => isString(p['sessionId']) && isString(p['model']),
+  'stream.session_ended': (p) =>
+    isString(p['sessionId']) && isString(p['timestamp']) && isString(p['reason']),
   // Critical: addPlanSkeleton calls steps.map — must be Array, not just present.
   'stream.plan_created': (p) =>
     isString(p['planId']) && Array.isArray(p['steps']),

--- a/aceclaw-dashboard/src/hooks/useSessions.ts
+++ b/aceclaw-dashboard/src/hooks/useSessions.ts
@@ -52,7 +52,13 @@ export function useSessions(wsUrl: string | null): SessionInfo[] {
   const [sessions, setSessions] = useState<SessionInfo[]>([]);
 
   useEffect(() => {
-    if (!wsUrl) return;
+    if (!wsUrl) {
+      // Clear any rows from a prior connection so the sidebar doesn't
+      // keep showing ghost sessions when the dashboard is detached
+      // (e.g. user back on the session-prompt screen).
+      setSessions([]);
+      return;
+    }
     let ws: WebSocket | null = null;
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
     let backoffMs = RECONNECT_INITIAL_MS;
@@ -230,16 +236,18 @@ function sortByCreatedDesc(list: SessionInfo[]): SessionInfo[] {
 
 /**
  * Merges a fresh sessions.list snapshot into the current state, keyed by
- * sessionId, so live events that arrived before the snapshot is delivered
- * aren't clobbered. Rules:
+ * sessionId. The snapshot is authoritative for *membership* — sessions
+ * absent from it are dropped, even if local state still has them. This is
+ * the only way the sidebar self-heals after a disconnect during which we
+ * missed a {@code stream.session_ended} broadcast: once we reconnect and
+ * re-fetch the snapshot, the stale row goes away.
  *
- *   - Sessions only in the snapshot are added.
- *   - Sessions only in local state are kept (they were observed via a live
- *     event that the daemon's snapshot pre-dated).
- *   - For overlaps, snapshot wins on immutable fields (projectPath, model,
- *     createdAt) but a locally-observed terminal {@code active=false} is
- *     preserved over a snapshot {@code active=true} — the end event is
- *     newer than the snapshot capture even if it raced ahead of delivery.
+ * The one exception is a locally-observed terminal {@code active=false}
+ * over a snapshot {@code active=true}. That race (broadcast lands before
+ * the snapshot reply, even though both are sent on the same socket) is
+ * narrow but possible because the daemon dispatches them on separate code
+ * paths. Since active state only transitions one way, preferring "ended"
+ * is always safe.
  *
  * Exported for unit testing.
  */
@@ -247,18 +255,16 @@ export function mergeSnapshot(
   prev: SessionInfo[],
   snapshot: SessionInfo[],
 ): SessionInfo[] {
-  const merged = new Map<string, SessionInfo>();
-  for (const s of snapshot) merged.set(s.sessionId, s);
-  for (const s of prev) {
-    const fromSnap = merged.get(s.sessionId);
-    if (!fromSnap) {
-      merged.set(s.sessionId, s);
-      continue;
-    }
-    // Locally-observed end event beats snapshot's stale active=true.
-    if (!s.active && fromSnap.active) {
-      merged.set(s.sessionId, { ...fromSnap, active: false });
+  const prevById = new Map(prev.map((s) => [s.sessionId, s]));
+  const out: SessionInfo[] = [];
+  for (const fromSnap of snapshot) {
+    const local = prevById.get(fromSnap.sessionId);
+    // Honour a locally-observed end over a stale snapshot active=true.
+    if (local && !local.active && fromSnap.active) {
+      out.push({ ...fromSnap, active: false });
+    } else {
+      out.push(fromSnap);
     }
   }
-  return sortByCreatedDesc([...merged.values()]);
+  return sortByCreatedDesc(out);
 }

--- a/aceclaw-dashboard/src/hooks/useSessions.ts
+++ b/aceclaw-dashboard/src/hooks/useSessions.ts
@@ -1,0 +1,180 @@
+/**
+ * useSessions (issue #445).
+ *
+ * Owns its OWN WebSocket connection (separate from {@link useExecutionTree})
+ * to drive the SessionList sidebar. Two responsibilities:
+ *
+ *   1. On open, send the daemon a {@code sessions.list} request and seed the
+ *      list from the one-shot reply (snapshot of state at request time).
+ *   2. Listen for {@code stream.session_started} / {@code stream.session_ended}
+ *      envelopes broadcast on the same socket and apply them as live deltas.
+ *
+ * Why a second WS connection rather than sharing the tree's? The tree hook
+ * filters envelopes by sessionId, so it can't observe other-session events.
+ * Splitting keeps each hook's contract narrow (one tree per session, one
+ * sidebar per dashboard) and keeps the wire format unchanged. Two
+ * localhost connections are essentially free.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+/** One row in the sidebar — what the daemon's sessions.list reply carries. */
+export interface SessionInfo {
+  sessionId: string;
+  projectPath: string;
+  /** ISO-8601 timestamp; daemon-assigned. */
+  createdAt: string;
+  active: boolean;
+}
+
+const SESSIONS_LIST_REQUEST = JSON.stringify({ method: 'sessions.list' });
+
+/**
+ * Subscribes to the daemon's session set. Returns a stable array sorted by
+ * createdAt descending so the most recently started session appears first.
+ *
+ * @param wsUrl daemon bridge URL — same as used by {@link useExecutionTree}.
+ *              Pass {@code null} to disable the connection (e.g. while the
+ *              user is still on the session-prompt screen).
+ */
+export function useSessions(wsUrl: string | null): SessionInfo[] {
+  const [sessions, setSessions] = useState<SessionInfo[]>([]);
+  // Stable handler so the useEffect dep array doesn't churn.
+  const apply = useCallback((next: SessionInfo[]) => setSessions(next), []);
+
+  useEffect(() => {
+    if (!wsUrl) return;
+    let ws: WebSocket | null = null;
+    let cancelled = false;
+
+    try {
+      ws = new WebSocket(wsUrl);
+    } catch {
+      // Malformed URL — caller should sanitise before passing in.
+      return;
+    }
+
+    ws.onopen = () => {
+      if (cancelled) return;
+      ws?.send(SESSIONS_LIST_REQUEST);
+    };
+
+    ws.onmessage = (e: MessageEvent<string>) => {
+      if (cancelled) return;
+      let data: unknown;
+      try {
+        data = JSON.parse(e.data);
+      } catch {
+        return;
+      }
+      if (!isPlainObject(data)) return;
+
+      // sessions.list.result — non-enveloped one-shot reply. Snapshot of
+      // active sessions at the moment we asked.
+      if (data['method'] === 'sessions.list.result') {
+        const list = parseSessionsListResult(data);
+        if (list) apply(sortByCreatedDesc(list));
+        return;
+      }
+
+      // Otherwise it's a regular envelope; pluck the session_started /
+      // session_ended events and ignore everything else (the tree hook
+      // handles its own dispatch). Validate the shape ourselves rather
+      // than reusing useExecutionTree's parseEnvelope — we need the wider
+      // event view (no critical-field gate) so a missing optional doesn't
+      // drop the whole envelope.
+      const event = data['event'];
+      if (!isPlainObject(event)) return;
+      const method = typeof event['method'] === 'string' ? event['method'] : null;
+      const rawParams = event['params'];
+      const params: Record<string, unknown> = isPlainObject(rawParams) ? rawParams : {};
+      if (method === 'stream.session_started') {
+        const sessionId = typeof params['sessionId'] === 'string' ? params['sessionId'] : null;
+        if (!sessionId) return;
+        // The session_started event doesn't carry projectPath, so we fall
+        // back to "(unknown)" until the next sessions.list refresh — the
+        // sidebar will replace it on its next mount/reconnect.
+        const created =
+          typeof params['timestamp'] === 'string'
+            ? params['timestamp']
+            : new Date().toISOString();
+        setSessions((prev) =>
+          prev.some((s) => s.sessionId === sessionId)
+            ? prev
+            : sortByCreatedDesc([
+                ...prev,
+                {
+                  sessionId,
+                  projectPath: '(unknown)',
+                  createdAt: created,
+                  active: true,
+                },
+              ]),
+        );
+      } else if (method === 'stream.session_ended') {
+        const sessionId = typeof params['sessionId'] === 'string' ? params['sessionId'] : null;
+        if (!sessionId) return;
+        setSessions((prev) =>
+          prev.map((s) => (s.sessionId === sessionId ? { ...s, active: false } : s)),
+        );
+      }
+    };
+
+    return () => {
+      cancelled = true;
+      if (ws) {
+        ws.onopen = null;
+        ws.onmessage = null;
+        ws.onclose = null;
+        ws.onerror = null;
+        ws.close();
+      }
+    };
+  }, [wsUrl, apply]);
+
+  return sessions;
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Validates the daemon's sessions.list.result reply and narrows it to a
+ * typed array. Tolerates extra fields (forward-compat) but drops any entry
+ * missing a critical key (sessionId, projectPath, …) — bad rows get
+ * silently filtered rather than crashing the sidebar.
+ *
+ * Exported for unit testing.
+ */
+export function parseSessionsListResult(
+  data: Record<string, unknown>,
+): SessionInfo[] | null {
+  const raw = data['sessions'];
+  if (!Array.isArray(raw)) return null;
+  const out: SessionInfo[] = [];
+  for (const entry of raw) {
+    if (!isPlainObject(entry)) continue;
+    const sessionId = entry['sessionId'];
+    const projectPath = entry['projectPath'];
+    const createdAt = entry['createdAt'];
+    const active = entry['active'];
+    if (
+      typeof sessionId !== 'string' ||
+      typeof projectPath !== 'string' ||
+      typeof createdAt !== 'string' ||
+      typeof active !== 'boolean'
+    ) {
+      continue;
+    }
+    out.push({ sessionId, projectPath, createdAt, active });
+  }
+  return out;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function sortByCreatedDesc(list: SessionInfo[]): SessionInfo[] {
+  return [...list].sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}

--- a/aceclaw-dashboard/src/hooks/useSessions.ts
+++ b/aceclaw-dashboard/src/hooks/useSessions.ts
@@ -16,7 +16,7 @@
  * localhost connections are essentially free.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 /** One row in the sidebar — what the daemon's sessions.list reply carries. */
 export interface SessionInfo {
   sessionId: string;
@@ -50,8 +50,6 @@ const RECONNECT_MAX_MS = 30_000;
  */
 export function useSessions(wsUrl: string | null): SessionInfo[] {
   const [sessions, setSessions] = useState<SessionInfo[]>([]);
-  // Stable handler so the useEffect dep array doesn't churn.
-  const apply = useCallback((next: SessionInfo[]) => setSessions(next), []);
 
   useEffect(() => {
     if (!wsUrl) return;
@@ -89,10 +87,14 @@ export function useSessions(wsUrl: string | null): SessionInfo[] {
         if (!isPlainObject(data)) return;
 
         // sessions.list.result — non-enveloped one-shot reply. Snapshot of
-        // active sessions at the moment we asked.
+        // active sessions at the moment we asked. Merge into existing state
+        // rather than replacing wholesale: between the daemon capturing the
+        // snapshot and us receiving it, a stream.session_ended (or _started)
+        // may already have arrived on the wire. A blind replace would
+        // resurrect a just-ended session or drop one we just learned about.
         if (data['method'] === 'sessions.list.result') {
           const list = parseSessionsListResult(data);
-          if (list) apply(sortByCreatedDesc(list));
+          if (list) setSessions((prev) => mergeSnapshot(prev, list));
           return;
         }
 
@@ -166,7 +168,7 @@ export function useSessions(wsUrl: string | null): SessionInfo[] {
         ws.close();
       }
     };
-  }, [wsUrl, apply]);
+  }, [wsUrl]);
 
   return sessions;
 }
@@ -224,4 +226,39 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 
 function sortByCreatedDesc(list: SessionInfo[]): SessionInfo[] {
   return [...list].sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}
+
+/**
+ * Merges a fresh sessions.list snapshot into the current state, keyed by
+ * sessionId, so live events that arrived before the snapshot is delivered
+ * aren't clobbered. Rules:
+ *
+ *   - Sessions only in the snapshot are added.
+ *   - Sessions only in local state are kept (they were observed via a live
+ *     event that the daemon's snapshot pre-dated).
+ *   - For overlaps, snapshot wins on immutable fields (projectPath, model,
+ *     createdAt) but a locally-observed terminal {@code active=false} is
+ *     preserved over a snapshot {@code active=true} — the end event is
+ *     newer than the snapshot capture even if it raced ahead of delivery.
+ *
+ * Exported for unit testing.
+ */
+export function mergeSnapshot(
+  prev: SessionInfo[],
+  snapshot: SessionInfo[],
+): SessionInfo[] {
+  const merged = new Map<string, SessionInfo>();
+  for (const s of snapshot) merged.set(s.sessionId, s);
+  for (const s of prev) {
+    const fromSnap = merged.get(s.sessionId);
+    if (!fromSnap) {
+      merged.set(s.sessionId, s);
+      continue;
+    }
+    // Locally-observed end event beats snapshot's stale active=true.
+    if (!s.active && fromSnap.active) {
+      merged.set(s.sessionId, { ...fromSnap, active: false });
+    }
+  }
+  return sortByCreatedDesc([...merged.values()]);
 }

--- a/aceclaw-dashboard/src/hooks/useSessions.ts
+++ b/aceclaw-dashboard/src/hooks/useSessions.ts
@@ -27,10 +27,17 @@ export interface SessionInfo {
 }
 
 const SESSIONS_LIST_REQUEST = JSON.stringify({ method: 'sessions.list' });
+const RECONNECT_INITIAL_MS = 500;
+const RECONNECT_MAX_MS = 30_000;
 
 /**
  * Subscribes to the daemon's session set. Returns a stable array sorted by
  * createdAt descending so the most recently started session appears first.
+ *
+ * Reconnect: mirrors {@link useExecutionTree}'s exponential-backoff pattern
+ * so a daemon restart (the most common trigger in dev) doesn't leave the
+ * sidebar showing stale entries forever. Every successful reopen re-sends
+ * {@code sessions.list} so the snapshot is freshly authoritative.
  *
  * @param wsUrl daemon bridge URL — same as used by {@link useExecutionTree}.
  *              Pass {@code null} to disable the connection (e.g. while the
@@ -44,83 +51,108 @@ export function useSessions(wsUrl: string | null): SessionInfo[] {
   useEffect(() => {
     if (!wsUrl) return;
     let ws: WebSocket | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let backoffMs = RECONNECT_INITIAL_MS;
     let cancelled = false;
 
-    try {
-      ws = new WebSocket(wsUrl);
-    } catch {
-      // Malformed URL — caller should sanitise before passing in.
-      return;
-    }
-
-    ws.onopen = () => {
+    const connect = (): void => {
       if (cancelled) return;
-      ws?.send(SESSIONS_LIST_REQUEST);
-    };
-
-    ws.onmessage = (e: MessageEvent<string>) => {
-      if (cancelled) return;
-      let data: unknown;
       try {
-        data = JSON.parse(e.data);
+        ws = new WebSocket(wsUrl);
       } catch {
-        return;
-      }
-      if (!isPlainObject(data)) return;
-
-      // sessions.list.result — non-enveloped one-shot reply. Snapshot of
-      // active sessions at the moment we asked.
-      if (data['method'] === 'sessions.list.result') {
-        const list = parseSessionsListResult(data);
-        if (list) apply(sortByCreatedDesc(list));
+        // Malformed URL — caller should sanitise before passing in. No
+        // retry: the URL won't fix itself.
         return;
       }
 
-      // Otherwise it's a regular envelope; pluck the session_started /
-      // session_ended events and ignore everything else (the tree hook
-      // handles its own dispatch). Validate the shape ourselves rather
-      // than reusing useExecutionTree's parseEnvelope — we need the wider
-      // event view (no critical-field gate) so a missing optional doesn't
-      // drop the whole envelope.
-      const event = data['event'];
-      if (!isPlainObject(event)) return;
-      const method = typeof event['method'] === 'string' ? event['method'] : null;
-      const rawParams = event['params'];
-      const params: Record<string, unknown> = isPlainObject(rawParams) ? rawParams : {};
-      if (method === 'stream.session_started') {
-        const sessionId = typeof params['sessionId'] === 'string' ? params['sessionId'] : null;
-        if (!sessionId) return;
-        // The session_started event doesn't carry projectPath, so we fall
-        // back to "(unknown)" until the next sessions.list refresh — the
-        // sidebar will replace it on its next mount/reconnect.
-        const created =
-          typeof params['timestamp'] === 'string'
-            ? params['timestamp']
-            : new Date().toISOString();
-        setSessions((prev) =>
-          prev.some((s) => s.sessionId === sessionId)
-            ? prev
-            : sortByCreatedDesc([
-                ...prev,
-                {
-                  sessionId,
-                  projectPath: '(unknown)',
-                  createdAt: created,
-                  active: true,
-                },
-              ]),
-        );
-      } else if (method === 'stream.session_ended') {
-        const sessionId = typeof params['sessionId'] === 'string' ? params['sessionId'] : null;
-        if (!sessionId) return;
-        setSessions((prev) =>
-          prev.map((s) => (s.sessionId === sessionId ? { ...s, active: false } : s)),
-        );
-      }
+      ws.onopen = () => {
+        if (cancelled) return;
+        backoffMs = RECONNECT_INITIAL_MS;
+        // Re-request the snapshot on every reopen so the sidebar resyncs
+        // after a daemon restart instead of trusting stale entries.
+        ws?.send(SESSIONS_LIST_REQUEST);
+      };
+
+      ws.onmessage = (e: MessageEvent<string>) => {
+        if (cancelled) return;
+        let data: unknown;
+        try {
+          data = JSON.parse(e.data);
+        } catch {
+          return;
+        }
+        if (!isPlainObject(data)) return;
+
+        // sessions.list.result — non-enveloped one-shot reply. Snapshot of
+        // active sessions at the moment we asked.
+        if (data['method'] === 'sessions.list.result') {
+          const list = parseSessionsListResult(data);
+          if (list) apply(sortByCreatedDesc(list));
+          return;
+        }
+
+        // Otherwise it's a regular envelope; pluck the session_started /
+        // session_ended events and ignore everything else (the tree hook
+        // handles its own dispatch). Validate the shape ourselves rather
+        // than reusing useExecutionTree's parseEnvelope — we need the wider
+        // event view (no critical-field gate) so a missing optional doesn't
+        // drop the whole envelope.
+        const event = data['event'];
+        if (!isPlainObject(event)) return;
+        const method = typeof event['method'] === 'string' ? event['method'] : null;
+        const rawParams = event['params'];
+        const params: Record<string, unknown> = isPlainObject(rawParams) ? rawParams : {};
+        if (method === 'stream.session_started') {
+          const sessionId = typeof params['sessionId'] === 'string' ? params['sessionId'] : null;
+          if (!sessionId) return;
+          // The session_started event doesn't carry projectPath, so we fall
+          // back to "(unknown)" until the next sessions.list refresh — the
+          // sidebar will replace it on its next mount/reconnect.
+          const created =
+            typeof params['timestamp'] === 'string'
+              ? params['timestamp']
+              : new Date().toISOString();
+          setSessions((prev) =>
+            prev.some((s) => s.sessionId === sessionId)
+              ? prev
+              : sortByCreatedDesc([
+                  ...prev,
+                  {
+                    sessionId,
+                    projectPath: '(unknown)',
+                    createdAt: created,
+                    active: true,
+                  },
+                ]),
+          );
+        } else if (method === 'stream.session_ended') {
+          const sessionId = typeof params['sessionId'] === 'string' ? params['sessionId'] : null;
+          if (!sessionId) return;
+          setSessions((prev) =>
+            prev.map((s) => (s.sessionId === sessionId ? { ...s, active: false } : s)),
+          );
+        }
+      };
+
+      ws.onclose = () => {
+        if (cancelled) return;
+        // Schedule a reconnect with exponential backoff capped at
+        // RECONNECT_MAX_MS so a long-down daemon doesn't get hammered.
+        reconnectTimer = setTimeout(connect, backoffMs);
+        backoffMs = Math.min(backoffMs * 2, RECONNECT_MAX_MS);
+      };
+
+      ws.onerror = () => {
+        // onerror always precedes onclose for hard failures; the close
+        // handler does the reconnect, so no work needed here.
+      };
     };
+
+    connect();
 
     return () => {
       cancelled = true;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
       if (ws) {
         ws.onopen = null;
         ws.onmessage = null;

--- a/aceclaw-dashboard/src/hooks/useSessions.ts
+++ b/aceclaw-dashboard/src/hooks/useSessions.ts
@@ -24,6 +24,11 @@ export interface SessionInfo {
   /** ISO-8601 timestamp; daemon-assigned. */
   createdAt: string;
   active: boolean;
+  /**
+   * Effective model for the session (override or daemon default). Optional
+   * for forward/backward compat with daemons that don't yet emit it.
+   */
+  model?: string;
 }
 
 const SESSIONS_LIST_REQUEST = JSON.stringify({ method: 'sessions.list' });
@@ -190,6 +195,7 @@ export function parseSessionsListResult(
     const projectPath = entry['projectPath'];
     const createdAt = entry['createdAt'];
     const active = entry['active'];
+    const model = entry['model'];
     if (
       typeof sessionId !== 'string' ||
       typeof projectPath !== 'string' ||
@@ -198,7 +204,16 @@ export function parseSessionsListResult(
     ) {
       continue;
     }
-    out.push({ sessionId, projectPath, createdAt, active });
+    // model is optional — drop it silently if it's the wrong type rather
+    // than failing the whole row. exactOptionalPropertyTypes forbids
+    // assigning `undefined`, so spread it conditionally.
+    out.push({
+      sessionId,
+      projectPath,
+      createdAt,
+      active,
+      ...(typeof model === 'string' ? { model } : {}),
+    });
   }
   return out;
 }

--- a/aceclaw-dashboard/src/reducers/treeReducer.ts
+++ b/aceclaw-dashboard/src/reducers/treeReducer.ts
@@ -27,6 +27,7 @@ import type {
   PlanReplannedParams,
   PlanCompletedParams,
   PlanEscalatedParams,
+  SessionEndedParams,
   SessionStartedParams,
   SubAgentEndParams,
   SubAgentStartParams,
@@ -212,6 +213,36 @@ function addSessionNode(
     ...state,
     rootNodes: [...state.rootNodes, node],
     activeNodeId: node.id,
+  };
+}
+
+function closeSessionNode(
+  state: ExecutionTree,
+  params: SessionEndedParams,
+): ExecutionTree {
+  // No-op when the ended session is not the one this tree is rendering —
+  // useExecutionTree's cross-session filter usually catches that, but the
+  // reducer is single-session by contract anyway.
+  if (params.sessionId !== state.sessionId) return state;
+  const session = state.rootNodes.find(
+    (n) => n.type === 'session' && n.id === params.sessionId,
+  );
+  if (!session) return state;
+  // Mark the session node completed; preserve any in-flight child status
+  // (the daemon already emitted turn_completed / tool_completed for those
+  // before tearing the session down).
+  return {
+    ...state,
+    rootNodes: mapNode(state.rootNodes, params.sessionId, (n) => ({
+      ...n,
+      status: 'completed' as const,
+      endTime: Date.parse(params.timestamp),
+      metadata: {
+        ...(n.metadata ?? {}),
+        endReason: params.reason,
+      },
+    })),
+    activeNodeId: null,
   };
 }
 
@@ -836,6 +867,9 @@ export function executionTreeReducer(
   switch (event.method) {
     case 'stream.session_started':
       next = addSessionNode(state, event.params);
+      break;
+    case 'stream.session_ended':
+      next = closeSessionNode(state, event.params);
       break;
     case 'stream.turn_started':
       next = addTurnNode(state, event.params);

--- a/aceclaw-dashboard/src/types/events.ts
+++ b/aceclaw-dashboard/src/types/events.ts
@@ -58,6 +58,18 @@ export interface SessionStartedParams {
   timestamp: string; // ISO-8601
 }
 
+/**
+ * stream.session_ended — emitted when {@code SessionManager.destroySession}
+ * runs (issue #445). Lets the dashboard sidebar prune closed sessions
+ * without polling. Reason mirrors the daemon's destroy reason — "destroyed"
+ * for normal close, "shutdown" if the daemon is going down, etc.
+ */
+export interface SessionEndedParams {
+  sessionId: string;
+  timestamp: string; // ISO-8601
+  reason: string;
+}
+
 /** stream.turn_started — NEW (issue #439, daemon to add in #431). */
 export interface TurnStartedParams {
   sessionId: string;
@@ -307,6 +319,7 @@ export interface PermissionResponseParams {
 export type DaemonEvent =
   // Lifecycle (NEW — daemon must add in #431)
   | { method: 'stream.session_started'; params: SessionStartedParams }
+  | { method: 'stream.session_ended'; params: SessionEndedParams }
   | { method: 'stream.turn_started'; params: TurnStartedParams }
   | { method: 'stream.turn_completed'; params: TurnCompletedParams }
   // Streaming primitives
@@ -407,6 +420,7 @@ export interface UnknownDaemonEvent {
 export const DAEMON_EMISSION_MAP = {
   // NEW — to be added by #431
   'stream.session_started': { status: 'new', emitter: 'StreamingAgentHandler#startSession' },
+  'stream.session_ended': { status: 'new', emitter: 'AceClawDaemon#sessionEndCallback' },
   'stream.turn_started': { status: 'new', emitter: 'StreamingAgentHandler#beginTurn' },
   'stream.turn_completed': { status: 'new', emitter: 'StreamingAgentHandler#endTurn' },
   'stream.plan_step_fallback': { status: 'new', emitter: 'SequentialPlanExecutor#onStepFallback' },

--- a/aceclaw-dashboard/tests/treeReducer.test.ts
+++ b/aceclaw-dashboard/tests/treeReducer.test.ts
@@ -924,6 +924,66 @@ describe('subagent.end LIFO resolution', () => {
 });
 
 // ---------------------------------------------------------------------------
+// stream.session_ended (issue #445) — close the session node, clear focus
+// ---------------------------------------------------------------------------
+
+describe('stream.session_ended', () => {
+  it('closes the matching session node and records the reason', () => {
+    let state = runAll(
+      freshTree(),
+      envelope('stream.session_started', {
+        sessionId: 'sess-1',
+        model: 'm',
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.turn_started', {
+        sessionId: 'sess-1',
+        requestId: 'req-1',
+        turnNumber: 1,
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+    );
+    expect(state.activeNodeId).toBe('req-1');
+    state = runAll(
+      state,
+      envelope('stream.session_ended', {
+        sessionId: 'sess-1',
+        timestamp: new Date(2026, 0, 1, 1).toISOString(),
+        reason: 'destroyed',
+      }),
+    );
+    const session = state.rootNodes[0]!;
+    expect(session.type).toBe('session');
+    expect(session.status).toBe('completed');
+    expect(session.metadata?.['endReason']).toBe('destroyed');
+    expect(session.endTime).toBeGreaterThan(0);
+    // Active focus is cleared — no further events apply to this session.
+    expect(state.activeNodeId).toBeNull();
+  });
+
+  it('is a no-op when the ended session does not match this tree', () => {
+    const before = runAll(
+      freshTree(),
+      envelope('stream.session_started', {
+        sessionId: 'sess-1',
+        model: 'm',
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+    );
+    const after = runAll(
+      before,
+      envelope('stream.session_ended', {
+        sessionId: 'sess-other',
+        timestamp: new Date(2026, 0, 1).toISOString(),
+        reason: 'destroyed',
+      }),
+    );
+    expect(after.rootNodes).toEqual(before.rootNodes);
+    expect(after.activeNodeId).toBe(before.activeNodeId);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Forward-compat: unknown methods are ignored, watermark still advances
 // ---------------------------------------------------------------------------
 

--- a/aceclaw-dashboard/tests/useSessions.test.ts
+++ b/aceclaw-dashboard/tests/useSessions.test.ts
@@ -123,13 +123,16 @@ describe('mergeSnapshot', () => {
     expect(merged.map((s) => s.sessionId).sort()).toEqual(['s1', 's2']);
   });
 
-  it('keeps locally-observed sessions that the snapshot pre-dated', () => {
-    // Live session_started arrived for s2 between snapshot capture and delivery.
-    const local = [session({ sessionId: 's2', createdAt: '2026-04-29T09:00:00.000Z' })];
+  it('drops local-only sessions that the snapshot omits (post-reconnect heal)', () => {
+    // After a disconnect we may have missed a stream.session_ended for s2.
+    // The fresh snapshot is authoritative on membership — keeping s2 here
+    // would leave a permanent stale "active" row that never self-corrects.
+    const local = [
+      session({ sessionId: 's2', createdAt: '2026-04-29T09:00:00.000Z', active: true }),
+    ];
     const snap = [session({ sessionId: 's1', createdAt: '2026-04-29T08:00:00.000Z' })];
     const merged = mergeSnapshot(local, snap);
-    expect(merged).toHaveLength(2);
-    expect(merged.map((s) => s.sessionId)).toEqual(['s2', 's1']); // sorted by createdAt desc
+    expect(merged.map((s) => s.sessionId)).toEqual(['s1']);
   });
 
   it("preserves a locally-observed end (active=false) over a stale snapshot active=true", () => {

--- a/aceclaw-dashboard/tests/useSessions.test.ts
+++ b/aceclaw-dashboard/tests/useSessions.test.ts
@@ -75,4 +75,34 @@ describe('parseSessionsListResult', () => {
     });
     expect(result).toHaveLength(1);
   });
+
+  it('captures the model field when present and well-typed', () => {
+    const result = parseSessionsListResult({
+      sessions: [
+        {
+          sessionId: 's1',
+          projectPath: '/a',
+          createdAt: 't',
+          active: true,
+          model: 'claude-opus-4-7',
+        },
+      ],
+    });
+    expect(result).toHaveLength(1);
+    expect(result?.[0]!.model).toBe('claude-opus-4-7');
+  });
+
+  it('omits model when the field is missing or wrong-typed (older daemons)', () => {
+    const result = parseSessionsListResult({
+      sessions: [
+        // No model field — backward-compat with daemons that don't emit it.
+        { sessionId: 's1', projectPath: '/a', createdAt: 't', active: true },
+        // Wrong type — should be dropped silently, but the row stays.
+        { sessionId: 's2', projectPath: '/b', createdAt: 't', active: true, model: 42 },
+      ],
+    });
+    expect(result).toHaveLength(2);
+    expect(result?.[0]!.model).toBeUndefined();
+    expect(result?.[1]!.model).toBeUndefined();
+  });
 });

--- a/aceclaw-dashboard/tests/useSessions.test.ts
+++ b/aceclaw-dashboard/tests/useSessions.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { parseSessionsListResult } from '../src/hooks/useSessions';
+import { mergeSnapshot, parseSessionsListResult } from '../src/hooks/useSessions';
+import type { SessionInfo } from '../src/hooks/useSessions';
+
+const session = (overrides: Partial<SessionInfo> & { sessionId: string }): SessionInfo => ({
+  sessionId: overrides.sessionId,
+  projectPath: overrides.projectPath ?? '/p',
+  createdAt: overrides.createdAt ?? '2026-04-29T08:00:00.000Z',
+  active: overrides.active ?? true,
+  ...(overrides.model !== undefined ? { model: overrides.model } : {}),
+});
 
 /**
  * Tests for the sessions.list result parser. Hook behaviour (the WebSocket
@@ -104,5 +113,63 @@ describe('parseSessionsListResult', () => {
     expect(result).toHaveLength(2);
     expect(result?.[0]!.model).toBeUndefined();
     expect(result?.[1]!.model).toBeUndefined();
+  });
+});
+
+describe('mergeSnapshot', () => {
+  it('returns the snapshot unchanged when local state is empty', () => {
+    const snap = [session({ sessionId: 's1' }), session({ sessionId: 's2' })];
+    const merged = mergeSnapshot([], snap);
+    expect(merged.map((s) => s.sessionId).sort()).toEqual(['s1', 's2']);
+  });
+
+  it('keeps locally-observed sessions that the snapshot pre-dated', () => {
+    // Live session_started arrived for s2 between snapshot capture and delivery.
+    const local = [session({ sessionId: 's2', createdAt: '2026-04-29T09:00:00.000Z' })];
+    const snap = [session({ sessionId: 's1', createdAt: '2026-04-29T08:00:00.000Z' })];
+    const merged = mergeSnapshot(local, snap);
+    expect(merged).toHaveLength(2);
+    expect(merged.map((s) => s.sessionId)).toEqual(['s2', 's1']); // sorted by createdAt desc
+  });
+
+  it("preserves a locally-observed end (active=false) over a stale snapshot active=true", () => {
+    // Race: session_ended for s1 arrived locally before sessions.list reply.
+    const local = [session({ sessionId: 's1', active: false })];
+    const snap = [session({ sessionId: 's1', active: true })];
+    const merged = mergeSnapshot(local, snap);
+    expect(merged).toHaveLength(1);
+    expect(merged[0]!.active).toBe(false);
+  });
+
+  it('lets the snapshot resolve a stale local active=true (snapshot says ended)', () => {
+    // Inverse race — local thinks active, snapshot is authoritative on ended.
+    const local = [session({ sessionId: 's1', active: true })];
+    const snap = [session({ sessionId: 's1', active: false })];
+    const merged = mergeSnapshot(local, snap);
+    expect(merged[0]!.active).toBe(false);
+  });
+
+  it('uses snapshot for immutable fields (projectPath, model, createdAt) on overlap', () => {
+    const local = [
+      session({
+        sessionId: 's1',
+        projectPath: '(unknown)', // session_started fallback
+        createdAt: '2026-04-29T09:00:00.000Z', // client clock
+        active: true,
+      }),
+    ];
+    const snap = [
+      session({
+        sessionId: 's1',
+        projectPath: '/real/path',
+        createdAt: '2026-04-29T08:59:59.000Z',
+        active: true,
+        model: 'claude-opus-4-7',
+      }),
+    ];
+    const merged = mergeSnapshot(local, snap);
+    expect(merged[0]!.projectPath).toBe('/real/path');
+    expect(merged[0]!.model).toBe('claude-opus-4-7');
+    expect(merged[0]!.createdAt).toBe('2026-04-29T08:59:59.000Z');
   });
 });

--- a/aceclaw-dashboard/tests/useSessions.test.ts
+++ b/aceclaw-dashboard/tests/useSessions.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { parseSessionsListResult } from '../src/hooks/useSessions';
+
+/**
+ * Tests for the sessions.list result parser. Hook behaviour (the WebSocket
+ * subscribe + delta path) is integration-level and lives in #438; here we
+ * pin the boundary that decides which entries the sidebar trusts.
+ */
+
+describe('parseSessionsListResult', () => {
+  it('returns null when sessions field is missing', () => {
+    expect(parseSessionsListResult({})).toBeNull();
+  });
+
+  it('returns null when sessions is not an array', () => {
+    expect(parseSessionsListResult({ sessions: {} })).toBeNull();
+    expect(parseSessionsListResult({ sessions: 'foo' })).toBeNull();
+  });
+
+  it('returns the list when every entry has the expected shape', () => {
+    const result = parseSessionsListResult({
+      sessions: [
+        {
+          sessionId: 's1',
+          projectPath: '/a/b',
+          createdAt: '2026-04-29T08:00:00.000Z',
+          active: true,
+        },
+        {
+          sessionId: 's2',
+          projectPath: '/x/y',
+          createdAt: '2026-04-29T07:00:00.000Z',
+          active: false,
+        },
+      ],
+    });
+    expect(result).toHaveLength(2);
+    expect(result?.[0]!.sessionId).toBe('s1');
+    expect(result?.[1]!.active).toBe(false);
+  });
+
+  it('drops entries with malformed types instead of failing the whole list', () => {
+    // sessionId: number, missing active flag, projectPath wrong type.
+    const result = parseSessionsListResult({
+      sessions: [
+        {
+          sessionId: 's1',
+          projectPath: '/a/b',
+          createdAt: '2026-04-29T08:00:00.000Z',
+          active: true,
+        },
+        { sessionId: 42, projectPath: '/c/d', createdAt: 't', active: true },
+        { sessionId: 's3', projectPath: '/e/f', createdAt: 't' /* no active */ },
+        { sessionId: 's4', projectPath: 99, createdAt: 't', active: false },
+      ],
+    });
+    // Only the first row is well-formed; the rest are dropped silently so a
+    // bad daemon push doesn't take the sidebar down.
+    expect(result).toHaveLength(1);
+    expect(result?.[0]!.sessionId).toBe('s1');
+  });
+
+  it('tolerates extra forward-compat fields without dropping the row', () => {
+    const result = parseSessionsListResult({
+      sessions: [
+        {
+          sessionId: 's1',
+          projectPath: '/a',
+          createdAt: 't',
+          active: true,
+          // Future-tier field — should not affect parsing.
+          tier: 3,
+        },
+      ],
+    });
+    expect(result).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Solves the "how do I know what sessions are alive" problem from #444's open question. Before this, the user had to run \`aceclaw daemon status\` in a terminal, copy a UUID, and paste it into the URL. Now the dashboard's left sidebar lists every active session live, and clicking one switches the watched tree.

## Wire format additions (#439 contract update)

| Method | Direction | Wrapper | Semantics |
|---|---|---|---|
| \`stream.session_ended\` | daemon → all | DaemonEventEnvelope | Broadcast on \`SessionManager.destroySession\`. Sidebar prunes without polling. |
| \`sessions.list\` | client → daemon | none (raw) | Snapshot request. |
| \`sessions.list.result\` | daemon → requester | none (raw) | One-shot reply, point-to-point. |

The two non-enveloped messages are intentionally outside the streaming format — they're request-response, not stream events. The \`event\` field in the envelope is reserved for things that flow with time.

## Daemon

- \`AceClawDaemon.sessionEndCallback\` now broadcasts \`stream.session_ended\` before clearing session-scoped resources. Bridge-disabled deployments skip it entirely.
- \`WebSocketBridge.setInboundHandler\` is wired to a sessions.list handler that walks \`SessionManager.activeSessions()\`, serialises \`{sessionId, projectPath, createdAt, active}\`, and replies point-to-point to the requesting \`WsContext\` (not a broadcast — other tabs don't need a copy).

## Dashboard

- New \`useSessions(wsUrl)\` hook owns its own WebSocket. On open it sends \`sessions.list\`; on every inbound frame it branches:
  - \`{method: 'sessions.list.result', sessions: […]}\` — seed/refresh
  - envelope with \`stream.session_started\` — append (placeholder \`projectPath\` since the event doesn't carry it; the next list refresh fills it in)
  - envelope with \`stream.session_ended\` — flip \`active=false\`, keep the row visible briefly so the user sees the closure
  - Two WS connections per tab (one for sessions, one for tree) is the cheapest way to keep each hook's contract narrow — the tree hook's cross-session filter would otherwise hide the sibling events.
- New \`SessionList\` component (~240px sidebar) — project-path tail, short-id, relative time, status dot. Selected session has a left border + lighter bg.
- \`App.tsx\` now renders sidebar + main content side-by-side. Selecting a session updates the URL with \`replaceState\` (back button doesn't treat session-switching as navigation history) and the existing \`useExecutionTree\` sessionId-change effect resets the tree.

## Reducer

- New \`closeSessionNode\` handler for \`stream.session_ended\`: marks the matching session-typed root as completed, records the reason in metadata, clears \`activeNodeId\`.
- No-op when the ended session isn't this tree's session — defensive; \`useExecutionTree\`'s cross-session filter already drops it but the reducer is single-session by contract.

## Tests — 7 new cases, suite at 52

| Test | What it pins |
|---|---|
| \`stream.session_ended\` matching session | session node → completed, endTime, endReason metadata, activeNodeId cleared |
| \`stream.session_ended\` cross-session | full state byte-equal except watermark |
| \`parseSessionsListResult\` missing field | null |
| \`parseSessionsListResult\` wrong type | null |
| \`parseSessionsListResult\` happy path | parsed array |
| \`parseSessionsListResult\` malformed entry | bad rows filtered, good rows kept |
| \`parseSessionsListResult\` forward-compat | extra fields don't drop the row |

Hook-level WebSocket integration is integration-territory — goes in **#438**'s E2E suite where a real daemon drives both ends.

## Verified locally

- \`./gradlew :aceclaw-daemon:test\` — daemon green
- \`npm run typecheck\` — strict + \`exactOptionalPropertyTypes\`, zero errors
- \`npm test\` — **52/52** (24 reducer + 10 parseEnvelope + 5 layout + 5 useSessions + 4 sanitiseWsUrl + 4 scaffold)
- \`npm run build\` — **138.48 KB gzipped** (was 137.06; +1.42 KB for sidebar + hook, within 200 KB ceiling)

## How to demo

1. Start daemon with WS bridge enabled and dashboard origin allowlisted (same as PR #444).
2. \`cd aceclaw-dashboard && npm run dev\`
3. Run two CLI sessions in two terminals.
4. Open \`http://localhost:5173/\` — the sidebar shows both sessions; click to switch the watched tree.
5. Run \`aceclaw-cli daemon stop\` or destroy a session — its sidebar entry's dot goes grey.

## Out of scope

- Persisting "last viewed session" across reloads (cookies / localStorage) — minor follow-up
- Editing/cancelling a session from the sidebar — separate issue if ever
- Snapshot replay on session switch — covered by **#432**
- Single-process \`aceclaw dashboard\` subcommand — **#446**

Closes #445
Refs #430, #439, #431, #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent session list sidebar with status indicators, selectable sessions, and browser-navigation persistence.
  * Live session syncing via WebSocket snapshot + incremental updates; sessions show project path, short ID, and elapsed time.
  * Daemon now supports on-demand sessions list request-response and emits explicit session-ended broadcasts so ended sessions are marked completed.

* **Tests**
  * Added tests for session-list parsing/merge logic, reducer behavior on session end, and WebSocket request-response behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->