### PR TITLE
feat(daemon,dashboard): snapshot.request endpoint for late-joining clients (#432)

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -486,32 +486,15 @@ public final class AceClawDaemon {
             // requesting client and skip the EventMultiplexer fan-out path.
             final var sessionsRef = sessionManager;
             final var mapperRef = objectMapper;
+            final var bridgeRef = this.webSocketBridge;
             this.webSocketBridge.setInboundHandler((ctx, message) -> {
                 var methodNode = message.get("method");
                 if (methodNode == null) return;
                 var method = methodNode.asText("");
-                if (!"sessions.list".equals(method)) return;
-                try {
-                    var response = mapperRef.createObjectNode();
-                    response.put("method", "sessions.list.result");
-                    var sessionsArray = mapperRef.createArrayNode();
-                    for (var session : sessionsRef.activeSessions()) {
-                        var sNode = mapperRef.createObjectNode();
-                        sNode.put("sessionId", session.id());
-                        sNode.put("projectPath", session.projectPath().toString());
-                        sNode.put("createdAt", session.createdAt().toString());
-                        sNode.put("active", session.isActive());
-                        // Mirror the model carried by stream.session_started so the
-                        // sidebar can show the active model without waiting for the
-                        // next session start. getModelForSession falls back to the
-                        // daemon default when there's no per-session override.
-                        sNode.put("model", agentHandler.getModelForSession(session.id()));
-                        sessionsArray.add(sNode);
-                    }
-                    response.set("sessions", sessionsArray);
-                    ctx.send(mapperRef.writeValueAsString(response));
-                } catch (Exception e) {
-                    log.warn("Failed to send sessions.list reply: {}", e.getMessage());
+                switch (method) {
+                    case "sessions.list" -> handleSessionsList(ctx, mapperRef, sessionsRef, agentHandler);
+                    case "snapshot.request" -> handleSnapshotRequest(ctx, message, mapperRef, bridgeRef);
+                    default -> { /* unknown method: drop */ }
                 }
             });
 
@@ -821,6 +804,13 @@ public final class AceClawDaemon {
                     log.warn("Failed to broadcast stream.session_ended for {}: {}",
                             session.id(), e.getMessage());
                 }
+                // Drop the snapshot buffer for this session (issue #432). The
+                // session_ended event was just buffered above, so a tab that
+                // opens between this point and the buffer being cleared still
+                // gets a snapshot containing session_ended; afterward the
+                // session is gone from sessionManager, so sessions.list won't
+                // surface it and snapshot.request returns an empty list.
+                bridge.clearSession(session.id());
             }
 
             if (memoryStore != null) {
@@ -2340,6 +2330,96 @@ public final class AceClawDaemon {
             case CODEBASE_INSIGHT, ANTI_PATTERN, SUCCESSFUL_STRATEGY -> true;
             default -> false;
         };
+    }
+
+    /**
+     * Replies to a {@code sessions.list} inbound message with the list of
+     * sessions currently tracked by SessionManager (issue #445). Reply is
+     * point-to-point, not envelope-wrapped — semantically a request-response,
+     * not a stream event.
+     */
+    private static void handleSessionsList(io.javalin.websocket.WsContext ctx,
+                                           ObjectMapper mapper,
+                                           SessionManager sessions,
+                                           StreamingAgentHandler handler) {
+        try {
+            var response = mapper.createObjectNode();
+            response.put("method", "sessions.list.result");
+            var sessionsArray = mapper.createArrayNode();
+            for (var session : sessions.activeSessions()) {
+                var sNode = mapper.createObjectNode();
+                sNode.put("sessionId", session.id());
+                sNode.put("projectPath", session.projectPath().toString());
+                sNode.put("createdAt", session.createdAt().toString());
+                sNode.put("active", session.isActive());
+                sNode.put("model", handler.getModelForSession(session.id()));
+                sessionsArray.add(sNode);
+            }
+            response.set("sessions", sessionsArray);
+            ctx.send(mapper.writeValueAsString(response));
+        } catch (Exception e) {
+            log.warn("Failed to send sessions.list reply: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Replies to a {@code snapshot.request} inbound message with every
+     * envelope the bridge currently holds for the requested session (issue
+     * #432). The dashboard reducer replays them to reconstruct the tree on
+     * first paint and on every reconnect, then deduplicates the live stream
+     * via the {@code lastEventId} watermark.
+     *
+     * <p>Reply shape (point-to-point, NOT envelope-wrapped):
+     * <pre>{@code
+     * {
+     *   "method": "snapshot.response",
+     *   "sessionId": "<requested>",
+     *   "lastEventId": <last envelope id in the events array, 0 if empty>,
+     *   "events": [<DaemonEventEnvelope>, ...]   // oldest → newest
+     * }
+     * }</pre>
+     *
+     * <p>An empty buffer is a valid reply, not an error: it means the session
+     * exists in SessionManager but no broadcast has happened yet, OR the
+     * session is unknown to the bridge. The dashboard treats both as "no
+     * snapshot, listen for live deltas".
+     */
+    private static void handleSnapshotRequest(io.javalin.websocket.WsContext ctx,
+                                              com.fasterxml.jackson.databind.JsonNode message,
+                                              ObjectMapper mapper,
+                                              WebSocketBridge bridge) {
+        try {
+            var paramsNode = message.get("params");
+            if (paramsNode == null || !paramsNode.has("sessionId")) {
+                log.warn("snapshot.request missing params.sessionId; dropping");
+                return;
+            }
+            var sessionId = paramsNode.get("sessionId").asText();
+            if (sessionId.isBlank()) {
+                log.warn("snapshot.request with blank sessionId; dropping");
+                return;
+            }
+            var envelopes = bridge.eventBuffer().snapshot(sessionId);
+            var response = mapper.createObjectNode();
+            response.put("method", "snapshot.response");
+            response.put("sessionId", sessionId);
+            // lastEventId is the eventId of the newest envelope in the snapshot.
+            // The dashboard uses it to drop any subsequent live event whose
+            // eventId is less-than-or-equal — those are already in the snapshot.
+            // Empty snapshot → 0, so every live event passes the dedup gate.
+            long lastEventId = envelopes.isEmpty()
+                    ? 0L
+                    : envelopes.get(envelopes.size() - 1).get("eventId").asLong();
+            response.put("lastEventId", lastEventId);
+            var eventsArray = mapper.createArrayNode();
+            for (var env : envelopes) {
+                eventsArray.add(env);
+            }
+            response.set("events", eventsArray);
+            ctx.send(mapper.writeValueAsString(response));
+        } catch (Exception e) {
+            log.warn("Failed to send snapshot.response: {}", e.getMessage());
+        }
     }
 
     private static ObjectMapper createObjectMapper() {

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/SessionEventBuffer.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/SessionEventBuffer.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -47,6 +48,48 @@ public final class SessionEventBuffer {
 
     /** Default per-session cap. 5000 envelopes ~ 1-5MB JSON per session. */
     public static final int DEFAULT_PER_SESSION_CAPACITY = 5000;
+
+    /**
+     * Methods whose envelopes the dashboard reducer relies on to build the
+     * tree's structural skeleton (root node, turn nodes, plan steps, tool
+     * boxes, subagent groups). Plain FIFO eviction when the cap is hit
+     * would drop the oldest envelope first, which is always
+     * {@code stream.session_started} — losing it means the reducer never
+     * creates a root node and the snapshot rebuilds an empty tree.
+     *
+     * <p>On overflow we evict the oldest <em>non-pinned</em> envelope so
+     * structural events survive arbitrarily long sessions while noisy
+     * high-volume events (text deltas, heartbeats, usage) get dropped
+     * first. The trade-off: a long session loses some text history from
+     * earlier turns, but the tree shape and tool calls remain intact —
+     * which is the contract the dashboard's "click into a session, see
+     * the tree" UX depends on.
+     *
+     * <p>Not pinned: {@code stream.text}, {@code stream.thinking},
+     * {@code stream.heartbeat}, {@code stream.usage},
+     * {@code stream.compaction}, {@code stream.gate} — these are either
+     * high-volume noise or terminal status the reducer doesn't replay.
+     */
+    private static final Set<String> PINNED_METHODS = Set.of(
+            "stream.session_started",
+            "stream.session_ended",
+            "stream.turn_started",
+            "stream.turn_completed",
+            "stream.plan_created",
+            "stream.plan_step_started",
+            "stream.plan_step_completed",
+            "stream.plan_step_fallback",
+            "stream.plan_replanned",
+            "stream.plan_completed",
+            "stream.plan_escalated",
+            "stream.tool_use",
+            "stream.tool_completed",
+            "stream.subagent.start",
+            "stream.subagent.end",
+            "stream.error",
+            "stream.cancelled",
+            "stream.budget_exhausted",
+            "permission.request");
 
     private final int capacity;
     private final ConcurrentHashMap<String, SessionLog> bySession = new ConcurrentHashMap<>();
@@ -119,15 +162,41 @@ public final class SessionEventBuffer {
 
         synchronized void append(ObjectNode envelope) {
             if (envelopes.size() >= capacity) {
-                envelopes.pollFirst();
+                evictOldestNonPinned();
                 if (!overflowLogged) {
                     log.warn("SessionEventBuffer overflow for session {} (cap={}); "
-                                    + "evicting oldest envelopes. Snapshot will be partial.",
+                                    + "evicting oldest non-structural envelopes. "
+                                    + "Snapshot will be partial.",
                             sessionId, capacity);
                     overflowLogged = true;
                 }
             }
             envelopes.addLast(envelope);
+        }
+
+        /**
+         * Removes the oldest envelope whose method is NOT in
+         * {@link #PINNED_METHODS}. Falls back to plain FIFO eviction when
+         * every envelope in the buffer is structural — at that point the
+         * buffer is full of session-shape events and we'd rather lose the
+         * oldest one than refuse new events. ArrayDeque's iterator runs
+         * head-to-tail (oldest → newest) and supports {@code remove}.
+         */
+        private void evictOldestNonPinned() {
+            var it = envelopes.iterator();
+            while (it.hasNext()) {
+                var env = it.next();
+                var method = env.path("event").path("method").asText("");
+                if (!PINNED_METHODS.contains(method)) {
+                    it.remove();
+                    return;
+                }
+            }
+            // All-pinned fallback. Practically impossible at the default
+            // 5000 cap (a real session generates far more text/heartbeat
+            // than structural events) but the safe fallback keeps the
+            // append path deterministic.
+            envelopes.pollFirst();
         }
 
         synchronized List<ObjectNode> snapshot() {

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/SessionEventBuffer.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/SessionEventBuffer.java
@@ -1,0 +1,137 @@
+package dev.aceclaw.daemon;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Per-session ring buffer of broadcast envelopes for the snapshot endpoint
+ * (issue #432). When a browser tab joins mid-execution (first paint, refresh,
+ * tab switch in the sidebar), it sends {@code snapshot.request} and we ship
+ * back every envelope we still hold for that session. The dashboard reducer
+ * replays them to reconstruct the tree, then deduplicates the live stream
+ * via the {@code lastEventId} watermark already wired in #435.
+ *
+ * <p>Why a buffer of envelopes and not a derived state object: the dashboard's
+ * reducer is the source of truth for "events → tree". Reproducing that logic
+ * in Java would double the surface area; shipping the events back lets the
+ * existing reducer build state once and only once. The cost is buffer size:
+ * Tier 1 sessions are interactive (minutes, hundreds of events ~ tens of KB
+ * per session) so the cap below keeps daemon memory bounded even under
+ * pathological event volume without paying the maintenance cost of a
+ * server-side reducer.
+ *
+ * <p>Capacity is per-session to keep one runaway session from evicting other
+ * sessions' history. When a session crosses the cap we drop the oldest
+ * envelope — losing pre-history is a smaller harm than refusing to record
+ * recent events. A single WARN log per session marks the first overflow so
+ * the operator can correlate dashboard "missing root" reports with bursty
+ * sessions.
+ *
+ * <p>Thread safety: an outer {@link ConcurrentHashMap} keys by sessionId; per
+ * session we hold a synchronized {@link ArrayDeque}. Broadcasts come from
+ * Jetty's WS thread pool; {@code snapshot.request} also reads from a Jetty
+ * thread; the cross-thread race is "append while iterating" which the
+ * snapshot path avoids by taking a snapshot copy under the deque's monitor.
+ */
+public final class SessionEventBuffer {
+
+    private static final Logger log = LoggerFactory.getLogger(SessionEventBuffer.class);
+
+    /** Default per-session cap. 5000 envelopes ~ 1-5MB JSON per session. */
+    public static final int DEFAULT_PER_SESSION_CAPACITY = 5000;
+
+    private final int capacity;
+    private final ConcurrentHashMap<String, SessionLog> bySession = new ConcurrentHashMap<>();
+
+    public SessionEventBuffer() {
+        this(DEFAULT_PER_SESSION_CAPACITY);
+    }
+
+    public SessionEventBuffer(int capacity) {
+        if (capacity <= 0) {
+            throw new IllegalArgumentException("capacity must be > 0; got " + capacity);
+        }
+        this.capacity = capacity;
+    }
+
+    /**
+     * Records {@code envelope} as the most recent event for {@code sessionId}.
+     * Evicts the oldest envelope if the per-session cap is reached.
+     */
+    public void append(String sessionId, ObjectNode envelope) {
+        Objects.requireNonNull(sessionId, "sessionId");
+        Objects.requireNonNull(envelope, "envelope");
+        var slot = bySession.computeIfAbsent(sessionId, k -> new SessionLog(sessionId, capacity));
+        slot.append(envelope);
+    }
+
+    /**
+     * Returns a snapshot of every envelope currently held for {@code sessionId},
+     * in insertion order (oldest → newest). Empty list when the session is
+     * unknown or has no recorded events. The list is a defensive copy so the
+     * caller can iterate without holding the deque's monitor.
+     */
+    public List<ObjectNode> snapshot(String sessionId) {
+        Objects.requireNonNull(sessionId, "sessionId");
+        var slot = bySession.get(sessionId);
+        if (slot == null) {
+            return List.of();
+        }
+        return slot.snapshot();
+    }
+
+    /**
+     * Drops every envelope held for {@code sessionId}. Called when a session
+     * leaves SessionManager so the buffer can't outlive the session's
+     * lifetime in the daemon. No-op if the session is unknown.
+     */
+    public void clear(String sessionId) {
+        Objects.requireNonNull(sessionId, "sessionId");
+        bySession.remove(sessionId);
+    }
+
+    /** Number of sessions currently tracked. Test helper. */
+    int sessionCount() {
+        return bySession.size();
+    }
+
+    private static final class SessionLog {
+        private final String sessionId;
+        private final int capacity;
+        private final Deque<ObjectNode> envelopes;
+        // First overflow per session is logged at WARN; subsequent evictions
+        // stay silent so a runaway session doesn't drown the log.
+        private boolean overflowLogged;
+
+        SessionLog(String sessionId, int capacity) {
+            this.sessionId = sessionId;
+            this.capacity = capacity;
+            this.envelopes = new ArrayDeque<>(Math.min(capacity, 256));
+        }
+
+        synchronized void append(ObjectNode envelope) {
+            if (envelopes.size() >= capacity) {
+                envelopes.pollFirst();
+                if (!overflowLogged) {
+                    log.warn("SessionEventBuffer overflow for session {} (cap={}); "
+                                    + "evicting oldest envelopes. Snapshot will be partial.",
+                            sessionId, capacity);
+                    overflowLogged = true;
+                }
+            }
+            envelopes.addLast(envelope);
+        }
+
+        synchronized List<ObjectNode> snapshot() {
+            return new ArrayList<>(envelopes);
+        }
+    }
+}

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/WebSocketBridge.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/WebSocketBridge.java
@@ -1,6 +1,7 @@
 package dev.aceclaw.daemon;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.javalin.Javalin;
 import io.javalin.websocket.WsContext;
 import org.slf4j.Logger;
@@ -86,6 +87,13 @@ public final class WebSocketBridge {
      * the {@code lastEventId} watermark.
      */
     private final AtomicLong eventIdCounter = new AtomicLong();
+    /**
+     * Per-session ring buffer of envelopes, populated on every {@link #broadcast}
+     * regardless of whether any client is currently connected. The snapshot
+     * endpoint (#432) reads this so a late-joining tab can reconstruct the
+     * tree without replaying real history.
+     */
+    private final SessionEventBuffer eventBuffer = new SessionEventBuffer();
 
     private volatile Javalin app;
     private volatile InboundHandler inboundHandler = (ctx, message) -> { /* default: drop */ };
@@ -229,12 +237,13 @@ public final class WebSocketBridge {
         // and that contract requires an unbroken sequence regardless of
         // whether any tab was connected when each event was produced.
         long eventId = eventIdCounter.incrementAndGet();
-        if (clients.isEmpty()) {
-            return;
-        }
+        // Build the envelope unconditionally — even with zero connected
+        // clients, #432 needs the buffer populated so a tab that opens AFTER
+        // the event was emitted can replay it via snapshot.request.
+        ObjectNode envelope;
         String message;
         try {
-            var envelope = objectMapper.createObjectNode();
+            envelope = objectMapper.createObjectNode();
             envelope.put("eventId", eventId);
             envelope.put("sessionId", sessionId);
             envelope.put("receivedAt", Instant.now().toString());
@@ -245,6 +254,10 @@ public final class WebSocketBridge {
             message = objectMapper.writeValueAsString(envelope);
         } catch (Exception e) {
             log.warn("Failed to serialise WS broadcast for {}: {}", method, e.getMessage());
+            return;
+        }
+        eventBuffer.append(sessionId, envelope);
+        if (clients.isEmpty()) {
             return;
         }
         for (var client : clients) {
@@ -287,6 +300,27 @@ public final class WebSocketBridge {
      */
     public long currentEventId() {
         return eventIdCounter.get();
+    }
+
+    /**
+     * Returns the per-session envelope buffer that backs {@code snapshot.request}
+     * (issue #432). Daemon code reads from it via the inbound handler; tests
+     * use it to assert that broadcasts populate the buffer correctly.
+     */
+    public SessionEventBuffer eventBuffer() {
+        return eventBuffer;
+    }
+
+    /**
+     * Drops every envelope held for {@code sessionId}. The daemon calls this
+     * from {@link SessionManager}'s end callback after the
+     * {@code stream.session_ended} broadcast has been buffered, so a snapshot
+     * fetched in the brief window between session-end-broadcast and
+     * session-removal still includes the {@code session_ended} event but
+     * memory is reclaimed once the session is gone.
+     */
+    public void clearSession(String sessionId) {
+        eventBuffer.clear(sessionId);
     }
 
     /**

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/SessionEventBufferTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/SessionEventBufferTest.java
@@ -130,6 +130,53 @@ class SessionEventBufferTest {
     }
 
     @Test
+    void evictionPreservesStructuralEventsLikeSessionStarted() {
+        // The reducer needs stream.session_started to build the tree's
+        // root node. With plain FIFO eviction, the oldest envelope
+        // (which is always session_started, by daemon construction) would
+        // be evicted first whenever the buffer overflows — the dashboard
+        // would then rebuild an empty tree from a snapshot full of tools
+        // with no parent. Pinned-aware eviction targets noisy events
+        // (stream.text here) instead so structure survives.
+        var buffer = new SessionEventBuffer(3);
+        buffer.append("s1", envelopeWithMethod(1, "stream.session_started"));
+        buffer.append("s1", envelopeWithMethod(2, "stream.text"));
+        buffer.append("s1", envelopeWithMethod(3, "stream.text"));
+        // Cap=3 reached. Next append must evict — but the oldest non-pinned
+        // envelope (eventId=2) goes, NOT the oldest envelope (eventId=1).
+        buffer.append("s1", envelopeWithMethod(4, "stream.text"));
+
+        var snapshot = buffer.snapshot("s1");
+        assertThat(snapshot).hasSize(3);
+        // session_started survived eviction — first slot.
+        assertThat(snapshot.get(0).get("event").get("method").asText())
+                .isEqualTo("stream.session_started");
+        assertThat(snapshot.get(0).get("eventId").asLong()).isEqualTo(1L);
+        // The two newest text events are still there; eventId=2 was the
+        // one evicted (oldest non-pinned).
+        assertThat(snapshot.get(1).get("eventId").asLong()).isEqualTo(3L);
+        assertThat(snapshot.get(2).get("eventId").asLong()).isEqualTo(4L);
+    }
+
+    @Test
+    void evictionFallsBackToFifoWhenEveryEnvelopeIsPinned() {
+        // Pathological case: a buffer somehow holds only structural events
+        // (tool_use here, all pinned). The cap-exceed path can't preserve
+        // them all, so it degrades to FIFO — losing the oldest pinned
+        // is better than refusing new events. In production the noisy
+        // events guarantee this branch is rarely taken.
+        var buffer = new SessionEventBuffer(2);
+        buffer.append("s1", envelopeWithMethod(1, "stream.tool_use"));
+        buffer.append("s1", envelopeWithMethod(2, "stream.tool_use"));
+        buffer.append("s1", envelopeWithMethod(3, "stream.tool_use"));
+
+        var snapshot = buffer.snapshot("s1");
+        assertThat(snapshot).hasSize(2);
+        assertThat(snapshot.get(0).get("eventId").asLong()).isEqualTo(2L);
+        assertThat(snapshot.get(1).get("eventId").asLong()).isEqualTo(3L);
+    }
+
+    @Test
     void rejectsNonPositiveCapacity() {
         org.junit.jupiter.api.Assertions.assertThrows(
                 IllegalArgumentException.class, () -> new SessionEventBuffer(0));
@@ -141,6 +188,22 @@ class SessionEventBufferTest {
         var env = mapper.createObjectNode();
         env.put("eventId", id);
         env.put("sessionId", "s1");
+        return env;
+    }
+
+    /**
+     * Builds an envelope whose {@code event.method} matters to eviction
+     * (the pinning decision reads this path). The bridge always populates
+     * it; without it, the test envelope counts as "non-pinned" and
+     * eviction degrades to plain FIFO — which is what the
+     * {@link #capacityEvictsOldestEnvelopes} test relies on.
+     */
+    private com.fasterxml.jackson.databind.node.ObjectNode envelopeWithMethod(
+            long id, String method) {
+        var env = envelopeWithEventId(id);
+        var event = mapper.createObjectNode();
+        event.put("method", method);
+        env.set("event", event);
         return env;
     }
 }

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/SessionEventBufferTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/SessionEventBufferTest.java
@@ -1,0 +1,146 @@
+package dev.aceclaw.daemon;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link SessionEventBuffer}. The contract under test:
+ *
+ * <ul>
+ *   <li>Append + snapshot returns insertion-order envelopes.</li>
+ *   <li>Per-session cap evicts oldest, leaving the newest {@code capacity}.</li>
+ *   <li>{@link SessionEventBuffer#clear} drops one session without affecting
+ *       other sessions.</li>
+ *   <li>Concurrent appenders + a snapshot reader don't corrupt state or
+ *       throw {@link java.util.ConcurrentModificationException}.</li>
+ * </ul>
+ *
+ * The hot path is "broadcast in Jetty thread, snapshot in another Jetty
+ * thread" so the concurrency test exercises that exact shape.
+ */
+class SessionEventBufferTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void snapshotReturnsAppendedEnvelopesInOrder() {
+        var buffer = new SessionEventBuffer();
+        for (int i = 1; i <= 3; i++) {
+            buffer.append("s1", envelopeWithEventId(i));
+        }
+        var snapshot = buffer.snapshot("s1");
+        assertThat(snapshot).hasSize(3);
+        assertThat(snapshot.get(0).get("eventId").asLong()).isEqualTo(1);
+        assertThat(snapshot.get(2).get("eventId").asLong()).isEqualTo(3);
+    }
+
+    @Test
+    void snapshotForUnknownSessionIsEmpty() {
+        var buffer = new SessionEventBuffer();
+        assertThat(buffer.snapshot("never-seen")).isEmpty();
+    }
+
+    @Test
+    void capacityEvictsOldestEnvelopes() {
+        // cap=3 makes the eviction fence easy to assert without flooding
+        // the deque with junk.
+        var buffer = new SessionEventBuffer(3);
+        for (int i = 1; i <= 5; i++) {
+            buffer.append("s1", envelopeWithEventId(i));
+        }
+        var snapshot = buffer.snapshot("s1");
+        // Newest 3: eventId 3, 4, 5. Oldest two evicted.
+        assertThat(snapshot).hasSize(3);
+        assertThat(snapshot.get(0).get("eventId").asLong()).isEqualTo(3);
+        assertThat(snapshot.get(2).get("eventId").asLong()).isEqualTo(5);
+    }
+
+    @Test
+    void clearDropsOneSessionWithoutAffectingOthers() {
+        var buffer = new SessionEventBuffer();
+        buffer.append("s1", envelopeWithEventId(1));
+        buffer.append("s2", envelopeWithEventId(1));
+        buffer.append("s2", envelopeWithEventId(2));
+        buffer.clear("s1");
+        assertThat(buffer.snapshot("s1")).isEmpty();
+        assertThat(buffer.snapshot("s2")).hasSize(2);
+        assertThat(buffer.sessionCount()).isEqualTo(1);
+    }
+
+    @Test
+    void concurrentAppendsAndSnapshotsAreSafe() throws InterruptedException {
+        // 8 producers × 100 events = 800 envelopes total, well under the
+        // default cap (no eviction during the race). A reader thread polls
+        // snapshot() concurrently to provoke ArrayDeque iteration vs. mutation
+        // races; without the deque's monitor this would throw or return
+        // partial entries.
+        var buffer = new SessionEventBuffer();
+        var readyToStart = new CountDownLatch(1);
+        var done = new CountDownLatch(9);
+        var anyError = new AtomicInteger();
+
+        var pool = Executors.newFixedThreadPool(9);
+        try {
+            for (int p = 0; p < 8; p++) {
+                final int producerId = p;
+                pool.submit(() -> {
+                    try {
+                        readyToStart.await();
+                        for (int i = 0; i < 100; i++) {
+                            buffer.append("s1", envelopeWithEventId(producerId * 100L + i));
+                        }
+                    } catch (Throwable t) {
+                        anyError.incrementAndGet();
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            pool.submit(() -> {
+                try {
+                    readyToStart.await();
+                    while (done.getCount() > 1) {
+                        // Just iterate the snapshot — corruption would surface
+                        // here as a CME or NPE inside the deque iterator.
+                        for (var env : buffer.snapshot("s1")) {
+                            env.get("eventId");
+                        }
+                    }
+                } catch (Throwable t) {
+                    anyError.incrementAndGet();
+                } finally {
+                    done.countDown();
+                }
+            });
+            readyToStart.countDown();
+            assertThat(done.await(5, TimeUnit.SECONDS)).isTrue();
+        } finally {
+            pool.shutdownNow();
+        }
+        assertThat(anyError.get()).isZero();
+        assertThat(buffer.snapshot("s1")).hasSize(800);
+    }
+
+    @Test
+    void rejectsNonPositiveCapacity() {
+        org.junit.jupiter.api.Assertions.assertThrows(
+                IllegalArgumentException.class, () -> new SessionEventBuffer(0));
+        org.junit.jupiter.api.Assertions.assertThrows(
+                IllegalArgumentException.class, () -> new SessionEventBuffer(-1));
+    }
+
+    private com.fasterxml.jackson.databind.node.ObjectNode envelopeWithEventId(long id) {
+        var env = mapper.createObjectNode();
+        env.put("eventId", id);
+        env.put("sessionId", "s1");
+        return env;
+    }
+}

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/WebSocketBridgeTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/WebSocketBridgeTest.java
@@ -339,6 +339,153 @@ final class WebSocketBridgeTest {
         wsOther.sendClose(WebSocket.NORMAL_CLOSURE, "bye").get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
     }
 
+    @Test
+    void broadcastPopulatesEventBufferEvenWithZeroClients() throws Exception {
+        // The snapshot endpoint (#432) must work for tabs that connect AFTER
+        // an event was emitted. That means broadcast has to populate the
+        // buffer regardless of whether anyone is currently listening — the
+        // historical bug here was a clients.isEmpty() short-circuit that
+        // skipped both the send loop AND the buffer write.
+        bridge = startOnRandomPort();
+        bridge.broadcast("s1", "stream.text", java.util.Map.of("delta", "hi"));
+        bridge.broadcast("s1", "stream.text", java.util.Map.of("delta", " world"));
+
+        var snap = bridge.eventBuffer().snapshot("s1");
+        assertThat(snap).hasSize(2);
+        assertThat(snap.get(0).get("event").get("method").asText()).isEqualTo("stream.text");
+        assertThat(snap.get(0).get("eventId").asLong()).isEqualTo(1L);
+        assertThat(snap.get(1).get("eventId").asLong()).isEqualTo(2L);
+    }
+
+    @Test
+    void clearSessionDropsBufferedEnvelopes() throws Exception {
+        // Ensures the daemon's session-end callback can reclaim memory.
+        bridge = startOnRandomPort();
+        bridge.broadcast("s1", "stream.text", java.util.Map.of("delta", "hi"));
+        bridge.broadcast("s2", "stream.text", java.util.Map.of("delta", "ok"));
+        bridge.clearSession("s1");
+        assertThat(bridge.eventBuffer().snapshot("s1")).isEmpty();
+        assertThat(bridge.eventBuffer().snapshot("s2")).hasSize(1);
+    }
+
+    @Test
+    void snapshotRequestRepliesPointToPointWithBufferedEvents() throws Exception {
+        // End-to-end pin of #432's wire contract: a client sends
+        // {method:"snapshot.request", params:{sessionId}} → daemon replies
+        // {method:"snapshot.response", sessionId, lastEventId, events:[...]}.
+        // The reply lands ONLY on the requesting client (point-to-point) and
+        // contains the envelopes the bridge has buffered for that session.
+        // We wire the same handler the daemon installs in production, just
+        // inlined here so the test doesn't depend on AceClawDaemon's full
+        // wiring.
+        bridge = startOnRandomPort();
+        var bridgeRef = bridge;
+        bridge.setInboundHandler((ctx, message) -> {
+            if (!message.has("method")) return;
+            if (!"snapshot.request".equals(message.get("method").asText())) return;
+            var sessionId = message.get("params").get("sessionId").asText();
+            var envelopes = bridgeRef.eventBuffer().snapshot(sessionId);
+            try {
+                var response = objectMapper.createObjectNode();
+                response.put("method", "snapshot.response");
+                response.put("sessionId", sessionId);
+                long lastId = envelopes.isEmpty() ? 0L
+                        : envelopes.get(envelopes.size() - 1).get("eventId").asLong();
+                response.put("lastEventId", lastId);
+                var arr = objectMapper.createArrayNode();
+                for (var env : envelopes) arr.add(env);
+                response.set("events", arr);
+                ctx.send(objectMapper.writeValueAsString(response));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // Pre-populate the buffer with a session_started + a tool_use, like
+        // a tab joining mid-execution would find on the wire.
+        bridge.broadcast("s1", "stream.session_started",
+                java.util.Map.of("sessionId", "s1", "model", "claude-opus-4-7"));
+        bridge.broadcast("s1", "stream.tool_use",
+                java.util.Map.of("toolUseId", "t1", "toolName", "bash"));
+        bridge.broadcast("other-session", "stream.text",
+                java.util.Map.of("delta", "noise"));
+
+        var connected = new CountDownLatch(1);
+        bridge.addConnectionListener(_ -> connected.countDown());
+        var queue = new LinkedBlockingQueue<String>();
+        var ws = connect(queue::add);
+        assertThat(connected.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS)).isTrue();
+
+        ws.sendText("{\"method\":\"snapshot.request\",\"params\":{\"sessionId\":\"s1\"}}", true)
+                .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
+        var reply = queue.poll(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertThat(reply).isNotNull();
+        var response = objectMapper.readTree(reply);
+        assertThat(response.get("method").asText()).isEqualTo("snapshot.response");
+        assertThat(response.get("sessionId").asText()).isEqualTo("s1");
+        // Two events were broadcast for s1 → eventIds 1 and 2 (the third
+        // broadcast was for other-session and got eventId=3, but it is NOT in
+        // s1's snapshot because the buffer is keyed by sessionId).
+        var events = response.get("events");
+        assertThat(events.size()).isEqualTo(2);
+        assertThat(events.get(0).get("event").get("method").asText())
+                .isEqualTo("stream.session_started");
+        assertThat(events.get(1).get("event").get("method").asText())
+                .isEqualTo("stream.tool_use");
+        // lastEventId is the id of the newest envelope in the snapshot — the
+        // dashboard uses it to gate live deltas via eventId<=lastEventId.
+        // In the bridge's overall counter that's eventId=2 for s1's last
+        // event (the other-session broadcast got eventId=3 but doesn't show
+        // up in s1's snapshot).
+        assertThat(response.get("lastEventId").asLong()).isEqualTo(2L);
+
+        ws.sendClose(WebSocket.NORMAL_CLOSURE, "bye").get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    void snapshotRequestForUnknownSessionReturnsEmptyArray() throws Exception {
+        // Empty snapshot is a valid reply, not an error: the dashboard treats
+        // it as "nothing to replay, listen for live deltas". lastEventId=0
+        // ensures every subsequent live event passes the eventId<=lastEventId
+        // dedup gate (the bridge's eventId counter starts at 1).
+        bridge = startOnRandomPort();
+        var bridgeRef = bridge;
+        bridge.setInboundHandler((ctx, message) -> {
+            if (!"snapshot.request".equals(message.get("method").asText())) return;
+            var sessionId = message.get("params").get("sessionId").asText();
+            var envelopes = bridgeRef.eventBuffer().snapshot(sessionId);
+            try {
+                var response = objectMapper.createObjectNode();
+                response.put("method", "snapshot.response");
+                response.put("sessionId", sessionId);
+                response.put("lastEventId", envelopes.isEmpty() ? 0L
+                        : envelopes.get(envelopes.size() - 1).get("eventId").asLong());
+                response.set("events", objectMapper.createArrayNode());
+                ctx.send(objectMapper.writeValueAsString(response));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        var connected = new CountDownLatch(1);
+        bridge.addConnectionListener(_ -> connected.countDown());
+        var queue = new LinkedBlockingQueue<String>();
+        var ws = connect(queue::add);
+        assertThat(connected.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS)).isTrue();
+
+        ws.sendText("{\"method\":\"snapshot.request\",\"params\":{\"sessionId\":\"never-seen\"}}", true)
+                .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
+        var reply = queue.poll(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertThat(reply).isNotNull();
+        var response = objectMapper.readTree(reply);
+        assertThat(response.get("events").size()).isZero();
+        assertThat(response.get("lastEventId").asLong()).isZero();
+
+        ws.sendClose(WebSocket.NORMAL_CLOSURE, "bye").get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    }
+
     private WebSocketBridge startOnRandomPort() throws Exception {
         return startOnRandomPort(List.of());
     }

--- a/aceclaw-dashboard/src/components/ExecutionTree.tsx
+++ b/aceclaw-dashboard/src/components/ExecutionTree.tsx
@@ -54,12 +54,15 @@ export function ExecutionTree({ tree }: ExecutionTreeProps) {
   // they've taken control so the dashboard doesn't fight the operator's eyes.
   const userControlledRef = useRef(false);
 
-  // Auto-fit the layout into view on the first render that has a non-empty
-  // tree. We compute the scale that fits the layout into the container's
-  // bounding box (with a 10% margin), and centre it. Re-runs whenever the
-  // layout's overall bounding-box changes — typically only on the very
-  // first node arriving.
-  const layoutSignature = `${layout.width}x${layout.height}`;
+  // Auto-fit the layout into view whenever the diagram grows. Re-fitting
+  // on every new node is cheaper than letting the operator hunt for the
+  // off-screen part of an actively-growing tree. The signature includes
+  // the node count, not just the bounding box, because some events
+  // (status updates, tool_completed) don't change width/height but still
+  // mark a new "moment" the user wants in view. The {@code userControlledRef}
+  // guard below stops the auto-fit fighting the operator once they pan
+  // or zoom — autopilot yields, manual stays.
+  const layoutSignature = `${layout.width}x${layout.height}#${layout.nodes.length}`;
   const lastFitRef = useRef<string>('');
   useEffect(() => {
     if (userControlledRef.current) return;
@@ -185,6 +188,28 @@ export function ExecutionTree({ tree }: ExecutionTreeProps) {
       className="relative h-full w-full cursor-grab overflow-hidden bg-zinc-950 active:cursor-grabbing"
     >
       <svg className="h-full w-full" role="img" aria-label="execution tree">
+        {/*
+          Arrowhead marker for sequence/flow edges. Shape: a thin triangle
+          oriented along the path tangent (orient="auto") so it points
+          where the edge points, regardless of straight-line vs bezier.
+          Sized in user-space units so it scales with the SVG group's
+          transform. Fill matches GrowingEdge's SEQUENCE_STROKE so the
+          arrowhead and line look like one piece.
+        */}
+        <defs>
+          <marker
+            id="seq-arrow"
+            viewBox="0 0 10 10"
+            refX="9"
+            refY="5"
+            markerWidth="7"
+            markerHeight="7"
+            orient="auto-start-reverse"
+            markerUnits="userSpaceOnUse"
+          >
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#52525b" opacity={0.7} />
+          </marker>
+        </defs>
         <g transform={transform}>
           <AnimatePresence>
             {layout.edges.map((e) => (

--- a/aceclaw-dashboard/src/components/ExecutionTree.tsx
+++ b/aceclaw-dashboard/src/components/ExecutionTree.tsx
@@ -50,22 +50,21 @@ export function ExecutionTree({ tree }: ExecutionTreeProps) {
   const dragRef = useRef<{ startX: number; startY: number; baseX: number; baseY: number } | null>(
     null,
   );
-  // Tracks whether the user has manually interacted; auto-scroll yields once
-  // they've taken control so the dashboard doesn't fight the operator's eyes.
-  const userControlledRef = useRef(false);
-
-  // Auto-fit the layout into view whenever the diagram grows. Re-fitting
-  // on every new node is cheaper than letting the operator hunt for the
-  // off-screen part of an actively-growing tree. The signature includes
-  // the node count, not just the bounding box, because some events
-  // (status updates, tool_completed) don't change width/height but still
-  // mark a new "moment" the user wants in view. The {@code userControlledRef}
-  // guard below stops the auto-fit fighting the operator once they pan
-  // or zoom — autopilot yields, manual stays.
+  // Auto-fit the layout into view whenever the diagram grows. Streaming
+  // execution is the dashboard's reason to exist — readers want the new
+  // node in view, not buried off-screen. We skip the fit only while a
+  // pointer drag is in progress (so we don't yank the view out from under
+  // the user mid-gesture); a wheel zoom is instantaneous, so there's
+  // nothing to interrupt. After a manual pan or zoom completes, the next
+  // arriving event re-fits — that's the contract the user asked for.
+  //
+  // Signature includes node count, not just bounding box, because some
+  // events (status updates, tool_completed) don't change width×height
+  // but still mark a new "moment" the user wants in view.
   const layoutSignature = `${layout.width}x${layout.height}#${layout.nodes.length}`;
   const lastFitRef = useRef<string>('');
   useEffect(() => {
-    if (userControlledRef.current) return;
+    if (dragRef.current) return;
     if (layout.width <= 0 || layout.height <= 0) return;
     if (lastFitRef.current === layoutSignature) return;
     const el = containerRef.current;
@@ -91,10 +90,11 @@ export function ExecutionTree({ tree }: ExecutionTreeProps) {
     lastFitRef.current = layoutSignature;
   }, [layout.width, layout.height, layoutSignature]);
 
-  // Auto-scroll: smoothly recentre the active leaf as the daemon emits new
-  // events. We adjust pan only; the scale stays where the user left it.
+  // Auto-scroll: recentre the active leaf as the daemon emits new events.
+  // Adjusts pan only; the scale stays where auto-fit left it. Skipped
+  // mid-drag so the view doesn't fight the user's gesture.
   useEffect(() => {
-    if (userControlledRef.current) return;
+    if (dragRef.current) return;
     if (!tree.activeNodeId) return;
     const target = layout.nodes.find((n) => n.id === tree.activeNodeId);
     if (!target) return;
@@ -112,7 +112,6 @@ export function ExecutionTree({ tree }: ExecutionTreeProps) {
     // Stop the page from scrolling while the operator is zooming the tree.
     // React's onWheel listener is non-passive, so preventDefault is honoured.
     e.preventDefault();
-    userControlledRef.current = true;
     const delta = -e.deltaY * ZOOM_STEP;
     setViewport((prev) => {
       const next = Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, prev.scale + delta));
@@ -133,7 +132,6 @@ export function ExecutionTree({ tree }: ExecutionTreeProps) {
 
   const handlePointerDown = (e: ReactPointerEvent<HTMLDivElement>): void => {
     if (e.button !== 0) return;
-    userControlledRef.current = true;
     dragRef.current = {
       startX: e.clientX,
       startY: e.clientY,

--- a/aceclaw-dashboard/src/components/ExecutionTree.tsx
+++ b/aceclaw-dashboard/src/components/ExecutionTree.tsx
@@ -50,30 +50,31 @@ export function ExecutionTree({ tree }: ExecutionTreeProps) {
   const dragRef = useRef<{ startX: number; startY: number; baseX: number; baseY: number } | null>(
     null,
   );
-  // Auto-fit the layout into view whenever the diagram grows. Streaming
-  // execution is the dashboard's reason to exist — readers want the new
-  // node in view, not buried off-screen. We skip the fit only while a
-  // pointer drag is in progress (so we don't yank the view out from under
-  // the user mid-gesture); a wheel zoom is instantaneous, so there's
-  // nothing to interrupt. After a manual pan or zoom completes, the next
-  // arriving event re-fits — that's the contract the user asked for.
+  // Initial auto-fit: pick a scale that shows the whole tree on the first
+  // render that has content, then NEVER refit afterward. Later events
+  // pan to the active node at the chosen scale (see auto-scroll below)
+  // so the camera follows the action without zooming out to fit a
+  // growing tree — the user complaint here was "after response, don't
+  // jump back to show everything; stop where you are". A constant
+  // scale combined with active-node-following gives that.
   //
-  // Signature includes node count, not just bounding box, because some
-  // events (status updates, tool_completed) don't change width×height
-  // but still mark a new "moment" the user wants in view.
-  const layoutSignature = `${layout.width}x${layout.height}#${layout.nodes.length}`;
-  const lastFitRef = useRef<string>('');
+  // Reset on sessionId change so picking a new session re-fits to its
+  // dimensions; lastFitRef would otherwise leak the previous session's
+  // signature.
+  const lastFitRef = useRef<string | null>(null);
+  useEffect(() => {
+    lastFitRef.current = null;
+  }, [tree.sessionId]);
   useEffect(() => {
     if (dragRef.current) return;
+    if (lastFitRef.current !== null) return;
     if (layout.width <= 0 || layout.height <= 0) return;
-    if (lastFitRef.current === layoutSignature) return;
     const el = containerRef.current;
     if (!el) return;
     const { width: cw, height: ch } = el.getBoundingClientRect();
     if (cw <= 0 || ch <= 0) {
       // Container hasn't been measured yet (hidden tab, deferred layout, …).
-      // Don't mark this layout as fitted — the next render still in this
-      // size class should retry once the container becomes measurable.
+      // Leave lastFitRef null so the next render retries once measurable.
       return;
     }
     const margin = 0.9;
@@ -84,15 +85,16 @@ export function ExecutionTree({ tree }: ExecutionTreeProps) {
       x: (cw - layout.width * scale) / 2,
       y: (ch - layout.height * scale) / 2,
     });
-    // Mark this layout signature as fitted ONLY after we successfully
-    // applied a fit — otherwise an early-return above (zero container size)
-    // would permanently skip the initial fit for this size class.
-    lastFitRef.current = layoutSignature;
-  }, [layout.width, layout.height, layoutSignature]);
+    lastFitRef.current = 'fitted';
+  }, [layout.width, layout.height]);
 
-  // Auto-scroll: recentre the active leaf as the daemon emits new events.
-  // Adjusts pan only; the scale stays where auto-fit left it. Skipped
-  // mid-drag so the view doesn't fight the user's gesture.
+  // Auto-scroll: pan to the active node whenever the focus moves OR a
+  // new node arrives (layout.nodes identity changes on every reducer
+  // step, so this fires on every event the running session emits). The
+  // scale stays where the initial fit left it — no rescale per event.
+  // Once the turn completes and activeNodeId stops changing, the camera
+  // sits on the last active node and stays there: that's the "stop
+  // after response" behaviour.
   useEffect(() => {
     if (dragRef.current) return;
     if (!tree.activeNodeId) return;

--- a/aceclaw-dashboard/src/components/GrowingEdge.tsx
+++ b/aceclaw-dashboard/src/components/GrowingEdge.tsx
@@ -52,6 +52,13 @@ export function GrowingEdge({ edge }: GrowingEdgeProps) {
   const isSequence = edge.kind === 'sequence';
   const stroke = isSequence ? SEQUENCE_STROKE : STATUS_COLOR[edge.status];
   const d = isSequence ? straightPath(edge) : bezierPath(edge);
+  // Sequence edges carry a directional arrowhead so reads can tell flow
+  // direction at a glance — important once parallel tools merge into the
+  // next thinking and the eye needs to track multiple converging dashes.
+  // Containment edges don't get one: the parent-on-the-left, child-on-
+  // the-right convention plus the bezier shape already imply direction,
+  // and adding arrowheads to every containment edge would be visual noise.
+  const markerEnd = isSequence ? 'url(#seq-arrow)' : undefined;
   return (
     <motion.path
       d={d}
@@ -62,6 +69,9 @@ export function GrowingEdge({ edge }: GrowingEdgeProps) {
       initial={{ pathLength: 0, opacity: 0 }}
       animate={{ pathLength: 1, opacity: isSequence ? 0.5 : 0.85 }}
       transition={{ duration: 0.4, ease: 'easeOut' }}
+      // exactOptionalPropertyTypes: avoid passing undefined to the
+      // optional markerEnd attribute.
+      {...(markerEnd ? { markerEnd } : {})}
     />
   );
 }

--- a/aceclaw-dashboard/src/components/GrowingEdge.tsx
+++ b/aceclaw-dashboard/src/components/GrowingEdge.tsx
@@ -1,7 +1,16 @@
 /**
- * GrowingEdge — a single bezier curve between two nodes, animated to
- * "draw" itself from source to target on first appearance via Framer
- * Motion's {@code pathLength} primitive.
+ * GrowingEdge — a single edge between two nodes, animated to "draw"
+ * itself from source to target on first appearance via Framer Motion's
+ * {@code pathLength} primitive.
+ *
+ * Two visual variants keyed by {@code edge.kind}:
+ *
+ * - {@code containment} (default): solid bezier, status-coloured. Reads
+ *   as "child belongs to parent" — what the reducer's tree shape
+ *   produces.
+ * - {@code sequence}: dashed straight line in muted grey. Reads as
+ *   "this happened after that, but they're peers" — for turn-after-turn
+ *   under a session, or thinking-after-thinking across ReAct iterations.
  *
  * Edge status colour matches the TARGET node's status — readers track
  * the edge into the next state, not out of the previous one.
@@ -26,16 +35,32 @@ function bezierPath(edge: LayoutEdge): string {
   return `M ${from.x} ${from.y} C ${midX} ${from.y}, ${midX} ${to.y}, ${to.x} ${to.y}`;
 }
 
+/**
+ * Straight-line path between two points. Used for sequence edges where
+ * a curve would suggest causation (which a sequence edge specifically
+ * does NOT — it's just temporal order between siblings).
+ */
+function straightPath(edge: LayoutEdge): string {
+  const { from, to } = edge;
+  return `M ${from.x} ${from.y} L ${to.x} ${to.y}`;
+}
+
+/** Muted neutral for sequence edges so they recede behind containment edges. */
+const SEQUENCE_STROKE = '#52525b';
+
 export function GrowingEdge({ edge }: GrowingEdgeProps) {
-  const stroke = STATUS_COLOR[edge.status];
+  const isSequence = edge.kind === 'sequence';
+  const stroke = isSequence ? SEQUENCE_STROKE : STATUS_COLOR[edge.status];
+  const d = isSequence ? straightPath(edge) : bezierPath(edge);
   return (
     <motion.path
-      d={bezierPath(edge)}
+      d={d}
       stroke={stroke}
-      strokeWidth={1.75}
+      strokeWidth={isSequence ? 1.25 : 1.75}
+      strokeDasharray={isSequence ? '4 4' : undefined}
       fill="none"
       initial={{ pathLength: 0, opacity: 0 }}
-      animate={{ pathLength: 1, opacity: 0.85 }}
+      animate={{ pathLength: 1, opacity: isSequence ? 0.5 : 0.85 }}
       transition={{ duration: 0.4, ease: 'easeOut' }}
     />
   );

--- a/aceclaw-dashboard/src/components/GrowingNode.tsx
+++ b/aceclaw-dashboard/src/components/GrowingNode.tsx
@@ -9,76 +9,76 @@
  * Spring-in animation pushes the node from {@code -40px} on the x-axis up
  * to its final dagre-computed position so newly-added nodes feel like they
  * "snap in" along the flow direction.
+ *
+ * <h3>Palette: tinted-glass on dark</h3>
+ *
+ * <p>Each node renders as a translucent tinted card — accent colour at low
+ * opacity for the fill, full-opacity accent for the border. Running nodes
+ * have a higher fill alpha so they look "lit" against their muted
+ * completed siblings, without the heavy dark-jewel saturation an opaque
+ * fill would carry. The look matches modern dark-mode dashboards
+ * (Linear/Vercel/Notion) — light, airy, consistent.
+ *
+ * <p>Three node types pick distinct hue families so the eye can sort them
+ * at a glance:
+ *
+ *   - {@code tool}     — sky/emerald (the workhorse default)
+ *   - {@code thinking} — violet      (model reasoning)
+ *   - {@code text}     — amber       (final answer)
+ *
+ * Within a type, brightness/opacity contrasts running vs completed.
  */
 
 import { motion } from 'framer-motion';
 import type { LayoutNode } from '../types/tree';
 import { STATUS_COLOR, StatusIcon } from './StatusIcon';
 
-const STATUS_BG: Record<string, string> = {
-  pending: '#1e293b',
-  running: '#1e3a5f',
-  completed: '#14532d',
-  failed: '#7f1d1d',
-  paused: '#713f12',
-  cancelled: '#1f2937',
-};
-
 /**
- * Per-type palette overrides. The system is one harmonious jewel-tone
- * family at matched saturation/depth so the three node types read as
- * variants of the same look, not as clashing accents:
- *
- *   - {@code tool}     — default blue→green (runs, then succeeds)
- *   - {@code thinking} — indigo/violet     (cool jewel, model reasoning)
- *   - {@code text}     — amber/gold        (warm jewel, final answer)
- *
- * All three share the same depth (Tailwind 700/800 for running, 900/950
- * for completed) so the brightness contrast carries the running ↔ done
- * signal across types. Hue separation tells you what kind of work it
- * is. Other types fall through to {@link STATUS_BG}.
+ * Accent colour per (type, status). Used as both fill (with low opacity)
+ * and stroke (full opacity). Default branch is the tool palette —
+ * everything that isn't thinking/text inherits it.
  */
-const TYPE_BG: Partial<Record<string, Record<string, string>>> = {
+const TYPE_ACCENT: Record<string, Record<string, string>> = {
+  default: {
+    pending: '#94a3b8', // slate-400
+    running: '#60a5fa', // blue-400 — clear sky blue while active
+    completed: '#4ade80', // green-400 — fresh green when done
+    failed: '#f87171', // red-400
+    paused: '#fbbf24', // amber-400
+    cancelled: '#71717a', // zinc-500
+  },
   thinking: {
-    pending: '#312e81', // indigo-900
-    running: '#5b21b6', // violet-800 — bright while actively thinking
-    completed: '#1e1b4b', // indigo-950 — muted once the turn moves on
-    failed: '#7f1d1d',
-    paused: '#713f12',
-    cancelled: '#1f2937',
+    pending: '#a5b4fc', // indigo-300
+    running: '#a78bfa', // violet-400 — bright lavender while reasoning
+    completed: '#c4b5fd', // violet-300 — paler, recedes once sealed
+    failed: '#f87171',
+    paused: '#fbbf24',
+    cancelled: '#71717a',
   },
   text: {
-    pending: '#78350f', // amber-900
-    running: '#b45309', // amber-700 — bright while streaming response
-    completed: '#78350f', // amber-900 — muted once the turn ends
-    failed: '#7f1d1d',
-    paused: '#713f12',
-    cancelled: '#1f2937',
+    pending: '#fcd34d', // amber-300
+    running: '#fbbf24', // amber-400 — warm gold while streaming
+    completed: '#fde68a', // amber-200 — paler gold once muted
+    failed: '#f87171',
+    paused: '#fbbf24',
+    cancelled: '#71717a',
   },
 };
 
 /**
- * Per-type stroke overrides. Mirrors {@link TYPE_BG} so the border
- * outline is consistent with the fill. Falls through to the default
- * status-colour border for un-overridden types.
+ * Fill alpha per status. Running nodes pop; completed recede. The
+ * difference here, plus the colour shift between accent palettes, is
+ * what carries the running ↔ done signal — opacity contrast on a
+ * shared dark background reads as "active vs at rest" without the
+ * heaviness of fully opaque tile fills.
  */
-const TYPE_BORDER: Partial<Record<string, Record<string, string>>> = {
-  thinking: {
-    pending: '#6366f1', // indigo-500
-    running: '#a78bfa', // violet-400
-    completed: '#818cf8', // indigo-400 (muted)
-    failed: '#ef4444',
-    paused: '#f59e0b',
-    cancelled: '#71717a',
-  },
-  text: {
-    pending: '#fbbf24', // amber-400
-    running: '#f59e0b', // amber-500
-    completed: '#fcd34d', // amber-300 (muted)
-    failed: '#ef4444',
-    paused: '#f59e0b',
-    cancelled: '#71717a',
-  },
+const FILL_ALPHA: Record<string, number> = {
+  pending: 0.08,
+  running: 0.22,
+  completed: 0.12,
+  failed: 0.2,
+  paused: 0.18,
+  cancelled: 0.08,
 };
 
 interface GrowingNodeProps {
@@ -94,10 +94,15 @@ function truncate(s: string, max = 24): string {
 }
 
 export function GrowingNode({ node }: GrowingNodeProps) {
-  const typeBg = TYPE_BG[node.type]?.[node.status];
-  const typeBorder = TYPE_BORDER[node.type]?.[node.status];
-  const bg = typeBg ?? STATUS_BG[node.status] ?? STATUS_BG['pending']!;
-  const border = typeBorder ?? STATUS_COLOR[node.status];
+  const palette = TYPE_ACCENT[node.type] ?? TYPE_ACCENT['default']!;
+  // The accent picks per-type-and-status; if a type is missing a status
+  // fallback (shouldn't happen with the palette above), drop back to the
+  // default tool palette — same reason a missing-key in TYPE_ACCENT does.
+  const accent =
+    palette[node.status] ??
+    TYPE_ACCENT['default']![node.status] ??
+    STATUS_COLOR[node.status];
+  const fillAlpha = FILL_ALPHA[node.status] ?? FILL_ALPHA['pending']!;
   // Top-left corner of the node in dagre coords (it gives us centres).
   const left = node.x - node.width / 2;
   const top = node.y - node.height / 2;
@@ -112,9 +117,9 @@ export function GrowingNode({ node }: GrowingNodeProps) {
     ? {
         animate: {
           filter: [
-            `drop-shadow(0 0 2px ${border}55)`,
-            `drop-shadow(0 0 8px ${border}cc)`,
-            `drop-shadow(0 0 2px ${border}55)`,
+            `drop-shadow(0 0 2px ${accent}55)`,
+            `drop-shadow(0 0 8px ${accent}cc)`,
+            `drop-shadow(0 0 2px ${accent}55)`,
           ],
         },
         transition: {
@@ -139,8 +144,9 @@ export function GrowingNode({ node }: GrowingNodeProps) {
         width={node.width}
         height={node.height}
         rx={8}
-        fill={bg}
-        stroke={border}
+        fill={accent}
+        fillOpacity={fillAlpha}
+        stroke={accent}
         strokeWidth={1.5}
         {...pulseProps}
       />

--- a/aceclaw-dashboard/src/components/GrowingNode.tsx
+++ b/aceclaw-dashboard/src/components/GrowingNode.tsx
@@ -25,10 +25,16 @@ const STATUS_BG: Record<string, string> = {
 };
 
 /**
- * Per-type background overrides. Thinking gets a purple palette so it's
- * visually distinct from tool execution (which inherits the default
- * blue/green/red status colours) — the eye can tell at a glance which
- * boxes are model reasoning vs tool work. Other types fall through to
+ * Per-type background overrides. Each non-default type gets its own
+ * palette so the eye can tell — at a glance — what kind of work each
+ * box represents:
+ *
+ *   - {@code thinking}: indigo/violet — model reasoning
+ *   - {@code text} (response): rose/pink — final answer to the user
+ *
+ * Tool nodes inherit the default blue/green status palette (running
+ * blue → completed green) since they're the "default" work type and
+ * make up the bulk of the tree. Other types fall through to
  * {@link STATUS_BG}.
  */
 const TYPE_BG: Partial<Record<string, Record<string, string>>> = {
@@ -36,6 +42,14 @@ const TYPE_BG: Partial<Record<string, Record<string, string>>> = {
     pending: '#312e81', // indigo-900
     running: '#5b21b6', // violet-800 — bright while actively thinking
     completed: '#1e1b4b', // indigo-950 — muted once the turn moves on
+    failed: '#7f1d1d',
+    paused: '#713f12',
+    cancelled: '#1f2937',
+  },
+  text: {
+    pending: '#831843', // pink-900
+    running: '#be185d', // pink-700 — bright while streaming response
+    completed: '#831843', // pink-900 — muted once the turn ends
     failed: '#7f1d1d',
     paused: '#713f12',
     cancelled: '#1f2937',
@@ -52,6 +66,14 @@ const TYPE_BORDER: Partial<Record<string, Record<string, string>>> = {
     pending: '#6366f1', // indigo-500
     running: '#a78bfa', // violet-400
     completed: '#818cf8', // indigo-400 (muted)
+    failed: '#ef4444',
+    paused: '#f59e0b',
+    cancelled: '#71717a',
+  },
+  text: {
+    pending: '#f472b6', // pink-400
+    running: '#ec4899', // pink-500
+    completed: '#f9a8d4', // pink-300 (muted)
     failed: '#ef4444',
     paused: '#f59e0b',
     cancelled: '#71717a',

--- a/aceclaw-dashboard/src/components/GrowingNode.tsx
+++ b/aceclaw-dashboard/src/components/GrowingNode.tsx
@@ -150,7 +150,7 @@ export function GrowingNode({ node }: GrowingNodeProps) {
         strokeWidth={1.5}
         {...pulseProps}
       />
-      <StatusIcon status={node.status} cx={left + 16} cy={node.y} />
+      <StatusIcon status={node.status} cx={left + 16} cy={node.y} color={accent} />
       <text
         x={left + 30}
         y={node.y + 4}

--- a/aceclaw-dashboard/src/components/GrowingNode.tsx
+++ b/aceclaw-dashboard/src/components/GrowingNode.tsx
@@ -25,17 +25,18 @@ const STATUS_BG: Record<string, string> = {
 };
 
 /**
- * Per-type background overrides. Each non-default type gets its own
- * palette so the eye can tell — at a glance — what kind of work each
- * box represents:
+ * Per-type palette overrides. The system is one harmonious jewel-tone
+ * family at matched saturation/depth so the three node types read as
+ * variants of the same look, not as clashing accents:
  *
- *   - {@code thinking}: indigo/violet — model reasoning
- *   - {@code text} (response): rose/pink — final answer to the user
+ *   - {@code tool}     — default blue→green (runs, then succeeds)
+ *   - {@code thinking} — indigo/violet     (cool jewel, model reasoning)
+ *   - {@code text}     — amber/gold        (warm jewel, final answer)
  *
- * Tool nodes inherit the default blue/green status palette (running
- * blue → completed green) since they're the "default" work type and
- * make up the bulk of the tree. Other types fall through to
- * {@link STATUS_BG}.
+ * All three share the same depth (Tailwind 700/800 for running, 900/950
+ * for completed) so the brightness contrast carries the running ↔ done
+ * signal across types. Hue separation tells you what kind of work it
+ * is. Other types fall through to {@link STATUS_BG}.
  */
 const TYPE_BG: Partial<Record<string, Record<string, string>>> = {
   thinking: {
@@ -47,9 +48,9 @@ const TYPE_BG: Partial<Record<string, Record<string, string>>> = {
     cancelled: '#1f2937',
   },
   text: {
-    pending: '#831843', // pink-900
-    running: '#be185d', // pink-700 — bright while streaming response
-    completed: '#831843', // pink-900 — muted once the turn ends
+    pending: '#78350f', // amber-900
+    running: '#b45309', // amber-700 — bright while streaming response
+    completed: '#78350f', // amber-900 — muted once the turn ends
     failed: '#7f1d1d',
     paused: '#713f12',
     cancelled: '#1f2937',
@@ -71,9 +72,9 @@ const TYPE_BORDER: Partial<Record<string, Record<string, string>>> = {
     cancelled: '#71717a',
   },
   text: {
-    pending: '#f472b6', // pink-400
-    running: '#ec4899', // pink-500
-    completed: '#f9a8d4', // pink-300 (muted)
+    pending: '#fbbf24', // amber-400
+    running: '#f59e0b', // amber-500
+    completed: '#fcd34d', // amber-300 (muted)
     failed: '#ef4444',
     paused: '#f59e0b',
     cancelled: '#71717a',

--- a/aceclaw-dashboard/src/components/GrowingNode.tsx
+++ b/aceclaw-dashboard/src/components/GrowingNode.tsx
@@ -24,6 +24,40 @@ const STATUS_BG: Record<string, string> = {
   cancelled: '#1f2937',
 };
 
+/**
+ * Per-type background overrides. Thinking gets a purple palette so it's
+ * visually distinct from tool execution (which inherits the default
+ * blue/green/red status colours) — the eye can tell at a glance which
+ * boxes are model reasoning vs tool work. Other types fall through to
+ * {@link STATUS_BG}.
+ */
+const TYPE_BG: Partial<Record<string, Record<string, string>>> = {
+  thinking: {
+    pending: '#312e81', // indigo-900
+    running: '#5b21b6', // violet-800 — bright while actively thinking
+    completed: '#1e1b4b', // indigo-950 — muted once the turn moves on
+    failed: '#7f1d1d',
+    paused: '#713f12',
+    cancelled: '#1f2937',
+  },
+};
+
+/**
+ * Per-type stroke overrides. Mirrors {@link TYPE_BG} so the border
+ * outline is consistent with the fill. Falls through to the default
+ * status-colour border for un-overridden types.
+ */
+const TYPE_BORDER: Partial<Record<string, Record<string, string>>> = {
+  thinking: {
+    pending: '#6366f1', // indigo-500
+    running: '#a78bfa', // violet-400
+    completed: '#818cf8', // indigo-400 (muted)
+    failed: '#ef4444',
+    paused: '#f59e0b',
+    cancelled: '#71717a',
+  },
+};
+
 interface GrowingNodeProps {
   node: LayoutNode;
 }
@@ -37,8 +71,10 @@ function truncate(s: string, max = 24): string {
 }
 
 export function GrowingNode({ node }: GrowingNodeProps) {
-  const bg = STATUS_BG[node.status] ?? STATUS_BG['pending']!;
-  const border = STATUS_COLOR[node.status];
+  const typeBg = TYPE_BG[node.type]?.[node.status];
+  const typeBorder = TYPE_BORDER[node.type]?.[node.status];
+  const bg = typeBg ?? STATUS_BG[node.status] ?? STATUS_BG['pending']!;
+  const border = typeBorder ?? STATUS_COLOR[node.status];
   // Top-left corner of the node in dagre coords (it gives us centres).
   const left = node.x - node.width / 2;
   const top = node.y - node.height / 2;

--- a/aceclaw-dashboard/src/components/StatusIcon.tsx
+++ b/aceclaw-dashboard/src/components/StatusIcon.tsx
@@ -23,30 +23,37 @@ interface StatusIconProps {
   /** Centre of the icon in the parent {@code <g>}'s coordinate space. */
   cx: number;
   cy: number;
+  /**
+   * Optional override for the icon stroke/fill — lets the caller
+   * tie the glyph to the node's type-specific accent (so a completed
+   * thinking shows a violet check, a completed response an amber one)
+   * instead of every check being the same status-default green.
+   */
+  color?: string;
 }
 
-export function StatusIcon({ status, cx, cy }: StatusIconProps) {
-  const color = COLORS[status];
+export function StatusIcon({ status, cx, cy, color }: StatusIconProps) {
+  const resolved = color ?? COLORS[status];
   switch (status) {
     case 'pending':
       // Empty circle — "not started yet".
       return (
-        <circle cx={cx} cy={cy} r={5} fill="none" stroke={color} strokeWidth={1.5} />
+        <circle cx={cx} cy={cy} r={5} fill="none" stroke={resolved} strokeWidth={1.5} />
       );
     case 'running':
       // Filled circle with a thin halo — pulses via parent GrowingNode.
-      return <circle cx={cx} cy={cy} r={4.5} fill={color} />;
+      return <circle cx={cx} cy={cy} r={4.5} fill={resolved} />;
     case 'completed':
-      // Checkmark inside a green-tinted box.
+      // Checkmark inside the node's accent colour (passed in via `color`).
       return (
-        <g stroke={color} strokeWidth={1.8} fill="none" strokeLinecap="round">
+        <g stroke={resolved} strokeWidth={1.8} fill="none" strokeLinecap="round">
           <path d={`M ${cx - 4} ${cy} L ${cx - 1} ${cy + 3} L ${cx + 4} ${cy - 3}`} />
         </g>
       );
     case 'failed':
       // Cross.
       return (
-        <g stroke={color} strokeWidth={1.8} strokeLinecap="round">
+        <g stroke={resolved} strokeWidth={1.8} strokeLinecap="round">
           <line x1={cx - 4} y1={cy - 4} x2={cx + 4} y2={cy + 4} />
           <line x1={cx - 4} y1={cy + 4} x2={cx + 4} y2={cy - 4} />
         </g>
@@ -54,7 +61,7 @@ export function StatusIcon({ status, cx, cy }: StatusIconProps) {
     case 'paused':
       // Two parallel bars (pause symbol).
       return (
-        <g fill={color}>
+        <g fill={resolved}>
           <rect x={cx - 4} y={cy - 4} width={2} height={8} />
           <rect x={cx + 2} y={cy - 4} width={2} height={8} />
         </g>
@@ -62,7 +69,7 @@ export function StatusIcon({ status, cx, cy }: StatusIconProps) {
     case 'cancelled':
       // Circle with a slash through it — clearly "wasn't allowed to finish".
       return (
-        <g stroke={color} strokeWidth={1.5} fill="none">
+        <g stroke={resolved} strokeWidth={1.5} fill="none">
           <circle cx={cx} cy={cy} r={5} />
           <line x1={cx - 4} y1={cy + 4} x2={cx + 4} y2={cy - 4} />
         </g>

--- a/aceclaw-dashboard/src/hooks/useExecutionTree.ts
+++ b/aceclaw-dashboard/src/hooks/useExecutionTree.ts
@@ -179,13 +179,52 @@ export function useExecutionTree(
       ws.onopen = () => {
         backoffMs = RECONNECT_INITIAL_MS;
         setStatus('open');
-        // TODO(#432): once the snapshot endpoint exists, send
-        // { method: "snapshot.subscribe", sessionId, lastEventId: tree.lastEventId }
-        // here so the daemon replays only events the browser hasn't seen.
+        // Ask the daemon to replay every envelope it still holds for this
+        // session (issue #432). Without this, a tab opened mid-execution
+        // would only see events emitted AFTER it connected — root node,
+        // first turn, and any in-flight tools would all be missing.
+        // Reconnect after a drop also goes through this path; the reducer
+        // dedups overlap via state.lastEventId so the snapshot-then-live
+        // sequence is idempotent on either ordering.
+        ws?.send(
+          JSON.stringify({ method: 'snapshot.request', params: { sessionId } }),
+        );
       };
 
       ws.onmessage = (e: MessageEvent<string>) => {
-        const result = parseEnvelope(e.data);
+        // snapshot.response is non-enveloped (point-to-point reply, like
+        // sessions.list.result from #445). Detect and replay before falling
+        // through to the live-envelope path.
+        let data: unknown;
+        try {
+          data = JSON.parse(e.data);
+        } catch {
+          return;
+        }
+        if (
+          isPlainObject(data) &&
+          data['method'] === 'snapshot.response' &&
+          data['sessionId'] === sessionId &&
+          Array.isArray(data['events'])
+        ) {
+          for (const env of data['events']) {
+            const parsed = parseEnvelopeFromObject(env);
+            if (!parsed) continue;
+            if (parsed.sessionId !== sessionId) continue;
+            if (parsed.kind === 'unknown') {
+              setTree((prev) =>
+                prev.lastEventId >= parsed.eventId
+                  ? prev
+                  : { ...prev, lastEventId: parsed.eventId },
+              );
+              continue;
+            }
+            dispatch(parsed.envelope);
+          }
+          return;
+        }
+
+        const result = parseEnvelopeFromObject(data);
         if (!result) return;
         // Cross-session filter: the bridge broadcasts every session's events
         // to every connected client. A multi-tenant browser tab on its own
@@ -280,6 +319,16 @@ export function parseEnvelope(raw: string): ParseResult {
   } catch {
     return null;
   }
+  return parseEnvelopeFromObject(data);
+}
+
+/**
+ * Same shape and validation as {@link parseEnvelope}, but takes an
+ * already-parsed JSON value. Used by {@code snapshot.response} replay so
+ * each event in the array runs through the exact same validation gate as
+ * a live frame, without paying for a JSON round-trip per event.
+ */
+export function parseEnvelopeFromObject(data: unknown): ParseResult {
   if (!isPlainObject(data)) return null;
   const eventId = data['eventId'];
   const sessionId = data['sessionId'];

--- a/aceclaw-dashboard/src/hooks/useExecutionTree.ts
+++ b/aceclaw-dashboard/src/hooks/useExecutionTree.ts
@@ -170,6 +170,21 @@ export function useExecutionTree(
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
     let backoffMs = RECONNECT_INITIAL_MS;
     let cancelled = false;
+    // Snapshot handshake gate. While true, every live envelope arriving
+    // on the socket is BUFFERED instead of dispatched — the reducer's
+    // {@code lastEventId} watermark is the dedup gate against snapshot
+    // replay, and a live event slipping in before the snapshot lands
+    // would advance that watermark past every snapshot envelope (which
+    // are necessarily older), so all snapshot replay would be deduped
+    // and the tree would miss its structural roots. Once
+    // {@code snapshot.response} is applied we flush the queue in
+    // arrival order through the reducer (same dedup rules apply, so a
+    // queued event whose eventId is <= the snapshot watermark is
+    // correctly dropped — but events that ARE newer than the snapshot
+    // get applied normally). Reset on every reconnect, since a fresh
+    // handshake is needed for each new socket.
+    let snapshotPending = false;
+    let pendingLive: Array<DaemonEventEnvelope<DaemonEvent>> = [];
 
     const connect = (): void => {
       if (cancelled) return;
@@ -179,13 +194,15 @@ export function useExecutionTree(
       ws.onopen = () => {
         backoffMs = RECONNECT_INITIAL_MS;
         setStatus('open');
+        // Reset handshake state for this fresh socket. Reconnect after
+        // a drop runs through the same path: send snapshot.request, gate
+        // live events until the response lands, flush queue, run live.
+        snapshotPending = true;
+        pendingLive = [];
         // Ask the daemon to replay every envelope it still holds for this
         // session (issue #432). Without this, a tab opened mid-execution
         // would only see events emitted AFTER it connected — root node,
         // first turn, and any in-flight tools would all be missing.
-        // Reconnect after a drop also goes through this path; the reducer
-        // dedups overlap via state.lastEventId so the snapshot-then-live
-        // sequence is idempotent on either ordering.
         ws?.send(
           JSON.stringify({ method: 'snapshot.request', params: { sessionId } }),
         );
@@ -221,6 +238,17 @@ export function useExecutionTree(
             }
             dispatch(parsed.envelope);
           }
+          // Flush every live envelope that arrived during the snapshot
+          // wait. Order is preserved (it's just the receive order off the
+          // socket), and the reducer's dedup gate handles overlap with
+          // the snapshot — events whose eventId fell into the snapshot's
+          // range are skipped, the rest apply.
+          const queued = pendingLive;
+          pendingLive = [];
+          snapshotPending = false;
+          for (const envelope of queued) {
+            dispatch(envelope);
+          }
           return;
         }
 
@@ -234,12 +262,25 @@ export function useExecutionTree(
           // Forward-compat (Tier 2/3) methods bypass the reducer but still
           // bump the watermark — without this, #432's snapshot replay would
           // re-deliver them indefinitely whenever they're the newest events
-          // the browser saw.
+          // the browser saw. During the snapshot handshake we deliberately
+          // skip the watermark advance (and skip the event) — the snapshot
+          // path will set lastEventId via its own envelope replay, and an
+          // unknown live event arriving during the wait shouldn't poison
+          // that watermark.
+          if (snapshotPending) return;
           setTree((prev) =>
             prev.lastEventId >= result.eventId
               ? prev
               : { ...prev, lastEventId: result.eventId },
           );
+          return;
+        }
+        // GATE: hold live envelopes until snapshot replay lands, then
+        // flush them in order. Without this, a live event arriving before
+        // snapshot.response would advance lastEventId past every snapshot
+        // envelope and dedup the whole replay.
+        if (snapshotPending) {
+          pendingLive.push(result.envelope);
           return;
         }
         dispatch(result.envelope);

--- a/aceclaw-dashboard/src/hooks/useTreeLayout.ts
+++ b/aceclaw-dashboard/src/hooks/useTreeLayout.ts
@@ -41,19 +41,115 @@ const VIEWBOX_PADDING = 24;
  * the execution tree. Walks pre-order so the dagre node insertion order
  * matches event arrival order — useful when dagre's tie-breaking falls back
  * to insertion order.
+ *
+ * <p>Skips containment edges that the flow-edge pass (see
+ * {@link addReActFlowEdges}) will replace. Specifically: the second-and-later
+ * {@code thinking} children of a turn don't get a direct turn → thinking
+ * containment edge — they're reached via the flow chain
+ * (thinking[i] tools → thinking[i+1]). Same for the {@code text} response
+ * when any thinking exists. Without this skip, dagre would draw a long
+ * containment line from turn to thinking[i+1] that crosses the chain
+ * visually for no semantic gain.
  */
 function populateGraph(
   graph: dagre.graphlib.Graph,
   nodes: ExecutionNode[],
-  parentId: string | null,
+  parent: ExecutionNode | null,
 ): void {
   for (const n of nodes) {
     graph.setNode(n.id, { width: NODE_WIDTH, height: NODE_HEIGHT });
-    if (parentId !== null) {
-      graph.setEdge(parentId, n.id);
+    if (parent !== null && !shouldSkipContainment(parent, n)) {
+      graph.setEdge(parent.id, n.id);
     }
     if (n.children.length > 0) {
-      populateGraph(graph, n.children, n.id);
+      populateGraph(graph, n.children, n);
+    }
+  }
+}
+
+/**
+ * True iff the {@code child}'s containment edge from {@code parent} is
+ * redundant with a flow edge that {@link addReActFlowEdges} will add.
+ *
+ * - A non-first {@code thinking} child of a turn: the chain enters via
+ *   the previous thinking's tool outputs.
+ * - A {@code text} (response) child of a turn that has at least one
+ *   thinking sibling: the chain enters via the last thinking's tool
+ *   outputs (or the last thinking directly when it had no tools).
+ */
+function shouldSkipContainment(
+  parent: ExecutionNode,
+  child: ExecutionNode,
+): boolean {
+  if (parent.type !== 'turn') return false;
+  if (child.type === 'thinking') {
+    const firstThinking = parent.children.find((c) => c.type === 'thinking');
+    return firstThinking !== child;
+  }
+  if (child.type === 'text') {
+    return parent.children.some((c) => c.type === 'thinking');
+  }
+  return false;
+}
+
+/**
+ * Adds dashed flow edges to the graph so the dagre layout chains
+ * thinking/tool/thinking/.../response left-to-right within a turn.
+ *
+ * For each turn that has multiple thinking iterations:
+ *   - Each tool of {@code thinking[i]} gets a flow edge to
+ *     {@code thinking[i+1]}. Multiple parallel tools all merge into
+ *     the next thinking, mirroring "tool results feed the next LLM call".
+ *   - When {@code thinking[i]} has no tool children (rare — a thinking
+ *     that produced no tool_use), a direct
+ *     {@code thinking[i] → thinking[i+1]} flow edge is used instead.
+ *
+ * For the response (text node) at the end of a turn: every tool of the
+ * final thinking gets a flow edge to it, or the final thinking itself
+ * when it had no tools.
+ *
+ * Flow edges carry a {@code { flow: true }} label so the readback pass
+ * can mark them {@code kind: 'sequence'} and the renderer draws them
+ * dashed.
+ */
+function addReActFlowEdges(
+  graph: dagre.graphlib.Graph,
+  nodes: ExecutionNode[],
+): void {
+  for (const parent of nodes) {
+    if (parent.type === 'turn') {
+      const thinkings = parent.children.filter((c) => c.type === 'thinking');
+      const responses = parent.children.filter((c) => c.type === 'text');
+
+      for (let i = 0; i < thinkings.length - 1; i += 1) {
+        const curr = thinkings[i]!;
+        const next = thinkings[i + 1]!;
+        const tools = curr.children.filter((c) => c.type === 'tool');
+        if (tools.length > 0) {
+          for (const t of tools) {
+            graph.setEdge(t.id, next.id, { flow: true });
+          }
+        } else {
+          graph.setEdge(curr.id, next.id, { flow: true });
+        }
+      }
+
+      if (thinkings.length > 0 && responses.length > 0) {
+        const last = thinkings[thinkings.length - 1]!;
+        const lastTools = last.children.filter((c) => c.type === 'tool');
+        for (const r of responses) {
+          if (lastTools.length > 0) {
+            for (const t of lastTools) {
+              graph.setEdge(t.id, r.id, { flow: true });
+            }
+          } else {
+            graph.setEdge(last.id, r.id, { flow: true });
+          }
+        }
+      }
+    }
+    if (parent.children.length > 0) {
+      addReActFlowEdges(graph, parent.children);
     }
   }
 }
@@ -69,12 +165,19 @@ function flattenNodes(nodes: ExecutionNode[], out: ExecutionNode[]): void {
 }
 
 /**
- * Types whose sibling-order is semantically meaningful and worth showing
- * with a dashed sequence edge in the layout. Other types either don't
- * sequence (tools — can be parallel) or never have multiple instances
- * sharing a parent (sessions, plans).
+ * Types that get a vertical dashed sibling-sequence edge between
+ * consecutive same-type peers in {@link addSequenceEdges}. Currently
+ * only {@code turn} — turns under a session stack vertically at the
+ * same rank in LR layout, so a short vertical dashed connector is the
+ * clearest expression of "next turn".
+ *
+ * Thinking nodes used to be on this list, but their ReAct-iteration
+ * ordering is now expressed via horizontal flow edges through the tool
+ * chain (see {@link addReActFlowEdges}). Tools are excluded by design —
+ * within a thinking parent they're parallel; outside one we can't tell
+ * parallel from sequential.
  */
-const SEQUENCE_TYPES: ReadonlyArray<ExecutionNode['type']> = ['turn', 'thinking'];
+const SEQUENCE_TYPES: ReadonlyArray<ExecutionNode['type']> = ['turn'];
 
 /**
  * Walks the tree and pushes a {@code sequence}-kind edge between every
@@ -142,6 +245,7 @@ export function useTreeLayout(tree: ExecutionTree): TreeLayout {
     });
     graph.setDefaultEdgeLabel(() => ({}));
     populateGraph(graph, tree.rootNodes, null);
+    addReActFlowEdges(graph, tree.rootNodes);
     dagre.layout(graph);
 
     // Walk tree again pre-order; dagre stores positions on its internal
@@ -174,22 +278,26 @@ export function useTreeLayout(tree: ExecutionTree): TreeLayout {
       const fromY = from ? from.y : 0;
       const toX = to ? to.x - to.width / 2 : 0;
       const toY = to ? to.y : 0;
+      // Flow edges carry { flow: true } in their dagre label (set by
+      // addReActFlowEdges); containment edges have the default empty
+      // label. Detect by reading the label back.
+      const label = graph.edge(e.v, e.w) as { flow?: boolean } | undefined;
+      const kind: LayoutEdge['kind'] = label?.flow ? 'sequence' : 'containment';
       return {
         id: `${e.v}->${e.w}`,
-        kind: 'containment' as const,
+        kind,
         from: { x: fromX, y: fromY },
         to: { x: toX, y: toY },
         status: to?.status ?? 'pending',
       };
     });
 
-    // Sequence edges: dashed connectors between consecutive same-type
-    // siblings whose ordering carries meaning. Turns happen one after
-    // another under their owning session/step; thinking nodes happen one
-    // ReAct iteration after another under their owning turn. Tools are
-    // intentionally excluded — within a thinking they're parallel by
-    // construction (one LLM response), and outside one we can't tell
-    // sequential from parallel without execution-order metadata.
+    // Sibling-sequence edges (vertical dashed) between consecutive turns
+    // under a session/step — turns stack vertically at the same rank, so
+    // the connector is short and clean as a post-layout overlay.
+    // Thinking-to-thinking sequencing within a turn is handled in dagre
+    // via flow edges (see addReActFlowEdges) — those go horizontally
+    // through the tool chain and need dagre's rank-aware layout.
     addSequenceEdges(tree.rootNodes, nodesById, layoutEdges);
 
     const g = graph.graph();

--- a/aceclaw-dashboard/src/hooks/useTreeLayout.ts
+++ b/aceclaw-dashboard/src/hooks/useTreeLayout.ts
@@ -69,6 +69,53 @@ function flattenNodes(nodes: ExecutionNode[], out: ExecutionNode[]): void {
 }
 
 /**
+ * Types whose sibling-order is semantically meaningful and worth showing
+ * with a dashed sequence edge in the layout. Other types either don't
+ * sequence (tools — can be parallel) or never have multiple instances
+ * sharing a parent (sessions, plans).
+ */
+const SEQUENCE_TYPES: ReadonlyArray<ExecutionNode['type']> = ['turn', 'thinking'];
+
+/**
+ * Walks the tree and pushes a {@code sequence}-kind edge between every
+ * pair of consecutive same-type siblings whose type appears in
+ * {@link SEQUENCE_TYPES}. Coordinates are derived from the dagre layout
+ * positions: in LR layout siblings stack vertically at the same x, so
+ * the edge runs from the bottom of {@code prev} to the top of
+ * {@code curr}.
+ */
+function addSequenceEdges(
+  siblings: ExecutionNode[],
+  layoutById: Map<string, LayoutNode>,
+  out: LayoutEdge[],
+): void {
+  for (let i = 1; i < siblings.length; i += 1) {
+    const prev = siblings[i - 1]!;
+    const curr = siblings[i]!;
+    if (
+      prev.type === curr.type &&
+      SEQUENCE_TYPES.includes(prev.type as ExecutionNode['type'])
+    ) {
+      const p = layoutById.get(prev.id);
+      const c = layoutById.get(curr.id);
+      if (!p || !c) continue;
+      out.push({
+        id: `seq:${prev.id}->${curr.id}`,
+        kind: 'sequence',
+        from: { x: p.x, y: p.y + p.height / 2 },
+        to: { x: c.x, y: c.y - c.height / 2 },
+        status: c.status,
+      });
+    }
+  }
+  for (const sibling of siblings) {
+    if (sibling.children.length > 0) {
+      addSequenceEdges(sibling.children, layoutById, out);
+    }
+  }
+}
+
+/**
  * Reactive layout pass. Returns an empty layout for an empty tree (avoids
  * dagre's 0×0 viewBox edge case), otherwise the full dagre output decorated
  * with the source ExecutionNode for each LayoutNode.
@@ -129,11 +176,21 @@ export function useTreeLayout(tree: ExecutionTree): TreeLayout {
       const toY = to ? to.y : 0;
       return {
         id: `${e.v}->${e.w}`,
+        kind: 'containment' as const,
         from: { x: fromX, y: fromY },
         to: { x: toX, y: toY },
         status: to?.status ?? 'pending',
       };
     });
+
+    // Sequence edges: dashed connectors between consecutive same-type
+    // siblings whose ordering carries meaning. Turns happen one after
+    // another under their owning session/step; thinking nodes happen one
+    // ReAct iteration after another under their owning turn. Tools are
+    // intentionally excluded — within a thinking they're parallel by
+    // construction (one LLM response), and outside one we can't tell
+    // sequential from parallel without execution-order metadata.
+    addSequenceEdges(tree.rootNodes, nodesById, layoutEdges);
 
     const g = graph.graph();
     const width = g.width ?? 0;

--- a/aceclaw-dashboard/src/reducers/treeReducer.ts
+++ b/aceclaw-dashboard/src/reducers/treeReducer.ts
@@ -283,6 +283,11 @@ function addTurnNode(
     ...state,
     rootNodes,
     activeNodeId: turn.id,
+    // A new turn always starts a fresh ReAct loop — clear the thinking
+    // anchor so the first tool of this turn doesn't accidentally graft
+    // itself onto the previous turn's last thinking node.
+    currentThinkingId: null,
+    thinkingSealed: false,
     stats: { ...state.stats, totalTurns: state.stats.totalTurns + 1 },
   };
 }
@@ -311,13 +316,18 @@ function addToolNode(
   state: ExecutionTree,
   params: ToolUseParams,
 ): ExecutionTree {
-  // Tools always nest under the nearest running turn. Without one, the event
-  // arrived out of order; surface it at root so the operator sees something.
+  // Tools attach to the most recent thinking anchor under the running turn
+  // when extended thinking is enabled — that captures the ReAct semantic of
+  // "thinking is the cause, tool calls are its effects" and groups parallel
+  // tools from one LLM response under one parent. With no thinking events
+  // (e.g. extended thinking disabled), tools fall back to attaching to the
+  // turn itself, preserving the pre-thinking-anchor behaviour.
   const turn = findNearestAncestor(
     state.rootNodes,
     state.activeNodeId,
     (n) => n.type === 'turn' && n.status === 'running',
   );
+  const anchorId = state.currentThinkingId ?? (turn ? turn.id : null);
 
   const tool: ExecutionNode = {
     id: params.id,
@@ -329,21 +339,26 @@ function addToolNode(
   };
 
   let rootNodes: ExecutionNode[];
-  if (turn) {
-    // Parallel-detection: if any sibling tool is already running, mark the
-    // turn as having executed parallel work. One-way flag — once true, stays.
-    const hasRunningSibling = turn.children.some(
-      (c) => c.type === 'tool' && c.status === 'running',
-    );
-    rootNodes = mapNode(state.rootNodes, turn.id, (t) => ({
-      ...t,
-      // One-way flag: once a turn has had parallel work, we keep that record
-      // even after every tool finishes. Conditional spread because
-      // exactOptionalPropertyTypes forbids assigning `undefined` to an
-      // optional property.
-      ...(hasRunningSibling || t.parallel ? { parallel: true } : {}),
-      children: [...t.children, tool],
+  if (anchorId) {
+    // Parallel detection: a running sibling tool under the same anchor (be
+    // that the thinking or the turn) means this is a parallel call from
+    // the same LLM response. One-way flag on the turn for sidebar stats.
+    const anchorPath = findPath(state.rootNodes, anchorId);
+    const anchorNode = anchorPath ? anchorPath[anchorPath.length - 1]! : null;
+    const hasRunningSibling = anchorNode
+      ? anchorNode.children.some(
+          (c) => c.type === 'tool' && c.status === 'running',
+        )
+      : false;
+    rootNodes = mapNode(state.rootNodes, anchorId, (a) => ({
+      ...a,
+      children: [...a.children, tool],
     }));
+    if (turn && (hasRunningSibling || turn.parallel)) {
+      // Conditional spread because exactOptionalPropertyTypes forbids
+      // assigning `undefined` to an optional property.
+      rootNodes = mapNode(rootNodes, turn.id, (t) => ({ ...t, parallel: true }));
+    }
   } else {
     rootNodes = [...state.rootNodes, tool];
   }
@@ -352,6 +367,12 @@ function addToolNode(
     ...state,
     rootNodes,
     activeNodeId: tool.id,
+    // Seal the current thinking anchor: any subsequent thinking delta is
+    // from a NEW LLM call (next ReAct iteration) and should mint a new
+    // thinking node rather than concatenate into this one. Parallel
+    // tool_use events that follow within the SAME LLM call don't get a
+    // thinking delta between them, so the anchor stays valid for them.
+    thinkingSealed: true,
     stats: { ...state.stats, totalTools: state.stats.totalTools + 1 },
   };
 }
@@ -405,38 +426,43 @@ function appendTextToCurrentTurn(
   if (!turn) return state;
 
   const existing = turn.children.find((c) => c.type === 'text');
+  let rootNodes: ExecutionNode[];
   if (existing) {
-    return {
-      ...state,
-      rootNodes: mapNode(state.rootNodes, existing.id, (t) => ({
-        ...t,
-        text: (t.text ?? '') + params.delta,
-      })),
+    rootNodes = mapNode(state.rootNodes, existing.id, (t) => ({
+      ...t,
+      text: (t.text ?? '') + params.delta,
+    }));
+  } else {
+    const textNode: ExecutionNode = {
+      id: textNodeId(turn.id),
+      type: 'text',
+      status: 'running',
+      label: 'response',
+      children: [],
+      text: params.delta,
     };
+    rootNodes = appendChild(state.rootNodes, turn.id, textNode);
   }
-  const textNode: ExecutionNode = {
-    id: textNodeId(turn.id),
-    type: 'text',
-    status: 'running',
-    label: 'response',
-    children: [],
-    text: params.delta,
-  };
-  return {
-    ...state,
-    rootNodes: appendChild(state.rootNodes, turn.id, textNode),
-  };
+  // Seal the thinking anchor: a text response means the model has decided
+  // to talk rather than tool-call, so any subsequent thinking is the next
+  // ReAct iteration (or — typically — there is no next iteration).
+  return { ...state, rootNodes, thinkingSealed: true };
 }
 
 function appendThinkingToCurrentTurn(
   state: ExecutionTree,
   params: ThinkingDeltaParams,
 ): ExecutionTree {
-  // Mirrors {@link appendTextToCurrentTurn} but rolls up extended-thinking
-  // deltas into a separate {@code thinking}-typed child. The reducer used
-  // to drop these — meaning a turn that only thought (no tools, no text
-  // yet) showed up as an empty parent in the tree, which left the user
-  // wondering what the agent was doing during the visible "running" pulse.
+  // Builds a {@code thinking}-typed node under the running turn. The
+  // reducer used to drop these — meaning a turn that only thought (no
+  // tools, no text yet) showed up as an empty parent. A turn can have
+  // MULTIPLE thinking nodes, one per ReAct iteration — each iteration is a
+  // separate LLM call, and the boundary is detected via {@link
+  // ExecutionTree#thinkingSealed}: a tool_use or text delta seals the
+  // current thinking node, so the next thinking delta starts a fresh one.
+  // Parallel tool_use events from a single LLM response don't seal the
+  // anchor between themselves (no thinking delta arrives between them), so
+  // they correctly attach to the same parent.
   const turn = findNearestAncestor(
     state.rootNodes,
     state.activeNodeId,
@@ -444,18 +470,28 @@ function appendThinkingToCurrentTurn(
   );
   if (!turn) return state;
 
-  const existing = turn.children.find((c) => c.type === 'thinking');
-  if (existing) {
+  // Same iteration: append the delta to the existing thinking node.
+  if (state.currentThinkingId && !state.thinkingSealed) {
     return {
       ...state,
-      rootNodes: mapNode(state.rootNodes, existing.id, (t) => ({
+      rootNodes: mapNode(state.rootNodes, state.currentThinkingId, (t) => ({
         ...t,
         text: (t.text ?? '') + params.delta,
       })),
     };
   }
+
+  // New iteration: mint a new thinking node. Use a synthetic id keyed on
+  // the turn + an index so multiple thinking nodes per turn each get a
+  // unique id (the first uses the existing `${turnId}:thinking` id; later
+  // iterations append a counter).
+  const existingThinkingCount = countDescendantsOfType(turn, 'thinking');
+  const id =
+    existingThinkingCount === 0
+      ? thinkingNodeId(turn.id)
+      : `${thinkingNodeId(turn.id)}:${existingThinkingCount}`;
   const thinkingNode: ExecutionNode = {
-    id: thinkingNodeId(turn.id),
+    id,
     type: 'thinking',
     status: 'running',
     label: 'thinking',
@@ -465,7 +501,28 @@ function appendThinkingToCurrentTurn(
   return {
     ...state,
     rootNodes: appendChild(state.rootNodes, turn.id, thinkingNode),
+    currentThinkingId: id,
+    thinkingSealed: false,
   };
+}
+
+/**
+ * Counts every descendant of {@code root} (any depth) whose type matches.
+ * Used to mint stable unique ids for repeated-per-turn synthetic nodes
+ * (e.g. multiple thinking blocks across ReAct iterations).
+ */
+function countDescendantsOfType(
+  root: ExecutionNode,
+  type: ExecutionNode['type'],
+): number {
+  let count = 0;
+  const stack: ExecutionNode[] = [...root.children];
+  while (stack.length > 0) {
+    const n = stack.pop()!;
+    if (n.type === type) count += 1;
+    if (n.children.length > 0) stack.push(...n.children);
+  }
+  return count;
 }
 
 function addPlanSkeleton(

--- a/aceclaw-dashboard/src/reducers/treeReducer.ts
+++ b/aceclaw-dashboard/src/reducers/treeReducer.ts
@@ -307,13 +307,17 @@ function completeTurnNode(
     endTime: Date.parse(params.timestamp),
     duration: params.durationMs,
   }));
-  // After a turn completes, the active node is the parent (step / session).
-  const path = findPath(rootNodes, params.requestId) ?? [];
-  const parent = path.length >= 2 ? path[path.length - 2] : null;
+  // Don't bubble activeNodeId up to the parent (session/step) when the
+  // turn closes — that yanks the dashboard's auto-scroll back to the
+  // session box, hiding the response the user just watched stream in.
+  // Leaving activeNodeId on the last leaf makes the camera stay on the
+  // response. The auto-scroll effect re-runs because layout.nodes
+  // identity changed (turn status flipped to completed), but the
+  // target is the leaf the user was already looking at, so the pan
+  // is a no-op.
   return {
     ...state,
     rootNodes,
-    activeNodeId: parent ? parent.id : null,
   };
 }
 
@@ -462,14 +466,17 @@ function appendTextToCurrentTurn(
 
   const existing = turn.children.find((c) => c.type === 'text');
   let rootNodes: ExecutionNode[];
+  let textId: string;
   if (existing) {
+    textId = existing.id;
     rootNodes = mapNode(state.rootNodes, existing.id, (t) => ({
       ...t,
       text: (t.text ?? '') + params.delta,
     }));
   } else {
+    textId = textNodeId(turn.id);
     const textNode: ExecutionNode = {
-      id: textNodeId(turn.id),
+      id: textId,
       type: 'text',
       status: 'running',
       label: 'response',
@@ -486,10 +493,16 @@ function appendTextToCurrentTurn(
       t.status === 'running' ? { ...t, status: 'completed' as const } : t,
     );
   }
+  // Move auto-scroll focus onto the response. Without this, activeNodeId
+  // stays on the previous tool and the camera centres there while the
+  // model is actually streaming text — the user wants to watch the
+  // response form, not stare at a finished tool. Subsequent text deltas
+  // are no-ops for activeNodeId (still pointing at the same response
+  // node), so the camera sits on the response until the turn closes.
   // Seal the thinking anchor: a text response means the model has decided
   // to talk rather than tool-call, so any subsequent thinking is the next
   // ReAct iteration (or — typically — there is no next iteration).
-  return { ...state, rootNodes, thinkingSealed: true };
+  return { ...state, rootNodes, activeNodeId: textId, thinkingSealed: true };
 }
 
 function appendThinkingToCurrentTurn(

--- a/aceclaw-dashboard/src/reducers/treeReducer.ts
+++ b/aceclaw-dashboard/src/reducers/treeReducer.ts
@@ -32,6 +32,7 @@ import type {
   SubAgentEndParams,
   SubAgentStartParams,
   TextDeltaParams,
+  ThinkingDeltaParams,
   ToolCompletedParams,
   ToolUseParams,
   TurnCompletedParams,
@@ -67,6 +68,11 @@ export function stepNodeId(planId: string, stepIndex: number): string {
 /** ID for the rolled-up text-bubble child of a turn. One per turn. */
 export function textNodeId(turnId: string): string {
   return `${turnId}:text`;
+}
+
+/** ID for the rolled-up thinking-bubble child of a turn. One per turn. */
+export function thinkingNodeId(turnId: string): string {
+  return `${turnId}:thinking`;
 }
 
 // ---------------------------------------------------------------------------
@@ -419,6 +425,46 @@ function appendTextToCurrentTurn(
   return {
     ...state,
     rootNodes: appendChild(state.rootNodes, turn.id, textNode),
+  };
+}
+
+function appendThinkingToCurrentTurn(
+  state: ExecutionTree,
+  params: ThinkingDeltaParams,
+): ExecutionTree {
+  // Mirrors {@link appendTextToCurrentTurn} but rolls up extended-thinking
+  // deltas into a separate {@code thinking}-typed child. The reducer used
+  // to drop these — meaning a turn that only thought (no tools, no text
+  // yet) showed up as an empty parent in the tree, which left the user
+  // wondering what the agent was doing during the visible "running" pulse.
+  const turn = findNearestAncestor(
+    state.rootNodes,
+    state.activeNodeId,
+    (n) => n.type === 'turn' && n.status === 'running',
+  );
+  if (!turn) return state;
+
+  const existing = turn.children.find((c) => c.type === 'thinking');
+  if (existing) {
+    return {
+      ...state,
+      rootNodes: mapNode(state.rootNodes, existing.id, (t) => ({
+        ...t,
+        text: (t.text ?? '') + params.delta,
+      })),
+    };
+  }
+  const thinkingNode: ExecutionNode = {
+    id: thinkingNodeId(turn.id),
+    type: 'thinking',
+    status: 'running',
+    label: 'thinking',
+    children: [],
+    text: params.delta,
+  };
+  return {
+    ...state,
+    rootNodes: appendChild(state.rootNodes, turn.id, thinkingNode),
   };
 }
 
@@ -885,6 +931,9 @@ export function executionTreeReducer(
       break;
     case 'stream.text':
       next = appendTextToCurrentTurn(state, event.params);
+      break;
+    case 'stream.thinking':
+      next = appendThinkingToCurrentTurn(state, event.params);
       break;
     case 'stream.plan_created':
       next = addPlanSkeleton(state, event.params);

--- a/aceclaw-dashboard/src/reducers/treeReducer.ts
+++ b/aceclaw-dashboard/src/reducers/treeReducer.ts
@@ -296,8 +296,13 @@ function completeTurnNode(
   state: ExecutionTree,
   params: TurnCompletedParams,
 ): ExecutionTree {
+  // Mark the turn AND every still-running thinking/text descendant as
+  // completed. Tools manage their own status via stream.tool_completed,
+  // but thinking and text are delta-only — there's no explicit "ended"
+  // event for them, so without this sweep they'd stay in the 'running'
+  // visual state (pulsing glow) forever even after the turn is over.
   const rootNodes = mapNode(state.rootNodes, params.requestId, (n) => ({
-    ...n,
+    ...completeRunningDeltaDescendants(n),
     status: 'completed' as const,
     endTime: Date.parse(params.timestamp),
     duration: params.durationMs,
@@ -310,6 +315,25 @@ function completeTurnNode(
     rootNodes,
     activeNodeId: parent ? parent.id : null,
   };
+}
+
+/**
+ * Returns {@code node} with every descendant of type {@code thinking} or
+ * {@code text} that's still {@code running} flipped to {@code completed}.
+ * Pure recursion; preserves all other fields. Used by
+ * {@link completeTurnNode} so the turn's delta-stream children stop
+ * pulsing the moment the turn closes.
+ */
+function completeRunningDeltaDescendants(node: ExecutionNode): ExecutionNode {
+  if (node.children.length === 0) return node;
+  const updated = node.children.map((c) => {
+    const child = completeRunningDeltaDescendants(c);
+    if ((child.type === 'thinking' || child.type === 'text') && child.status === 'running') {
+      return { ...child, status: 'completed' as const };
+    }
+    return child;
+  });
+  return { ...node, children: updated };
 }
 
 function addToolNode(
@@ -361,6 +385,17 @@ function addToolNode(
     }
   } else {
     rootNodes = [...state.rootNodes, tool];
+  }
+
+  // Mark the thinking anchor as completed: the LLM has stopped thinking
+  // and is now acting. Without this, the thinking node would keep its
+  // running-status pulse indefinitely while tools execute, even though
+  // the model is no longer actively thinking. Only flip 'running' →
+  // 'completed' so we don't clobber a thinking that already failed/etc.
+  if (state.currentThinkingId) {
+    rootNodes = mapNode(rootNodes, state.currentThinkingId, (t) =>
+      t.status === 'running' ? { ...t, status: 'completed' as const } : t,
+    );
   }
 
   return {
@@ -442,6 +477,14 @@ function appendTextToCurrentTurn(
       text: params.delta,
     };
     rootNodes = appendChild(state.rootNodes, turn.id, textNode);
+  }
+  // Mark the thinking anchor as completed: text response means the LLM
+  // has stopped thinking and is now responding (mirrors the thinking →
+  // tool transition in addToolNode). Only flip running → completed.
+  if (state.currentThinkingId) {
+    rootNodes = mapNode(rootNodes, state.currentThinkingId, (t) =>
+      t.status === 'running' ? { ...t, status: 'completed' as const } : t,
+    );
   }
   // Seal the thinking anchor: a text response means the model has decided
   // to talk rather than tool-call, so any subsequent thinking is the next

--- a/aceclaw-dashboard/src/types/tree.ts
+++ b/aceclaw-dashboard/src/types/tree.ts
@@ -148,9 +148,25 @@ export interface LayoutNode extends ExecutionNode {
   height: number;
 }
 
+/**
+ * Visual semantic of an edge:
+ *
+ * - {@code containment}: parent-child relationship ("属于"). Solid stroke,
+ *   curved bezier. The reducer's tree shape produces these — every node
+ *   below the root has exactly one containment-edge in.
+ * - {@code sequence}: temporal order between same-rank siblings whose
+ *   ordering is meaningful (turns under a session, thinking nodes under
+ *   a turn). Dashed stroke, straight line. Synthesized post-layout from
+ *   sibling order — they're not in the dagre graph because forcing dagre
+ *   to honour them would push siblings into different ranks and break the
+ *   LR "siblings stack vertically" pattern.
+ */
+export type EdgeKind = 'containment' | 'sequence';
+
 /** A directional edge between two laid-out nodes. */
 export interface LayoutEdge {
   id: string;
+  kind: EdgeKind;
   from: { x: number; y: number };
   to: { x: number; y: number };
   status: ExecutionStatus;

--- a/aceclaw-dashboard/src/types/tree.ts
+++ b/aceclaw-dashboard/src/types/tree.ts
@@ -84,6 +84,24 @@ export interface ExecutionTree {
    * same tree.
    */
   nextSyntheticId: number;
+  /**
+   * The thinking node that subsequent {@code stream.tool_use} events should
+   * attach to as a child. Captures the ReAct semantic: thinking is the
+   * cause, tool calls are its effects. Parallel tools from a single LLM
+   * call share the same anchor (no thinking delta arrives between them);
+   * the next iteration's thinking delta creates a fresh node and rotates
+   * the anchor. {@code null} when no thinking has been emitted yet (e.g.
+   * extended thinking disabled) — tools fall back to attaching to the turn.
+   */
+  currentThinkingId: string | null;
+  /**
+   * True when the current {@link #currentThinkingId} has been "sealed" by a
+   * subsequent {@code tool_use} or text delta. The next thinking delta
+   * creates a new thinking node instead of appending to the sealed one,
+   * so multi-iteration ReAct turns produce one thinking node per
+   * iteration rather than one fat concatenated node per turn.
+   */
+  thinkingSealed: boolean;
   /** Aggregate counters surfaced in the UI sidebar. */
   stats: TreeStats;
 }
@@ -105,6 +123,8 @@ export function emptyTree(sessionId: string): ExecutionTree {
     activeNodeId: null,
     lastEventId: 0,
     nextSyntheticId: 1,
+    currentThinkingId: null,
+    thinkingSealed: false,
     stats: {
       totalTools: 0,
       completedTools: 0,

--- a/aceclaw-dashboard/src/types/tree.ts
+++ b/aceclaw-dashboard/src/types/tree.ts
@@ -16,7 +16,8 @@ export type ExecutionNodeType =
   | 'turn'
   | 'tool'
   | 'subagent'
-  | 'text';
+  | 'text'
+  | 'thinking';
 
 /** Lifecycle status, presentation-agnostic. */
 export type ExecutionStatus =

--- a/aceclaw-dashboard/tests/snapshotReplay.test.ts
+++ b/aceclaw-dashboard/tests/snapshotReplay.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+import { parseEnvelopeFromObject } from '../src/hooks/useExecutionTree';
+import { executionTreeReducer } from '../src/reducers/treeReducer';
+import { emptyTree } from '../src/types/tree';
+
+/**
+ * Pins the snapshot replay path (issue #432). The hook's WebSocket plumbing
+ * itself is integration-level (jsdom + mock ws) and lives in #438; here we
+ * verify the boundary that decides:
+ *
+ *   - Each envelope inside a {@code snapshot.response} array goes through
+ *     the same validator gate as a live frame (no second code path that
+ *     could drift from {@link parseEnvelope}).
+ *   - Replaying a snapshot through the reducer produces the same tree
+ *     state as if those envelopes had arrived live, including
+ *     {@code state.lastEventId} matching the newest envelope's id.
+ *   - A subsequent live event with {@code eventId <= lastEventId} is
+ *     deduped (the reducer's existing guard, exercised here so the
+ *     contract between snapshot and live stream is locked).
+ */
+
+function buildEnvelope(
+  eventId: number,
+  sessionId: string,
+  method: string,
+  params: Record<string, unknown>,
+) {
+  return {
+    eventId,
+    sessionId,
+    receivedAt: '2026-04-29T00:00:00.000Z',
+    event: { method, params },
+  };
+}
+
+describe('snapshot replay (#432)', () => {
+  it('replays a session_started + tool_use snapshot into a tree the dispatcher can extend', () => {
+    const envelopes = [
+      buildEnvelope(1, 'sess-1', 'stream.session_started', {
+        sessionId: 'sess-1',
+        model: 'claude-opus-4-7',
+      }),
+      buildEnvelope(2, 'sess-1', 'stream.turn_started', {
+        requestId: 'r1',
+        turnNumber: 1,
+      }),
+      buildEnvelope(3, 'sess-1', 'stream.tool_use', {
+        id: 't1',
+        name: 'bash',
+      }),
+    ];
+
+    let tree = emptyTree('sess-1');
+    for (const env of envelopes) {
+      const parsed = parseEnvelopeFromObject(env);
+      expect(parsed).not.toBeNull();
+      if (parsed?.kind === 'known') {
+        tree = executionTreeReducer(tree, parsed.envelope);
+      }
+    }
+
+    expect(tree.lastEventId).toBe(3);
+    // Every replayed envelope produced its tree contribution: a session
+    // root, a turn child, and an in-flight tool node.
+    expect(tree.rootNodes.find((n) => n.type === 'session')).toBeDefined();
+    expect(tree.stats.totalTurns).toBe(1);
+    expect(tree.stats.totalTools).toBe(1);
+  });
+
+  it('dedups a live event whose eventId is at or below the snapshot watermark', () => {
+    // Snapshot delivered: events 1..3, lastEventId=3. Then a live frame
+    // with eventId=3 arrives — daemon hasn't dropped it yet because the
+    // bridge fans out to every connected client without a per-client
+    // ack. Reducer must skip it instead of double-applying.
+    const snapshot = [
+      buildEnvelope(1, 'sess-1', 'stream.session_started', {
+        sessionId: 'sess-1',
+        model: 'claude-opus-4-7',
+      }),
+      buildEnvelope(2, 'sess-1', 'stream.turn_started', {
+        requestId: 'r1',
+        turnNumber: 1,
+      }),
+      buildEnvelope(3, 'sess-1', 'stream.tool_use', {
+        id: 't1',
+        name: 'bash',
+      }),
+    ];
+    let tree = emptyTree('sess-1');
+    for (const env of snapshot) {
+      const parsed = parseEnvelopeFromObject(env);
+      if (parsed?.kind === 'known') {
+        tree = executionTreeReducer(tree, parsed.envelope);
+      }
+    }
+
+    const liveDup = parseEnvelopeFromObject(
+      buildEnvelope(3, 'sess-1', 'stream.tool_use', {
+        id: 't1',
+        name: 'bash',
+      }),
+    );
+    expect(liveDup?.kind).toBe('known');
+    if (liveDup?.kind === 'known') {
+      const next = executionTreeReducer(tree, liveDup.envelope);
+      // Tree state unchanged because the dedup gate fires.
+      expect(next).toBe(tree);
+      expect(next.stats.totalTools).toBe(1);
+    }
+  });
+
+  it('applies a live event whose eventId is strictly above the snapshot watermark', () => {
+    // Same snapshot as above. A new live event (eventId=4) gets through.
+    const snapshot = [
+      buildEnvelope(1, 'sess-1', 'stream.session_started', {
+        sessionId: 'sess-1',
+        model: 'claude-opus-4-7',
+      }),
+      buildEnvelope(2, 'sess-1', 'stream.turn_started', {
+        requestId: 'r1',
+        turnNumber: 1,
+      }),
+    ];
+    let tree = emptyTree('sess-1');
+    for (const env of snapshot) {
+      const parsed = parseEnvelopeFromObject(env);
+      if (parsed?.kind === 'known') {
+        tree = executionTreeReducer(tree, parsed.envelope);
+      }
+    }
+    expect(tree.lastEventId).toBe(2);
+
+    const liveNew = parseEnvelopeFromObject(
+      buildEnvelope(4, 'sess-1', 'stream.tool_use', {
+        id: 't1',
+        name: 'bash',
+      }),
+    );
+    if (liveNew?.kind === 'known') {
+      const next = executionTreeReducer(tree, liveNew.envelope);
+      expect(next.lastEventId).toBe(4);
+      expect(next.stats.totalTools).toBe(1);
+    }
+  });
+
+  it('rejects malformed envelopes inside a snapshot the same way live frames are rejected', () => {
+    // A daemon-side bug that put a non-string eventId on the wire would
+    // otherwise leak past parseEnvelopeFromObject and crash the reducer.
+    expect(
+      parseEnvelopeFromObject({
+        eventId: 'one',
+        sessionId: 's',
+        receivedAt: 't',
+        event: { method: 'stream.text', params: {} },
+      }),
+    ).toBeNull();
+    expect(
+      parseEnvelopeFromObject({
+        eventId: 1,
+        sessionId: 's',
+        receivedAt: 't',
+        event: { method: 'stream.tool_use', params: { id: 't1' /* missing name */ } },
+      }),
+    ).toBeNull();
+  });
+
+  it('returns kind=unknown for forward-compat methods so callers can advance the watermark', () => {
+    // Snapshot may include events whose method we don't know yet (Tier
+    // 2/3 events the dashboard wasn't built to render). The reducer
+    // skips them, but the hook caller still bumps lastEventId so the
+    // next reconnect doesn't re-replay them forever.
+    const parsed = parseEnvelopeFromObject(
+      buildEnvelope(7, 'sess-1', 'stream.future_event', { foo: 'bar' }),
+    );
+    expect(parsed?.kind).toBe('unknown');
+    expect(parsed?.eventId).toBe(7);
+  });
+});

--- a/aceclaw-dashboard/tests/treeReducer.test.ts
+++ b/aceclaw-dashboard/tests/treeReducer.test.ts
@@ -554,6 +554,59 @@ describe('text accumulation', () => {
     );
     expect(state.rootNodes).toHaveLength(0);
   });
+
+  it('rolls thinking deltas into a single thinking child of the running turn', () => {
+    // The reducer used to drop stream.thinking entirely (missing case in
+    // the switch), so a turn that thought before tool-using showed up as
+    // an empty parent. Mirrors the text behaviour: one thinking node per
+    // turn, deltas concatenate.
+    const state = runAll(
+      freshTree(),
+      envelope('stream.session_started', {
+        sessionId: 'sess-1',
+        model: 'm',
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.turn_started', {
+        sessionId: 'sess-1',
+        requestId: 'req-1',
+        turnNumber: 1,
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.thinking', { delta: 'Let me ' }),
+      envelope('stream.thinking', { delta: 'consider…' }),
+    );
+    const turn = state.rootNodes[0]!.children[0]!;
+    const thinkingChildren = turn.children.filter((c) => c.type === 'thinking');
+    expect(thinkingChildren).toHaveLength(1);
+    expect(thinkingChildren[0]!.text).toBe('Let me consider…');
+    expect(thinkingChildren[0]!.label).toBe('thinking');
+  });
+
+  it('keeps thinking and text as siblings under the same turn', () => {
+    // A real turn often thinks then responds; both nodes should hang off
+    // the turn so the layout shows two distinct children rather than one
+    // collapsing into the other.
+    const state = runAll(
+      freshTree(),
+      envelope('stream.session_started', {
+        sessionId: 'sess-1',
+        model: 'm',
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.turn_started', {
+        sessionId: 'sess-1',
+        requestId: 'req-1',
+        turnNumber: 1,
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.thinking', { delta: 'reasoning' }),
+      envelope('stream.text', { delta: 'response' }),
+    );
+    const turn = state.rootNodes[0]!.children[0]!;
+    const childTypes = turn.children.map((c) => c.type).sort();
+    expect(childTypes).toEqual(['text', 'thinking']);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/aceclaw-dashboard/tests/treeReducer.test.ts
+++ b/aceclaw-dashboard/tests/treeReducer.test.ts
@@ -714,6 +714,7 @@ describe('thinking-anchored tool grouping (ReAct iterations)', () => {
         turnNumber: 1,
         timestamp: new Date(2026, 0, 1).toISOString(),
         durationMs: 100,
+        toolCount: 1,
       }),
       envelope('stream.turn_started', {
         sessionId: 'sess-1',

--- a/aceclaw-dashboard/tests/treeReducer.test.ts
+++ b/aceclaw-dashboard/tests/treeReducer.test.ts
@@ -688,6 +688,56 @@ describe('thinking-anchored tool grouping (ReAct iterations)', () => {
     expect(thinkingChildren[1]!.children.map((c) => c.id)).toEqual(['t2']);
   });
 
+  it('marks the thinking node completed when a tool_use seals it', () => {
+    // Without this transition, the thinking node keeps its 'running'
+    // status (and the renderer's pulse animation) indefinitely while
+    // tools execute — the user's "thinking 不停 thinking 了就别闪了"
+    // complaint.
+    const state = runAll(
+      startedTurn(),
+      envelope('stream.thinking', { delta: 'reasoning' }),
+      envelope('stream.tool_use', { id: 't1', name: 'bash' }),
+    );
+    const turn = state.rootNodes[0]!.children[0]!;
+    const thinking = turn.children.find((c) => c.type === 'thinking')!;
+    expect(thinking.status).toBe('completed');
+  });
+
+  it('marks the thinking node completed when a text response seals it', () => {
+    const state = runAll(
+      startedTurn(),
+      envelope('stream.thinking', { delta: 'about to respond' }),
+      envelope('stream.text', { delta: 'hi' }),
+    );
+    const turn = state.rootNodes[0]!.children[0]!;
+    const thinking = turn.children.find((c) => c.type === 'thinking')!;
+    expect(thinking.status).toBe('completed');
+  });
+
+  it('marks remaining running thinking/text nodes completed when the turn ends', () => {
+    // Edge case: a turn ends while a delta-stream child is still
+    // 'running' (for example, the model emitted thinking but the turn
+    // closed before any tool_use/text ever sealed it). turn_completed
+    // sweeps still-running thinking and text into 'completed' so the
+    // pulse stops with the turn.
+    const state = runAll(
+      startedTurn(),
+      envelope('stream.thinking', { delta: 'no tool, no text' }),
+      envelope('stream.turn_completed', {
+        sessionId: 'sess-1',
+        requestId: 'req-1',
+        turnNumber: 1,
+        timestamp: new Date(2026, 0, 1).toISOString(),
+        durationMs: 50,
+        toolCount: 0,
+      }),
+    );
+    const turn = state.rootNodes[0]!.children[0]!;
+    expect(turn.status).toBe('completed');
+    const thinking = turn.children.find((c) => c.type === 'thinking')!;
+    expect(thinking.status).toBe('completed');
+  });
+
   it('falls back to attaching tools to the turn when no thinking has been emitted', () => {
     // Extended thinking disabled: stream.thinking never fires, so tools
     // attach to the turn directly (preserves the pre-anchor shape).

--- a/aceclaw-dashboard/tests/treeReducer.test.ts
+++ b/aceclaw-dashboard/tests/treeReducer.test.ts
@@ -610,6 +610,131 @@ describe('text accumulation', () => {
 });
 
 // ---------------------------------------------------------------------------
+// ReAct iteration grouping: thinking owns the tools it spawned
+// ---------------------------------------------------------------------------
+
+describe('thinking-anchored tool grouping (ReAct iterations)', () => {
+  function startedTurn(): ExecutionTree {
+    return runAll(
+      freshTree(),
+      envelope('stream.session_started', {
+        sessionId: 'sess-1',
+        model: 'm',
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.turn_started', {
+        sessionId: 'sess-1',
+        requestId: 'req-1',
+        turnNumber: 1,
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+    );
+  }
+
+  it('attaches a tool_use under the most recent thinking node, not the turn', () => {
+    // ReAct semantic: thinking is the cause, the tool call is its effect.
+    // Without an anchor the tool would attach to the turn, making thinking
+    // and the tool look like unrelated siblings instead of cause→effect.
+    const state = runAll(
+      startedTurn(),
+      envelope('stream.thinking', { delta: 'I should run bash' }),
+      envelope('stream.tool_use', { id: 't1', name: 'bash' }),
+    );
+    const turn = state.rootNodes[0]!.children[0]!;
+    expect(turn.children).toHaveLength(1);
+    expect(turn.children[0]!.type).toBe('thinking');
+    const thinking = turn.children[0]!;
+    expect(thinking.children).toHaveLength(1);
+    expect(thinking.children[0]!.id).toBe('t1');
+    expect(thinking.children[0]!.type).toBe('tool');
+  });
+
+  it('places parallel tool_use calls from one LLM response under the same thinking', () => {
+    // No thinking delta arrives between two parallel tool_uses (they come
+    // from a single LLM streaming response), so the anchor stays valid for
+    // both — they end up as siblings under the same thinking node.
+    const state = runAll(
+      startedTurn(),
+      envelope('stream.thinking', { delta: 'parallel work' }),
+      envelope('stream.tool_use', { id: 't1', name: 'bash' }),
+      envelope('stream.tool_use', { id: 't2', name: 'read' }),
+    );
+    const turn = state.rootNodes[0]!.children[0]!;
+    const thinking = turn.children[0]!;
+    expect(thinking.children).toHaveLength(2);
+    expect(thinking.children.map((c) => c.id).sort()).toEqual(['t1', 't2']);
+    // Turn still gets the parallel flag for sidebar stats.
+    expect(turn.parallel).toBe(true);
+  });
+
+  it('creates a new thinking node when a delta arrives after a tool_use (ReAct iteration boundary)', () => {
+    // After tool_use the anchor is sealed: the model has finished one LLM
+    // call. The next thinking delta is a new iteration and must mint a new
+    // thinking node rather than concatenate into the previous one.
+    const state = runAll(
+      startedTurn(),
+      envelope('stream.thinking', { delta: 'iter 1 thinking' }),
+      envelope('stream.tool_use', { id: 't1', name: 'bash' }),
+      envelope('stream.thinking', { delta: 'iter 2 thinking' }),
+      envelope('stream.tool_use', { id: 't2', name: 'read' }),
+    );
+    const turn = state.rootNodes[0]!.children[0]!;
+    // Two thinking siblings under the turn, each with one tool child.
+    const thinkingChildren = turn.children.filter((c) => c.type === 'thinking');
+    expect(thinkingChildren).toHaveLength(2);
+    expect(thinkingChildren[0]!.text).toBe('iter 1 thinking');
+    expect(thinkingChildren[0]!.children.map((c) => c.id)).toEqual(['t1']);
+    expect(thinkingChildren[1]!.text).toBe('iter 2 thinking');
+    expect(thinkingChildren[1]!.children.map((c) => c.id)).toEqual(['t2']);
+  });
+
+  it('falls back to attaching tools to the turn when no thinking has been emitted', () => {
+    // Extended thinking disabled: stream.thinking never fires, so tools
+    // attach to the turn directly (preserves the pre-anchor shape).
+    const state = runAll(
+      startedTurn(),
+      envelope('stream.tool_use', { id: 't1', name: 'bash' }),
+    );
+    const turn = state.rootNodes[0]!.children[0]!;
+    expect(turn.children).toHaveLength(1);
+    expect(turn.children[0]!.id).toBe('t1');
+  });
+
+  it('resets the anchor across turns so a new turn starts a fresh ReAct loop', () => {
+    // Without the reset, turn 2's first tool would graft onto turn 1's
+    // last thinking node — which is in a different subtree and not
+    // running.
+    const state = runAll(
+      startedTurn(),
+      envelope('stream.thinking', { delta: 'turn 1 thought' }),
+      envelope('stream.tool_use', { id: 't1', name: 'bash' }),
+      envelope('stream.turn_completed', {
+        sessionId: 'sess-1',
+        requestId: 'req-1',
+        turnNumber: 1,
+        timestamp: new Date(2026, 0, 1).toISOString(),
+        durationMs: 100,
+      }),
+      envelope('stream.turn_started', {
+        sessionId: 'sess-1',
+        requestId: 'req-2',
+        turnNumber: 2,
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.tool_use', { id: 't2', name: 'read' }),
+    );
+    // currentThinkingId stays null because turn 2 had no thinking event
+    // before its tool_use — and addTurnNode wiped turn 1's anchor on entry.
+    // The tool fell back to the turn-as-anchor branch.
+    expect(state.currentThinkingId).toBeNull();
+    const turn2 = state.rootNodes[0]!.children[1]!;
+    expect(turn2.children).toHaveLength(1);
+    expect(turn2.children[0]!.id).toBe('t2');
+    expect(turn2.children[0]!.type).toBe('tool');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Sub-agent: completion matches the most-recent running entry by agentType
 // ---------------------------------------------------------------------------
 

--- a/aceclaw-dashboard/tests/useExecutionTreeSnapshotGate.test.tsx
+++ b/aceclaw-dashboard/tests/useExecutionTreeSnapshotGate.test.tsx
@@ -1,0 +1,258 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useExecutionTree } from '../src/hooks/useExecutionTree';
+
+/**
+ * Pins the snapshot handshake gate (codex P1 finding on PR #448).
+ *
+ * The race the gate fixes:
+ *
+ *   1. Tab opens WS, sends {@code snapshot.request}.
+ *   2. Daemon broadcasts a fresh live event (e.g. eventId=120) BEFORE its
+ *      snapshot handler runs ctx.send. Both messages are queued on the
+ *      same socket; whichever {@code send()} ran first is delivered first.
+ *   3. If the live event lands first, the reducer's lastEventId watermark
+ *      jumps to 120. The subsequent snapshot.response, with envelopes
+ *      1..120, is then entirely dedup'd by the watermark — and the tree
+ *      misses every structural node it was supposed to recover.
+ *
+ * The fix: while the hook is waiting for snapshot.response, every live
+ * envelope is QUEUED instead of dispatched. After snapshot replay lands,
+ * the queue is drained in arrival order through the reducer; events that
+ * fall inside the snapshot's range are correctly dedup'd, events newer
+ * than the snapshot are applied normally.
+ *
+ * The race is impossible to deterministically reproduce against a real
+ * Jetty server in unit tests, so this file mocks {@code WebSocket} and
+ * drives the message order from the test.
+ */
+
+interface FakeMessageHandler {
+  (event: { data: string }): void;
+}
+
+class FakeWebSocket {
+  static last: FakeWebSocket | null = null;
+
+  url: string;
+  // Captured handlers — onopen/onmessage are assigned by the hook's
+  // useEffect, and the test invokes them directly to simulate ordering.
+  onopen: (() => void) | null = null;
+  onmessage: FakeMessageHandler | null = null;
+  onerror: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  // Frames the hook sent on this socket — used to confirm
+  // snapshot.request was dispatched before any deliver() calls.
+  sent: string[] = [];
+
+  constructor(url: string) {
+    this.url = url;
+    FakeWebSocket.last = this;
+  }
+
+  // Browsers' WebSocket constructor immediately tries to connect; the
+  // real DOM API would fire onopen on success. The hook synchronously
+  // sets onopen during the same tick, so the test triggers open()
+  // explicitly to keep the order-of-events assertable.
+  open(): void {
+    this.onopen?.();
+  }
+
+  deliver(payload: object): void {
+    this.onmessage?.({ data: JSON.stringify(payload) });
+  }
+
+  send(message: string): void {
+    this.sent.push(message);
+  }
+
+  close(): void {
+    this.onclose?.();
+  }
+}
+
+describe('useExecutionTree snapshot handshake gate (P1)', () => {
+  beforeEach(() => {
+    vi.stubGlobal('WebSocket', FakeWebSocket);
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    FakeWebSocket.last = null;
+  });
+
+  /** Builds a DaemonEventEnvelope JSON object the way the bridge would. */
+  function envelope(
+    eventId: number,
+    sessionId: string,
+    method: string,
+    params: Record<string, unknown>,
+  ): Record<string, unknown> {
+    return {
+      eventId,
+      sessionId,
+      receivedAt: '2026-04-29T00:00:00.000Z',
+      event: { method, params },
+    };
+  }
+
+  it('queues a live envelope that arrives before snapshot.response and applies it after replay', async () => {
+    const { result } = renderHook(() =>
+      useExecutionTree('ws://test/ws', 'sess-1'),
+    );
+    const ws = FakeWebSocket.last!;
+
+    act(() => ws.open());
+    // Confirm the hook sent snapshot.request on open — that's the gate
+    // signal: until snapshot.response arrives, live envelopes queue.
+    expect(ws.sent[0]).toContain('"method":"snapshot.request"');
+
+    // A live event arrives first (race scenario): tool_use with
+    // eventId=10. Without the gate this would advance the reducer's
+    // watermark to 10 and dedup every snapshot envelope.
+    act(() =>
+      ws.deliver(
+        envelope(10, 'sess-1', 'stream.tool_use', { id: 't1', name: 'bash' }),
+      ),
+    );
+
+    // Tree is still empty: the gate is buffering, not dispatching.
+    expect(result.current.tree.rootNodes).toHaveLength(0);
+    expect(result.current.tree.lastEventId).toBe(0);
+
+    // Now snapshot.response arrives with the structural events the tab
+    // missed (session_started + turn_started). lastEventId in the
+    // snapshot is 5; the queued live tool_use (eventId=10) is newer and
+    // SHOULD survive the dedup gate after the flush.
+    act(() =>
+      ws.deliver({
+        method: 'snapshot.response',
+        sessionId: 'sess-1',
+        lastEventId: 5,
+        events: [
+          envelope(1, 'sess-1', 'stream.session_started', {
+            sessionId: 'sess-1',
+            model: 'claude-opus-4-7',
+          }),
+          envelope(5, 'sess-1', 'stream.turn_started', {
+            requestId: 'r1',
+            turnNumber: 1,
+          }),
+        ],
+      }),
+    );
+
+    // After flush: session root + turn child + tool_use under the turn
+    // (or under whatever the reducer chooses — without thinking it's
+    // the turn). The key invariant: the QUEUED live event was NOT
+    // dropped just because it raced ahead of snapshot.response.
+    await waitFor(() => {
+      expect(result.current.tree.rootNodes).toHaveLength(1);
+    });
+    const session = result.current.tree.rootNodes[0]!;
+    expect(session.type).toBe('session');
+    const turn = session.children[0]!;
+    expect(turn.type).toBe('turn');
+    const tool = turn.children.find((c) => c.type === 'tool');
+    expect(tool).toBeDefined();
+    expect(tool!.id).toBe('t1');
+    // Watermark advanced past the queued live event — subsequent live
+    // events with eventId<=10 dedup correctly.
+    expect(result.current.tree.lastEventId).toBeGreaterThanOrEqual(10);
+  });
+
+  it('drops a queued live event whose eventId falls inside the snapshot range', async () => {
+    // The dedup gate (eventId<=lastEventId) still works for queued
+    // events — anything that was already in the snapshot doesn't get
+    // double-applied when the queue flushes.
+    const { result } = renderHook(() =>
+      useExecutionTree('ws://test/ws', 'sess-1'),
+    );
+    const ws = FakeWebSocket.last!;
+    act(() => ws.open());
+
+    // Live event with eventId=3 arrives during the wait. The snapshot
+    // we'll send next includes events 1..5, so this 3 is inside the
+    // range and should be dropped on flush.
+    act(() =>
+      ws.deliver(
+        envelope(3, 'sess-1', 'stream.tool_use', {
+          id: 'duplicate',
+          name: 'bash',
+        }),
+      ),
+    );
+
+    act(() =>
+      ws.deliver({
+        method: 'snapshot.response',
+        sessionId: 'sess-1',
+        lastEventId: 5,
+        events: [
+          envelope(1, 'sess-1', 'stream.session_started', {
+            sessionId: 'sess-1',
+            model: 'claude-opus-4-7',
+          }),
+          envelope(2, 'sess-1', 'stream.turn_started', {
+            requestId: 'r1',
+            turnNumber: 1,
+          }),
+          envelope(3, 'sess-1', 'stream.tool_use', {
+            id: 't-canonical',
+            name: 'bash',
+          }),
+        ],
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.tree.rootNodes).toHaveLength(1);
+    });
+    const turn = result.current.tree.rootNodes[0]!.children[0]!;
+    const tools = turn.children.filter((c) => c.type === 'tool');
+    // Only the snapshot's canonical tool exists; the queued live tool
+    // with the same eventId was dedup'd.
+    expect(tools).toHaveLength(1);
+    expect(tools[0]!.id).toBe('t-canonical');
+  });
+
+  it('after snapshot lands, subsequent live events flow normally', async () => {
+    // Once the gate releases, the hook is back to plain dispatch — no
+    // re-gating until the next reconnect.
+    const { result } = renderHook(() =>
+      useExecutionTree('ws://test/ws', 'sess-1'),
+    );
+    const ws = FakeWebSocket.last!;
+    act(() => ws.open());
+
+    act(() =>
+      ws.deliver({
+        method: 'snapshot.response',
+        sessionId: 'sess-1',
+        lastEventId: 0,
+        events: [],
+      }),
+    );
+
+    act(() =>
+      ws.deliver(
+        envelope(1, 'sess-1', 'stream.session_started', {
+          sessionId: 'sess-1',
+          model: 'm',
+        }),
+      ),
+    );
+    act(() =>
+      ws.deliver(
+        envelope(2, 'sess-1', 'stream.turn_started', {
+          requestId: 'r1',
+          turnNumber: 1,
+        }),
+      ),
+    );
+
+    await waitFor(() => {
+      expect(result.current.tree.rootNodes).toHaveLength(1);
+    });
+    expect(result.current.tree.lastEventId).toBe(2);
+  });
+});

--- a/aceclaw-dashboard/tests/useTreeLayout.test.ts
+++ b/aceclaw-dashboard/tests/useTreeLayout.test.ts
@@ -100,6 +100,68 @@ describe('useTreeLayout', () => {
     }
   });
 
+  it('emits a dashed sequence edge between consecutive sibling turns', () => {
+    // Two turns under a session: solid containment edges from session to
+    // each turn, plus a dashed sequence edge between turn1 → turn2 to
+    // express temporal order. Tools and other types don't get sequence
+    // edges (parallelism is ambiguous without metadata).
+    const session: ExecutionNode = {
+      id: 's',
+      type: 'session',
+      status: 'running',
+      label: 'session',
+      children: [
+        {
+          id: 't1',
+          type: 'turn',
+          status: 'completed',
+          label: 'turn 1',
+          children: [],
+        },
+        {
+          id: 't2',
+          type: 'turn',
+          status: 'running',
+          label: 'turn 2',
+          children: [],
+        },
+      ],
+    };
+    const { result } = renderHook(() => useTreeLayout(tree([session])));
+    const containment = result.current.edges.filter((e) => e.kind === 'containment');
+    const sequence = result.current.edges.filter((e) => e.kind === 'sequence');
+    // Two containment edges (session→t1, session→t2) and one sequence
+    // edge (t1→t2).
+    expect(containment).toHaveLength(2);
+    expect(sequence).toHaveLength(1);
+    expect(sequence[0]!.id).toBe('seq:t1->t2');
+    // Sequence-edge status follows the target — this is what the renderer
+    // uses to colour the line; for a sequence edge GrowingEdge ignores
+    // status anyway and uses the muted neutral, but the shape contract
+    // mirrors containment so consumers can switch on kind alone.
+    expect(sequence[0]!.status).toBe('running');
+  });
+
+  it('does not emit sequence edges between sibling tools (parallel/sequential ambiguous)', () => {
+    // Two parallel tools under a turn: only containment edges, no
+    // sequence edge between them. Without execution-order metadata we
+    // can't say whether they ran in parallel or sequentially, and a
+    // wrong sequence edge is worse than no edge.
+    const turn: ExecutionNode = {
+      id: 't',
+      type: 'turn',
+      status: 'running',
+      label: 'turn',
+      children: [
+        leaf('tool-a'),
+        leaf('tool-b'),
+      ],
+    };
+    const { result } = renderHook(() => useTreeLayout(tree([turn])));
+    const sequence = result.current.edges.filter((e) => e.kind === 'sequence');
+    expect(sequence).toHaveLength(0);
+  });
+
   it('attaches the dagre coordinates while preserving every ExecutionNode field', () => {
     const root: ExecutionNode = {
       id: 'r',

--- a/aceclaw-dashboard/tests/useTreeLayout.test.ts
+++ b/aceclaw-dashboard/tests/useTreeLayout.test.ts
@@ -142,6 +142,64 @@ describe('useTreeLayout', () => {
     expect(sequence[0]!.status).toBe('running');
   });
 
+  it('chains thinking → tools → next thinking via flow edges (ReAct pipeline)', () => {
+    // Two ReAct iterations under one turn:
+    //   thinking1 ─┬─ toolA
+    //              └─ toolB ─ ─ ─ ─ ─ thinking2 ─── toolC ─ ─ ─ response
+    // The dashed flow edges from each tool of thinking1 land on thinking2,
+    // expressing "tool results feed the next LLM call". Same idea for
+    // toolC → response: response is the final output of the chain.
+    const turn: ExecutionNode = {
+      id: 't',
+      type: 'turn',
+      status: 'running',
+      label: 'turn',
+      children: [
+        {
+          id: 'th1',
+          type: 'thinking',
+          status: 'completed',
+          label: 'thinking',
+          children: [leaf('toolA'), leaf('toolB')],
+        },
+        {
+          id: 'th2',
+          type: 'thinking',
+          status: 'running',
+          label: 'thinking',
+          children: [leaf('toolC')],
+        },
+        {
+          id: 'resp',
+          type: 'text',
+          status: 'running',
+          label: 'response',
+          children: [],
+        },
+      ],
+    };
+    const { result } = renderHook(() => useTreeLayout(tree([turn])));
+    const flow = result.current.edges.filter((e) => e.kind === 'sequence');
+    const flowIds = flow.map((e) => e.id).sort();
+    // Two flows from thinking1's tools to thinking2 (toolA→th2, toolB→th2).
+    // One flow from thinking2's tool to response (toolC→resp).
+    expect(flowIds).toContain('toolA->th2');
+    expect(flowIds).toContain('toolB->th2');
+    expect(flowIds).toContain('toolC->resp');
+
+    // Containment edges shouldn't include redundant turn→thinking2 or
+    // turn→response — those paths are reached via the flow chain.
+    const containment = result.current.edges.filter((e) => e.kind === 'containment');
+    const containmentIds = containment.map((e) => e.id);
+    expect(containmentIds).toContain('t->th1');
+    expect(containmentIds).not.toContain('t->th2');
+    expect(containmentIds).not.toContain('t->resp');
+    // But thinking → tool containments are intact.
+    expect(containmentIds).toContain('th1->toolA');
+    expect(containmentIds).toContain('th1->toolB');
+    expect(containmentIds).toContain('th2->toolC');
+  });
+
   it('does not emit sequence edges between sibling tools (parallel/sequential ambiguous)', () => {
     // Two parallel tools under a turn: only containment edges, no
     // sequence edge between them. Without execution-order metadata we


### PR DESCRIPTION
## Summary

Closes #432.

A browser tab connecting mid-execution (clicking a session in the sidebar, refresh, tab switch) used to see only events emitted **after** it connected — root nodes, in-flight tools, and assistant text were all missing. This adds a snapshot endpoint so the dashboard can rebuild its tree from history on first paint.

**Architecture decision** (deviation from issue): events-list snapshot, not state-object snapshot. The reducer is the source of truth for "events → tree"; reproducing that logic in Java would double the surface area. Shipping the buffered envelopes lets the existing reducer build state once. Cost: snapshot 10-100KB per Tier 1 session vs <10KB state object — fine for interactive sessions, capped at 5000 envelopes per session with drop-oldest eviction.

## Changes

### Daemon
- New `SessionEventBuffer`: per-session capped ring buffer of broadcast envelopes
- `WebSocketBridge.broadcast` appends to buffer unconditionally (even with zero clients) so tabs that open AFTER an event was emitted still see it on replay
- New WS inbound method: ` snapshot.request {sessionId}` → `snapshot.response {sessionId, lastEventId, events:[]}`. Point-to-point reply (sibling of `sessions.list` from #445)
- Buffer cleared in `setSessionEndCallback` after `session_ended` broadcast lands so the brief race window still includes `session_ended` in the snapshot

### Dashboard
- `useExecutionTree.onopen` sends `snapshot.request`; reconnects re-issue automatically
- `onmessage` detects `snapshot.response` and replays each envelope through the same validator as live frames
- Existing reducer dedup (`eventId <= state.lastEventId`) handles snapshot/live overlap, regardless of arrival order

## Bugs this fixes (all from #445 testing)
- Clicking into a session shows no root node → snapshot includes `session_started`
- Switching sessions wipes the dashboard → new sessionId re-fetches snapshot
- Refresh loses everything → reconnect re-fetches snapshot

## Test plan
- [x] SessionEventBufferTest: append/snapshot order, cap-and-evict, clear isolation, concurrent appends + reader (5 cases)
- [x] WebSocketBridgeTest: broadcast-populates-buffer-with-zero-clients, clearSession isolation, snapshot.request E2E with cross-session filtering, empty-snapshot reply (4 new cases)
- [x] snapshotReplay.test.ts: tree shape after replay, eventId<=lastEventId dedup, eventId>lastEventId apply, malformed rejection, forward-compat unknown method (5 cases)
- [x] All daemon tests pass (`./gradlew :aceclaw-daemon:test --rerun-tasks`)
- [x] All dashboard tests pass (`npm test -- --run` → 64/64)
- [x] Live smoke test: snapshot.request via Python WebSocket against rebuilt daemon → correct empty reply for unknown session
- [ ] Live browser test: open dashboard mid-session, verify root node + tool boxes + text response all present (user verification pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added snapshot replay functionality enabling clients to request and restore past events upon reconnection, ensuring no event history is lost during temporary disconnections.
  * Implemented event buffering to preserve recent activity during zero-client periods for later retrieval.

* **Bug Fixes**
  * Improved session cleanup to prevent stale snapshot data from being delivered to subsequent reconnections.

* **Tests**
  * Added comprehensive test coverage for snapshot request/response behavior and concurrent event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->