### PR TITLE
feat(daemon): accept permission.response over WebSocket (#433)

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -494,6 +494,12 @@ public final class AceClawDaemon {
                 switch (method) {
                     case "sessions.list" -> handleSessionsList(ctx, mapperRef, sessionsRef, agentHandler);
                     case "snapshot.request" -> handleSnapshotRequest(ctx, message, mapperRef, bridgeRef);
+                    // Browser approve/deny → route to the same per-context
+                    // CompletableFuture the CLI socket monitor would (issue
+                    // #433). First response wins; the loser is logged and
+                    // dropped. Per-context map cleanup is handled inside
+                    // routePermissionResponse via the daemon-wide registry.
+                    case "permission.response" -> agentHandler.routePermissionResponse(message);
                     default -> { /* unknown method: drop */ }
                 }
             });

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -169,6 +169,20 @@ public final class StreamingAgentHandler {
     private volatile WebSocketBridge webSocketBridge;
     /** Sessions for which {@code stream.session_started} has already been emitted. */
     private final Set<String> sessionsStartedSignaled = ConcurrentHashMap.newKeySet();
+    /**
+     * Daemon-wide registry of pending permission requests keyed by
+     * requestId (issue #433). The CLI's per-context monitor and the
+     * WebSocket bridge's inbound handler both route
+     * {@code permission.response} messages through here, so either
+     * channel can win the response. {@link CancelAwareStreamContext}
+     * mirrors its per-context {@code pendingPermissions} writes into
+     * this map; when one channel completes a future, the other path
+     * sees a no-op (CompletableFuture.complete is idempotent + the
+     * remove is atomic). Per-context shutdown removes its own entries
+     * without affecting other concurrent prompts.
+     */
+    private final ConcurrentHashMap<String, CompletableFuture<JsonNode>> permissionRegistry =
+            new ConcurrentHashMap<>();
 
     /** Per-session turn locks for serializing main turns within a session. */
     private final ConcurrentHashMap<String, ReentrantLock> sessionTurnLocks =
@@ -211,6 +225,40 @@ public final class StreamingAgentHandler {
      */
     public void setWebSocketBridge(WebSocketBridge bridge) {
         this.webSocketBridge = bridge;
+    }
+
+    /**
+     * Routes a {@code permission.response} message arriving on the
+     * WebSocket bridge into the per-context {@link CompletableFuture}
+     * the requesting tool is blocked on (issue #433). Returns
+     * {@code true} if the response landed on a still-pending request,
+     * {@code false} if the requestId is unknown (already completed by
+     * the CLI, timed out, or never existed).
+     *
+     * <p>The CLI socket monitor and this method share a single
+     * {@link #permissionRegistry} keyed by requestId, so first response
+     * wins regardless of channel. {@link CompletableFuture#complete}
+     * is idempotent on the future's side — late duplicates are safe.
+     *
+     * <p>Public for the WS inbound dispatcher in {@code AceClawDaemon}
+     * to call. Not part of the CLI's UDS protocol.
+     */
+    public boolean routePermissionResponse(JsonNode message) {
+        if (message == null) return false;
+        var params = message.get("params");
+        if (params == null) return false;
+        var ridNode = params.get("requestId");
+        if (ridNode == null) return false;
+        var requestId = ridNode.asText("");
+        if (requestId.isEmpty()) return false;
+        var future = permissionRegistry.remove(requestId);
+        if (future == null) {
+            log.warn("WS permission.response: no pending request for requestId={}, "
+                    + "dropping (already completed by CLI, timed out, or unknown)",
+                    requestId);
+            return false;
+        }
+        return future.complete(message);
     }
 
     /**
@@ -290,8 +338,9 @@ public final class StreamingAgentHandler {
         cancelContext = bridge != null
                 ? new CancelAwareStreamContext(
                         context, new EventMultiplexer(context, bridge, sessionId),
-                        cancellationToken, objectMapper)
-                : new CancelAwareStreamContext(context, cancellationToken, objectMapper);
+                        cancellationToken, objectMapper, permissionRegistry)
+                : new CancelAwareStreamContext(context, cancellationToken, objectMapper,
+                        permissionRegistry);
 
         // Create a StreamEventHandler that forwards events via the cancel-aware context
         var eventHandler = new StreamingNotificationHandler(cancelContext, objectMapper);
@@ -3315,6 +3364,13 @@ public final class StreamingAgentHandler {
         private final SocketChannel channel;
         private final StringBuilder lineBuilder;
         private final ConcurrentHashMap<String, CompletableFuture<JsonNode>> pendingPermissions = new ConcurrentHashMap<>();
+        /**
+         * Daemon-wide registry shared with the WS bridge (issue #433) so a
+         * browser-sent {@code permission.response} can complete the same
+         * future the CLI socket monitor would. Null when running outside a
+         * full daemon (tests). All writes mirror {@link #pendingPermissions}.
+         */
+        private final ConcurrentHashMap<String, CompletableFuture<JsonNode>> globalPermissionRegistry;
         private final BlockingQueue<JsonNode> unmatchedResponses = new LinkedBlockingQueue<>();
         private final Object permissionLifecycleLock = new Object();
         private final java.util.concurrent.atomic.AtomicInteger toolUseCount =
@@ -3325,7 +3381,13 @@ public final class StreamingAgentHandler {
 
         CancelAwareStreamContext(StreamContext delegate, CancellationToken cancellationToken,
                                  ObjectMapper objectMapper) {
-            this(delegate, delegate, cancellationToken, objectMapper);
+            this(delegate, delegate, cancellationToken, objectMapper, null);
+        }
+
+        CancelAwareStreamContext(StreamContext delegate, CancellationToken cancellationToken,
+                                 ObjectMapper objectMapper,
+                                 ConcurrentHashMap<String, CompletableFuture<JsonNode>> globalPermissionRegistry) {
+            this(delegate, delegate, cancellationToken, objectMapper, globalPermissionRegistry);
         }
 
         /**
@@ -3336,9 +3398,16 @@ public final class StreamingAgentHandler {
          */
         CancelAwareStreamContext(StreamContext rawContext, StreamContext outboundContext,
                                  CancellationToken cancellationToken, ObjectMapper objectMapper) {
+            this(rawContext, outboundContext, cancellationToken, objectMapper, null);
+        }
+
+        CancelAwareStreamContext(StreamContext rawContext, StreamContext outboundContext,
+                                 CancellationToken cancellationToken, ObjectMapper objectMapper,
+                                 ConcurrentHashMap<String, CompletableFuture<JsonNode>> globalPermissionRegistry) {
             this.delegate = outboundContext;
             this.cancellationToken = cancellationToken;
             this.objectMapper = objectMapper;
+            this.globalPermissionRegistry = globalPermissionRegistry;
 
             // Extract the channel and lineBuilder from the underlying ChannelStreamContext
             if (rawContext instanceof ConnectionBridge.ChannelStreamContext channelCtx) {
@@ -3372,6 +3441,12 @@ public final class StreamingAgentHandler {
                     future.cancel(false);
                     throw new IllegalStateException("Duplicate permission requestId: " + requestId);
                 }
+                // Mirror into the daemon-wide registry so the WS bridge's
+                // permission.response routing (issue #433) can complete
+                // the same future without knowing which context owns it.
+                if (globalPermissionRegistry != null) {
+                    globalPermissionRegistry.put(requestId, future);
+                }
             }
             return future;
         }
@@ -3385,6 +3460,9 @@ public final class StreamingAgentHandler {
             CompletableFuture<JsonNode> future;
             synchronized (permissionLifecycleLock) {
                 future = pendingPermissions.remove(requestId);
+                if (globalPermissionRegistry != null) {
+                    globalPermissionRegistry.remove(requestId);
+                }
             }
             if (future != null && !future.isDone()) {
                 future.cancel(false);
@@ -3414,7 +3492,16 @@ public final class StreamingAgentHandler {
             stopped = true;
             // Cancel all pending permission futures so waiting threads unblock
             synchronized (permissionLifecycleLock) {
-                pendingPermissions.forEach((_, future) -> future.cancel(false));
+                pendingPermissions.forEach((rid, future) -> {
+                    future.cancel(false);
+                    if (globalPermissionRegistry != null) {
+                        // Drop only OUR entries from the daemon-wide registry —
+                        // other concurrent prompts may still have pending
+                        // permissions there. Iterating pendingPermissions
+                        // (per-context) gives us the correct subset.
+                        globalPermissionRegistry.remove(rid, future);
+                    }
+                });
                 pendingPermissions.clear();
             }
             var sel = selector;
@@ -3484,6 +3571,13 @@ public final class StreamingAgentHandler {
                                             ? respParams.get("requestId").asText() : null;
                                     if (rid != null) {
                                         var future = pendingPermissions.remove(rid);
+                                        // Keep the daemon-wide registry in sync — if a
+                                        // browser also tries to respond, its lookup
+                                        // (#433) should now miss instead of double-
+                                        // completing the future.
+                                        if (globalPermissionRegistry != null) {
+                                            globalPermissionRegistry.remove(rid);
+                                        }
                                         if (future != null) {
                                             future.complete(message);
                                         } else {

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -180,9 +180,26 @@ public final class StreamingAgentHandler {
      * sees a no-op (CompletableFuture.complete is idempotent + the
      * remove is atomic). Per-context shutdown removes its own entries
      * without affecting other concurrent prompts.
+     *
+     * <p>Each entry holds the originating session id alongside the
+     * future. {@link #routePermissionResponse} validates that a
+     * browser-sent response carries a matching {@code sessionId} —
+     * without this check, any WS client that observed the broadcast
+     * {@code permission.request} (which fans out to all connected
+     * clients) could replay its {@code requestId} and approve/deny
+     * tools on a session it doesn't own. The CLI path bypasses the
+     * sessionId check because UDS connections are inherently
+     * per-session at the transport layer.
      */
-    private final ConcurrentHashMap<String, CompletableFuture<JsonNode>> permissionRegistry =
+    private final ConcurrentHashMap<String, PendingPermission> permissionRegistry =
             new ConcurrentHashMap<>();
+
+    /**
+     * Tuple stored in {@link #permissionRegistry}: the originating
+     * session and the future to complete. Used by the WS routing
+     * path to validate cross-session attempts.
+     */
+    private record PendingPermission(String sessionId, CompletableFuture<JsonNode> future) {}
 
     /** Per-session turn locks for serializing main turns within a session. */
     private final ConcurrentHashMap<String, ReentrantLock> sessionTurnLocks =
@@ -251,14 +268,37 @@ public final class StreamingAgentHandler {
         if (ridNode == null) return false;
         var requestId = ridNode.asText("");
         if (requestId.isEmpty()) return false;
-        var future = permissionRegistry.remove(requestId);
-        if (future == null) {
+        var pending = permissionRegistry.get(requestId);
+        if (pending == null) {
             log.warn("WS permission.response: no pending request for requestId={}, "
                     + "dropping (already completed by CLI, timed out, or unknown)",
                     requestId);
             return false;
         }
-        return future.complete(message);
+        // Cross-session guard: WS clients see ALL permission.request
+        // broadcasts (the bridge fans out to every connected tab), so
+        // a tab viewing session B could otherwise replay session A's
+        // requestId and approve/deny on A's behalf. The browser must
+        // include the sessionId it observed on the request envelope;
+        // we reject mismatches and missing values.
+        var sidNode = params.get("sessionId");
+        var responseSessionId = sidNode == null ? null : sidNode.asText("");
+        if (responseSessionId == null || responseSessionId.isEmpty()) {
+            log.warn("WS permission.response missing sessionId for requestId={}, dropping",
+                    requestId);
+            return false;
+        }
+        if (!pending.sessionId().equals(responseSessionId)) {
+            log.warn("WS permission.response sessionId mismatch for requestId={}: "
+                    + "expected {}, got {} — dropping (cross-session attempt)",
+                    requestId, pending.sessionId(), responseSessionId);
+            return false;
+        }
+        // Atomic remove-if-still-present; if the CLI got there first,
+        // remove returns false and we leave the pre-existing completion
+        // alone.
+        if (!permissionRegistry.remove(requestId, pending)) return false;
+        return pending.future().complete(message);
     }
 
     /**
@@ -3368,9 +3408,11 @@ public final class StreamingAgentHandler {
          * Daemon-wide registry shared with the WS bridge (issue #433) so a
          * browser-sent {@code permission.response} can complete the same
          * future the CLI socket monitor would. Null when running outside a
-         * full daemon (tests). All writes mirror {@link #pendingPermissions}.
+         * full daemon (tests). All writes mirror {@link #pendingPermissions};
+         * value type carries the sessionId for the cross-session guard in
+         * {@link StreamingAgentHandler#routePermissionResponse}.
          */
-        private final ConcurrentHashMap<String, CompletableFuture<JsonNode>> globalPermissionRegistry;
+        private final ConcurrentHashMap<String, PendingPermission> globalPermissionRegistry;
         private final BlockingQueue<JsonNode> unmatchedResponses = new LinkedBlockingQueue<>();
         private final Object permissionLifecycleLock = new Object();
         private final java.util.concurrent.atomic.AtomicInteger toolUseCount =
@@ -3386,7 +3428,7 @@ public final class StreamingAgentHandler {
 
         CancelAwareStreamContext(StreamContext delegate, CancellationToken cancellationToken,
                                  ObjectMapper objectMapper,
-                                 ConcurrentHashMap<String, CompletableFuture<JsonNode>> globalPermissionRegistry) {
+                                 ConcurrentHashMap<String, PendingPermission> globalPermissionRegistry) {
             this(delegate, delegate, cancellationToken, objectMapper, globalPermissionRegistry);
         }
 
@@ -3403,7 +3445,7 @@ public final class StreamingAgentHandler {
 
         CancelAwareStreamContext(StreamContext rawContext, StreamContext outboundContext,
                                  CancellationToken cancellationToken, ObjectMapper objectMapper,
-                                 ConcurrentHashMap<String, CompletableFuture<JsonNode>> globalPermissionRegistry) {
+                                 ConcurrentHashMap<String, PendingPermission> globalPermissionRegistry) {
             this.delegate = outboundContext;
             this.cancellationToken = cancellationToken;
             this.objectMapper = objectMapper;
@@ -3428,8 +3470,9 @@ public final class StreamingAgentHandler {
          * Registers a pending permission request keyed by requestId.
          * Returns a future that will be completed when the matching response arrives.
          */
-        CompletableFuture<JsonNode> registerPermissionRequest(String requestId) {
+        CompletableFuture<JsonNode> registerPermissionRequest(String requestId, String sessionId) {
             Objects.requireNonNull(requestId, "requestId");
+            Objects.requireNonNull(sessionId, "sessionId");
             var future = new CompletableFuture<JsonNode>();
             synchronized (permissionLifecycleLock) {
                 if (stopped) {
@@ -3444,8 +3487,9 @@ public final class StreamingAgentHandler {
                 // Mirror into the daemon-wide registry so the WS bridge's
                 // permission.response routing (issue #433) can complete
                 // the same future without knowing which context owns it.
+                // Tag with sessionId for the cross-session guard.
                 if (globalPermissionRegistry != null) {
-                    globalPermissionRegistry.put(requestId, future);
+                    globalPermissionRegistry.put(requestId, new PendingPermission(sessionId, future));
                 }
             }
             return future;
@@ -3826,7 +3870,7 @@ public final class StreamingAgentHandler {
                     var requestId = "perm-" + UUID.randomUUID();
                     long timeoutMs = CancelAwareStreamContext.PERMISSION_RESPONSE_TIMEOUT_MS;
 
-                    var future = context.registerPermissionRequest(requestId);
+                    var future = context.registerPermissionRequest(requestId, sessionId);
                     if (future.isCancelled()) {
                         return new ToolResult("Permission denied: request cancelled", true);
                     }

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -3615,14 +3615,19 @@ public final class StreamingAgentHandler {
                                             ? respParams.get("requestId").asText() : null;
                                     if (rid != null) {
                                         var future = pendingPermissions.remove(rid);
-                                        // Keep the daemon-wide registry in sync — if a
-                                        // browser also tries to respond, its lookup
-                                        // (#433) should now miss instead of double-
-                                        // completing the future.
-                                        if (globalPermissionRegistry != null) {
-                                            globalPermissionRegistry.remove(rid);
-                                        }
                                         if (future != null) {
+                                            // Keep the daemon-wide registry in sync —
+                                            // only when THIS context owned the request
+                                            // (local future found). Removing
+                                            // unconditionally would let a stale or
+                                            // cross-session CLI message delete another
+                                            // context's legitimate entry, causing the
+                                            // browser response for that request to be
+                                            // rejected as "unknown requestId" until
+                                            // timeout (codex P1 review on PR #454).
+                                            if (globalPermissionRegistry != null) {
+                                                globalPermissionRegistry.remove(rid);
+                                            }
                                             future.complete(message);
                                         } else {
                                             log.warn("Cancel monitor: no pending request for requestId={}, dropping stale permission.response", rid);

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/PermissionResponseRoutingTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/PermissionResponseRoutingTest.java
@@ -1,0 +1,134 @@
+package dev.aceclaw.daemon;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link StreamingAgentHandler#routePermissionResponse}
+ * (issue #433).
+ *
+ * <p>The method is the entry point the {@code AceClawDaemon} inbound
+ * dispatcher calls when the WebSocket bridge receives a browser-sent
+ * {@code permission.response}. It looks up the daemon-wide registry
+ * keyed by {@code requestId} and completes the matching
+ * {@link CompletableFuture}; the CLI socket monitor mirrors writes
+ * into the same registry so first-response-wins works regardless of
+ * which channel the response arrived on.
+ *
+ * <p>Tests reach into the private {@code permissionRegistry} field via
+ * reflection to populate test futures without spinning up a real
+ * permission flow. The contract under test is the routing logic
+ * itself: lookup, complete, idempotency, defensive parsing.
+ */
+class PermissionResponseRoutingTest {
+
+    private StreamingAgentHandler handler;
+    private ObjectMapper mapper;
+    private ConcurrentHashMap<String, CompletableFuture<JsonNode>> registry;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() throws Exception {
+        mapper = new ObjectMapper();
+        var sessionManager = new SessionManager();
+        var mockClient = new MockLlmClient();
+        var toolRegistry = new dev.aceclaw.core.agent.ToolRegistry();
+        var permissionManager = new dev.aceclaw.security.PermissionManager(
+                new dev.aceclaw.security.DefaultPermissionPolicy("auto-accept"));
+        var agentLoop = new dev.aceclaw.core.agent.StreamingAgentLoop(
+                mockClient, toolRegistry, "test-model", "test prompt");
+        handler = new StreamingAgentHandler(
+                sessionManager, agentLoop, toolRegistry, permissionManager, mapper);
+
+        // The registry is private — for unit testing we reach in to
+        // populate test futures the way CancelAwareStreamContext.
+        // registerPermissionRequest would in production.
+        Field f = StreamingAgentHandler.class.getDeclaredField("permissionRegistry");
+        f.setAccessible(true);
+        registry = (ConcurrentHashMap<String, CompletableFuture<JsonNode>>) f.get(handler);
+    }
+
+    private JsonNode response(String requestId, boolean approved) {
+        var root = mapper.createObjectNode();
+        root.put("method", "permission.response");
+        var params = root.putObject("params");
+        if (requestId != null) params.put("requestId", requestId);
+        params.put("approved", approved);
+        return root;
+    }
+
+    @Test
+    void completesPendingFutureForKnownRequestId() throws Exception {
+        var future = new CompletableFuture<JsonNode>();
+        registry.put("perm-abc", future);
+        boolean routed = handler.routePermissionResponse(response("perm-abc", true));
+        assertThat(routed).isTrue();
+        var msg = future.get(1, TimeUnit.SECONDS);
+        assertThat(msg.get("params").get("requestId").asText()).isEqualTo("perm-abc");
+        assertThat(msg.get("params").get("approved").asBoolean()).isTrue();
+        // The matched entry has been removed — second route returns false
+        // (the contract that lets us drop late duplicates safely).
+        assertThat(registry.containsKey("perm-abc")).isFalse();
+    }
+
+    @Test
+    void returnsFalseForUnknownRequestId() {
+        // No future registered for this id — typical when the CLI got
+        // there first and removed it, or when the request expired.
+        assertThat(handler.routePermissionResponse(response("perm-never", true))).isFalse();
+    }
+
+    @Test
+    void returnsFalseOnSecondRouteEvenWithSameId() throws Exception {
+        // Idempotency: late duplicates from the OTHER channel (CLI sent
+        // first, then browser sends; or browser sends twice from a
+        // double-clicked button) safely no-op.
+        var future = new CompletableFuture<JsonNode>();
+        registry.put("perm-once", future);
+        assertThat(handler.routePermissionResponse(response("perm-once", true))).isTrue();
+        assertThat(handler.routePermissionResponse(response("perm-once", false))).isFalse();
+        // First route's value wins (browser approving) — second one
+        // (denying) is dropped.
+        assertThat(future.get(1, TimeUnit.SECONDS)
+                .get("params").get("approved").asBoolean()).isTrue();
+    }
+
+    @Test
+    void returnsFalseWhenMessageIsMissingParams() {
+        var bad = mapper.createObjectNode();
+        bad.put("method", "permission.response");
+        // no params field
+        assertThat(handler.routePermissionResponse(bad)).isFalse();
+    }
+
+    @Test
+    void returnsFalseWhenRequestIdIsMissing() {
+        // params present but no requestId — defensive parse, not a
+        // throw, since malformed messages shouldn't crash the handler.
+        var bad = mapper.createObjectNode();
+        bad.put("method", "permission.response");
+        bad.putObject("params").put("approved", true);
+        assertThat(handler.routePermissionResponse(bad)).isFalse();
+    }
+
+    @Test
+    void returnsFalseWhenRequestIdIsEmptyString() {
+        // Daemon's UUID-derived ids never produce empty strings, but a
+        // fuzzed/manual client could — guard against it.
+        assertThat(handler.routePermissionResponse(response("", true))).isFalse();
+    }
+
+    @Test
+    void returnsFalseForNullMessage() {
+        assertThat(handler.routePermissionResponse(null)).isFalse();
+    }
+}

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/PermissionResponseRoutingTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/PermissionResponseRoutingTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -25,15 +26,20 @@ import static org.assertj.core.api.Assertions.assertThat;
  * which channel the response arrived on.
  *
  * <p>Tests reach into the private {@code permissionRegistry} field via
- * reflection to populate test futures without spinning up a real
+ * reflection to populate test entries without spinning up a real
  * permission flow. The contract under test is the routing logic
- * itself: lookup, complete, idempotency, defensive parsing.
+ * itself: lookup, complete, idempotency, defensive parsing, and the
+ * cross-session guard added to prevent one client from resolving
+ * another session's pending approval (codex P1 review on PR #454).
  */
 class PermissionResponseRoutingTest {
 
+    private static final String SESSION_ID = "sess-1";
+
     private StreamingAgentHandler handler;
     private ObjectMapper mapper;
-    private ConcurrentHashMap<String, CompletableFuture<JsonNode>> registry;
+    private ConcurrentHashMap<String, Object> registry;
+    private Constructor<?> pendingPermissionCtor;
 
     @BeforeEach
     @SuppressWarnings("unchecked")
@@ -49,19 +55,42 @@ class PermissionResponseRoutingTest {
         handler = new StreamingAgentHandler(
                 sessionManager, agentLoop, toolRegistry, permissionManager, mapper);
 
-        // The registry is private — for unit testing we reach in to
-        // populate test futures the way CancelAwareStreamContext.
-        // registerPermissionRequest would in production.
+        // The registry + PendingPermission record are private — for
+        // unit testing we reach in to populate entries the way
+        // CancelAwareStreamContext.registerPermissionRequest would in
+        // production. The raw cast loses type safety but the test only
+        // needs to put/inspect entries.
         Field f = StreamingAgentHandler.class.getDeclaredField("permissionRegistry");
         f.setAccessible(true);
-        registry = (ConcurrentHashMap<String, CompletableFuture<JsonNode>>) f.get(handler);
+        registry = (ConcurrentHashMap<String, Object>) f.get(handler);
+
+        // Locate the private PendingPermission record's constructor for
+        // populating test entries (it's a record, so the canonical
+        // constructor takes (String sessionId, CompletableFuture future)).
+        Class<?> pendingPermissionClass = null;
+        for (Class<?> inner : StreamingAgentHandler.class.getDeclaredClasses()) {
+            if (inner.getSimpleName().equals("PendingPermission")) {
+                pendingPermissionClass = inner;
+                break;
+            }
+        }
+        assertThat(pendingPermissionClass).isNotNull();
+        pendingPermissionCtor = pendingPermissionClass.getDeclaredConstructor(
+                String.class, CompletableFuture.class);
+        pendingPermissionCtor.setAccessible(true);
     }
 
-    private JsonNode response(String requestId, boolean approved) {
+    private Object pending(String sessionId, CompletableFuture<JsonNode> future) throws Exception {
+        return pendingPermissionCtor.newInstance(sessionId, future);
+    }
+
+    /** Browser-shaped response carrying sessionId. */
+    private JsonNode response(String requestId, String sessionId, boolean approved) {
         var root = mapper.createObjectNode();
         root.put("method", "permission.response");
         var params = root.putObject("params");
         if (requestId != null) params.put("requestId", requestId);
+        if (sessionId != null) params.put("sessionId", sessionId);
         params.put("approved", approved);
         return root;
     }
@@ -69,8 +98,8 @@ class PermissionResponseRoutingTest {
     @Test
     void completesPendingFutureForKnownRequestId() throws Exception {
         var future = new CompletableFuture<JsonNode>();
-        registry.put("perm-abc", future);
-        boolean routed = handler.routePermissionResponse(response("perm-abc", true));
+        registry.put("perm-abc", pending(SESSION_ID, future));
+        boolean routed = handler.routePermissionResponse(response("perm-abc", SESSION_ID, true));
         assertThat(routed).isTrue();
         var msg = future.get(1, TimeUnit.SECONDS);
         assertThat(msg.get("params").get("requestId").asText()).isEqualTo("perm-abc");
@@ -82,9 +111,10 @@ class PermissionResponseRoutingTest {
 
     @Test
     void returnsFalseForUnknownRequestId() {
-        // No future registered for this id — typical when the CLI got
+        // No entry registered for this id — typical when the CLI got
         // there first and removed it, or when the request expired.
-        assertThat(handler.routePermissionResponse(response("perm-never", true))).isFalse();
+        assertThat(handler.routePermissionResponse(response("perm-never", SESSION_ID, true)))
+                .isFalse();
     }
 
     @Test
@@ -93,13 +123,49 @@ class PermissionResponseRoutingTest {
         // first, then browser sends; or browser sends twice from a
         // double-clicked button) safely no-op.
         var future = new CompletableFuture<JsonNode>();
-        registry.put("perm-once", future);
-        assertThat(handler.routePermissionResponse(response("perm-once", true))).isTrue();
-        assertThat(handler.routePermissionResponse(response("perm-once", false))).isFalse();
-        // First route's value wins (browser approving) — second one
-        // (denying) is dropped.
+        registry.put("perm-once", pending(SESSION_ID, future));
+        assertThat(handler.routePermissionResponse(response("perm-once", SESSION_ID, true)))
+                .isTrue();
+        assertThat(handler.routePermissionResponse(response("perm-once", SESSION_ID, false)))
+                .isFalse();
+        // First route's value wins (approving) — second one (denying) dropped.
         assertThat(future.get(1, TimeUnit.SECONDS)
                 .get("params").get("approved").asBoolean()).isTrue();
+    }
+
+    @Test
+    void rejectsCrossSessionResponse() throws Exception {
+        // Cross-session guard: a browser tab viewing session B observes
+        // session A's broadcast permission.request and tries to approve
+        // by replaying its requestId. Daemon must reject because the
+        // sessionId in the response does not match the registered
+        // session. Without this guard the future would complete and
+        // a tool the responder doesn't own would execute.
+        var future = new CompletableFuture<JsonNode>();
+        registry.put("perm-cross", pending("sess-A", future));
+        boolean routed = handler.routePermissionResponse(
+                response("perm-cross", "sess-B-attacker", true));
+        assertThat(routed).isFalse();
+        // Future stays pending — only the legitimate sessionId can
+        // complete it (or it'll time out at 120s).
+        assertThat(future.isDone()).isFalse();
+        // Entry stays in the registry too — a follow-up legitimate
+        // response should still be able to complete it.
+        assertThat(registry.containsKey("perm-cross")).isTrue();
+    }
+
+    @Test
+    void rejectsResponseMissingSessionId() throws Exception {
+        // Older client / malformed payload that omits sessionId.
+        // Cannot validate the cross-session guard without it, so we
+        // reject conservatively rather than guessing.
+        var future = new CompletableFuture<JsonNode>();
+        registry.put("perm-no-sid", pending(SESSION_ID, future));
+        var bad = mapper.createObjectNode();
+        bad.put("method", "permission.response");
+        bad.putObject("params").put("requestId", "perm-no-sid").put("approved", true);
+        assertThat(handler.routePermissionResponse(bad)).isFalse();
+        assertThat(future.isDone()).isFalse();
     }
 
     @Test
@@ -116,7 +182,7 @@ class PermissionResponseRoutingTest {
         // throw, since malformed messages shouldn't crash the handler.
         var bad = mapper.createObjectNode();
         bad.put("method", "permission.response");
-        bad.putObject("params").put("approved", true);
+        bad.putObject("params").put("approved", true).put("sessionId", SESSION_ID);
         assertThat(handler.routePermissionResponse(bad)).isFalse();
     }
 
@@ -124,7 +190,7 @@ class PermissionResponseRoutingTest {
     void returnsFalseWhenRequestIdIsEmptyString() {
         // Daemon's UUID-derived ids never produce empty strings, but a
         // fuzzed/manual client could — guard against it.
-        assertThat(handler.routePermissionResponse(response("", true))).isFalse();
+        assertThat(handler.routePermissionResponse(response("", SESSION_ID, true))).isFalse();
     }
 
     @Test

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/WebSocketBridgeTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/WebSocketBridgeTest.java
@@ -369,9 +369,12 @@ final class WebSocketBridgeTest {
         var ws = connect(queue::add);
         assertThat(connected.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS)).isTrue();
 
+        // Browser-shaped permission.response: includes sessionId for
+        // the cross-session guard the daemon validates server-side.
         ws.sendText(
                 "{\"method\":\"permission.response\","
                         + "\"params\":{\"requestId\":\"perm-abc-123\","
+                        + "\"sessionId\":\"sess-1\","
                         + "\"approved\":true,\"remember\":false}}",
                 true)
                 .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -379,6 +382,7 @@ final class WebSocketBridgeTest {
         var landed = handlerReceived.get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
         var params = landed.get("params");
         assertThat(params.get("requestId").asText()).isEqualTo("perm-abc-123");
+        assertThat(params.get("sessionId").asText()).isEqualTo("sess-1");
         assertThat(params.get("approved").asBoolean()).isTrue();
         assertThat(params.get("remember").asBoolean()).isFalse();
 

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/WebSocketBridgeTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/WebSocketBridgeTest.java
@@ -1,5 +1,6 @@
 package dev.aceclaw.daemon;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -337,6 +338,51 @@ final class WebSocketBridgeTest {
 
         ws.sendClose(WebSocket.NORMAL_CLOSURE, "bye").get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
         wsOther.sendClose(WebSocket.NORMAL_CLOSURE, "bye").get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    void inboundHandlerRoutesPermissionResponseByRequestId() throws Exception {
+        // Pins the wire contract that #433 relies on: a browser-sent
+        // {method: permission.response, params: {requestId, approved}}
+        // arriving on the WS bridge gets dispatched to whatever handler
+        // the daemon installed (in production: AceClawDaemon's
+        // dispatcher, which calls StreamingAgentHandler.routePermissionResponse).
+        // The test stands in for the routePermissionResponse step with a
+        // CompletableFuture so we can assert the message reached the
+        // handler intact. Logic of the routing itself (registry lookup,
+        // first-response-wins, idempotency) is contract-of-CompletableFuture
+        // and exercised in production code paths; what we test here is
+        // that the bridge plumbs the message to the right place.
+        bridge = startOnRandomPort();
+        var handlerReceived = new CompletableFuture<JsonNode>();
+        bridge.setInboundHandler((ctx, message) -> {
+            var methodNode = message.get("method");
+            if (methodNode == null) return;
+            if ("permission.response".equals(methodNode.asText(""))) {
+                handlerReceived.complete(message);
+            }
+        });
+
+        var connected = new CountDownLatch(1);
+        bridge.addConnectionListener(_ -> connected.countDown());
+        var queue = new LinkedBlockingQueue<String>();
+        var ws = connect(queue::add);
+        assertThat(connected.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS)).isTrue();
+
+        ws.sendText(
+                "{\"method\":\"permission.response\","
+                        + "\"params\":{\"requestId\":\"perm-abc-123\","
+                        + "\"approved\":true,\"remember\":false}}",
+                true)
+                .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
+        var landed = handlerReceived.get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        var params = landed.get("params");
+        assertThat(params.get("requestId").asText()).isEqualTo("perm-abc-123");
+        assertThat(params.get("approved").asBoolean()).isTrue();
+        assertThat(params.get("remember").asBoolean()).isFalse();
+
+        ws.sendClose(WebSocket.NORMAL_CLOSURE, "bye").get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #433.

Lets browser dashboard clients approve/deny permission requests via WebSocket. The CLI socket monitor and the WS bridge now share a single per-daemon registry keyed by `requestId` — **first response wins** regardless of which channel it came from.

## Architecture (no new concurrency model)

- \`StreamingAgentHandler.permissionRegistry\` — daemon-wide \`ConcurrentHashMap<String, CompletableFuture<JsonNode>>\`
- \`CancelAwareStreamContext\` mirrors its per-context \`pendingPermissions\` into this registry on every register/unregister/complete/shutdown — per-context cleanup removes only its own entries, so concurrent prompts on other contexts aren't affected
- New \`StreamingAgentHandler.routePermissionResponse(JsonNode)\` — public entry point for the WS inbound dispatcher
- \`AceClawDaemon\`'s inbound dispatcher gains a \`permission.response\` case (next to existing \`sessions.list\` and \`snapshot.request\`)

Idempotency falls out: \`ConcurrentHashMap.remove\` is atomic, so only one channel wins; \`CompletableFuture.complete\` on a completed future is a no-op.

## Acceptance (from issue)

- [x] Browser can send \`permission.response\` via WebSocket
- [x] First-response-wins works correctly (CLI vs Browser race) — `remove` is atomic
- [x] Late/duplicate responses are safely dropped — second \`route\` returns false
- [x] 120s timeout still works if neither CLI nor Browser responds — unchanged
- (Frontend UI for the approve/deny buttons is #437)

## Test plan
- [x] 7 unit tests on \`routePermissionResponse\` (known/unknown id, idempotency, malformed payloads, null message)
- [x] WS-bridge integration test sends \`permission.response\` over real WS connection
- [x] Full daemon test suite green
- [ ] Manual repro: browser sends approve while CLI's prompt is open, daemon completes the request, CLI's later response logs as stale

## Out of scope

- Frontend UI (#437)
- Enriching \`permission.request\` payload with tool args/risk level — the issue's last bullet, but a separate UX enhancement; needs design work and pairs better with #437
- \`PermissionDecision\` schema additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Enhanced permission request handling with daemon-wide routing for permission responses, enabling secure cross-session protection to ensure responses are matched correctly to their requests.

## Tests
* Added comprehensive test coverage for permission response routing, including validation of correct message handling and protection against malformed or cross-session responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->