### PR TITLE
feat(dashboard): cron jobs sidebar panel (#459 layer 2)

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -515,6 +515,14 @@ public final class AceClawDaemon {
                 switch (method) {
                     case "sessions.list" -> handleSessionsList(ctx, mapperRef, sessionsRef, agentHandler);
                     case "snapshot.request" -> handleSnapshotRequest(ctx, message, mapperRef, bridgeRef);
+                    // #459 layer 2: dashboard sidebar fetches the current
+                    // cron-job snapshot on connect. Reply is point-to-point
+                    // (not broadcast), same one-shot pattern as sessions.list.
+                    // Field reads of cronJobStore/cronScheduler are lazy via
+                    // `this` so a dashboard that connects before cron has
+                    // started just sees an empty job list.
+                    case "scheduler.cron.status" ->
+                            handleSchedulerCronStatus(ctx, mapperRef, cronJobStore, cronScheduler);
                     // Browser approve/deny → route to the same per-context
                     // CompletableFuture the CLI socket monitor would (issue
                     // #433). First response wins; the loser is logged and
@@ -1271,54 +1279,11 @@ public final class AceClawDaemon {
             }
         });
 
-        // Scheduler feed polling for foreground CLI notifications.
-        router.register("scheduler.cron.status", params -> {
-            var result = objectMapper.createObjectNode();
-            boolean schedulerRunning = cronScheduler != null && cronScheduler.isRunning();
-            result.put("schedulerRunning", schedulerRunning);
-            if (cronScheduler != null) {
-                result.put("jobRunning", cronScheduler.isJobRunning());
-                if (cronScheduler.currentJobId() != null) {
-                    result.put("currentJobId", cronScheduler.currentJobId());
-                }
-                if (cronScheduler.currentJobStartedAt() != null) {
-                    result.put("currentJobStartedAt", cronScheduler.currentJobStartedAt().toString());
-                }
-            } else {
-                result.put("jobRunning", false);
-            }
-
-            var jobs = objectMapper.createArrayNode();
-            for (CronJob job : cronJobStore.all().stream()
-                    .sorted(Comparator.comparing(CronJob::id))
-                    .toList()) {
-                var jn = objectMapper.createObjectNode();
-                jn.put("id", job.id());
-                jn.put("name", job.name());
-                jn.put("expression", job.expression());
-                jn.put("enabled", job.enabled());
-                jn.put("heartbeat", job.id().startsWith(HeartbeatRunner.JOB_ID_PREFIX));
-                jn.put("kind", cronKind(job));
-                jn.put("description", summarizePrompt(job.prompt()));
-                if (job.lastRunAt() != null) {
-                    jn.put("lastRunAt", job.lastRunAt().toString());
-                }
-                if (job.lastError() != null && !job.lastError().isBlank()) {
-                    jn.put("lastError", job.lastError());
-                }
-                try {
-                    Instant lastRun = job.lastRunAt() != null ? job.lastRunAt() : Instant.EPOCH;
-                    Instant nextFire = CronExpression.parse(job.expression()).nextFireTime(lastRun);
-                    if (nextFire != null) {
-                        jn.put("nextFireAt", nextFire.toString());
-                    }
-                } catch (Exception ignored) {
-                }
-                jobs.add(jn);
-            }
-            result.set("jobs", jobs);
-            return result;
-        });
+        // Scheduler status (CLI poll endpoint + dashboard sidebar bootstrap).
+        // Body extracted into buildCronStatusReply so the WS inbound path
+        // (#459 layer 2) can serve the same shape over the bridge.
+        router.register("scheduler.cron.status", params ->
+                buildCronStatusReply(objectMapper, cronJobStore, cronScheduler));
 
         // Scheduler feed polling for foreground CLI notifications.
         router.register("scheduler.events.poll", params -> {
@@ -1900,6 +1865,101 @@ public final class AceClawDaemon {
 
     /** Translated form of a {@link SchedulerEvent} ready to broadcast over WS. */
     record SchedulerNotification(String method, com.fasterxml.jackson.databind.node.ObjectNode params) {}
+
+    /**
+     * Builds the {@code scheduler.cron.status} reply body — a snapshot of
+     * scheduler state plus every configured job, sorted by id. Shared by
+     * the CLI's JSON-RPC handler and the dashboard's WS inbound handler so
+     * the two surfaces speak exactly the same wire shape.
+     *
+     * <p>Tolerates a null scheduler (daemon started before cron was wired)
+     * by reporting {@code schedulerRunning=false} and an empty jobs list
+     * derived from whatever the store happens to hold.
+     */
+    private static com.fasterxml.jackson.databind.node.ObjectNode buildCronStatusReply(
+            ObjectMapper mapper,
+            dev.aceclaw.daemon.cron.JobStore jobStore,
+            dev.aceclaw.daemon.cron.CronScheduler scheduler) {
+        var result = mapper.createObjectNode();
+        boolean schedulerRunning = scheduler != null && scheduler.isRunning();
+        result.put("schedulerRunning", schedulerRunning);
+        if (scheduler != null) {
+            result.put("jobRunning", scheduler.isJobRunning());
+            if (scheduler.currentJobId() != null) {
+                result.put("currentJobId", scheduler.currentJobId());
+            }
+            if (scheduler.currentJobStartedAt() != null) {
+                result.put("currentJobStartedAt", scheduler.currentJobStartedAt().toString());
+            }
+        } else {
+            result.put("jobRunning", false);
+        }
+        var jobs = mapper.createArrayNode();
+        if (jobStore != null) {
+            for (CronJob job : jobStore.all().stream()
+                    .sorted(java.util.Comparator.comparing(CronJob::id))
+                    .toList()) {
+                var jn = mapper.createObjectNode();
+                jn.put("id", job.id());
+                jn.put("name", job.name());
+                jn.put("expression", job.expression());
+                jn.put("enabled", job.enabled());
+                jn.put("heartbeat", job.id().startsWith(HeartbeatRunner.JOB_ID_PREFIX));
+                jn.put("kind", cronKind(job));
+                jn.put("description", summarizePrompt(job.prompt()));
+                if (job.lastRunAt() != null) {
+                    jn.put("lastRunAt", job.lastRunAt().toString());
+                }
+                if (job.lastError() != null && !job.lastError().isBlank()) {
+                    jn.put("lastError", job.lastError());
+                }
+                try {
+                    Instant lastRun = job.lastRunAt() != null ? job.lastRunAt() : Instant.EPOCH;
+                    Instant nextFire = dev.aceclaw.daemon.cron.CronExpression.parse(job.expression())
+                            .nextFireTime(lastRun);
+                    if (nextFire != null) {
+                        jn.put("nextFireAt", nextFire.toString());
+                    }
+                } catch (Exception ignored) {
+                    // Bad expression — surface the rest of the job, just no nextFireAt.
+                }
+                jobs.add(jn);
+            }
+        }
+        result.set("jobs", jobs);
+        return result;
+    }
+
+    /**
+     * Replies to a {@code scheduler.cron.status} inbound message from the
+     * dashboard with the same snapshot the CLI would get over JSON-RPC,
+     * wrapped as a one-shot point-to-point reply (NOT broadcast). Mirrors
+     * {@link #handleSessionsList}.
+     *
+     * <p>Reply shape:
+     * <pre>{@code
+     * {
+     *   "method": "scheduler.cron.status.result",
+     *   "schedulerRunning": <bool>,
+     *   "jobRunning": <bool>,
+     *   "jobs": [{ id, name, expression, enabled, lastRunAt?, nextFireAt?, ... }]
+     * }
+     * }</pre>
+     */
+    private static void handleSchedulerCronStatus(io.javalin.websocket.WsContext ctx,
+                                                   ObjectMapper mapper,
+                                                   dev.aceclaw.daemon.cron.JobStore jobStore,
+                                                   dev.aceclaw.daemon.cron.CronScheduler scheduler) {
+        try {
+            var body = buildCronStatusReply(mapper, jobStore, scheduler);
+            // Tag with the result method so the dashboard's hook can match it
+            // against the request it sent on connect.
+            body.put("method", "scheduler.cron.status.result");
+            ctx.send(mapper.writeValueAsString(body));
+        } catch (Exception e) {
+            log.warn("Failed to send scheduler.cron.status.result reply: {}", e.getMessage());
+        }
+    }
 
     private static String cronKind(CronJob job) {
         if (job.id() != null && job.id().startsWith(HeartbeatRunner.JOB_ID_PREFIX)) {

--- a/aceclaw-dashboard/src/App.tsx
+++ b/aceclaw-dashboard/src/App.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
+import { CronJobsList } from './components/CronJobsList';
 import { ExecutionTree } from './components/ExecutionTree';
 import { SessionList } from './components/SessionList';
+import { useCronJobs } from './hooks/useCronJobs';
 import { useExecutionTree } from './hooks/useExecutionTree';
 import { useSessions } from './hooks/useSessions';
 
@@ -60,6 +62,7 @@ export function App() {
   const [sessionId, setSessionId] = useState(initialSession);
   const [wsUrl] = useState(initialWs);
   const sessions = useSessions(wsUrl);
+  const cronJobs = useCronJobs(wsUrl);
 
   // Selecting a session in the sidebar replaces the URL so reload preserves
   // the selection — replaceState rather than pushState so the back button
@@ -79,6 +82,7 @@ export function App() {
         sessions={sessions}
         selectedSessionId={sessionId || null}
         onSelect={selectSession}
+        footer={<CronJobsList jobs={cronJobs} />}
       />
       <div className="flex flex-1 flex-col overflow-hidden">
         {sessionId ? (

--- a/aceclaw-dashboard/src/components/CronJobsList.tsx
+++ b/aceclaw-dashboard/src/components/CronJobsList.tsx
@@ -1,0 +1,145 @@
+/**
+ * CronJobsList — sidebar section showing the daemon's cron jobs (#459 layer 2).
+ *
+ * Sourced from {@link useCronJobs}. Each row shows the job's name, cron
+ * expression, last-run status (icon + relative time), and the next
+ * scheduled fire time. Click handlers, history expansion, and
+ * jump-to-session are deferred to a follow-up — this layer's job is to
+ * make the daemon's scheduling layer simply *visible*.
+ */
+
+import type { CronJobInfo } from '../hooks/useCronJobs';
+
+interface CronJobsListProps {
+  jobs: CronJobInfo[];
+}
+
+export function CronJobsList({ jobs }: CronJobsListProps) {
+  return (
+    <section className="flex shrink-0 flex-col border-t border-zinc-800">
+      <header className="flex items-center justify-between border-b border-zinc-800 px-3 py-2 text-[11px] uppercase tracking-wider text-zinc-500">
+        <span>Scheduled jobs</span>
+        <span className="font-mono text-zinc-600">{jobs.length}</span>
+      </header>
+      {jobs.length === 0 ? (
+        <p className="px-3 py-4 text-xs text-zinc-500">
+          No cron jobs.{' '}
+          <span className="text-zinc-600">Add one with the CLI.</span>
+        </p>
+      ) : (
+        <ul className="max-h-72 overflow-y-auto">
+          {jobs.map((job) => (
+            <CronJobRow key={job.id} job={job} />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+interface CronJobRowProps {
+  job: CronJobInfo;
+}
+
+function CronJobRow({ job }: CronJobRowProps) {
+  const dotColor = statusDotColor(job);
+  const subtitle = subtitleFor(job);
+  return (
+    <li>
+      <div
+        className="flex w-full items-start gap-2 px-3 py-2 text-left text-xs"
+        title={job.lastError ?? job.description ?? job.id}
+      >
+        <span
+          className={`mt-1 h-2 w-2 shrink-0 rounded-full ${dotColor}`}
+          aria-label={`status: ${job.lastStatus ?? 'idle'}`}
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="truncate text-zinc-200">{job.name}</span>
+            {!job.enabled && (
+              <span className="rounded bg-zinc-800 px-1 py-px font-mono text-[9px] uppercase text-zinc-500">
+                disabled
+              </span>
+            )}
+          </div>
+          <div className="flex items-center gap-2 text-[10px] text-zinc-500">
+            <span className="truncate font-mono">{job.expression}</span>
+            <span>·</span>
+            <span className="whitespace-nowrap">{subtitle}</span>
+          </div>
+        </div>
+      </div>
+    </li>
+  );
+}
+
+/**
+ * Picks the dot colour from the most recent observed status, falling back
+ * to grey when nothing's happened since the dashboard connected.
+ */
+function statusDotColor(job: CronJobInfo): string {
+  if (!job.enabled) return 'bg-zinc-700';
+  switch (job.lastStatus) {
+    case 'running':
+      return 'bg-blue-500 animate-pulse';
+    case 'completed':
+      return 'bg-emerald-500';
+    case 'failed':
+      return 'bg-rose-500';
+    case 'skipped':
+      return 'bg-amber-500';
+    default:
+      // No event observed yet but the daemon may have run it pre-connect:
+      // surface failed-from-snapshot first, then last-run-at, else idle.
+      if (job.lastError) return 'bg-rose-500';
+      if (job.lastRunAt) return 'bg-emerald-700';
+      return 'bg-zinc-600';
+  }
+}
+
+/**
+ * Per-row second line. Prefer "next fires in Xm" when we have it (this is
+ * the unique value a scheduler dashboard adds over a generic log viewer);
+ * fall back to "ran Xm ago" so a job that's already past its last fire
+ * still surfaces something useful.
+ */
+function subtitleFor(job: CronJobInfo): string {
+  if (job.nextFireAt) {
+    const next = relativeFutureTime(job.nextFireAt);
+    if (next) return `next ${next}`;
+  }
+  if (job.lastRunAt) {
+    return `ran ${relativePastTime(job.lastRunAt)}`;
+  }
+  return 'never run';
+}
+
+/** "in 23m" / "in 2h" / "in 3d" — null when the timestamp is in the past. */
+function relativeFutureTime(iso: string): string | null {
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return null;
+  const seconds = Math.floor((t - Date.now()) / 1000);
+  if (seconds < 0) return null;
+  if (seconds < 60) return `in ${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `in ${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `in ${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `in ${days}d`;
+}
+
+/** "Xs ago" / "Xm ago" / "Xh ago" / "Xd ago" — same format as SessionList. */
+function relativePastTime(iso: string): string {
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return '—';
+  const seconds = Math.max(0, Math.floor((Date.now() - t) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}

--- a/aceclaw-dashboard/src/components/SessionList.tsx
+++ b/aceclaw-dashboard/src/components/SessionList.tsx
@@ -21,9 +21,21 @@ interface SessionListProps {
   sessions: SessionInfo[];
   selectedSessionId: string | null;
   onSelect: (sessionId: string) => void;
+  /**
+   * Optional content rendered at the bottom of the sidebar, beneath the
+   * session rows. Used by App to mount the CronJobsList panel (#459)
+   * without wrapping SessionList in another container — the parent
+   * &lt;aside&gt; here is already the dashboard's left rail.
+   */
+  footer?: React.ReactNode;
 }
 
-export function SessionList({ sessions, selectedSessionId, onSelect }: SessionListProps) {
+export function SessionList({
+  sessions,
+  selectedSessionId,
+  onSelect,
+  footer,
+}: SessionListProps) {
   return (
     <aside className="flex h-full w-60 shrink-0 flex-col border-r border-zinc-800 bg-zinc-900/40">
       <header className="flex items-center justify-between border-b border-zinc-800 px-3 py-2 text-[11px] uppercase tracking-wider text-zinc-500">
@@ -47,6 +59,7 @@ export function SessionList({ sessions, selectedSessionId, onSelect }: SessionLi
           ))}
         </ul>
       )}
+      {footer}
     </aside>
   );
 }

--- a/aceclaw-dashboard/src/hooks/useCronJobs.ts
+++ b/aceclaw-dashboard/src/hooks/useCronJobs.ts
@@ -122,7 +122,24 @@ export function useCronJobs(wsUrl: string | null): CronJobInfo[] {
         const jobId = typeof params['jobId'] === 'string' ? params['jobId'] : null;
         if (!jobId) return;
 
-        setJobs((prev) => applyEventDelta(prev, method, jobId, params));
+        setJobs((prev) => {
+          if (!hasJob(prev, jobId)) {
+            // Job was created after our snapshot — applyEventDelta would
+            // silently drop the event. Re-request the status so the new
+            // row appears (the snapshot reply will replace this state
+            // wholesale; returning `prev` here just keeps the UI stable
+            // for the few ms of round-trip). The send is idempotent so
+            // React's strict-mode double-invocation is harmless.
+            try {
+              ws?.send(STATUS_REQUEST);
+            } catch {
+              // Socket transitioning — next reconnect's onopen will
+              // re-fetch anyway.
+            }
+            return prev;
+          }
+          return applyEventDelta(prev, method, jobId, params);
+        });
       };
 
       ws.onclose = () => {
@@ -197,10 +214,21 @@ export function parseStatusResult(data: Record<string, unknown>): CronJobInfo[] 
 }
 
 /**
+ * True when {@code prev} contains a job with the given id. Exposed
+ * separately from {@link applyEventDelta} so the hook can fire a
+ * snapshot refresh BEFORE applying the delta when the event references
+ * a job created after our last snapshot — without that refresh the
+ * sidebar would silently drop events for newly-created jobs.
+ */
+export function hasJob(prev: CronJobInfo[], jobId: string): boolean {
+  return prev.some((j) => j.id === jobId);
+}
+
+/**
  * Folds a {@code scheduler.job_*} event into the existing job list. If
  * the event references a job we don't know about (e.g. a job created
- * after our snapshot), the call is a no-op — the next reconnect /
- * status refresh will pick it up.
+ * after our snapshot), the call is a no-op — the caller should fire
+ * a status refresh, see {@link hasJob}.
  *
  * Exported for unit tests so the four event types are pinned by name.
  */

--- a/aceclaw-dashboard/src/hooks/useCronJobs.ts
+++ b/aceclaw-dashboard/src/hooks/useCronJobs.ts
@@ -1,0 +1,241 @@
+/**
+ * useCronJobs — sidebar data source for the cron-jobs panel (#459 layer 2).
+ *
+ * Owns its OWN WebSocket connection (separate from
+ * {@link useExecutionTree} and {@link useSessions}) for the same reason
+ * sidebars do: a per-session reducer can't observe daemon-wide events.
+ * Three responsibilities:
+ *
+ *   1. On open, request {@code scheduler.cron.status} and seed the job
+ *      list from the one-shot reply (snapshot of state at request time).
+ *   2. Listen for live {@code scheduler.job_triggered/completed/failed/skipped}
+ *      envelopes — those carry the {@code __global__} sentinel sessionId
+ *      so {@link useExecutionTree} naturally ignores them. We apply each
+ *      as a delta so the list is fresh without re-fetching.
+ *   3. Reconnect with exponential backoff, mirroring {@link useSessions}.
+ *
+ * The wire shape from the daemon ({@code scheduler.cron.status.result}
+ * and {@code scheduler.job_*}) lives in
+ * {@code aceclaw-daemon/.../AceClawDaemon.java}.
+ */
+
+import { useEffect, useState } from 'react';
+
+/** One row in the cron-jobs sidebar. Mirrors the daemon's reply shape. */
+export interface CronJobInfo {
+  id: string;
+  name: string;
+  /** Five-field cron expression. */
+  expression: string;
+  enabled: boolean;
+  /** Best-effort kind hint from the daemon: "scheduled", "one-shot", … */
+  kind?: string;
+  description?: string;
+  /** ISO-8601 of the last run start, if any. */
+  lastRunAt?: string;
+  /** ISO-8601 of the next computed fire time, if the expression is valid. */
+  nextFireAt?: string;
+  /** Last error message — present only when the most recent run failed. */
+  lastError?: string;
+  /**
+   * Synthesised by the hook from the most recent {@code scheduler.job_*}
+   * envelope so the sidebar can render a status dot without re-fetching:
+   *   - {@code "running"}  while a triggered run hasn't completed
+   *   - {@code "completed"} after a clean run
+   *   - {@code "failed"}    after a failure (also see {@link lastError})
+   *   - {@code "skipped"}   when the daemon skipped a fire (e.g. previous run busy)
+   *   - {@code undefined}   when no event has been observed since connect
+   */
+  lastStatus?: 'running' | 'completed' | 'failed' | 'skipped';
+}
+
+const STATUS_REQUEST = JSON.stringify({ method: 'scheduler.cron.status' });
+const RECONNECT_INITIAL_MS = 500;
+const RECONNECT_MAX_MS = 30_000;
+
+/**
+ * Subscribes to the daemon's cron-job set. Returns a stable array sorted
+ * by job id (matching the daemon's wire order) so React's keyed children
+ * stay stable across re-renders.
+ *
+ * @param wsUrl daemon bridge URL — same as {@link useExecutionTree}.
+ *              Pass {@code null} to disable the connection.
+ */
+export function useCronJobs(wsUrl: string | null): CronJobInfo[] {
+  const [jobs, setJobs] = useState<CronJobInfo[]>([]);
+
+  useEffect(() => {
+    if (!wsUrl) {
+      // Drop any rows from a prior connection so the sidebar doesn't
+      // ghost stale jobs while the dashboard is detached.
+      setJobs([]);
+      return;
+    }
+    let ws: WebSocket | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let backoffMs = RECONNECT_INITIAL_MS;
+    let cancelled = false;
+
+    const connect = (): void => {
+      if (cancelled) return;
+      try {
+        ws = new WebSocket(wsUrl);
+      } catch {
+        return;
+      }
+
+      ws.onopen = () => {
+        if (cancelled) return;
+        backoffMs = RECONNECT_INITIAL_MS;
+        // Refresh on every reopen so a daemon restart doesn't leave us
+        // showing stale lastRunAt values.
+        ws?.send(STATUS_REQUEST);
+      };
+
+      ws.onmessage = (e: MessageEvent<string>) => {
+        if (cancelled) return;
+        let data: unknown;
+        try {
+          data = JSON.parse(e.data);
+        } catch {
+          return;
+        }
+        if (!isPlainObject(data)) return;
+
+        // Point-to-point reply to our STATUS_REQUEST. Snapshot of the
+        // current job set; replace local state.
+        if (data['method'] === 'scheduler.cron.status.result') {
+          const next = parseStatusResult(data);
+          if (next) setJobs(next);
+          return;
+        }
+
+        // Live envelope. Filter by the GLOBAL_SESSION_ID sentinel so we
+        // don't accidentally pick up stream.* events from any session.
+        if (data['sessionId'] !== '__global__') return;
+        const event = data['event'];
+        if (!isPlainObject(event)) return;
+        const method = typeof event['method'] === 'string' ? event['method'] : null;
+        if (!method || !method.startsWith('scheduler.job_')) return;
+        const rawParams = event['params'];
+        const params: Record<string, unknown> = isPlainObject(rawParams) ? rawParams : {};
+        const jobId = typeof params['jobId'] === 'string' ? params['jobId'] : null;
+        if (!jobId) return;
+
+        setJobs((prev) => applyEventDelta(prev, method, jobId, params));
+      };
+
+      ws.onclose = () => {
+        if (cancelled) return;
+        reconnectTimer = setTimeout(connect, backoffMs);
+        backoffMs = Math.min(backoffMs * 2, RECONNECT_MAX_MS);
+      };
+
+      ws.onerror = () => {
+        // onerror always precedes onclose for hard failures; the close
+        // handler reconnects, so no work needed here.
+      };
+    };
+
+    connect();
+
+    return () => {
+      cancelled = true;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      if (ws) {
+        ws.onopen = null;
+        ws.onmessage = null;
+        ws.onclose = null;
+        ws.onerror = null;
+        ws.close();
+      }
+    };
+  }, [wsUrl]);
+
+  return jobs;
+}
+
+// ---------------------------------------------------------------------------
+// Validation + delta helpers (exported for unit tests)
+// ---------------------------------------------------------------------------
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isString(v: unknown): v is string {
+  return typeof v === 'string';
+}
+
+/**
+ * Parses a {@code scheduler.cron.status.result} payload. Returns null when
+ * the shape is unusable (so the hook falls back to whatever it had).
+ *
+ * Exported so unit tests can pin the wire-format contract directly.
+ */
+export function parseStatusResult(data: Record<string, unknown>): CronJobInfo[] | null {
+  const jobs = data['jobs'];
+  if (!Array.isArray(jobs)) return null;
+  const out: CronJobInfo[] = [];
+  for (const j of jobs) {
+    if (!isPlainObject(j)) continue;
+    if (!isString(j['id']) || !isString(j['name']) || !isString(j['expression'])) continue;
+    const row: CronJobInfo = {
+      id: j['id'],
+      name: j['name'],
+      expression: j['expression'],
+      enabled: typeof j['enabled'] === 'boolean' ? j['enabled'] : true,
+    };
+    if (isString(j['kind'])) row.kind = j['kind'];
+    if (isString(j['description'])) row.description = j['description'];
+    if (isString(j['lastRunAt'])) row.lastRunAt = j['lastRunAt'];
+    if (isString(j['nextFireAt'])) row.nextFireAt = j['nextFireAt'];
+    if (isString(j['lastError'])) row.lastError = j['lastError'];
+    out.push(row);
+  }
+  return out;
+}
+
+/**
+ * Folds a {@code scheduler.job_*} event into the existing job list. If
+ * the event references a job we don't know about (e.g. a job created
+ * after our snapshot), the call is a no-op — the next reconnect /
+ * status refresh will pick it up.
+ *
+ * Exported for unit tests so the four event types are pinned by name.
+ */
+export function applyEventDelta(
+  prev: CronJobInfo[],
+  method: string,
+  jobId: string,
+  params: Record<string, unknown>,
+): CronJobInfo[] {
+  const ts = isString(params['timestamp']) ? params['timestamp'] : null;
+  return prev.map((j) => {
+    if (j.id !== jobId) return j;
+    switch (method) {
+      case 'scheduler.job_triggered': {
+        const next: CronJobInfo = { ...j, lastStatus: 'running' };
+        if (ts) next.lastRunAt = ts;
+        delete next.lastError;
+        return next;
+      }
+      case 'scheduler.job_completed': {
+        const next: CronJobInfo = { ...j, lastStatus: 'completed' };
+        if (ts) next.lastRunAt = ts;
+        delete next.lastError;
+        return next;
+      }
+      case 'scheduler.job_failed': {
+        const next: CronJobInfo = { ...j, lastStatus: 'failed' };
+        if (ts) next.lastRunAt = ts;
+        if (isString(params['error'])) next.lastError = params['error'];
+        return next;
+      }
+      case 'scheduler.job_skipped':
+        return { ...j, lastStatus: 'skipped' };
+      default:
+        return j;
+    }
+  });
+}

--- a/aceclaw-dashboard/tests/useCronJobs.test.ts
+++ b/aceclaw-dashboard/tests/useCronJobs.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Unit tests for useCronJobs's pure helpers (#459 layer 2).
+ *
+ * The hook itself wires WebSocket plumbing — we test it via the helpers
+ * (parseStatusResult, applyEventDelta) so wire-format and delta logic
+ * have a fast safety net independent of a live socket.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  applyEventDelta,
+  parseStatusResult,
+  type CronJobInfo,
+} from '../src/hooks/useCronJobs';
+
+describe('parseStatusResult', () => {
+  it('returns null for non-array jobs', () => {
+    expect(parseStatusResult({})).toBeNull();
+    expect(parseStatusResult({ jobs: 'oops' })).toBeNull();
+  });
+
+  it('parses a minimal valid job', () => {
+    const out = parseStatusResult({
+      jobs: [{ id: 'a', name: 'Daily', expression: '0 2 * * *', enabled: true }],
+    });
+    expect(out).toEqual([
+      { id: 'a', name: 'Daily', expression: '0 2 * * *', enabled: true },
+    ]);
+  });
+
+  it('skips rows missing required fields', () => {
+    const out = parseStatusResult({
+      jobs: [
+        { id: 'a', name: 'ok', expression: '* * * * *', enabled: true },
+        { id: 42, name: 'bad-id', expression: '* * * * *' }, // bad: id not string
+        { id: 'c', name: 'no-expr' },                          // bad: missing expression
+        'not-an-object',                                       // bad: not object
+      ],
+    });
+    expect(out).toHaveLength(1);
+    expect(out![0]!.id).toBe('a');
+  });
+
+  it('passes through optional fields when present and valid', () => {
+    const out = parseStatusResult({
+      jobs: [{
+        id: 'a',
+        name: 'Daily',
+        expression: '0 2 * * *',
+        enabled: true,
+        kind: 'scheduled',
+        description: 'cleanup',
+        lastRunAt: '2026-05-01T10:00:00Z',
+        nextFireAt: '2026-05-02T02:00:00Z',
+        lastError: 'previous failure',
+      }],
+    });
+    expect(out![0]).toMatchObject({
+      kind: 'scheduled',
+      description: 'cleanup',
+      lastRunAt: '2026-05-01T10:00:00Z',
+      nextFireAt: '2026-05-02T02:00:00Z',
+      lastError: 'previous failure',
+    });
+  });
+
+  it('omits optional fields rather than assigning undefined (exactOptionalPropertyTypes)', () => {
+    const out = parseStatusResult({
+      jobs: [{ id: 'a', name: 'X', expression: '* * * * *', enabled: true }],
+    });
+    // Property must not exist, so consumers using `'kind' in row` style checks
+    // get truthful answers. (in undefined === false in JS, but the test
+    // documents the contract.)
+    expect(Object.prototype.hasOwnProperty.call(out![0], 'kind')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(out![0], 'lastRunAt')).toBe(false);
+  });
+
+  it('defaults enabled=true when the field is missing or non-boolean', () => {
+    const out = parseStatusResult({
+      jobs: [{ id: 'a', name: 'X', expression: '* * * * *' }],
+    });
+    expect(out![0]!.enabled).toBe(true);
+  });
+});
+
+describe('applyEventDelta', () => {
+  const baseJob = (over: Partial<CronJobInfo> = {}): CronJobInfo => ({
+    id: 'a',
+    name: 'Daily',
+    expression: '0 2 * * *',
+    enabled: true,
+    ...over,
+  });
+
+  it('marks the matching job running on triggered + clears prior error', () => {
+    const prev = [baseJob({ lastError: 'old failure' })];
+    const next = applyEventDelta(prev, 'scheduler.job_triggered', 'a', {
+      timestamp: '2026-05-01T10:00:00Z',
+    });
+    expect(next[0]).toEqual({
+      ...prev[0]!,
+      lastError: undefined, // delete leaves no own key — undefined access OK
+      lastRunAt: '2026-05-01T10:00:00Z',
+      lastStatus: 'running',
+    });
+    expect('lastError' in next[0]!).toBe(false); // delete removed the key
+  });
+
+  it('marks the matching job completed on completed', () => {
+    const prev = [baseJob()];
+    const next = applyEventDelta(prev, 'scheduler.job_completed', 'a', {
+      timestamp: '2026-05-01T10:01:00Z',
+    });
+    expect(next[0]!.lastStatus).toBe('completed');
+    expect(next[0]!.lastRunAt).toBe('2026-05-01T10:01:00Z');
+  });
+
+  it('marks failed and stamps the error text', () => {
+    // Field-swap regression guard: a copy-paste typo that put params.error
+    // into the wrong field would silently render an empty tooltip.
+    const prev = [baseJob()];
+    const next = applyEventDelta(prev, 'scheduler.job_failed', 'a', {
+      error: 'tool exec timeout',
+      attempt: 2,
+      maxAttempts: 5,
+      timestamp: '2026-05-01T10:02:00Z',
+    });
+    expect(next[0]!.lastStatus).toBe('failed');
+    expect(next[0]!.lastError).toBe('tool exec timeout');
+    expect(next[0]!.lastRunAt).toBe('2026-05-01T10:02:00Z');
+  });
+
+  it('marks skipped without disturbing lastRunAt', () => {
+    const prev = [baseJob({ lastRunAt: '2026-05-01T09:00:00Z' })];
+    const next = applyEventDelta(prev, 'scheduler.job_skipped', 'a', {
+      reason: 'previous run still active',
+    });
+    expect(next[0]!.lastStatus).toBe('skipped');
+    // skipped does not change lastRunAt — the previous run remains the
+    // most recent actual execution.
+    expect(next[0]!.lastRunAt).toBe('2026-05-01T09:00:00Z');
+  });
+
+  it('is a no-op when the jobId is unknown', () => {
+    const prev = [baseJob()];
+    const next = applyEventDelta(prev, 'scheduler.job_triggered', 'unknown-id', {
+      timestamp: '2026-05-01T10:00:00Z',
+    });
+    expect(next).toEqual(prev);
+  });
+
+  it('does not mutate the input array', () => {
+    const prev = [baseJob()];
+    applyEventDelta(prev, 'scheduler.job_completed', 'a', {
+      timestamp: '2026-05-01T10:01:00Z',
+    });
+    expect(prev[0]!.lastStatus).toBeUndefined();
+  });
+});

--- a/aceclaw-dashboard/tests/useCronJobs.test.ts
+++ b/aceclaw-dashboard/tests/useCronJobs.test.ts
@@ -9,6 +9,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   applyEventDelta,
+  hasJob,
   parseStatusResult,
   type CronJobInfo,
 } from '../src/hooks/useCronJobs';
@@ -142,6 +143,9 @@ describe('applyEventDelta', () => {
   });
 
   it('is a no-op when the jobId is unknown', () => {
+    // The hook's responsibility is to detect this case via `hasJob` and
+    // fire a status refresh — the delta itself stays a pure no-op so
+    // the function can keep its plain (prev → next) shape.
     const prev = [baseJob()];
     const next = applyEventDelta(prev, 'scheduler.job_triggered', 'unknown-id', {
       timestamp: '2026-05-01T10:00:00Z',
@@ -155,5 +159,30 @@ describe('applyEventDelta', () => {
       timestamp: '2026-05-01T10:01:00Z',
     });
     expect(prev[0]!.lastStatus).toBeUndefined();
+  });
+});
+
+describe('hasJob', () => {
+  // The hook uses hasJob to gate "apply delta vs fire snapshot refresh"
+  // — so a `scheduler.job_*` event for a job created after our snapshot
+  // triggers a re-fetch instead of being silently dropped. This is the
+  // counterpart to applyEventDelta's "no-op on unknown id" contract.
+  const baseJob = (id: string): CronJobInfo => ({
+    id,
+    name: 'X',
+    expression: '* * * * *',
+    enabled: true,
+  });
+
+  it('returns true for an id present in the list', () => {
+    expect(hasJob([baseJob('a'), baseJob('b')], 'b')).toBe(true);
+  });
+
+  it('returns false for an id missing from the list', () => {
+    expect(hasJob([baseJob('a')], 'unknown')).toBe(false);
+  });
+
+  it('returns false for an empty list', () => {
+    expect(hasJob([], 'a')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Layer 2 of #459 — the daemon's cron scheduler is now **visible** in the dashboard sidebar, beneath the existing sessions list. With layer 1 (#460) already shipping events over the WS bridge, this PR is the consumer side.

- New `useCronJobs(wsUrl)` hook (own WS connection, mirrors `useSessions`). On open it requests `scheduler.cron.status` for the snapshot, then folds live `scheduler.job_*` envelopes into the list as deltas. Reconnect with exponential backoff.
- New `CronJobsList` component: status dot + job name + cron expression + "next in Xm" / "ran Xm ago" / "never run". Disabled jobs get a small badge.
- `SessionList` gained a `footer?` prop so the panel mounts inside the same left-rail aside; no second sidebar column.
- Daemon: extracted the existing `scheduler.cron.status` body into a shared `buildCronStatusReply` helper so the CLI's JSON-RPC handler and the new dashboard WS inbound handler return the literally-same shape.

## What you should see when you run it

1. Daemon up with `webSocket.enabled: true` (already done from #460 testing).
2. `cd aceclaw-dashboard && npm run dev`, open the dashboard.
3. Below the "Sessions" section in the left sidebar: a new "Scheduled jobs" section listing every cron job the daemon knows about. Each row updates live when a `scheduler.job_*` event fires — green dot on completion, red on failure, blue pulse while running.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 12 new tests, 151 total, all green
- [x] `npx vite build` — clean
- [x] `./gradlew :aceclaw-daemon:test` — clean
- [ ] Manual: add a `* * * * *` cron job, watch the row's last-run dot turn blue → green within a minute

## Out of scope (follow-ups in #459)

- Click a job → expand recent triggers (history list)
- Click a trigger → jump to the produced session (needs `sessionId` field on SchedulerEvent records — daemon schema change)
- Layer 3: top swimlane timeline widget

🤖 Generated with [Claude Code](https://claude.com/claude-code)