### PR TITLE
fix(daemon,dashboard): include projectPath in stream.session_started (#452)

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -385,6 +385,13 @@ public final class StreamingAgentHandler {
                 p.put("sessionId", sessionId);
                 p.put("model", getModelForSession(sessionId));
                 p.put("timestamp", Instant.now().toString());
+                // Include projectPath so the dashboard sidebar can render
+                // the session's directory immediately, instead of falling
+                // back to "(unknown)" until the next sessions.list refresh
+                // (issue #452 — particularly visible after a Ctrl+C double
+                // cancel + new-session-in-same-dir, where the cancelled row
+                // still showed the path while the new row read "(unknown)").
+                p.put("projectPath", session.projectPath().toString());
                 emitBrowserOnly(sessionId, "stream.session_started", p);
             }
             var ts = objectMapper.createObjectNode();

--- a/aceclaw-dashboard/src/hooks/useSessions.ts
+++ b/aceclaw-dashboard/src/hooks/useSessions.ts
@@ -116,27 +116,12 @@ export function useSessions(wsUrl: string | null): SessionInfo[] {
         const rawParams = event['params'];
         const params: Record<string, unknown> = isPlainObject(rawParams) ? rawParams : {};
         if (method === 'stream.session_started') {
-          const sessionId = typeof params['sessionId'] === 'string' ? params['sessionId'] : null;
-          if (!sessionId) return;
-          // The session_started event doesn't carry projectPath, so we fall
-          // back to "(unknown)" until the next sessions.list refresh — the
-          // sidebar will replace it on its next mount/reconnect.
-          const created =
-            typeof params['timestamp'] === 'string'
-              ? params['timestamp']
-              : new Date().toISOString();
+          const row = sessionInfoFromSessionStarted(params);
+          if (!row) return;
           setSessions((prev) =>
-            prev.some((s) => s.sessionId === sessionId)
+            prev.some((s) => s.sessionId === row.sessionId)
               ? prev
-              : sortByCreatedDesc([
-                  ...prev,
-                  {
-                    sessionId,
-                    projectPath: '(unknown)',
-                    createdAt: created,
-                    active: true,
-                  },
-                ]),
+              : sortByCreatedDesc([...prev, row]),
           );
         } else if (method === 'stream.session_ended') {
           const sessionId = typeof params['sessionId'] === 'string' ? params['sessionId'] : null;
@@ -182,6 +167,40 @@ export function useSessions(wsUrl: string | null): SessionInfo[] {
 // ---------------------------------------------------------------------------
 // Validation helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Reads a {@code stream.session_started} event's params and produces the
+ * {@link SessionInfo} row the sidebar should render. Falls back gracefully
+ * when fields are missing — older daemons that don't emit
+ * {@code projectPath} (issue #452) get the {@code "(unknown)"} placeholder
+ * the hook used pre-fix; daemons that don't yet emit {@code model} skip
+ * the field instead of stamping an empty string.
+ *
+ * Returns {@code null} when the event is unusable (no sessionId).
+ * Exported for unit testing — the hook calls this inline.
+ */
+export function sessionInfoFromSessionStarted(
+  params: Record<string, unknown>,
+): SessionInfo | null {
+  const sessionId = typeof params['sessionId'] === 'string' ? params['sessionId'] : null;
+  if (!sessionId) return null;
+  const projectPath =
+    typeof params['projectPath'] === 'string' && params['projectPath'].length > 0
+      ? params['projectPath']
+      : '(unknown)';
+  const model = typeof params['model'] === 'string' ? params['model'] : null;
+  const createdAt =
+    typeof params['timestamp'] === 'string'
+      ? params['timestamp']
+      : new Date().toISOString();
+  return {
+    sessionId,
+    projectPath,
+    createdAt,
+    active: true,
+    ...(model ? { model } : {}),
+  };
+}
 
 /**
  * Validates the daemon's sessions.list.result reply and narrows it to a

--- a/aceclaw-dashboard/src/types/events.ts
+++ b/aceclaw-dashboard/src/types/events.ts
@@ -56,6 +56,13 @@ export interface SessionStartedParams {
   sessionId: string;
   model: string;
   timestamp: string; // ISO-8601
+  /**
+   * Filesystem path the session is bound to. Optional for forward/
+   * backward compat with daemons that don't yet emit it (issue #452 —
+   * older daemons leave this blank and the dashboard falls back to
+   * "(unknown)" until the next {@code sessions.list} refresh).
+   */
+  projectPath?: string;
 }
 
 /**

--- a/aceclaw-dashboard/tests/useSessions.test.ts
+++ b/aceclaw-dashboard/tests/useSessions.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { mergeSnapshot, parseSessionsListResult } from '../src/hooks/useSessions';
+import {
+  mergeSnapshot,
+  parseSessionsListResult,
+  sessionInfoFromSessionStarted,
+} from '../src/hooks/useSessions';
 import type { SessionInfo } from '../src/hooks/useSessions';
 
 const session = (overrides: Partial<SessionInfo> & { sessionId: string }): SessionInfo => ({
@@ -174,5 +178,74 @@ describe('mergeSnapshot', () => {
     expect(merged[0]!.projectPath).toBe('/real/path');
     expect(merged[0]!.model).toBe('claude-opus-4-7');
     expect(merged[0]!.createdAt).toBe('2026-04-29T08:59:59.000Z');
+  });
+});
+
+describe('sessionInfoFromSessionStarted (issue #452)', () => {
+  it('reads projectPath from the event payload when the daemon emits it', () => {
+    // The fix this guards: daemons ≥ #452 include projectPath on
+    // stream.session_started so the sidebar shows the real path
+    // immediately, instead of falling back to "(unknown)" until the
+    // next sessions.list refresh.
+    const row = sessionInfoFromSessionStarted({
+      sessionId: 's1',
+      model: 'claude-opus-4-7',
+      timestamp: '2026-04-30T10:00:00.000Z',
+      projectPath: '/Users/me/project',
+    });
+    expect(row).not.toBeNull();
+    expect(row!.sessionId).toBe('s1');
+    expect(row!.projectPath).toBe('/Users/me/project');
+    expect(row!.model).toBe('claude-opus-4-7');
+    expect(row!.createdAt).toBe('2026-04-30T10:00:00.000Z');
+    expect(row!.active).toBe(true);
+  });
+
+  it('falls back to "(unknown)" when older daemons omit projectPath', () => {
+    const row = sessionInfoFromSessionStarted({
+      sessionId: 's1',
+      model: 'claude-opus-4-7',
+      timestamp: '2026-04-30T10:00:00.000Z',
+    });
+    expect(row!.projectPath).toBe('(unknown)');
+  });
+
+  it('falls back to "(unknown)" for blank or wrong-typed projectPath', () => {
+    expect(
+      sessionInfoFromSessionStarted({
+        sessionId: 's1',
+        projectPath: '',
+      })!.projectPath,
+    ).toBe('(unknown)');
+    expect(
+      sessionInfoFromSessionStarted({
+        sessionId: 's1',
+        projectPath: 42,
+      })!.projectPath,
+    ).toBe('(unknown)');
+  });
+
+  it('omits the model field when missing rather than stamping empty-string', () => {
+    const row = sessionInfoFromSessionStarted({
+      sessionId: 's1',
+      projectPath: '/p',
+    });
+    expect(row!.model).toBeUndefined();
+  });
+
+  it('returns null when sessionId is missing', () => {
+    expect(sessionInfoFromSessionStarted({ projectPath: '/p' })).toBeNull();
+    expect(sessionInfoFromSessionStarted({ sessionId: 42 })).toBeNull();
+  });
+
+  it('uses the current time as createdAt when timestamp is missing', () => {
+    const before = Date.now();
+    const row = sessionInfoFromSessionStarted({ sessionId: 's1' });
+    const stamped = Date.parse(row!.createdAt);
+    const after = Date.now();
+    // createdAt is a fresh ISO timestamp; sanity-check it lands in
+    // the wall-clock window the call ran in.
+    expect(stamped).toBeGreaterThanOrEqual(before);
+    expect(stamped).toBeLessThanOrEqual(after);
   });
 });


### PR DESCRIPTION
## Summary

Closes #452.

When a session was cancelled (Ctrl+C × 2) and a new one opened in the same directory, the sidebar showed the new (active) row as `(unknown)` while the old (inactive) row kept the real path — looking like the dead session had \"preempted\" the path. Just a placeholder hangover: `stream.session_started` didn't carry `projectPath`, so `useSessions` filled in `(unknown)` until the next `sessions.list` refresh.

## Changes

- **Daemon** `StreamingAgentHandler`: include `session.projectPath().toString()` in the `stream.session_started` broadcast.
- **Schema** `SessionStartedParams.projectPath` optional for forward/backward compat with older daemons.
- **Dashboard** `useSessions`: extracted `sessionInfoFromSessionStarted` helper so the parsing logic is unit-testable. Reads `projectPath` from the payload, falls back to `(unknown)` when missing/empty/wrong-typed. Also picks up `model` (was on the wire but ignored).

## Test plan
- [x] 6 new helper tests (path present / missing / blank / wrong-type / missing model / missing sessionId / missing timestamp)
- [x] 98/98 dashboard tests green
- [x] Daemon `compileJava` clean
- [ ] Manual repro: restart daemon, cancel session A, open B in same dir → B shows real path immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Project directory path now displays immediately upon session creation without waiting for a list refresh, providing faster feedback on session information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->