### PR TITLE
feat(daemon): bridge SchedulerEvent to WebSocket for cron viz (#459)

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -114,7 +114,15 @@ public final class AceClawDaemon {
     private DeferredActionStore deferredActionStore;
     private DeferCheckTool deferCheckTool;
     /** Browser dashboard bridge (issue #431); null when {@code webSocket.enabled=false}. */
-    private WebSocketBridge webSocketBridge;
+    /**
+     * Volatile because {@link #forwardSchedulerEventToWs} reads this on
+     * eventBus subscriber threads and the field is written once in
+     * {@link #start()}. Without volatile the JMM only guarantees visibility
+     * via the eventBus queue's internal synchronization — true in practice
+     * but fragile to refactor. The volatile read is essentially free and
+     * documents the cross-thread access.
+     */
+    private volatile WebSocketBridge webSocketBridge;
 
     private volatile boolean running;
 

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -141,9 +141,10 @@ public final class AceClawDaemon {
         eventBus.subscribe(SchedulerEvent.class, schedulerEventFeed::append);
         // #459: also forward scheduler events to the dashboard via the WS
         // bridge (when one is configured). Lazy-reads webSocketBridge at
-        // fire time because the bridge is constructed later in start();
-        // before that point the forwarder is a no-op so the CLI's
-        // schedulerEventFeed::append path is unaffected.
+        // fire time because the bridge is constructed later in start().
+        // The null-check is pure defense in depth — the cron scheduler
+        // itself isn't started until after the bridge is up (see start()),
+        // so in practice no SchedulerEvent can fire while bridge is null.
         eventBus.subscribe(SchedulerEvent.class, this::forwardSchedulerEventToWs);
         this.deferredEventFeed = new DeferredEventFeed();
         eventBus.subscribe(DeferEvent.class, deferredEventFeed::append);
@@ -1843,38 +1844,54 @@ public final class AceClawDaemon {
             return;
         }
         try {
-            var params = objectMapper.createObjectNode();
-            params.put("jobId", event.jobId());
-            String method = switch (event) {
-                case SchedulerEvent.JobTriggered e -> {
-                    params.put("cronExpression", e.cronExpression());
-                    params.put("timestamp", e.timestamp().toString());
-                    yield "scheduler.job_triggered";
-                }
-                case SchedulerEvent.JobCompleted e -> {
-                    params.put("durationMs", e.durationMs());
-                    params.put("summary", e.summary());
-                    params.put("timestamp", e.timestamp().toString());
-                    yield "scheduler.job_completed";
-                }
-                case SchedulerEvent.JobFailed e -> {
-                    params.put("error", e.error());
-                    params.put("attempt", e.attempt());
-                    params.put("maxAttempts", e.maxAttempts());
-                    params.put("timestamp", e.timestamp().toString());
-                    yield "scheduler.job_failed";
-                }
-                case SchedulerEvent.JobSkipped e -> {
-                    params.put("reason", e.reason());
-                    params.put("timestamp", e.timestamp().toString());
-                    yield "scheduler.job_skipped";
-                }
-            };
-            bridge.broadcastGlobal(method, params);
+            var notification = translateSchedulerEvent(objectMapper, event);
+            bridge.broadcastGlobal(notification.method(), notification.params());
         } catch (Exception e) {
             log.warn("Failed to forward SchedulerEvent to WS bridge: {}", e.getMessage());
         }
     }
+
+    /**
+     * Translation rule for {@link SchedulerEvent} → JSON-RPC notification.
+     * Pure and static so it can be unit-tested in isolation — the wiring
+     * in {@link #forwardSchedulerEventToWs} becomes a thin caller, and
+     * the dashboard's wire contract (method name + param shape) is pinned
+     * by direct unit tests instead of by a missing integration test.
+     */
+    static SchedulerNotification translateSchedulerEvent(
+            ObjectMapper mapper, SchedulerEvent event) {
+        var params = mapper.createObjectNode();
+        params.put("jobId", event.jobId());
+        String method = switch (event) {
+            case SchedulerEvent.JobTriggered e -> {
+                params.put("cronExpression", e.cronExpression());
+                params.put("timestamp", e.timestamp().toString());
+                yield "scheduler.job_triggered";
+            }
+            case SchedulerEvent.JobCompleted e -> {
+                params.put("durationMs", e.durationMs());
+                params.put("summary", e.summary());
+                params.put("timestamp", e.timestamp().toString());
+                yield "scheduler.job_completed";
+            }
+            case SchedulerEvent.JobFailed e -> {
+                params.put("error", e.error());
+                params.put("attempt", e.attempt());
+                params.put("maxAttempts", e.maxAttempts());
+                params.put("timestamp", e.timestamp().toString());
+                yield "scheduler.job_failed";
+            }
+            case SchedulerEvent.JobSkipped e -> {
+                params.put("reason", e.reason());
+                params.put("timestamp", e.timestamp().toString());
+                yield "scheduler.job_skipped";
+            }
+        };
+        return new SchedulerNotification(method, params);
+    }
+
+    /** Translated form of a {@link SchedulerEvent} ready to broadcast over WS. */
+    record SchedulerNotification(String method, com.fasterxml.jackson.databind.node.ObjectNode params) {}
 
     private static String cronKind(CronJob job) {
         if (job.id() != null && job.id().startsWith(HeartbeatRunner.JOB_ID_PREFIX)) {

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -139,6 +139,12 @@ public final class AceClawDaemon {
         eventBus.start();
         this.schedulerEventFeed = new SchedulerEventFeed();
         eventBus.subscribe(SchedulerEvent.class, schedulerEventFeed::append);
+        // #459: also forward scheduler events to the dashboard via the WS
+        // bridge (when one is configured). Lazy-reads webSocketBridge at
+        // fire time because the bridge is constructed later in start();
+        // before that point the forwarder is a no-op so the CLI's
+        // schedulerEventFeed::append path is unaffected.
+        eventBus.subscribe(SchedulerEvent.class, this::forwardSchedulerEventToWs);
         this.deferredEventFeed = new DeferredEventFeed();
         eventBus.subscribe(DeferEvent.class, deferredEventFeed::append);
         this.skillDraftEventFeed = new SkillDraftEventFeed();
@@ -1811,6 +1817,63 @@ public final class AceClawDaemon {
             return firstLine;
         }
         return firstLine.substring(0, 117) + "...";
+    }
+
+    /**
+     * #459 layer 1: forwards a {@link SchedulerEvent} to the dashboard via
+     * the WebSocket bridge. Translates the typed event into one of four
+     * JSON-RPC notification methods ({@code scheduler.job_triggered},
+     * {@code scheduler.job_completed}, {@code scheduler.job_failed},
+     * {@code scheduler.job_skipped}) and broadcasts it globally — scheduler
+     * events are session-less, so the dashboard's per-session reducers
+     * filter them out and only the global {@code useCronJobs} hook
+     * picks them up.
+     *
+     * <p>No-op when the WS bridge is disabled (or not yet constructed) —
+     * the CLI continues to receive scheduler updates via the
+     * {@link SchedulerEventFeed} polling endpoint untouched.
+     *
+     * <p>Defensive against subscriber-thread interruption: any exception
+     * here is logged and swallowed so a misbehaving WS path can't kill
+     * the eventBus subscriber chain.
+     */
+    private void forwardSchedulerEventToWs(SchedulerEvent event) {
+        var bridge = this.webSocketBridge;
+        if (bridge == null) {
+            return;
+        }
+        try {
+            var params = objectMapper.createObjectNode();
+            params.put("jobId", event.jobId());
+            String method = switch (event) {
+                case SchedulerEvent.JobTriggered e -> {
+                    params.put("cronExpression", e.cronExpression());
+                    params.put("timestamp", e.timestamp().toString());
+                    yield "scheduler.job_triggered";
+                }
+                case SchedulerEvent.JobCompleted e -> {
+                    params.put("durationMs", e.durationMs());
+                    params.put("summary", e.summary());
+                    params.put("timestamp", e.timestamp().toString());
+                    yield "scheduler.job_completed";
+                }
+                case SchedulerEvent.JobFailed e -> {
+                    params.put("error", e.error());
+                    params.put("attempt", e.attempt());
+                    params.put("maxAttempts", e.maxAttempts());
+                    params.put("timestamp", e.timestamp().toString());
+                    yield "scheduler.job_failed";
+                }
+                case SchedulerEvent.JobSkipped e -> {
+                    params.put("reason", e.reason());
+                    params.put("timestamp", e.timestamp().toString());
+                    yield "scheduler.job_skipped";
+                }
+            };
+            bridge.broadcastGlobal(method, params);
+        } catch (Exception e) {
+            log.warn("Failed to forward SchedulerEvent to WS bridge: {}", e.getMessage());
+        }
     }
 
     private static String cronKind(CronJob job) {

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/WebSocketBridge.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/WebSocketBridge.java
@@ -239,6 +239,16 @@ public final class WebSocketBridge {
      */
     public void broadcast(String sessionId, String method, Object params) {
         Objects.requireNonNull(sessionId, "sessionId");
+        // Guard against routing a globally-scoped event through the
+        // per-session path by mistake — the sentinel must only ever be
+        // emitted by broadcastGlobal, which deliberately skips the
+        // SessionEventBuffer. A typo'd call here would silently pollute
+        // the buffer with entries no snapshot.request would ever read.
+        if (GLOBAL_SESSION_ID.equals(sessionId)) {
+            throw new IllegalArgumentException(
+                    "Use broadcastGlobal(method, params) for globally-scoped events; "
+                            + "the GLOBAL_SESSION_ID sentinel must not appear in broadcast(sessionId, ...)");
+        }
         if (app == null) {
             return;
         }

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/WebSocketBridge.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/WebSocketBridge.java
@@ -57,6 +57,18 @@ public final class WebSocketBridge {
 
     private static final Logger log = LoggerFactory.getLogger(WebSocketBridge.class);
 
+    /**
+     * Sentinel sessionId stamped on globally-scoped envelopes (e.g. cron
+     * scheduler events from #459). Per-session reducers filter envelopes by
+     * matching the connected tab's sessionId, so this sentinel is invisible
+     * to {@code useExecutionTree} and only the global hooks
+     * ({@code useCronJobs}, …) opt in by checking for it. Late-joiners
+     * backfill via dedicated polling endpoints (e.g. {@code scheduler.events.poll})
+     * — global events deliberately do NOT go through the per-session
+     * snapshot buffer, so this sentinel never accumulates entries there.
+     */
+    public static final String GLOBAL_SESSION_ID = "__global__";
+
     private final String host;
     /**
      * Configured port. {@code 0} means "let Jetty pick an ephemeral port"; in
@@ -230,20 +242,59 @@ public final class WebSocketBridge {
         if (app == null) {
             return;
         }
-        // Increment BEFORE the no-clients short-circuit so eventId stays
-        // monotonic and gap-free across zero-client periods. #432's snapshot
-        // endpoint exposes currentEventId() as the reconnect watermark; the
-        // browser uses it to deduplicate the live stream against the snapshot,
-        // and that contract requires an unbroken sequence regardless of
-        // whether any tab was connected when each event was produced.
+        var built = buildEnvelope(sessionId, method, params);
+        if (built == null) {
+            return;
+        }
+        // Append to the per-session ring buffer unconditionally — even with
+        // zero connected clients, #432 needs the buffer populated so a tab
+        // that opens AFTER the event was emitted can replay it via
+        // snapshot.request.
+        eventBuffer.append(sessionId, built.envelope());
+        sendToAllClients(built.message());
+    }
+
+    /**
+     * Broadcasts a globally-scoped event (no owning session) to every
+     * connected client. Used by daemon-wide subsystems such as the cron
+     * scheduler (#459) whose events are not tied to any one session.
+     *
+     * <p>The envelope still carries a {@code sessionId} field — set to
+     * {@link #GLOBAL_SESSION_ID} — so the dashboard's per-session
+     * {@code useExecutionTree} naturally filters these out, and global
+     * hooks like {@code useCronJobs} opt in by matching that sentinel.
+     *
+     * <p>Globally-scoped events deliberately do NOT enter the per-session
+     * snapshot ring buffer: late-joining tabs backfill via dedicated
+     * polling endpoints (e.g. {@code scheduler.events.poll}), which is
+     * cheaper than an ever-growing global bucket inside
+     * {@link SessionEventBuffer} that no per-session snapshot.request
+     * would ever read.
+     */
+    public void broadcastGlobal(String method, Object params) {
+        if (app == null) {
+            return;
+        }
+        var built = buildEnvelope(GLOBAL_SESSION_ID, method, params);
+        if (built == null) {
+            return;
+        }
+        sendToAllClients(built.message());
+    }
+
+    /** Carrier for buildEnvelope's two outputs (object form for buffer, string form for the wire). */
+    private record Built(ObjectNode envelope, String message) {}
+
+    private Built buildEnvelope(String sessionId, String method, Object params) {
+        // Increment BEFORE any no-op early-return so eventId stays monotonic
+        // and gap-free. #432's snapshot endpoint exposes currentEventId() as
+        // the reconnect watermark; the browser uses it to deduplicate the
+        // live stream against the snapshot, and that contract requires an
+        // unbroken sequence regardless of whether any tab was connected
+        // when each event was produced.
         long eventId = eventIdCounter.incrementAndGet();
-        // Build the envelope unconditionally — even with zero connected
-        // clients, #432 needs the buffer populated so a tab that opens AFTER
-        // the event was emitted can replay it via snapshot.request.
-        ObjectNode envelope;
-        String message;
         try {
-            envelope = objectMapper.createObjectNode();
+            var envelope = objectMapper.createObjectNode();
             envelope.put("eventId", eventId);
             envelope.put("sessionId", sessionId);
             envelope.put("receivedAt", Instant.now().toString());
@@ -251,12 +302,14 @@ public final class WebSocketBridge {
             event.put("method", method);
             event.set("params", objectMapper.valueToTree(params));
             envelope.set("event", event);
-            message = objectMapper.writeValueAsString(envelope);
+            return new Built(envelope, objectMapper.writeValueAsString(envelope));
         } catch (Exception e) {
             log.warn("Failed to serialise WS broadcast for {}: {}", method, e.getMessage());
-            return;
+            return null;
         }
-        eventBuffer.append(sessionId, envelope);
+    }
+
+    private void sendToAllClients(String message) {
         if (clients.isEmpty()) {
             return;
         }

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/SchedulerEventTranslationTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/SchedulerEventTranslationTest.java
@@ -1,0 +1,101 @@
+package dev.aceclaw.daemon;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.aceclaw.infra.event.SchedulerEvent;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the wire contract for {@link AceClawDaemon#translateSchedulerEvent}
+ * — the daemon-side mapping that turns a typed {@link SchedulerEvent} into
+ * the JSON-RPC notification (method + params) the dashboard's
+ * {@code useCronJobs} hook will subscribe to.
+ *
+ * <p>Without this test the only safety net for typos in method names
+ * (e.g. {@code "scheduler.job_trigerred"}) or field swaps (e.g. {@code attempt}
+ * vs {@code maxAttempts}) would be a manual end-to-end run with both the
+ * daemon AND the dashboard up — which #459 layer 2 doesn't exist yet to
+ * provide.
+ */
+final class SchedulerEventTranslationTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private static final Instant T = Instant.parse("2026-05-01T12:00:00Z");
+
+    @Test
+    void jobTriggered_translatesToScheduledJobTriggered() {
+        var event = new SchedulerEvent.JobTriggered("daily-backup", "0 2 * * *", T);
+        var n = AceClawDaemon.translateSchedulerEvent(mapper, event);
+
+        assertThat(n.method()).isEqualTo("scheduler.job_triggered");
+        assertThat(n.params().get("jobId").asText()).isEqualTo("daily-backup");
+        assertThat(n.params().get("cronExpression").asText()).isEqualTo("0 2 * * *");
+        assertThat(n.params().get("timestamp").asText()).isEqualTo(T.toString());
+    }
+
+    @Test
+    void jobCompleted_translatesToSchedulerJobCompleted() {
+        var event = new SchedulerEvent.JobCompleted(
+                "daily-backup", 1234L, "Backed up 42 files", T);
+        var n = AceClawDaemon.translateSchedulerEvent(mapper, event);
+
+        assertThat(n.method()).isEqualTo("scheduler.job_completed");
+        assertThat(n.params().get("jobId").asText()).isEqualTo("daily-backup");
+        assertThat(n.params().get("durationMs").asLong()).isEqualTo(1234L);
+        assertThat(n.params().get("summary").asText()).isEqualTo("Backed up 42 files");
+        assertThat(n.params().get("timestamp").asText()).isEqualTo(T.toString());
+    }
+
+    @Test
+    void jobFailed_translatesToSchedulerJobFailedWithRetryFields() {
+        // Field-swap regression guard: a copy-paste typo that swaps attempt
+        // and maxAttempts would silently confuse the dashboard's retry UI
+        // (showing "attempt 3/2" or similar) without breaking any other
+        // contract — this test pins the assignment.
+        var event = new SchedulerEvent.JobFailed(
+                "flaky-job", "tool exec timeout", 2, 5, T);
+        var n = AceClawDaemon.translateSchedulerEvent(mapper, event);
+
+        assertThat(n.method()).isEqualTo("scheduler.job_failed");
+        assertThat(n.params().get("jobId").asText()).isEqualTo("flaky-job");
+        assertThat(n.params().get("error").asText()).isEqualTo("tool exec timeout");
+        assertThat(n.params().get("attempt").asInt()).isEqualTo(2);
+        assertThat(n.params().get("maxAttempts").asInt()).isEqualTo(5);
+        assertThat(n.params().get("timestamp").asText()).isEqualTo(T.toString());
+    }
+
+    @Test
+    void jobSkipped_translatesToSchedulerJobSkipped() {
+        var event = new SchedulerEvent.JobSkipped(
+                "long-running", "previous run still active", T);
+        var n = AceClawDaemon.translateSchedulerEvent(mapper, event);
+
+        assertThat(n.method()).isEqualTo("scheduler.job_skipped");
+        assertThat(n.params().get("jobId").asText()).isEqualTo("long-running");
+        assertThat(n.params().get("reason").asText()).isEqualTo("previous run still active");
+        assertThat(n.params().get("timestamp").asText()).isEqualTo(T.toString());
+    }
+
+    @Test
+    void allMethodsLiveUnderSchedulerNamespace() {
+        // Cheap guard against a partial rename — every event type's method
+        // should sit under the scheduler.* namespace so dashboard filters
+        // can do a single prefix match.
+        var t = AceClawDaemon.translateSchedulerEvent(mapper,
+                new SchedulerEvent.JobTriggered("a", "* * * * *", T)).method();
+        var c = AceClawDaemon.translateSchedulerEvent(mapper,
+                new SchedulerEvent.JobCompleted("a", 1L, "ok", T)).method();
+        var f = AceClawDaemon.translateSchedulerEvent(mapper,
+                new SchedulerEvent.JobFailed("a", "boom", 1, 1, T)).method();
+        var s = AceClawDaemon.translateSchedulerEvent(mapper,
+                new SchedulerEvent.JobSkipped("a", "busy", T)).method();
+
+        assertThat(t).startsWith("scheduler.");
+        assertThat(c).startsWith("scheduler.");
+        assertThat(f).startsWith("scheduler.");
+        assertThat(s).startsWith("scheduler.");
+    }
+}

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/WebSocketBridgeTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/WebSocketBridgeTest.java
@@ -442,6 +442,20 @@ final class WebSocketBridgeTest {
     }
 
     @Test
+    void broadcastRejectsGlobalSessionIdSentinel() throws Exception {
+        // Defense-in-depth: the GLOBAL_SESSION_ID sentinel is only meant to
+        // come from broadcastGlobal, which skips the per-session buffer.
+        // A typo'd `bridge.broadcast(GLOBAL_SESSION_ID, ...)` would
+        // silently pollute the buffer with entries no snapshot.request
+        // would ever consume; turn it into a loud failure instead.
+        bridge = startOnRandomPort();
+        org.junit.jupiter.api.Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> bridge.broadcast(WebSocketBridge.GLOBAL_SESSION_ID,
+                        "stream.text", Map.of("delta", "oops")));
+    }
+
+    @Test
     void broadcastGlobalAndPerSessionShareEventIdSequence() throws Exception {
         // The dashboard's snapshot-replay watermark assumes a single monotonic
         // eventId stream; globally-scoped broadcasts must not branch off a

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/WebSocketBridgeTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/WebSocketBridgeTest.java
@@ -408,6 +408,58 @@ final class WebSocketBridgeTest {
     }
 
     @Test
+    void broadcastGlobalSendsWithSentinelSessionIdAndSkipsBuffer() throws Exception {
+        // #459: globally-scoped events (cron scheduler) reach all clients but
+        // do NOT enter the per-session ring buffer — late-joiners backfill via
+        // dedicated polling endpoints, not snapshot.request, so the sentinel
+        // bucket would just grow forever for nobody's benefit.
+        bridge = startOnRandomPort();
+        var connected = new CountDownLatch(1);
+        bridge.addConnectionListener(_ -> connected.countDown());
+        var queue = new LinkedBlockingQueue<String>();
+        var ws = connect(queue::add);
+        assertThat(connected.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS)).isTrue();
+
+        bridge.broadcastGlobal("scheduler.job_triggered",
+                Map.of("jobId", "daily-backup", "cronExpression", "0 2 * * *"));
+
+        var msg = queue.poll(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertThat(msg).isNotNull();
+        var node = objectMapper.readTree(msg);
+        // Sentinel sessionId so per-session reducers naturally filter it out.
+        assertThat(node.get("sessionId").asText()).isEqualTo(WebSocketBridge.GLOBAL_SESSION_ID);
+        assertThat(node.get("event").get("method").asText()).isEqualTo("scheduler.job_triggered");
+        assertThat(node.get("event").get("params").get("jobId").asText()).isEqualTo("daily-backup");
+        // Monotonic eventId is shared with regular broadcasts.
+        assertThat(node.get("eventId").asLong()).isEqualTo(1L);
+
+        // Crucial: the sentinel sessionId must NOT have anything in the per-session buffer.
+        assertThat(bridge.eventBuffer().snapshot(WebSocketBridge.GLOBAL_SESSION_ID))
+                .as("globally-scoped events must not pollute the per-session snapshot buffer")
+                .isEmpty();
+
+        ws.sendClose(WebSocket.NORMAL_CLOSURE, "bye").get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    void broadcastGlobalAndPerSessionShareEventIdSequence() throws Exception {
+        // The dashboard's snapshot-replay watermark assumes a single monotonic
+        // eventId stream; globally-scoped broadcasts must not branch off a
+        // separate counter or per-session reducers would see eventId gaps.
+        bridge = startOnRandomPort();
+        bridge.broadcast("sess-A", "stream.text", Map.of("delta", "hi"));   // eventId 1
+        bridge.broadcastGlobal("scheduler.job_triggered", Map.of("jobId", "j")); // eventId 2
+        bridge.broadcast("sess-A", "stream.text", Map.of("delta", " world")); // eventId 3
+        assertThat(bridge.currentEventId()).isEqualTo(3L);
+
+        var snap = bridge.eventBuffer().snapshot("sess-A");
+        // Per-session buffer skipped the global event (eventId 2) entirely.
+        assertThat(snap).hasSize(2);
+        assertThat(snap.get(0).get("eventId").asLong()).isEqualTo(1L);
+        assertThat(snap.get(1).get("eventId").asLong()).isEqualTo(3L);
+    }
+
+    @Test
     void clearSessionDropsBufferedEnvelopes() throws Exception {
         // Ensures the daemon's session-end callback can reclaim memory.
         bridge = startOnRandomPort();


### PR DESCRIPTION
## Summary

Layer 1 of #459 — make cron scheduler events visible to the dashboard over the existing WebSocket bridge. The daemon already runs the cron scheduler, emits typed `SchedulerEvent`s, and exposes `scheduler.events.poll` for the CLI; the dashboard just needs the live push path.

- New `WebSocketBridge.broadcastGlobal(method, params)` for session-less events. Sentinel `sessionId = "__global__"` so per-session reducers naturally filter them out and global hooks (e.g. the upcoming `useCronJobs`) opt in.
- `broadcastGlobal` deliberately skips the per-session `SessionEventBuffer` — late-joiners backfill via `scheduler.events.poll`, not `snapshot.request`. No memory waste.
- Refactored `broadcast` and `broadcastGlobal` to share envelope construction + client fan-out via private helpers. Single monotonic `eventId` counter across both paths so dashboard watermarks don't see gaps.
- `AceClawDaemon` adds a second `eventBus.subscribe(SchedulerEvent.class, ...)` that translates each event into a JSON-RPC notification (`scheduler.job_triggered` / `scheduler.job_completed` / `scheduler.job_failed` / `scheduler.job_skipped`) and broadcasts globally. Lazy-reads `webSocketBridge` so subscription order doesn't matter; CLI's existing `schedulerEventFeed::append` path is untouched.

No schema change to `SchedulerEvent`. Existing `scheduler.cron.status` (job list with `nextFireAt`) and `scheduler.events.poll` (paginated history) already cover the rest of what layer 1 needs.

## Test plan

- [x] `WebSocketBridgeTest.broadcastGlobalSendsWithSentinelSessionIdAndSkipsBuffer` — sentinel sessionId + buffer skip
- [x] `WebSocketBridgeTest.broadcastGlobalAndPerSessionShareEventIdSequence` — monotonic eventId across both broadcast paths
- [x] `./gradlew :aceclaw-daemon:test` — all daemon tests green
- [x] `./gradlew build -x check` — full build green
- [ ] End-to-end manual test deferred to layer 2 (dashboard sidebar) where the new methods can actually be exercised in a browser

## Out of scope (follow-ups in #459)

- Layer 2: Dashboard `useCronJobs` hook + sidebar "Scheduled jobs" panel
- Layer 3: Top horizontal timeline widget with swimlanes per cron job

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time JSON-RPC WebSocket notifications for scheduler events (job triggered, completed, failed, skipped) with structured payloads.
  * Daemon-wide global broadcasts that deliver events to all connected clients.

* **Bug Fixes**
  * Improved delivery reliability and error handling to prevent notification failures from disrupting other subscribers.

* **Tests**
  * Added tests for global broadcast semantics, event-id sequencing, session isolation, and scheduler event translation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->