### PR TITLE
fix(dashboard): one text node per ReAct iteration, anchored on its thinking

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -400,6 +400,7 @@ public final class StreamingAgentHandler {
                         sessionId, session, cancelContext, eventHandler,
                         permissionAwareLoop, cancellationToken, metricsCollector, watchdog, requestToolNames);
                 if (resumeResult != null) {
+                    finalStopReason = extractStopReason(resumeResult, finalStopReason);
                     sendBudgetExhaustedNotificationIfNeeded(watchdog, cancelContext, sessionId, cancellationToken);
                     return resumeResult;
                 }
@@ -416,6 +417,7 @@ public final class StreamingAgentHandler {
                     var planResult = executePlannedPrompt(prompt, session, sessionId, cancelContext,
                             eventHandler, permissionAwareLoop, cancellationToken,
                             metricsCollector, watchdog, requestToolNames);
+                    finalStopReason = extractStopReason(planResult, finalStopReason);
                     sendBudgetExhaustedNotificationIfNeeded(watchdog, cancelContext, sessionId, cancellationToken);
                     return planResult;
                 }
@@ -442,6 +444,15 @@ public final class StreamingAgentHandler {
 
             String userMessage = formatLlmError(e);
             throw new IllegalStateException(userMessage);
+        } catch (RuntimeException | Error e) {
+            // Catch-all for non-LLM failures: anything thrown after
+            // requestId is assigned MUST be reported as ERROR on the
+            // turn_completed broadcast so the dashboard's truncated-
+            // turn badge fires. Without this branch the finally block
+            // would emit the END_TURN default for an aborted turn.
+            // Rethrow unchanged — error semantics elsewhere unchanged.
+            finalStopReason = "ERROR";
+            throw e;
         } finally {
             // Emit stream.turn_completed BEFORE releasing the lock so the
             // start→end window is fully serialised against other prompts on
@@ -713,7 +724,11 @@ public final class StreamingAgentHandler {
         var result = objectMapper.createObjectNode();
         result.put("sessionId", sessionId);
         result.put("response", responseSummary);
-        result.put("stopReason", "END_TURN");
+        // Use the planner-derived stopReason (END_TURN on success, ERROR
+        // on plan failure) instead of a hardcoded END_TURN — both the
+        // CLI and the dashboard's stream.turn_completed broadcast read
+        // this so mismatches confuse "did the plan really succeed?".
+        result.put("stopReason", plannedStopReason.name());
         result.put("planned", true);
         result.put("planSuccess", planResult.success());
         result.put("planSteps", planResult.plan().steps().size());
@@ -926,6 +941,22 @@ public final class StreamingAgentHandler {
 
     private static String shortenSessionId(String sessionId) {
         return sessionId.length() > 8 ? sessionId.substring(0, 8) : sessionId;
+    }
+
+    /**
+     * Reads the {@code stopReason} field from a planner / resume result
+     * payload so the {@code stream.turn_completed} broadcast reflects
+     * the real plan outcome (END_TURN on success, ERROR on failure)
+     * instead of the END_TURN default. Falls back to {@code current}
+     * when the result isn't a JSON object or doesn't carry the field —
+     * older code paths that haven't been updated keep working.
+     */
+    private static String extractStopReason(Object result, String current) {
+        if (result instanceof com.fasterxml.jackson.databind.node.ObjectNode obj
+                && obj.has("stopReason")) {
+            return obj.get("stopReason").asText(current);
+        }
+        return current;
     }
 
     private void recordPromptSkillCorrections(String sessionId, Path projectPath, String prompt) {
@@ -2833,7 +2864,10 @@ public final class StreamingAgentHandler {
         var result = objectMapper.createObjectNode();
         result.put("sessionId", sessionId);
         result.put("response", responseSummary);
-        result.put("stopReason", "END_TURN");
+        // Use the resumed-plan stopReason (END_TURN on success, ERROR
+        // on plan failure) instead of a hardcoded END_TURN — see the
+        // matching comment in executePlannedPrompt.
+        result.put("stopReason", plannedStopReason.name());
         result.put("planned", true);
         result.put("resumed", true);
         result.put("planSuccess", planResult.success());

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -350,6 +350,12 @@ public final class StreamingAgentHandler {
         // Acquire per-session turn lock (coordinates with DeferredActionScheduler)
         var turnLock = sessionTurnLocks.computeIfAbsent(sessionId, _ -> new ReentrantLock());
         turnLock.lock();
+        // Captured for the stream.turn_completed broadcast so the dashboard
+        // can render a "max_tokens" / "error" badge on truncated turns.
+        // Hoisted above the try so the finally block can read it. Each
+        // happy-path branch below overrides this with the Turn's actual
+        // finalStopReason; the LlmException catch overrides to ERROR.
+        String finalStopReason = "END_TURN";
         try {
             // Start the cancel monitor thread to read from the socket
             cancelContext.startMonitor();
@@ -417,6 +423,7 @@ public final class StreamingAgentHandler {
 
             var adaptive = runTurnWithAdaptiveContinuation(
                     permissionAwareLoop, prompt, conversationHistory, eventHandler, cancellationToken);
+            finalStopReason = adaptive.turn().finalStopReason().name();
 
             // Send cancelled / budget-exhausted notifications if applicable
             sendCancelledNotificationIfNeeded(cancellationToken, cancelContext, sessionId);
@@ -427,6 +434,7 @@ public final class StreamingAgentHandler {
 
         } catch (dev.aceclaw.core.llm.LlmException e) {
             // Translate LLM errors to user-friendly messages
+            finalStopReason = "ERROR";
             log.error("LLM error during prompt: statusCode={}, message={}",
                     e.statusCode(), e.getMessage(), e);
 
@@ -456,6 +464,10 @@ public final class StreamingAgentHandler {
                 tcp.put("durationMs", System.currentTimeMillis() - turnStartMillis);
                 tcp.put("toolCount", cancelContext.toolUseCount());
                 tcp.put("timestamp", Instant.now().toString());
+                // The dashboard renders a small badge on truncated turns
+                // (MAX_TOKENS / ERROR / etc) so the user can tell at a glance
+                // why a turn ended without the usual final-text response.
+                tcp.put("stopReason", finalStopReason);
                 emitBrowserOnly(sessionId, "stream.turn_completed", tcp);
             }
             if (watchdog != null) {

--- a/aceclaw-dashboard/src/components/ExecutionTree.tsx
+++ b/aceclaw-dashboard/src/components/ExecutionTree.tsx
@@ -202,12 +202,18 @@ export function ExecutionTree({ tree }: ExecutionTreeProps) {
             viewBox="0 0 10 10"
             refX="9"
             refY="5"
-            markerWidth="7"
-            markerHeight="7"
+            markerWidth="8"
+            markerHeight="8"
             orient="auto-start-reverse"
             markerUnits="userSpaceOnUse"
           >
-            <path d="M 0 0 L 10 5 L 0 10 z" fill="#52525b" opacity={0.7} />
+            {/*
+              Fill matches GrowingEdge's SEQUENCE_STROKE so the arrowhead
+              looks like the same piece as the dashed line. Bumped from
+              opacity 0.7 → 0.95 because at the previous strength the
+              arrow disappeared on the dark canvas.
+            */}
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#94a3b8" opacity={0.95} />
           </marker>
         </defs>
         <g transform={transform}>

--- a/aceclaw-dashboard/src/components/GrowingEdge.tsx
+++ b/aceclaw-dashboard/src/components/GrowingEdge.tsx
@@ -45,8 +45,14 @@ function straightPath(edge: LayoutEdge): string {
   return `M ${from.x} ${from.y} L ${to.x} ${to.y}`;
 }
 
-/** Muted neutral for sequence edges so they recede behind containment edges. */
-const SEQUENCE_STROKE = '#52525b';
+/**
+ * Stroke colour for sequence/flow edges. Picked light enough to read on
+ * the bg-zinc-950 canvas without competing visually with the saturated
+ * status colours on containment edges. zinc-400 (#94a3b8 → slate-400)
+ * survives the dark background; the 0.5 opacity earlier rendered as
+ * near-invisible.
+ */
+const SEQUENCE_STROKE = '#94a3b8';
 
 export function GrowingEdge({ edge }: GrowingEdgeProps) {
   const isSequence = edge.kind === 'sequence';
@@ -63,11 +69,15 @@ export function GrowingEdge({ edge }: GrowingEdgeProps) {
     <motion.path
       d={d}
       stroke={stroke}
-      strokeWidth={isSequence ? 1.25 : 1.75}
-      strokeDasharray={isSequence ? '4 4' : undefined}
+      // Sequence edges get the SAME stroke width as containment edges
+      // and a longer dash gap so they read as a clear, intentional
+      // dashed line on a dark background — not a faint hint.
+      strokeWidth={isSequence ? 1.75 : 1.75}
+      strokeDasharray={isSequence ? '7 5' : undefined}
+      strokeLinecap={isSequence ? 'round' : 'butt'}
       fill="none"
       initial={{ pathLength: 0, opacity: 0 }}
-      animate={{ pathLength: 1, opacity: isSequence ? 0.5 : 0.85 }}
+      animate={{ pathLength: 1, opacity: isSequence ? 0.85 : 0.85 }}
       transition={{ duration: 0.4, ease: 'easeOut' }}
       // exactOptionalPropertyTypes: avoid passing undefined to the
       // optional markerEnd attribute.

--- a/aceclaw-dashboard/src/components/GrowingEdge.tsx
+++ b/aceclaw-dashboard/src/components/GrowingEdge.tsx
@@ -66,19 +66,26 @@ export function GrowingEdge({ edge }: GrowingEdgeProps) {
   // and adding arrowheads to every containment edge would be visual noise.
   const markerEnd = isSequence ? 'url(#seq-arrow)' : undefined;
   return (
+    // Animation differs by edge kind: framer-motion's `pathLength`
+    // implements its draw-on animation by setting strokeDasharray
+    // internally — which silently clobbers any explicit dasharray we
+    // pass for sequence edges, rendering them as solid lines. So
+    // sequence edges drop pathLength and fade in via opacity instead;
+    // their custom dash pattern survives. Containment edges keep the
+    // line-drawing animation since they have no custom dasharray to
+    // preserve.
     <motion.path
       d={d}
       stroke={stroke}
-      // Sequence edges get the same stroke width as containment so they
-      // read on a dark background, but with butt linecaps and a wider
-      // gap-to-dash ratio so the dashes stay obviously discrete. Round
-      // caps blob the dash ends out by ~strokeWidth/2 each side, which
-      // closed the gaps and made the line look solid.
       strokeWidth={isSequence ? 1.75 : 1.75}
       strokeDasharray={isSequence ? '5 6' : undefined}
       fill="none"
-      initial={{ pathLength: 0, opacity: 0 }}
-      animate={{ pathLength: 1, opacity: isSequence ? 0.85 : 0.85 }}
+      initial={
+        isSequence ? { opacity: 0 } : { pathLength: 0, opacity: 0 }
+      }
+      animate={
+        isSequence ? { opacity: 0.85 } : { pathLength: 1, opacity: 0.85 }
+      }
       transition={{ duration: 0.4, ease: 'easeOut' }}
       // exactOptionalPropertyTypes: avoid passing undefined to the
       // optional markerEnd attribute.

--- a/aceclaw-dashboard/src/components/GrowingEdge.tsx
+++ b/aceclaw-dashboard/src/components/GrowingEdge.tsx
@@ -69,12 +69,13 @@ export function GrowingEdge({ edge }: GrowingEdgeProps) {
     <motion.path
       d={d}
       stroke={stroke}
-      // Sequence edges get the SAME stroke width as containment edges
-      // and a longer dash gap so they read as a clear, intentional
-      // dashed line on a dark background — not a faint hint.
+      // Sequence edges get the same stroke width as containment so they
+      // read on a dark background, but with butt linecaps and a wider
+      // gap-to-dash ratio so the dashes stay obviously discrete. Round
+      // caps blob the dash ends out by ~strokeWidth/2 each side, which
+      // closed the gaps and made the line look solid.
       strokeWidth={isSequence ? 1.75 : 1.75}
-      strokeDasharray={isSequence ? '7 5' : undefined}
-      strokeLinecap={isSequence ? 'round' : 'butt'}
+      strokeDasharray={isSequence ? '5 6' : undefined}
       fill="none"
       initial={{ pathLength: 0, opacity: 0 }}
       animate={{ pathLength: 1, opacity: isSequence ? 0.85 : 0.85 }}

--- a/aceclaw-dashboard/src/components/GrowingNode.tsx
+++ b/aceclaw-dashboard/src/components/GrowingNode.tsx
@@ -174,6 +174,26 @@ export function GrowingNode({ node }: GrowingNodeProps) {
             : `${(node.duration / 1000).toFixed(1)}s`}
         </text>
       ) : null}
+      {/*
+        Stop-reason badge on truncated turns: MAX_TOKENS / ERROR / etc
+        get a small amber tag at the bottom-right of the turn node so the
+        reader can tell at a glance why a turn ended without a normal
+        final-text response. END_TURN (the default) shows nothing.
+      */}
+      {node.type === 'turn' &&
+      typeof node.metadata?.['stopReason'] === 'string' &&
+      node.metadata['stopReason'] !== 'END_TURN' ? (
+        <text
+          x={left + node.width - 8}
+          y={top + node.height - 6}
+          textAnchor="end"
+          fontFamily="ui-monospace, 'JetBrains Mono', monospace"
+          fontSize={9}
+          fill="#fbbf24"
+        >
+          ⚠ {String(node.metadata['stopReason']).toLowerCase()}
+        </text>
+      ) : null}
     </motion.g>
   );
 }

--- a/aceclaw-dashboard/src/hooks/useTreeLayout.ts
+++ b/aceclaw-dashboard/src/hooks/useTreeLayout.ts
@@ -126,14 +126,23 @@ function addReActFlowEdges(
       for (let i = 0; i < thinkings.length - 1; i += 1) {
         const curr = thinkings[i]!;
         const next = thinkings[i + 1]!;
-        const tools = curr.children.filter((c) => c.type === 'tool');
+        // Tools can live either as direct children of the thinking
+        // (no narration this iteration) or under the iteration's text
+        // node (narration → tools chain). Either way, the iteration's
+        // "leaves" are what flow into the next thinking.
+        const text = curr.children.find((c) => c.type === 'text');
+        const directTools = curr.children.filter((c) => c.type === 'tool');
+        const narratedTools =
+          text?.children.filter((c) => c.type === 'tool') ?? [];
+        const tools = [...directTools, ...narratedTools];
         if (tools.length > 0) {
           for (const t of tools) {
             graph.setEdge(t.id, next.id, { flow: true });
           }
           continue;
         }
-        const text = curr.children.find((c) => c.type === 'text');
+        // No tools this iteration. Bridge via text when present (pure
+        // narration), else direct thinking → thinking.
         if (text) {
           graph.setEdge(text.id, next.id, { flow: true });
         } else {

--- a/aceclaw-dashboard/src/hooks/useTreeLayout.ts
+++ b/aceclaw-dashboard/src/hooks/useTreeLayout.ts
@@ -129,20 +129,31 @@ function addReActFlowEdges(
         // Tools can live either as direct children of the thinking
         // (no narration this iteration) or under the iteration's text
         // node (narration → tools chain). Either way, the iteration's
-        // "leaves" are what flow into the next thinking.
+        // productive leaves are what flow into the next thinking.
         const text = curr.children.find((c) => c.type === 'text');
         const directTools = curr.children.filter((c) => c.type === 'tool');
         const narratedTools =
           text?.children.filter((c) => c.type === 'tool') ?? [];
-        const tools = [...directTools, ...narratedTools];
-        if (tools.length > 0) {
-          for (const t of tools) {
+        // Failed tools render as dead-end leaves: they don't get a
+        // flow edge to the next iteration. Technically the error IS
+        // fed back to the model and IS what triggers recovery in the
+        // next thinking, but visually drawing the connection muddles
+        // "this tool's output drove the next step" with "this tool
+        // crashed and the model worked around it". The user reads the
+        // tree faster when failed tools look dead and successful tools
+        // carry the chain.
+        const productiveTools = [...directTools, ...narratedTools].filter(
+          (t) => t.status !== 'failed',
+        );
+        if (productiveTools.length > 0) {
+          for (const t of productiveTools) {
             graph.setEdge(t.id, next.id, { flow: true });
           }
           continue;
         }
-        // No tools this iteration. Bridge via text when present (pure
-        // narration), else direct thinking → thinking.
+        // No productive tools (none ran, or every one failed). Bridge
+        // via text when present (pure narration / model-recovered-from-
+        // total-failure), else direct thinking → thinking.
         if (text) {
           graph.setEdge(text.id, next.id, { flow: true });
         } else {

--- a/aceclaw-dashboard/src/hooks/useTreeLayout.ts
+++ b/aceclaw-dashboard/src/hooks/useTreeLayout.ts
@@ -73,9 +73,10 @@ function populateGraph(
  *
  * - A non-first {@code thinking} child of a turn: the chain enters via
  *   the previous thinking's tool outputs.
- * - A {@code text} (response) child of a turn that has at least one
- *   thinking sibling: the chain enters via the last thinking's tool
- *   outputs (or the last thinking directly when it had no tools).
+ *
+ * Text nodes are now anchored to their iteration's thinking (so they're
+ * never direct children of the turn), and the redundant-containment
+ * skip for them is no longer relevant.
  */
 function shouldSkipContainment(
   parent: ExecutionNode,
@@ -86,27 +87,29 @@ function shouldSkipContainment(
     const firstThinking = parent.children.find((c) => c.type === 'thinking');
     return firstThinking !== child;
   }
-  if (child.type === 'text') {
-    return parent.children.some((c) => c.type === 'thinking');
-  }
   return false;
 }
 
 /**
  * Adds dashed flow edges to the graph so the dagre layout chains
- * thinking/tool/thinking/.../response left-to-right within a turn.
+ * thinking/tool/thinking/... left-to-right within a turn.
  *
  * For each turn that has multiple thinking iterations:
  *   - Each tool of {@code thinking[i]} gets a flow edge to
  *     {@code thinking[i+1]}. Multiple parallel tools all merge into
  *     the next thinking, mirroring "tool results feed the next LLM call".
- *   - When {@code thinking[i]} has no tool children (rare — a thinking
- *     that produced no tool_use), a direct
- *     {@code thinking[i] → thinking[i+1]} flow edge is used instead.
+ *   - When {@code thinking[i]} has no tool children (a thinking
+ *     iteration that emitted only text), the iteration's text node
+ *     bridges to {@code thinking[i+1]} instead — so the chain stays
+ *     visually unbroken across iterations whose model response was
+ *     pure narration. Falls back to a direct
+ *     {@code thinking[i] → thinking[i+1]} flow when there's no text
+ *     either.
  *
- * For the response (text node) at the end of a turn: every tool of the
- * final thinking gets a flow edge to it, or the final thinking itself
- * when it had no tools.
+ * Each iteration's text node lives as a child of its thinking
+ * (sibling of that iteration's tools), so no separate response-flow
+ * branch is needed — the final iteration's text is just the last
+ * leaf in its iteration's subtree.
  *
  * Flow edges carry a {@code { flow: true }} label so the readback pass
  * can mark them {@code kind: 'sequence'} and the renderer draws them
@@ -119,7 +122,6 @@ function addReActFlowEdges(
   for (const parent of nodes) {
     if (parent.type === 'turn') {
       const thinkings = parent.children.filter((c) => c.type === 'thinking');
-      const responses = parent.children.filter((c) => c.type === 'text');
 
       for (let i = 0; i < thinkings.length - 1; i += 1) {
         const curr = thinkings[i]!;
@@ -129,22 +131,13 @@ function addReActFlowEdges(
           for (const t of tools) {
             graph.setEdge(t.id, next.id, { flow: true });
           }
+          continue;
+        }
+        const text = curr.children.find((c) => c.type === 'text');
+        if (text) {
+          graph.setEdge(text.id, next.id, { flow: true });
         } else {
           graph.setEdge(curr.id, next.id, { flow: true });
-        }
-      }
-
-      if (thinkings.length > 0 && responses.length > 0) {
-        const last = thinkings[thinkings.length - 1]!;
-        const lastTools = last.children.filter((c) => c.type === 'tool');
-        for (const r of responses) {
-          if (lastTools.length > 0) {
-            for (const t of lastTools) {
-              graph.setEdge(t.id, r.id, { flow: true });
-            }
-          } else {
-            graph.setEdge(last.id, r.id, { flow: true });
-          }
         }
       }
     }

--- a/aceclaw-dashboard/src/reducers/treeReducer.ts
+++ b/aceclaw-dashboard/src/reducers/treeReducer.ts
@@ -40,7 +40,7 @@ import type {
   UsageParams,
   CompactionParams,
 } from '../types/events';
-import type { ExecutionNode, ExecutionTree } from '../types/tree';
+import type { ExecutionNode, ExecutionStatus, ExecutionTree } from '../types/tree';
 
 /**
  * The reducer takes only well-typed envelopes. Forward-compatibility for
@@ -533,38 +533,59 @@ function appendTextToCurrentTurn(
   );
   if (!turn) return state;
 
+  // If we're starting a new iteration's text (previous iteration
+  // closed by a tool_use → textIsOpen=false → thinkingSealed=true)
+  // AND the model didn't emit a fresh stream.thinking event for this
+  // iteration, mint a SYNTHETIC thinking node to anchor it. Without
+  // this, the new text/tools all pile up under the previous
+  // iteration's thinking, producing 3-5+ text bubbles stacked
+  // vertically as siblings — visually reading as "parallel
+  // responses" when they're actually sequential iterations of one
+  // ReAct loop. The synthetic thinking is created status=completed
+  // (the model already finished thinking by the time we infer the
+  // boundary from a text delta) and gets the same shape as a real
+  // thinking node so the layout chains identically.
+  let workingState = state;
+  if (
+    !state.textIsOpen &&
+    state.thinkingSealed &&
+    state.currentThinkingId !== null
+  ) {
+    workingState = mintIterationThinking(state, turn, '', 'completed').state;
+  }
+
   let textId: string;
   let isNewNode: boolean;
-  let nextSyntheticId = state.nextSyntheticId;
-  if (state.currentTextId && state.textIsOpen) {
-    textId = state.currentTextId;
+  let nextSyntheticId = workingState.nextSyntheticId;
+  if (workingState.currentTextId && workingState.textIsOpen) {
+    textId = workingState.currentTextId;
     isNewNode = false;
   } else {
     // New iteration: mint a unique id keyed on (anchor, counter).
-    // The counter (nextSyntheticId) ensures uniqueness when an
+    // The counter (nextSyntheticId) ensures uniqueness even when an
     // iteration's text follows a tool_use without a fresh thinking
     // delta — both ids would key on the same currentThinkingId
     // otherwise and silently collide.
     const counter = nextSyntheticId;
     nextSyntheticId += 1;
     textId =
-      state.currentThinkingId !== null
-        ? `${state.currentThinkingId}:text:${counter}`
+      workingState.currentThinkingId !== null
+        ? `${workingState.currentThinkingId}:text:${counter}`
         : `${turn.id}:text:${counter}`;
     isNewNode = true;
   }
 
-  const existing = !isNewNode ? findNode(state.rootNodes, textId) : null;
+  const existing = !isNewNode ? findNode(workingState.rootNodes, textId) : null;
   const newText = (existing?.text ?? '') + params.delta;
   let rootNodes: ExecutionNode[];
   if (existing) {
-    rootNodes = mapNode(state.rootNodes, textId, (t) => ({
+    rootNodes = mapNode(workingState.rootNodes, textId, (t) => ({
       ...t,
       text: newText,
       label: previewLabel(newText),
     }));
   } else {
-    const anchorId = state.currentThinkingId ?? turn.id;
+    const anchorId = workingState.currentThinkingId ?? turn.id;
     const textNode: ExecutionNode = {
       id: textId,
       type: 'text',
@@ -573,22 +594,24 @@ function appendTextToCurrentTurn(
       children: [],
       text: newText,
     };
-    rootNodes = appendChild(state.rootNodes, anchorId, textNode);
+    rootNodes = appendChild(workingState.rootNodes, anchorId, textNode);
   }
 
   // Mark the thinking anchor as completed: text means the LLM has
   // stopped thinking and is now talking.
-  if (state.currentThinkingId) {
-    rootNodes = mapNode(rootNodes, state.currentThinkingId, (t) =>
+  if (workingState.currentThinkingId) {
+    rootNodes = mapNode(rootNodes, workingState.currentThinkingId, (t) =>
       t.status === 'running' ? { ...t, status: 'completed' as const } : t,
     );
   }
 
   // Move auto-scroll focus onto the streaming text. Subsequent deltas
   // keep the same id (textIsOpen stays true), so the camera sits on
-  // this bubble until tool_use closes it or the turn ends.
+  // this bubble until tool_use closes it or the turn ends. Spread
+  // workingState (not state) to preserve any synthetic-thinking
+  // mutations from the iteration-boundary helper above.
   return {
-    ...state,
+    ...workingState,
     rootNodes,
     activeNodeId: textId,
     currentTextId: textId,
@@ -596,6 +619,65 @@ function appendTextToCurrentTurn(
     thinkingSealed: true,
     ...(isNewNode ? { nextSyntheticId } : {}),
   };
+}
+
+/**
+ * Mints a new thinking node under {@code turn} and returns the updated
+ * tree state. Encapsulates the "iteration boundary" reconciliation
+ * (provisionally complete previous iteration's running work) plus the
+ * iteration-anchor reset (clear currentTextId/textIsOpen). Used by both
+ * {@link appendThinkingToCurrentTurn} (real thinking deltas) and
+ * {@link appendTextToCurrentTurn} (synthetic thinking when text starts a
+ * new iteration without a preceding stream.thinking event).
+ *
+ * @param initialDelta first thinking delta — for synthetic insertions
+ *   pass an empty string
+ * @param initialStatus 'running' for real thinking, 'completed' for
+ *   synthetic placeholders (the "model didn't think" case is already
+ *   over by the time we infer the iteration boundary from a text delta)
+ */
+function mintIterationThinking(
+  state: ExecutionTree,
+  turn: ExecutionNode,
+  initialDelta: string,
+  initialStatus: ExecutionStatus,
+): { state: ExecutionTree; thinkingId: string } {
+  // Reconcile previous iteration: provisionally complete any
+  // still-running tools/text under the prior thinking so they stop
+  // pulsing as soon as we know the next iteration has started. Real
+  // tool_completed events still apply normally when they arrive.
+  let preparedRootNodes = state.rootNodes;
+  if (state.currentThinkingId) {
+    preparedRootNodes = mapNode(state.rootNodes, state.currentThinkingId, (n) =>
+      provisionallyCompleteRunningWork(n),
+    );
+  }
+
+  const existingThinkingCount = countDescendantsOfType(turn, 'thinking');
+  const id =
+    existingThinkingCount === 0
+      ? thinkingNodeId(turn.id)
+      : `${thinkingNodeId(turn.id)}:${existingThinkingCount}`;
+  const thinkingNode: ExecutionNode = {
+    id,
+    type: 'thinking',
+    status: initialStatus,
+    label: 'thinking',
+    children: [],
+    text: initialDelta,
+  };
+  const newState: ExecutionTree = {
+    ...state,
+    rootNodes: appendChild(preparedRootNodes, turn.id, thinkingNode),
+    currentThinkingId: id,
+    thinkingSealed: false,
+    // New iteration: forget the previous iteration's text anchors so
+    // tools/text in this iteration attach to the new thinking, not the
+    // old text node.
+    currentTextId: null,
+    textIsOpen: false,
+  };
+  return { state: newState, thinkingId: id };
 }
 
 function appendThinkingToCurrentTurn(
@@ -630,54 +712,10 @@ function appendThinkingToCurrentTurn(
     };
   }
 
-  // New iteration boundary. The model has gathered the previous
-  // iteration's tool results and is now reasoning about the next step
-  // — by API definition, every tool from the previous iteration MUST
-  // have completed (otherwise the model wouldn't have results to
-  // reason about). Daemon's tool_completed events sometimes arrive
-  // AFTER the next iteration's first thinking deltas (the daemon
-  // kicks off the next LLM call before broadcasting completion), so
-  // without reconciliation here the previous iteration's tools would
-  // keep pulsing alongside the new thinking — visually looking
-  // "parallel" when they're really sequential. Provisionally complete
-  // the prior subtree's running tools/text now; when the real
-  // tool_completed event arrives it'll overwrite with the correct
-  // status (failed vs completed) plus duration/error metadata.
-  let preparedRootNodes = state.rootNodes;
-  if (state.currentThinkingId) {
-    preparedRootNodes = mapNode(state.rootNodes, state.currentThinkingId, (n) =>
-      provisionallyCompleteRunningWork(n),
-    );
-  }
-
-  // Mint a new thinking node. Use a synthetic id keyed on the turn +
-  // an index so multiple thinking nodes per turn each get a unique id
-  // (the first uses the existing `${turnId}:thinking` id; later
-  // iterations append a counter).
-  const existingThinkingCount = countDescendantsOfType(turn, 'thinking');
-  const id =
-    existingThinkingCount === 0
-      ? thinkingNodeId(turn.id)
-      : `${thinkingNodeId(turn.id)}:${existingThinkingCount}`;
-  const thinkingNode: ExecutionNode = {
-    id,
-    type: 'thinking',
-    status: 'running',
-    label: 'thinking',
-    children: [],
-    text: params.delta,
-  };
-  return {
-    ...state,
-    rootNodes: appendChild(preparedRootNodes, turn.id, thinkingNode),
-    currentThinkingId: id,
-    thinkingSealed: false,
-    // New iteration: forget the previous iteration's text anchors so
-    // tools/text in this iteration attach to the new thinking, not the
-    // old text node.
-    currentTextId: null,
-    textIsOpen: false,
-  };
+  // New iteration boundary — delegate to the shared mint helper which
+  // handles previous-iteration reconciliation (provisional completion
+  // of running tools/text), id minting, and anchor reset.
+  return mintIterationThinking(state, turn, params.delta, 'running').state;
 }
 
 /**

--- a/aceclaw-dashboard/src/reducers/treeReducer.ts
+++ b/aceclaw-dashboard/src/reducers/treeReducer.ts
@@ -321,11 +321,19 @@ function completeTurnNode(
   // but thinking and text are delta-only — there's no explicit "ended"
   // event for them, so without this sweep they'd stay in the 'running'
   // visual state (pulsing glow) forever even after the turn is over.
+  // Capture stopReason on the turn's metadata so the renderer can
+  // surface a badge for non-END_TURN endings (MAX_TOKENS, ERROR, …).
+  // Older daemons that don't emit stopReason produce undefined, which
+  // the renderer treats as "normal" — same visual as END_TURN.
   const rootNodes = mapNode(state.rootNodes, params.requestId, (n) => ({
     ...completeRunningDeltaDescendants(n),
     status: 'completed' as const,
     endTime: Date.parse(params.timestamp),
     duration: params.durationMs,
+    metadata: {
+      ...(n.metadata ?? {}),
+      ...(params.stopReason !== undefined ? { stopReason: params.stopReason } : {}),
+    },
   }));
   // Don't bubble activeNodeId up to the parent (session/step) when the
   // turn closes — that yanks the dashboard's auto-scroll back to the

--- a/aceclaw-dashboard/src/reducers/treeReducer.ts
+++ b/aceclaw-dashboard/src/reducers/treeReducer.ts
@@ -364,18 +364,28 @@ function addToolNode(
   state: ExecutionTree,
   params: ToolUseParams,
 ): ExecutionTree {
-  // Tools attach to the most recent thinking anchor under the running turn
-  // when extended thinking is enabled — that captures the ReAct semantic of
-  // "thinking is the cause, tool calls are its effects" and groups parallel
-  // tools from one LLM response under one parent. With no thinking events
-  // (e.g. extended thinking disabled), tools fall back to attaching to the
-  // turn itself, preserving the pre-thinking-anchor behaviour.
+  // Tools attach to the deepest causal node of the current iteration:
+  //   1. The iteration's narration (text) when one exists — narration is
+  //      the model verbalising its plan ("I'll call A and B"), and the
+  //      tools that follow are the execution of that plan. Parent → child.
+  //   2. Otherwise the iteration's thinking — when the model went straight
+  //      from reasoning to acting with no narration, thinking is the cause.
+  //   3. Otherwise the running turn — extended thinking off, or events
+  //      arrived out of order. Fallback so the tool still surfaces.
+  // Parallel tools from one LLM response don't get a thinking delta or
+  // a text delta between them, so they share the same anchor — they
+  // attach as siblings to whichever anchor was selected for the first
+  // tool of the call.
   const turn = findNearestAncestor(
     state.rootNodes,
     state.activeNodeId,
     (n) => n.type === 'turn' && n.status === 'running',
   );
-  const anchorId = state.currentThinkingId ?? (turn ? turn.id : null);
+  const narrationId = state.currentThinkingId
+    ? (findNode(state.rootNodes, textNodeId(state.currentThinkingId))?.id ?? null)
+    : null;
+  const anchorId =
+    narrationId ?? state.currentThinkingId ?? (turn ? turn.id : null);
 
   const tool: ExecutionNode = {
     id: params.id,
@@ -411,13 +421,18 @@ function addToolNode(
     rootNodes = [...state.rootNodes, tool];
   }
 
-  // Mark the thinking anchor as completed: the LLM has stopped thinking
-  // and is now acting. Without this, the thinking node would keep its
-  // running-status pulse indefinitely while tools execute, even though
-  // the model is no longer actively thinking. Only flip 'running' →
-  // 'completed' so we don't clobber a thinking that already failed/etc.
+  // Mark the thinking AND any narration text as completed: once
+  // tool_use starts, the LLM has stopped both reasoning and talking
+  // for this iteration — both should stop pulsing immediately so the
+  // visual state matches reality. Only flip 'running' → 'completed'
+  // so a node that already failed/etc. isn't clobbered.
   if (state.currentThinkingId) {
     rootNodes = mapNode(rootNodes, state.currentThinkingId, (t) =>
+      t.status === 'running' ? { ...t, status: 'completed' as const } : t,
+    );
+  }
+  if (narrationId) {
+    rootNodes = mapNode(rootNodes, narrationId, (t) =>
       t.status === 'running' ? { ...t, status: 'completed' as const } : t,
     );
   }

--- a/aceclaw-dashboard/src/reducers/treeReducer.ts
+++ b/aceclaw-dashboard/src/reducers/treeReducer.ts
@@ -65,9 +65,29 @@ export function stepNodeId(planId: string, stepIndex: number): string {
   return `${planId}:step:${stepIndex}`;
 }
 
-/** ID for the rolled-up text-bubble child of a turn. One per turn. */
-export function textNodeId(turnId: string): string {
-  return `${turnId}:text`;
+/**
+ * ID for the text bubble of a single ReAct iteration. The previous form
+ * keyed text on the turn ({@code `${turnId}:text`}) and rolled every
+ * delta the turn ever produced into one node — but a turn typically
+ * contains multiple LLM calls, each potentially emitting its own
+ * narrative text before tool_use, plus a final response text. Lumping
+ * them together produces a single ever-growing "response" node that
+ * lives from the very first delta and visually drags as later
+ * iterations are added. Keying on the iteration's thinking id instead
+ * gives one text node per LLM call, attached to that call's thinking
+ * as a sibling of its tools.
+ */
+export function textNodeId(thinkingId: string): string {
+  return `${thinkingId}:text`;
+}
+
+/**
+ * Fallback id for text emitted in an iteration that produced no
+ * thinking event (extended thinking off, or model emitted text first).
+ * Keyed on the turn so we still get at most one such node per turn.
+ */
+export function turnTextNodeId(turnId: string): string {
+  return `${turnId}:text:no-thinking`;
 }
 
 /** ID for the rolled-up thinking-bubble child of a turn. One per turn. */
@@ -450,13 +470,32 @@ function completeToolNode(
   };
 }
 
+/**
+ * Truncates text for use as a node label. Tier-1 nodes are 180 px wide
+ * and the renderer truncates to ~24 chars; we cap a bit shorter here
+ * so the live preview reads cleanly while the text streams. Strips
+ * leading whitespace because the model often opens a paragraph with a
+ * newline and an indent that would otherwise dominate the preview.
+ */
+function previewLabel(text: string, max = 22): string {
+  const trimmed = text.replace(/^\s+/, '');
+  if (trimmed.length <= max) return trimmed;
+  return `${trimmed.slice(0, max - 1)}…`;
+}
+
 function appendTextToCurrentTurn(
   state: ExecutionTree,
   params: TextDeltaParams,
 ): ExecutionTree {
-  // Text deltas roll up into a single text-typed child of the current turn so
-  // the renderer can show them as one streaming bubble. If no turn is active,
-  // drop the delta — there's no meaningful place to attach it.
+  // Text in a Claude streaming response is per-LLM-call: each ReAct
+  // iteration may emit one text block (narration before tools, or the
+  // final answer with no tools after). Keying the text node on the
+  // iteration's thinking id gives one bubble per call, attached as a
+  // sibling of that iteration's tools. The previous shape rolled
+  // every delta of every iteration into one turn-level text node,
+  // which created a "response" box on the very first delta and then
+  // visually dragged across the diagram as later iterations were
+  // appended.
   const turn = findNearestAncestor(
     state.rootNodes,
     state.activeNodeId,
@@ -464,44 +503,60 @@ function appendTextToCurrentTurn(
   );
   if (!turn) return state;
 
-  const existing = turn.children.find((c) => c.type === 'text');
+  // Anchor: the active thinking node's id, or the turn id when the
+  // model never emitted a thinking block (extended thinking off, or
+  // text-first content order). Fallback uses turnTextNodeId so a
+  // thinking-less turn still gets at most one text node, not one per
+  // delta.
+  const anchorId = state.currentThinkingId ?? turn.id;
+  const textId =
+    state.currentThinkingId !== null
+      ? textNodeId(state.currentThinkingId)
+      : turnTextNodeId(turn.id);
+
+  // Find the iteration's existing text node by id (not "first text
+  // child of turn" — that would still match a previous iteration's
+  // text under the same turn). Using a stable id keyed on the
+  // iteration anchor makes "extend the current call's text" trivial
+  // to detect.
+  const existing = findNode(state.rootNodes, textId);
+  const newText = (existing?.text ?? '') + params.delta;
   let rootNodes: ExecutionNode[];
-  let textId: string;
   if (existing) {
-    textId = existing.id;
-    rootNodes = mapNode(state.rootNodes, existing.id, (t) => ({
+    rootNodes = mapNode(state.rootNodes, textId, (t) => ({
       ...t,
-      text: (t.text ?? '') + params.delta,
+      text: newText,
+      label: previewLabel(newText),
     }));
   } else {
-    textId = textNodeId(turn.id);
     const textNode: ExecutionNode = {
       id: textId,
       type: 'text',
       status: 'running',
-      label: 'response',
+      label: previewLabel(newText),
       children: [],
-      text: params.delta,
+      text: newText,
     };
-    rootNodes = appendChild(state.rootNodes, turn.id, textNode);
+    rootNodes = appendChild(state.rootNodes, anchorId, textNode);
   }
-  // Mark the thinking anchor as completed: text response means the LLM
-  // has stopped thinking and is now responding (mirrors the thinking →
-  // tool transition in addToolNode). Only flip running → completed.
+
+  // Mark the thinking anchor as completed: text means the LLM has
+  // stopped thinking and is now talking. Mirrors the thinking → tool
+  // transition in addToolNode. Only flip running → completed.
   if (state.currentThinkingId) {
     rootNodes = mapNode(rootNodes, state.currentThinkingId, (t) =>
       t.status === 'running' ? { ...t, status: 'completed' as const } : t,
     );
   }
-  // Move auto-scroll focus onto the response. Without this, activeNodeId
-  // stays on the previous tool and the camera centres there while the
-  // model is actually streaming text — the user wants to watch the
-  // response form, not stare at a finished tool. Subsequent text deltas
-  // are no-ops for activeNodeId (still pointing at the same response
-  // node), so the camera sits on the response until the turn closes.
-  // Seal the thinking anchor: a text response means the model has decided
-  // to talk rather than tool-call, so any subsequent thinking is the next
-  // ReAct iteration (or — typically — there is no next iteration).
+
+  // Move auto-scroll focus onto the streaming text so the camera
+  // follows it. Subsequent deltas keep the same id, so the camera
+  // stays on this bubble until the next iteration starts (or the
+  // turn closes).
+  // Seal the thinking anchor: any subsequent thinking delta is from a
+  // NEW LLM call (next ReAct iteration). tool_use within the SAME
+  // call still attaches to the existing thinking — sealed only
+  // affects the next-thinking-delta branch.
   return { ...state, rootNodes, activeNodeId: textId, thinkingSealed: true };
 }
 

--- a/aceclaw-dashboard/src/reducers/treeReducer.ts
+++ b/aceclaw-dashboard/src/reducers/treeReducer.ts
@@ -607,9 +607,29 @@ function appendThinkingToCurrentTurn(
     };
   }
 
-  // New iteration: mint a new thinking node. Use a synthetic id keyed on
-  // the turn + an index so multiple thinking nodes per turn each get a
-  // unique id (the first uses the existing `${turnId}:thinking` id; later
+  // New iteration boundary. The model has gathered the previous
+  // iteration's tool results and is now reasoning about the next step
+  // — by API definition, every tool from the previous iteration MUST
+  // have completed (otherwise the model wouldn't have results to
+  // reason about). Daemon's tool_completed events sometimes arrive
+  // AFTER the next iteration's first thinking deltas (the daemon
+  // kicks off the next LLM call before broadcasting completion), so
+  // without reconciliation here the previous iteration's tools would
+  // keep pulsing alongside the new thinking — visually looking
+  // "parallel" when they're really sequential. Provisionally complete
+  // the prior subtree's running tools/text now; when the real
+  // tool_completed event arrives it'll overwrite with the correct
+  // status (failed vs completed) plus duration/error metadata.
+  let preparedRootNodes = state.rootNodes;
+  if (state.currentThinkingId) {
+    preparedRootNodes = mapNode(state.rootNodes, state.currentThinkingId, (n) =>
+      provisionallyCompleteRunningWork(n),
+    );
+  }
+
+  // Mint a new thinking node. Use a synthetic id keyed on the turn +
+  // an index so multiple thinking nodes per turn each get a unique id
+  // (the first uses the existing `${turnId}:thinking` id; later
   // iterations append a counter).
   const existingThinkingCount = countDescendantsOfType(turn, 'thinking');
   const id =
@@ -626,10 +646,36 @@ function appendThinkingToCurrentTurn(
   };
   return {
     ...state,
-    rootNodes: appendChild(state.rootNodes, turn.id, thinkingNode),
+    rootNodes: appendChild(preparedRootNodes, turn.id, thinkingNode),
     currentThinkingId: id,
     thinkingSealed: false,
   };
+}
+
+/**
+ * Returns {@code node} with every still-running {@code tool} or
+ * {@code text} descendant flipped to {@code completed}. Used at
+ * iteration boundaries to absorb the timing slop between a tool
+ * finishing on the daemon side and its {@code tool_completed} event
+ * arriving on the wire — the next iteration's events frequently
+ * overtake the completion broadcast, leaving previous-iteration tools
+ * stuck pulsing in the dashboard. The real tool_completed event is
+ * still applied normally when it arrives; this just removes the
+ * visual ambiguity in the gap.
+ */
+function provisionallyCompleteRunningWork(node: ExecutionNode): ExecutionNode {
+  if (node.children.length === 0) return node;
+  const updated = node.children.map((c) => {
+    const child = provisionallyCompleteRunningWork(c);
+    if (
+      (child.type === 'tool' || child.type === 'text') &&
+      child.status === 'running'
+    ) {
+      return { ...child, status: 'completed' as const };
+    }
+    return child;
+  });
+  return { ...node, children: updated };
 }
 
 /**

--- a/aceclaw-dashboard/src/reducers/treeReducer.ts
+++ b/aceclaw-dashboard/src/reducers/treeReducer.ts
@@ -304,10 +304,12 @@ function addTurnNode(
     rootNodes,
     activeNodeId: turn.id,
     // A new turn always starts a fresh ReAct loop — clear the thinking
-    // anchor so the first tool of this turn doesn't accidentally graft
-    // itself onto the previous turn's last thinking node.
+    // and text anchors so the first event of this turn doesn't graft
+    // itself onto the previous turn's last node.
     currentThinkingId: null,
     thinkingSealed: false,
+    currentTextId: null,
+    textIsOpen: false,
     stats: { ...state.stats, totalTurns: state.stats.totalTurns + 1 },
   };
 }
@@ -389,11 +391,15 @@ function addToolNode(
     state.activeNodeId,
     (n) => n.type === 'turn' && n.status === 'running',
   );
-  const narrationId = state.currentThinkingId
-    ? (findNode(state.rootNodes, textNodeId(state.currentThinkingId))?.id ?? null)
-    : null;
+  // Tool anchor preference: the active narration text (if one is open
+  // OR was the most recent under current thinking) > thinking > turn.
+  // currentTextId stays valid through parallel tool_use events so they
+  // share the same anchor. textIsOpen=false (after a tool closed the
+  // text) keeps the anchor for parallel-tool grouping but signals to
+  // the next text delta that it's a NEW iteration.
   const anchorId =
-    narrationId ?? state.currentThinkingId ?? (turn ? turn.id : null);
+    state.currentTextId ?? state.currentThinkingId ?? (turn ? turn.id : null);
+  const narrationId = state.currentTextId;
 
   const tool: ExecutionNode = {
     id: params.id,
@@ -449,12 +455,14 @@ function addToolNode(
     ...state,
     rootNodes,
     activeNodeId: tool.id,
-    // Seal the current thinking anchor: any subsequent thinking delta is
-    // from a NEW LLM call (next ReAct iteration) and should mint a new
-    // thinking node rather than concatenate into this one. Parallel
-    // tool_use events that follow within the SAME LLM call don't get a
-    // thinking delta between them, so the anchor stays valid for them.
+    // Seal both anchors: a tool_use means the model has stopped
+    // thinking AND stopped talking; the next thinking OR text delta is
+    // from a NEW LLM call (next ReAct iteration). Parallel tool_use
+    // events that follow within the SAME call don't have a thinking
+    // or text delta between them, so currentThinkingId / currentTextId
+    // stay valid for parallel-tool grouping.
     thinkingSealed: true,
+    textIsOpen: false,
     stats: { ...state.stats, totalTools: state.stats.totalTools + 1 },
   };
 }
@@ -510,15 +518,14 @@ function appendTextToCurrentTurn(
   state: ExecutionTree,
   params: TextDeltaParams,
 ): ExecutionTree {
-  // Text in a Claude streaming response is per-LLM-call: each ReAct
-  // iteration may emit one text block (narration before tools, or the
-  // final answer with no tools after). Keying the text node on the
-  // iteration's thinking id gives one bubble per call, attached as a
-  // sibling of that iteration's tools. The previous shape rolled
-  // every delta of every iteration into one turn-level text node,
-  // which created a "response" box on the very first delta and then
-  // visually dragged across the diagram as later iterations were
-  // appended.
+  // Text in a Claude streaming response is per-LLM-call. Two anchors
+  // separate "extend the live text" from "start a new iteration's
+  // text": currentTextId tracks the live node; textIsOpen=false (set
+  // by tool_use) signals that the text was sealed and the next delta
+  // belongs to a NEW iteration. Without this flag, an iteration that
+  // skips its thinking block (model went straight from tool result to
+  // final response) would silently merge into the previous iter's
+  // text node, because both ids would key on the same currentThinkingId.
   const turn = findNearestAncestor(
     state.rootNodes,
     state.activeNodeId,
@@ -526,23 +533,28 @@ function appendTextToCurrentTurn(
   );
   if (!turn) return state;
 
-  // Anchor: the active thinking node's id, or the turn id when the
-  // model never emitted a thinking block (extended thinking off, or
-  // text-first content order). Fallback uses turnTextNodeId so a
-  // thinking-less turn still gets at most one text node, not one per
-  // delta.
-  const anchorId = state.currentThinkingId ?? turn.id;
-  const textId =
-    state.currentThinkingId !== null
-      ? textNodeId(state.currentThinkingId)
-      : turnTextNodeId(turn.id);
+  let textId: string;
+  let isNewNode: boolean;
+  let nextSyntheticId = state.nextSyntheticId;
+  if (state.currentTextId && state.textIsOpen) {
+    textId = state.currentTextId;
+    isNewNode = false;
+  } else {
+    // New iteration: mint a unique id keyed on (anchor, counter).
+    // The counter (nextSyntheticId) ensures uniqueness when an
+    // iteration's text follows a tool_use without a fresh thinking
+    // delta — both ids would key on the same currentThinkingId
+    // otherwise and silently collide.
+    const counter = nextSyntheticId;
+    nextSyntheticId += 1;
+    textId =
+      state.currentThinkingId !== null
+        ? `${state.currentThinkingId}:text:${counter}`
+        : `${turn.id}:text:${counter}`;
+    isNewNode = true;
+  }
 
-  // Find the iteration's existing text node by id (not "first text
-  // child of turn" — that would still match a previous iteration's
-  // text under the same turn). Using a stable id keyed on the
-  // iteration anchor makes "extend the current call's text" trivial
-  // to detect.
-  const existing = findNode(state.rootNodes, textId);
+  const existing = !isNewNode ? findNode(state.rootNodes, textId) : null;
   const newText = (existing?.text ?? '') + params.delta;
   let rootNodes: ExecutionNode[];
   if (existing) {
@@ -552,6 +564,7 @@ function appendTextToCurrentTurn(
       label: previewLabel(newText),
     }));
   } else {
+    const anchorId = state.currentThinkingId ?? turn.id;
     const textNode: ExecutionNode = {
       id: textId,
       type: 'text',
@@ -564,23 +577,25 @@ function appendTextToCurrentTurn(
   }
 
   // Mark the thinking anchor as completed: text means the LLM has
-  // stopped thinking and is now talking. Mirrors the thinking → tool
-  // transition in addToolNode. Only flip running → completed.
+  // stopped thinking and is now talking.
   if (state.currentThinkingId) {
     rootNodes = mapNode(rootNodes, state.currentThinkingId, (t) =>
       t.status === 'running' ? { ...t, status: 'completed' as const } : t,
     );
   }
 
-  // Move auto-scroll focus onto the streaming text so the camera
-  // follows it. Subsequent deltas keep the same id, so the camera
-  // stays on this bubble until the next iteration starts (or the
-  // turn closes).
-  // Seal the thinking anchor: any subsequent thinking delta is from a
-  // NEW LLM call (next ReAct iteration). tool_use within the SAME
-  // call still attaches to the existing thinking — sealed only
-  // affects the next-thinking-delta branch.
-  return { ...state, rootNodes, activeNodeId: textId, thinkingSealed: true };
+  // Move auto-scroll focus onto the streaming text. Subsequent deltas
+  // keep the same id (textIsOpen stays true), so the camera sits on
+  // this bubble until tool_use closes it or the turn ends.
+  return {
+    ...state,
+    rootNodes,
+    activeNodeId: textId,
+    currentTextId: textId,
+    textIsOpen: true,
+    thinkingSealed: true,
+    ...(isNewNode ? { nextSyntheticId } : {}),
+  };
 }
 
 function appendThinkingToCurrentTurn(
@@ -657,6 +672,11 @@ function appendThinkingToCurrentTurn(
     rootNodes: appendChild(preparedRootNodes, turn.id, thinkingNode),
     currentThinkingId: id,
     thinkingSealed: false,
+    // New iteration: forget the previous iteration's text anchors so
+    // tools/text in this iteration attach to the new thinking, not the
+    // old text node.
+    currentTextId: null,
+    textIsOpen: false,
   };
 }
 

--- a/aceclaw-dashboard/src/reducers/treeReducer.ts
+++ b/aceclaw-dashboard/src/reducers/treeReducer.ts
@@ -533,23 +533,26 @@ function appendTextToCurrentTurn(
   );
   if (!turn) return state;
 
-  // If we're starting a new iteration's text (previous iteration
-  // closed by a tool_use → textIsOpen=false → thinkingSealed=true)
-  // AND the model didn't emit a fresh stream.thinking event for this
-  // iteration, mint a SYNTHETIC thinking node to anchor it. Without
-  // this, the new text/tools all pile up under the previous
-  // iteration's thinking, producing 3-5+ text bubbles stacked
-  // vertically as siblings — visually reading as "parallel
-  // responses" when they're actually sequential iterations of one
-  // ReAct loop. The synthetic thinking is created status=completed
-  // (the model already finished thinking by the time we infer the
-  // boundary from a text delta) and gets the same shape as a real
-  // thinking node so the layout chains identically.
+  // If we're starting a new iteration's text without a fresh
+  // stream.thinking event, mint a SYNTHETIC thinking node to anchor
+  // it. Two cases trigger this:
+  //   1. textIsOpen=false + thinkingSealed=true: previous iteration
+  //      closed by a tool_use, next call started with text directly.
+  //   2. textIsOpen=false + currentThinkingId=null: this is the very
+  //      first event of the turn AND it's a text (extended thinking
+  //      off, model went straight to text). Without the synthetic
+  //      thinking the text would land as a turn-direct child and
+  //      addReActFlowEdges (which only iterates thinking siblings)
+  //      would orphan it from the ReAct chain.
+  //
+  // The synthetic thinking is created status=completed — the model
+  // already finished thinking by the time we infer the boundary from
+  // a text delta — and gets the same shape as a real thinking node
+  // so the layout chains identically.
   let workingState = state;
   if (
     !state.textIsOpen &&
-    state.thinkingSealed &&
-    state.currentThinkingId !== null
+    (state.thinkingSealed || state.currentThinkingId === null)
   ) {
     workingState = mintIterationThinking(state, turn, '', 'completed').state;
   }

--- a/aceclaw-dashboard/src/types/events.ts
+++ b/aceclaw-dashboard/src/types/events.ts
@@ -86,6 +86,17 @@ export interface TurnCompletedParams {
   durationMs: number;
   toolCount: number;
   timestamp: string; // ISO-8601
+  /**
+   * Why the model stopped generating output for this turn. Optional for
+   * forward/backward compat with daemons that don't yet emit it. Values
+   * follow the daemon's StopReason enum: {@code END_TURN} (normal),
+   * {@code MAX_TOKENS}, {@code TOOL_USE}, {@code STOP_SEQUENCE},
+   * {@code ERROR}. The dashboard renders a small badge on the turn
+   * node when this is anything other than {@code END_TURN} so the
+   * reader can tell at a glance why a turn ended without a final-text
+   * response.
+   */
+  stopReason?: string;
 }
 
 // --- Existing daemon stream events ---

--- a/aceclaw-dashboard/src/types/tree.ts
+++ b/aceclaw-dashboard/src/types/tree.ts
@@ -102,6 +102,27 @@ export interface ExecutionTree {
    * iteration rather than one fat concatenated node per turn.
    */
   thinkingSealed: boolean;
+  /**
+   * The text (narration / response) node currently being streamed for the
+   * active iteration. Used as the anchor for {@code stream.tool_use}
+   * events that follow narration in the same LLM call (so tools nest
+   * under the text that announced them). Stays valid across parallel
+   * tool_use events so they share the same parent. Reset when a new
+   * iteration starts (new thinking delta, or when {@link textIsOpen}
+   * is false and the next text delta arrives).
+   */
+  currentTextId: string | null;
+  /**
+   * True while the current iteration's text block is open for more
+   * deltas. A {@code tool_use} closes the text block (the model has
+   * stopped talking and started acting) — we keep
+   * {@link currentTextId} for tool anchoring, but the next text delta
+   * must mint a NEW node, because it belongs to the NEXT iteration.
+   * Without this flag, an iteration that emits text without a
+   * preceding thinking delta would silently merge into the previous
+   * iteration's text (ids both keyed on {@link currentThinkingId}).
+   */
+  textIsOpen: boolean;
   /** Aggregate counters surfaced in the UI sidebar. */
   stats: TreeStats;
 }
@@ -125,6 +146,8 @@ export function emptyTree(sessionId: string): ExecutionTree {
     nextSyntheticId: 1,
     currentThinkingId: null,
     thinkingSealed: false,
+    currentTextId: null,
+    textIsOpen: false,
     stats: {
       totalTools: 0,
       completedTools: 0,

--- a/aceclaw-dashboard/tests/treeReducer.test.ts
+++ b/aceclaw-dashboard/tests/treeReducer.test.ts
@@ -583,10 +583,11 @@ describe('text accumulation', () => {
     expect(thinkingChildren[0]!.label).toBe('thinking');
   });
 
-  it('keeps thinking and text as siblings under the same turn', () => {
-    // A real turn often thinks then responds; both nodes should hang off
-    // the turn so the layout shows two distinct children rather than one
-    // collapsing into the other.
+  it('places text inside its iteration thinking, not as a sibling of the turn', () => {
+    // Text in a Claude streaming response is per-LLM-call. Anchoring
+    // it on the iteration's thinking lets multi-iteration turns keep
+    // each call's narration locally bound — the text node doesn't
+    // visually drift across the diagram as later iterations append.
     const state = runAll(
       freshTree(),
       envelope('stream.session_started', {
@@ -604,8 +605,103 @@ describe('text accumulation', () => {
       envelope('stream.text', { delta: 'response' }),
     );
     const turn = state.rootNodes[0]!.children[0]!;
-    const childTypes = turn.children.map((c) => c.type).sort();
-    expect(childTypes).toEqual(['text', 'thinking']);
+    expect(turn.children.map((c) => c.type)).toEqual(['thinking']);
+    const thinking = turn.children[0]!;
+    const textChildren = thinking.children.filter((c) => c.type === 'text');
+    expect(textChildren).toHaveLength(1);
+    expect(textChildren[0]!.text).toBe('response');
+  });
+
+  it('mints a separate text node per ReAct iteration (no cross-iteration accumulation)', () => {
+    // The bug this guards against: with text keyed on the turn, every
+    // iteration's text deltas would pile into one node that survives
+    // all the layout reshuffles. Per-iteration text bubbles stay where
+    // their iteration is.
+    const state = runAll(
+      freshTree(),
+      envelope('stream.session_started', {
+        sessionId: 'sess-1',
+        model: 'm',
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.turn_started', {
+        sessionId: 'sess-1',
+        requestId: 'req-1',
+        turnNumber: 1,
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      // Iter 1: thinking → text → tool
+      envelope('stream.thinking', { delta: 'iter 1 thought' }),
+      envelope('stream.text', { delta: 'iter 1 narration' }),
+      envelope('stream.tool_use', { id: 't1', name: 'bash' }),
+      // Iter 2: thinking → text (final response)
+      envelope('stream.thinking', { delta: 'iter 2 thought' }),
+      envelope('stream.text', { delta: 'iter 2 final answer' }),
+    );
+    const turn = state.rootNodes[0]!.children[0]!;
+    const thinkings = turn.children.filter((c) => c.type === 'thinking');
+    expect(thinkings).toHaveLength(2);
+    const text1 = thinkings[0]!.children.find((c) => c.type === 'text')!;
+    const text2 = thinkings[1]!.children.find((c) => c.type === 'text')!;
+    expect(text1.text).toBe('iter 1 narration');
+    expect(text2.text).toBe('iter 2 final answer');
+    // Texts have distinct ids — no leakage across iterations.
+    expect(text1.id).not.toBe(text2.id);
+  });
+
+  it('falls back to attaching text to the turn when no thinking has been emitted', () => {
+    // Extended thinking off, or model emitted text without a prior
+    // thinking block. Text still gets at most one node per turn,
+    // keyed on a turn-level fallback id.
+    const state = runAll(
+      freshTree(),
+      envelope('stream.session_started', {
+        sessionId: 'sess-1',
+        model: 'm',
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.turn_started', {
+        sessionId: 'sess-1',
+        requestId: 'req-1',
+        turnNumber: 1,
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.text', { delta: 'no thinking, just talk' }),
+      envelope('stream.text', { delta: ' more talk' }),
+    );
+    const turn = state.rootNodes[0]!.children[0]!;
+    const textChildren = turn.children.filter((c) => c.type === 'text');
+    expect(textChildren).toHaveLength(1);
+    expect(textChildren[0]!.text).toBe('no thinking, just talk more talk');
+  });
+
+  it('uses a truncated text preview as the node label', () => {
+    const state = runAll(
+      freshTree(),
+      envelope('stream.session_started', {
+        sessionId: 'sess-1',
+        model: 'm',
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.turn_started', {
+        sessionId: 'sess-1',
+        requestId: 'req-1',
+        turnNumber: 1,
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.thinking', { delta: 't' }),
+      envelope('stream.text', {
+        delta: 'this is a much longer response that exceeds the preview cap',
+      }),
+    );
+    const turn = state.rootNodes[0]!.children[0]!;
+    const text = turn.children[0]!.children.find((c) => c.type === 'text')!;
+    // Label is truncated and ends with the ellipsis sentinel.
+    expect(text.label.length).toBeLessThanOrEqual(22);
+    expect(text.label.endsWith('…')).toBe(true);
+    // But the full text is preserved on the node itself for the
+    // detail view / debugging.
+    expect(text.text!.length).toBeGreaterThan(text.label.length);
   });
 });
 

--- a/aceclaw-dashboard/tests/treeReducer.test.ts
+++ b/aceclaw-dashboard/tests/treeReducer.test.ts
@@ -834,6 +834,58 @@ describe('thinking-anchored tool grouping (ReAct iterations)', () => {
     expect(thinking.status).toBe('completed');
   });
 
+  it("provisionally completes previous iteration's running tools when next thinking starts", () => {
+    // The daemon races: a new iteration's thinking deltas often
+    // arrive before the previous iteration's tool_completed event.
+    // Without reconciliation the previous tool would keep pulsing
+    // while the new thinking pulses, looking visually parallel.
+    // Mint-time sweep flips any still-running tool/text in the prior
+    // subtree to completed; the real tool_completed event still
+    // applies normally when it arrives (with duration / isError).
+    const state = runAll(
+      startedTurn(),
+      envelope('stream.thinking', { delta: 'iter 1' }),
+      envelope('stream.tool_use', { id: 'tool-A', name: 'bash' }),
+      // No tool_completed yet — the daemon hasn't broadcast it. But
+      // the next iteration's thinking delta arrives:
+      envelope('stream.thinking', { delta: 'iter 2 (next call)' }),
+    );
+    const turn = state.rootNodes[0]!.children[0]!;
+    const thinking1 = turn.children[0]!;
+    const tool = thinking1.children.find((c) => c.id === 'tool-A')!;
+    // Tool is now completed (provisionally) even though no
+    // tool_completed event has arrived. New thinking is running.
+    expect(tool.status).toBe('completed');
+    const thinking2 = turn.children[1]!;
+    expect(thinking2.status).toBe('running');
+  });
+
+  it('lets a real tool_completed event overwrite the provisional status', () => {
+    // The provisional sweep marks running tools as 'completed'; a
+    // later tool_completed event with isError=true must still flip
+    // the tool to 'failed' (with the real error metadata).
+    const state = runAll(
+      startedTurn(),
+      envelope('stream.thinking', { delta: 'iter 1' }),
+      envelope('stream.tool_use', { id: 'tool-A', name: 'bash' }),
+      envelope('stream.thinking', { delta: 'iter 2' }),
+      // Real completion arrives late, with a failure result:
+      envelope('stream.tool_completed', {
+        id: 'tool-A',
+        name: 'bash',
+        durationMs: 1234,
+        isError: true,
+        error: 'exit code 1',
+      }),
+    );
+    const turn = state.rootNodes[0]!.children[0]!;
+    const thinking1 = turn.children[0]!;
+    const tool = thinking1.children.find((c) => c.id === 'tool-A')!;
+    expect(tool.status).toBe('failed');
+    expect(tool.error).toBe('exit code 1');
+    expect(tool.duration).toBe(1234);
+  });
+
   it('attaches tool_use as a child of the iteration narration when text exists', () => {
     // Causal chain: thinking → narration ("I'll call A and B") → tools
     // (the actions that narration described). When the iteration emits

--- a/aceclaw-dashboard/tests/treeReducer.test.ts
+++ b/aceclaw-dashboard/tests/treeReducer.test.ts
@@ -4,7 +4,7 @@ import type {
   DaemonEventEnvelope,
   EventParams,
 } from '../src/types/events';
-import { emptyTree, type ExecutionTree } from '../src/types/tree';
+import { emptyTree, type ExecutionNode, type ExecutionTree } from '../src/types/tree';
 import { executionTreeReducer, stepNodeId } from '../src/reducers/treeReducer';
 
 /**
@@ -925,14 +925,21 @@ describe('thinking-anchored tool grouping (ReAct iterations)', () => {
     expect(tool.duration).toBe(1234);
   });
 
-  it('mints a separate text node when the next iteration text follows a tool_use without new thinking', () => {
+  it('mints a synthetic thinking + text node when the next iteration emits text without a preceding thinking event', () => {
     // The bug this guards against: an iteration that emits text
-    // WITHOUT a preceding thinking event (model went straight from
-    // tool result → final response, e.g. extended thinking off or
-    // budget exhausted) used to merge into the previous iteration's
-    // text node, because both ids were keyed on the same
-    // currentThinkingId. After the fix, tool_use closes the text
-    // (textIsOpen=false), so the next text delta mints a new node.
+    // WITHOUT a preceding thinking event (extended thinking off or
+    // budget exhausted) used to silently merge into the previous
+    // iteration's text node — the dashboard rendered all iterations'
+    // narrations as siblings of one fat thinking, which dagre laid
+    // out as a vertical stack that read as "5 parallel responses".
+    //
+    // Fix: when text starts a new iteration without a fresh thinking
+    // delta, mint a SYNTHETIC thinking node (status=completed, since
+    // the model already finished thinking by the time we infer the
+    // boundary) so the new text/tools attach to a dedicated anchor.
+    // The result is a chain shape: th_1 → text_1 → tool → synth_th_2 →
+    // text_2 — exactly what the user expects from a multi-iteration
+    // ReAct turn.
     const state = runAll(
       startedTurn(),
       envelope('stream.thinking', { delta: 'iter 1' }),
@@ -944,30 +951,26 @@ describe('thinking-anchored tool grouping (ReAct iterations)', () => {
         durationMs: 100,
         isError: false,
       }),
-      // No stream.thinking before this — model skipped the thinking
-      // block and went straight to the final response. The previous
-      // shape would have appended these deltas to the "narration
-      // before tool" node.
+      // No stream.thinking before this — model went straight from
+      // tool result to final response.
       envelope('stream.text', { delta: 'final answer line 1' }),
       envelope('stream.text', { delta: ' line 2' }),
     );
     const turn = state.rootNodes[0]!.children[0]!;
-    const thinking = turn.children[0]!;
-    // Thinking should now have two text descendants: the narration
-    // (under thinking, with the tool as its child) and the final
-    // response (sibling, separate node).
-    const allTextNodes: ExecutionNode[] = [];
-    function walk(n: ExecutionNode) {
-      if (n.type === 'text') allTextNodes.push(n);
-      n.children.forEach(walk);
-    }
-    walk(thinking);
-    expect(allTextNodes).toHaveLength(2);
-    expect(allTextNodes[0]!.text).toBe('narration before tool');
-    expect(allTextNodes[1]!.text).toBe('final answer line 1 line 2');
-    // The two text nodes have distinct ids — proving the second
-    // iteration didn't accidentally append to the first.
-    expect(allTextNodes[0]!.id).not.toBe(allTextNodes[1]!.id);
+    const thinkings = turn.children.filter((c) => c.type === 'thinking');
+    expect(thinkings).toHaveLength(2);
+    const realThinking = thinkings[0]!;
+    const syntheticThinking = thinkings[1]!;
+    // Real thinking has its narration text + its tool child (under text)
+    expect(realThinking.text).toBe('iter 1');
+    const realText = realThinking.children.find((c) => c.type === 'text')!;
+    expect(realText.text).toBe('narration before tool');
+    // Synthetic thinking has the final response under it
+    expect(syntheticThinking.text).toBe('');
+    expect(syntheticThinking.status).toBe('completed');
+    const synthText = syntheticThinking.children.find((c) => c.type === 'text')!;
+    expect(synthText.text).toBe('final answer line 1 line 2');
+    expect(realText.id).not.toBe(synthText.id);
   });
 
   it('attaches tool_use as a child of the iteration narration when text exists', () => {

--- a/aceclaw-dashboard/tests/treeReducer.test.ts
+++ b/aceclaw-dashboard/tests/treeReducer.test.ts
@@ -541,8 +541,13 @@ describe('text accumulation', () => {
       envelope('stream.text', { delta: 'world' }),
       envelope('stream.text', { delta: '!' }),
     );
+    // Text-without-thinking now anchors on a synthetic thinking node
+    // (so it stays in the ReAct chain instead of orphaning at the
+    // turn level — see addReActFlowEdges in useTreeLayout).
     const turn = state.rootNodes[0]!.children[0]!;
-    const textChildren = turn.children.filter((c) => c.type === 'text');
+    const thinking = turn.children.find((c) => c.type === 'thinking')!;
+    expect(thinking).toBeDefined();
+    const textChildren = thinking.children.filter((c) => c.type === 'text');
     expect(textChildren).toHaveLength(1);
     expect(textChildren[0]!.text).toBe('Hello, world!');
   });
@@ -649,10 +654,12 @@ describe('text accumulation', () => {
     expect(text1.id).not.toBe(text2.id);
   });
 
-  it('falls back to attaching text to the turn when no thinking has been emitted', () => {
-    // Extended thinking off, or model emitted text without a prior
-    // thinking block. Text still gets at most one node per turn,
-    // keyed on a turn-level fallback id.
+  it('attaches text to a synthetic thinking when no real thinking has been emitted', () => {
+    // Extended thinking off, or model emitted text without any prior
+    // thinking block. The reducer mints a synthetic thinking so the
+    // text stays in the ReAct chain (addReActFlowEdges only iterates
+    // thinking children of a turn — text directly under a turn would
+    // be orphaned from the layout flow).
     const state = runAll(
       freshTree(),
       envelope('stream.session_started', {
@@ -670,7 +677,10 @@ describe('text accumulation', () => {
       envelope('stream.text', { delta: ' more talk' }),
     );
     const turn = state.rootNodes[0]!.children[0]!;
-    const textChildren = turn.children.filter((c) => c.type === 'text');
+    expect(turn.children.map((c) => c.type)).toEqual(['thinking']);
+    const synthThinking = turn.children[0]!;
+    expect(synthThinking.status).toBe('completed'); // synthetic, no real reasoning streamed
+    const textChildren = synthThinking.children.filter((c) => c.type === 'text');
     expect(textChildren).toHaveLength(1);
     expect(textChildren[0]!.text).toBe('no thinking, just talk more talk');
   });

--- a/aceclaw-dashboard/tests/treeReducer.test.ts
+++ b/aceclaw-dashboard/tests/treeReducer.test.ts
@@ -834,6 +834,33 @@ describe('thinking-anchored tool grouping (ReAct iterations)', () => {
     expect(thinking.status).toBe('completed');
   });
 
+  it('attaches tool_use as a child of the iteration narration when text exists', () => {
+    // Causal chain: thinking → narration ("I'll call A and B") → tools
+    // (the actions that narration described). When the iteration emits
+    // text before tools, the tools structurally hang off the text node,
+    // not the bare thinking — that puts narration in the right place
+    // visually as the immediate cause of the tools.
+    const state = runAll(
+      startedTurn(),
+      envelope('stream.thinking', { delta: 'plan: call A and B' }),
+      envelope('stream.text', { delta: "I'll call A and B" }),
+      envelope('stream.tool_use', { id: 'tA', name: 'bash' }),
+      envelope('stream.tool_use', { id: 'tB', name: 'read' }),
+    );
+    const turn = state.rootNodes[0]!.children[0]!;
+    const thinking = turn.children[0]!;
+    const text = thinking.children.find((c) => c.type === 'text')!;
+    // Tools hang off text, NOT off thinking.
+    const toolsUnderText = text.children.filter((c) => c.type === 'tool');
+    expect(toolsUnderText.map((t) => t.id).sort()).toEqual(['tA', 'tB']);
+    const toolsUnderThinking = thinking.children.filter((c) => c.type === 'tool');
+    expect(toolsUnderThinking).toHaveLength(0);
+    // Narration is marked completed once tools start (the model stopped
+    // talking and started acting); pulse stops in sync with thinking.
+    expect(text.status).toBe('completed');
+    expect(thinking.status).toBe('completed');
+  });
+
   it('falls back to attaching tools to the turn when no thinking has been emitted', () => {
     // Extended thinking disabled: stream.thinking never fires, so tools
     // attach to the turn directly (preserves the pre-anchor shape).

--- a/aceclaw-dashboard/tests/treeReducer.test.ts
+++ b/aceclaw-dashboard/tests/treeReducer.test.ts
@@ -810,6 +810,45 @@ describe('thinking-anchored tool grouping (ReAct iterations)', () => {
     expect(thinking.status).toBe('completed');
   });
 
+  it('captures stopReason on the turn metadata for the renderer to badge', () => {
+    // The dashboard's GrowingNode renders a small amber "⚠ max_tokens"
+    // tag on truncated turns. The reducer just stamps the value onto
+    // metadata; the renderer decides what to do with it.
+    const state = runAll(
+      startedTurn(),
+      envelope('stream.tool_use', { id: 't1', name: 'bash' }),
+      envelope('stream.turn_completed', {
+        sessionId: 'sess-1',
+        requestId: 'req-1',
+        turnNumber: 1,
+        timestamp: new Date(2026, 0, 1).toISOString(),
+        durationMs: 9999,
+        toolCount: 1,
+        stopReason: 'MAX_TOKENS',
+      }),
+    );
+    const turn = state.rootNodes[0]!.children[0]!;
+    expect(turn.status).toBe('completed');
+    expect(turn.metadata?.['stopReason']).toBe('MAX_TOKENS');
+  });
+
+  it('omits stopReason when the daemon does not emit it (older versions)', () => {
+    const state = runAll(
+      startedTurn(),
+      envelope('stream.tool_use', { id: 't1', name: 'bash' }),
+      envelope('stream.turn_completed', {
+        sessionId: 'sess-1',
+        requestId: 'req-1',
+        turnNumber: 1,
+        timestamp: new Date(2026, 0, 1).toISOString(),
+        durationMs: 100,
+        toolCount: 1,
+      }),
+    );
+    const turn = state.rootNodes[0]!.children[0]!;
+    expect(turn.metadata?.['stopReason']).toBeUndefined();
+  });
+
   it('marks remaining running thinking/text nodes completed when the turn ends', () => {
     // Edge case: a turn ends while a delta-stream child is still
     // 'running' (for example, the model emitted thinking but the turn

--- a/aceclaw-dashboard/tests/treeReducer.test.ts
+++ b/aceclaw-dashboard/tests/treeReducer.test.ts
@@ -925,6 +925,51 @@ describe('thinking-anchored tool grouping (ReAct iterations)', () => {
     expect(tool.duration).toBe(1234);
   });
 
+  it('mints a separate text node when the next iteration text follows a tool_use without new thinking', () => {
+    // The bug this guards against: an iteration that emits text
+    // WITHOUT a preceding thinking event (model went straight from
+    // tool result → final response, e.g. extended thinking off or
+    // budget exhausted) used to merge into the previous iteration's
+    // text node, because both ids were keyed on the same
+    // currentThinkingId. After the fix, tool_use closes the text
+    // (textIsOpen=false), so the next text delta mints a new node.
+    const state = runAll(
+      startedTurn(),
+      envelope('stream.thinking', { delta: 'iter 1' }),
+      envelope('stream.text', { delta: 'narration before tool' }),
+      envelope('stream.tool_use', { id: 't1', name: 'bash' }),
+      envelope('stream.tool_completed', {
+        id: 't1',
+        name: 'bash',
+        durationMs: 100,
+        isError: false,
+      }),
+      // No stream.thinking before this — model skipped the thinking
+      // block and went straight to the final response. The previous
+      // shape would have appended these deltas to the "narration
+      // before tool" node.
+      envelope('stream.text', { delta: 'final answer line 1' }),
+      envelope('stream.text', { delta: ' line 2' }),
+    );
+    const turn = state.rootNodes[0]!.children[0]!;
+    const thinking = turn.children[0]!;
+    // Thinking should now have two text descendants: the narration
+    // (under thinking, with the tool as its child) and the final
+    // response (sibling, separate node).
+    const allTextNodes: ExecutionNode[] = [];
+    function walk(n: ExecutionNode) {
+      if (n.type === 'text') allTextNodes.push(n);
+      n.children.forEach(walk);
+    }
+    walk(thinking);
+    expect(allTextNodes).toHaveLength(2);
+    expect(allTextNodes[0]!.text).toBe('narration before tool');
+    expect(allTextNodes[1]!.text).toBe('final answer line 1 line 2');
+    // The two text nodes have distinct ids — proving the second
+    // iteration didn't accidentally append to the first.
+    expect(allTextNodes[0]!.id).not.toBe(allTextNodes[1]!.id);
+  });
+
   it('attaches tool_use as a child of the iteration narration when text exists', () => {
     // Causal chain: thinking → narration ("I'll call A and B") → tools
     // (the actions that narration described). When the iteration emits

--- a/aceclaw-dashboard/tests/useTreeLayout.test.ts
+++ b/aceclaw-dashboard/tests/useTreeLayout.test.ts
@@ -204,6 +204,83 @@ describe('useTreeLayout', () => {
     expect(containmentIds).toContain('th2->toolC');
   });
 
+  it('does not draw a flow edge from a failed tool — only successful tools carry the chain', () => {
+    // Failed tools render as dead-end leaves: visually clearer that
+    // they didn't drive the next iteration, even though their error
+    // is what the model adapted to. With one tool succeeding and one
+    // failing, only the successful one gets a flow edge.
+    const turn: ExecutionNode = {
+      id: 't',
+      type: 'turn',
+      status: 'running',
+      label: 'turn',
+      children: [
+        {
+          id: 'th1',
+          type: 'thinking',
+          status: 'completed',
+          label: 'thinking',
+          children: [
+            { id: 'good', type: 'tool', status: 'completed', label: 'bash', children: [] },
+            { id: 'bad', type: 'tool', status: 'failed', label: 'bash', children: [] },
+          ],
+        },
+        {
+          id: 'th2',
+          type: 'thinking',
+          status: 'running',
+          label: 'thinking',
+          children: [],
+        },
+      ],
+    };
+    const { result } = renderHook(() => useTreeLayout(tree([turn])));
+    const flowIds = result.current.edges
+      .filter((e) => e.kind === 'sequence')
+      .map((e) => e.id);
+    expect(flowIds).toContain('good->th2');
+    expect(flowIds).not.toContain('bad->th2');
+  });
+
+  it('falls back to thinking-bridge when every tool in an iteration failed', () => {
+    // All-failed iteration: model recovered from a total failure.
+    // The chain still needs to reach the next thinking, so we bridge
+    // via the iteration's text/thinking instead of leaving it
+    // disconnected.
+    const turn: ExecutionNode = {
+      id: 't',
+      type: 'turn',
+      status: 'running',
+      label: 'turn',
+      children: [
+        {
+          id: 'th1',
+          type: 'thinking',
+          status: 'completed',
+          label: 'thinking',
+          children: [
+            { id: 'bad1', type: 'tool', status: 'failed', label: 'bash', children: [] },
+            { id: 'bad2', type: 'tool', status: 'failed', label: 'bash', children: [] },
+          ],
+        },
+        {
+          id: 'th2',
+          type: 'thinking',
+          status: 'running',
+          label: 'thinking',
+          children: [],
+        },
+      ],
+    };
+    const { result } = renderHook(() => useTreeLayout(tree([turn])));
+    const flowIds = result.current.edges
+      .filter((e) => e.kind === 'sequence')
+      .map((e) => e.id);
+    expect(flowIds).toContain('th1->th2');
+    expect(flowIds).not.toContain('bad1->th2');
+    expect(flowIds).not.toContain('bad2->th2');
+  });
+
   it('bridges to the next iteration via the text node when a thinking emitted only text', () => {
     // A pure-text iteration (no tools, just narration) still needs to
     // pass the flow baton to the next iteration's thinking. The text

--- a/aceclaw-dashboard/tests/useTreeLayout.test.ts
+++ b/aceclaw-dashboard/tests/useTreeLayout.test.ts
@@ -145,10 +145,13 @@ describe('useTreeLayout', () => {
   it('chains thinking → tools → next thinking via flow edges (ReAct pipeline)', () => {
     // Two ReAct iterations under one turn:
     //   thinking1 ─┬─ toolA
-    //              └─ toolB ─ ─ ─ ─ ─ thinking2 ─── toolC ─ ─ ─ response
-    // The dashed flow edges from each tool of thinking1 land on thinking2,
-    // expressing "tool results feed the next LLM call". Same idea for
-    // toolC → response: response is the final output of the chain.
+    //              └─ toolB ─ ─ ─ ─ ─ thinking2 ─── toolC
+    //                                              └─── response (under th2)
+    // The dashed flow edges from each tool of thinking1 land on
+    // thinking2, expressing "tool results feed the next LLM call".
+    // The response is a child of its iteration's thinking (th2), so
+    // the layout reaches it via the regular thinking→text containment
+    // — no separate response-flow edge is needed.
     const turn: ExecutionNode = {
       id: 't',
       type: 'turn',
@@ -167,14 +170,16 @@ describe('useTreeLayout', () => {
           type: 'thinking',
           status: 'running',
           label: 'thinking',
-          children: [leaf('toolC')],
-        },
-        {
-          id: 'resp',
-          type: 'text',
-          status: 'running',
-          label: 'response',
-          children: [],
+          children: [
+            leaf('toolC'),
+            {
+              id: 'resp',
+              type: 'text',
+              status: 'running',
+              label: 'response',
+              children: [],
+            },
+          ],
         },
       ],
     };
@@ -182,22 +187,65 @@ describe('useTreeLayout', () => {
     const flow = result.current.edges.filter((e) => e.kind === 'sequence');
     const flowIds = flow.map((e) => e.id).sort();
     // Two flows from thinking1's tools to thinking2 (toolA→th2, toolB→th2).
-    // One flow from thinking2's tool to response (toolC→resp).
     expect(flowIds).toContain('toolA->th2');
     expect(flowIds).toContain('toolB->th2');
-    expect(flowIds).toContain('toolC->resp');
+    // The response no longer gets its own flow edge — it's a child of
+    // th2 reached via plain containment.
+    expect(flowIds).not.toContain('toolC->resp');
 
-    // Containment edges shouldn't include redundant turn→thinking2 or
-    // turn→response — those paths are reached via the flow chain.
     const containment = result.current.edges.filter((e) => e.kind === 'containment');
     const containmentIds = containment.map((e) => e.id);
     expect(containmentIds).toContain('t->th1');
-    expect(containmentIds).not.toContain('t->th2');
-    expect(containmentIds).not.toContain('t->resp');
-    // But thinking → tool containments are intact.
+    expect(containmentIds).not.toContain('t->th2'); // reached via flow
+    // text under thinking IS containment now.
+    expect(containmentIds).toContain('th2->resp');
     expect(containmentIds).toContain('th1->toolA');
     expect(containmentIds).toContain('th1->toolB');
     expect(containmentIds).toContain('th2->toolC');
+  });
+
+  it('bridges to the next iteration via the text node when a thinking emitted only text', () => {
+    // A pure-text iteration (no tools, just narration) still needs to
+    // pass the flow baton to the next iteration's thinking. The text
+    // node serves as the bridge in that case.
+    const turn: ExecutionNode = {
+      id: 't',
+      type: 'turn',
+      status: 'running',
+      label: 'turn',
+      children: [
+        {
+          id: 'th1',
+          type: 'thinking',
+          status: 'completed',
+          label: 'thinking',
+          children: [
+            {
+              id: 'th1-text',
+              type: 'text',
+              status: 'completed',
+              label: 'narration',
+              children: [],
+            },
+          ],
+        },
+        {
+          id: 'th2',
+          type: 'thinking',
+          status: 'running',
+          label: 'thinking',
+          children: [leaf('toolA')],
+        },
+      ],
+    };
+    const { result } = renderHook(() => useTreeLayout(tree([turn])));
+    const flowIds = result.current.edges
+      .filter((e) => e.kind === 'sequence')
+      .map((e) => e.id);
+    // Flow goes from the text bridge (not the bare thinking) so the
+    // visual chain stays unbroken left-to-right.
+    expect(flowIds).toContain('th1-text->th2');
+    expect(flowIds).not.toContain('th1->th2');
   });
 
   it('does not emit sequence edges between sibling tools (parallel/sequential ambiguous)', () => {


### PR DESCRIPTION
## Summary

Bug discovered during live dashboard testing of #432.

A turn's first text delta (typically narration like \"let me check the file\") used to create a \"response\" node at that very first delta — the box appeared on screen immediately and then visually drifted across the diagram as later iterations were appended. Worse, every subsequent iteration's text appended to the SAME node (keyed on \`\${turnId}:text\`), so the box was actually a Frankenstein concat of every iteration's narration plus the final answer.

## Root cause

Text was treated as turn-level (one node per turn, all deltas roll up). In real Claude streaming each LLM call may emit one text block — intermediate narration before \`tool_use\` blocks, or the final answer with no tools after — so text is **per-iteration**, not per-turn.

## Fix

Mirror the per-iteration thinking and tool models:

- Text node id is now keyed on the iteration's thinking (\`\${thinkingId}:text\`); fallback \`turnTextNodeId\` for thinking-less iterations keeps one node per turn at most.
- Text attaches as a child of \`currentThinkingId\` (sibling of its iteration's tools).
- Label is a truncated preview of the streaming text instead of fixed \"response\".

Layout:
- \`shouldSkipContainment\` drops the dead text branch (text is no longer a turn-direct child).
- \`addReActFlowEdges\` no longer routes a separate response-flow; the response is reached via plain \`thinking → text\` containment. New branch: pure-narration iterations bridge to the next thinking via the text node, so the visual chain stays unbroken.

## Test plan
- [x] 84/84 dashboard tests pass (4 new reducer tests + 1 new layout test + 2 updated)
- [x] typecheck clean
- [ ] Live test against the trace that surfaced the bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Multi-step reasoning now nests each iteration’s response text under its iteration, isolating per-iteration text and preventing cross-iteration accumulation.
  * Sequence edges now flow only from successful tools; failures no longer carry the chain and are bridged via iteration text or thinking nodes as needed.

* **New Features**
  * Dashboard shows an amber stop-reason badge for turns that ended abnormally.
  * Turn-completed events may include a stopReason field to distinguish truncation, errors, or normal completion.

* **State**
  * Runtime state now tracks the current text anchor and whether a text stream is open to correctly attach streaming text and tool events.

* **Tests**
  * Expanded coverage for per-iteration text behavior, edge-generation rules, text preview truncation, and stopReason handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->