### PR TITLE
feat(dashboard): cron schedule timeline widget (#459 layer 3)

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -523,6 +523,13 @@ public final class AceClawDaemon {
                     // started just sees an empty job list.
                     case "scheduler.cron.status" ->
                             handleSchedulerCronStatus(ctx, mapperRef, cronJobStore, cronScheduler);
+                    // #459 layer 3: dashboard timeline backfills its
+                    // event window from this on connect. Same shape as
+                    // the CLI's scheduler.events.poll RPC; reply tagged
+                    // with .result for the hook to match.
+                    case "scheduler.events.poll" ->
+                            handleSchedulerEventsPoll(ctx, mapperRef, schedulerEventFeed,
+                                    message.get("params"));
                     // Browser approve/deny → route to the same per-context
                     // CompletableFuture the CLI socket monitor would (issue
                     // #433). First response wins; the loser is logged and
@@ -1285,58 +1292,13 @@ public final class AceClawDaemon {
         router.register("scheduler.cron.status", params ->
                 buildCronStatusReply(objectMapper, cronJobStore, cronScheduler));
 
-        // Scheduler feed polling for foreground CLI notifications.
-        router.register("scheduler.events.poll", params -> {
-            long afterSeq = 0L;
-            int limit = 20;
-            if (params != null) {
-                if (params.has("afterSeq")) {
-                    afterSeq = Math.max(0L, params.get("afterSeq").asLong());
-                }
-                if (params.has("limit")) {
-                    limit = params.get("limit").asInt(20);
-                }
-            }
-
-            var polled = schedulerEventFeed.poll(afterSeq, limit);
-            var result = objectMapper.createObjectNode();
-            result.put("nextSeq", polled.nextSequence());
-            var events = objectMapper.createArrayNode();
-            for (var entry : polled.entries()) {
-                var node = objectMapper.createObjectNode();
-                node.put("seq", entry.sequence());
-                var event = entry.event();
-                node.put("jobId", event.jobId());
-                switch (event) {
-                    case SchedulerEvent.JobTriggered e -> {
-                        node.put("type", "triggered");
-                        node.put("cronExpression", e.cronExpression());
-                        node.put("timestamp", e.timestamp().toString());
-                    }
-                    case SchedulerEvent.JobCompleted e -> {
-                        node.put("type", "completed");
-                        node.put("durationMs", e.durationMs());
-                        node.put("summary", e.summary());
-                        node.put("timestamp", e.timestamp().toString());
-                    }
-                    case SchedulerEvent.JobFailed e -> {
-                        node.put("type", "failed");
-                        node.put("error", e.error());
-                        node.put("attempt", e.attempt());
-                        node.put("maxAttempts", e.maxAttempts());
-                        node.put("timestamp", e.timestamp().toString());
-                    }
-                    case SchedulerEvent.JobSkipped e -> {
-                        node.put("type", "skipped");
-                        node.put("reason", e.reason());
-                        node.put("timestamp", e.timestamp().toString());
-                    }
-                }
-                events.add(node);
-            }
-            result.set("events", events);
-            return result;
-        });
+        // Scheduler event feed polling. CLI uses this for foreground
+        // notifications; dashboard timeline (#459 layer 3) uses it for
+        // history backfill on connect. Body extracted into
+        // buildSchedulerEventsPollReply so the WS inbound path serves
+        // exactly the same shape.
+        router.register("scheduler.events.poll", params ->
+                buildSchedulerEventsPollReply(objectMapper, schedulerEventFeed, params));
 
         // Deferred event feed polling for foreground CLI notifications.
         router.register("deferred.events.poll", params -> {
@@ -1928,6 +1890,93 @@ public final class AceClawDaemon {
         }
         result.set("jobs", jobs);
         return result;
+    }
+
+    /**
+     * Builds the {@code scheduler.events.poll} reply body — a paginated
+     * window into the {@link SchedulerEventFeed} ring buffer. Shared by
+     * the CLI's JSON-RPC handler and the dashboard's WS inbound handler
+     * (#459 layer 3) so both surfaces speak exactly the same wire shape.
+     *
+     * <p>Tolerates a null params node (defaults afterSeq=0, limit=20)
+     * and clamps {@code limit} via the feed's own bounds.
+     */
+    private static com.fasterxml.jackson.databind.node.ObjectNode buildSchedulerEventsPollReply(
+            ObjectMapper mapper,
+            SchedulerEventFeed feed,
+            com.fasterxml.jackson.databind.JsonNode params) {
+        long afterSeq = 0L;
+        int limit = 20;
+        if (params != null) {
+            if (params.has("afterSeq")) {
+                afterSeq = Math.max(0L, params.get("afterSeq").asLong());
+            }
+            if (params.has("limit")) {
+                limit = params.get("limit").asInt(20);
+            }
+        }
+        var result = mapper.createObjectNode();
+        if (feed == null) {
+            result.put("nextSeq", 0L);
+            result.set("events", mapper.createArrayNode());
+            return result;
+        }
+        var polled = feed.poll(afterSeq, limit);
+        result.put("nextSeq", polled.nextSequence());
+        var events = mapper.createArrayNode();
+        for (var entry : polled.entries()) {
+            var node = mapper.createObjectNode();
+            node.put("seq", entry.sequence());
+            var event = entry.event();
+            node.put("jobId", event.jobId());
+            switch (event) {
+                case SchedulerEvent.JobTriggered e -> {
+                    node.put("type", "triggered");
+                    node.put("cronExpression", e.cronExpression());
+                    node.put("timestamp", e.timestamp().toString());
+                }
+                case SchedulerEvent.JobCompleted e -> {
+                    node.put("type", "completed");
+                    node.put("durationMs", e.durationMs());
+                    node.put("summary", e.summary());
+                    node.put("timestamp", e.timestamp().toString());
+                }
+                case SchedulerEvent.JobFailed e -> {
+                    node.put("type", "failed");
+                    node.put("error", e.error());
+                    node.put("attempt", e.attempt());
+                    node.put("maxAttempts", e.maxAttempts());
+                    node.put("timestamp", e.timestamp().toString());
+                }
+                case SchedulerEvent.JobSkipped e -> {
+                    node.put("type", "skipped");
+                    node.put("reason", e.reason());
+                    node.put("timestamp", e.timestamp().toString());
+                }
+            }
+            events.add(node);
+        }
+        result.set("events", events);
+        return result;
+    }
+
+    /**
+     * Replies to a {@code scheduler.events.poll} inbound message from
+     * the dashboard timeline. Tags with {@code scheduler.events.poll.result}
+     * so the consumer hook can match it against its connect-time request.
+     * Mirrors {@link #handleSchedulerCronStatus}.
+     */
+    private static void handleSchedulerEventsPoll(io.javalin.websocket.WsContext ctx,
+                                                   ObjectMapper mapper,
+                                                   SchedulerEventFeed feed,
+                                                   com.fasterxml.jackson.databind.JsonNode params) {
+        try {
+            var body = buildSchedulerEventsPollReply(mapper, feed, params);
+            body.put("method", "scheduler.events.poll.result");
+            ctx.send(mapper.writeValueAsString(body));
+        } catch (Exception e) {
+            log.warn("Failed to send scheduler.events.poll.result reply: {}", e.getMessage());
+        }
     }
 
     /**

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -515,6 +515,14 @@ public final class AceClawDaemon {
                 switch (method) {
                     case "sessions.list" -> handleSessionsList(ctx, mapperRef, sessionsRef, agentHandler);
                     case "snapshot.request" -> handleSnapshotRequest(ctx, message, mapperRef, bridgeRef);
+                    // #459 layer 2: dashboard sidebar fetches the current
+                    // cron-job snapshot on connect. Reply is point-to-point
+                    // (not broadcast), same one-shot pattern as sessions.list.
+                    // Field reads of cronJobStore/cronScheduler are lazy via
+                    // `this` so a dashboard that connects before cron has
+                    // started just sees an empty job list.
+                    case "scheduler.cron.status" ->
+                            handleSchedulerCronStatus(ctx, mapperRef, cronJobStore, cronScheduler);
                     // Browser approve/deny → route to the same per-context
                     // CompletableFuture the CLI socket monitor would (issue
                     // #433). First response wins; the loser is logged and
@@ -1271,54 +1279,11 @@ public final class AceClawDaemon {
             }
         });
 
-        // Scheduler feed polling for foreground CLI notifications.
-        router.register("scheduler.cron.status", params -> {
-            var result = objectMapper.createObjectNode();
-            boolean schedulerRunning = cronScheduler != null && cronScheduler.isRunning();
-            result.put("schedulerRunning", schedulerRunning);
-            if (cronScheduler != null) {
-                result.put("jobRunning", cronScheduler.isJobRunning());
-                if (cronScheduler.currentJobId() != null) {
-                    result.put("currentJobId", cronScheduler.currentJobId());
-                }
-                if (cronScheduler.currentJobStartedAt() != null) {
-                    result.put("currentJobStartedAt", cronScheduler.currentJobStartedAt().toString());
-                }
-            } else {
-                result.put("jobRunning", false);
-            }
-
-            var jobs = objectMapper.createArrayNode();
-            for (CronJob job : cronJobStore.all().stream()
-                    .sorted(Comparator.comparing(CronJob::id))
-                    .toList()) {
-                var jn = objectMapper.createObjectNode();
-                jn.put("id", job.id());
-                jn.put("name", job.name());
-                jn.put("expression", job.expression());
-                jn.put("enabled", job.enabled());
-                jn.put("heartbeat", job.id().startsWith(HeartbeatRunner.JOB_ID_PREFIX));
-                jn.put("kind", cronKind(job));
-                jn.put("description", summarizePrompt(job.prompt()));
-                if (job.lastRunAt() != null) {
-                    jn.put("lastRunAt", job.lastRunAt().toString());
-                }
-                if (job.lastError() != null && !job.lastError().isBlank()) {
-                    jn.put("lastError", job.lastError());
-                }
-                try {
-                    Instant lastRun = job.lastRunAt() != null ? job.lastRunAt() : Instant.EPOCH;
-                    Instant nextFire = CronExpression.parse(job.expression()).nextFireTime(lastRun);
-                    if (nextFire != null) {
-                        jn.put("nextFireAt", nextFire.toString());
-                    }
-                } catch (Exception ignored) {
-                }
-                jobs.add(jn);
-            }
-            result.set("jobs", jobs);
-            return result;
-        });
+        // Scheduler status (CLI poll endpoint + dashboard sidebar bootstrap).
+        // Body extracted into buildCronStatusReply so the WS inbound path
+        // (#459 layer 2) can serve the same shape over the bridge.
+        router.register("scheduler.cron.status", params ->
+                buildCronStatusReply(objectMapper, cronJobStore, cronScheduler));
 
         // Scheduler feed polling for foreground CLI notifications.
         router.register("scheduler.events.poll", params -> {
@@ -1900,6 +1865,101 @@ public final class AceClawDaemon {
 
     /** Translated form of a {@link SchedulerEvent} ready to broadcast over WS. */
     record SchedulerNotification(String method, com.fasterxml.jackson.databind.node.ObjectNode params) {}
+
+    /**
+     * Builds the {@code scheduler.cron.status} reply body — a snapshot of
+     * scheduler state plus every configured job, sorted by id. Shared by
+     * the CLI's JSON-RPC handler and the dashboard's WS inbound handler so
+     * the two surfaces speak exactly the same wire shape.
+     *
+     * <p>Tolerates a null scheduler (daemon started before cron was wired)
+     * by reporting {@code schedulerRunning=false} and an empty jobs list
+     * derived from whatever the store happens to hold.
+     */
+    private static com.fasterxml.jackson.databind.node.ObjectNode buildCronStatusReply(
+            ObjectMapper mapper,
+            dev.aceclaw.daemon.cron.JobStore jobStore,
+            dev.aceclaw.daemon.cron.CronScheduler scheduler) {
+        var result = mapper.createObjectNode();
+        boolean schedulerRunning = scheduler != null && scheduler.isRunning();
+        result.put("schedulerRunning", schedulerRunning);
+        if (scheduler != null) {
+            result.put("jobRunning", scheduler.isJobRunning());
+            if (scheduler.currentJobId() != null) {
+                result.put("currentJobId", scheduler.currentJobId());
+            }
+            if (scheduler.currentJobStartedAt() != null) {
+                result.put("currentJobStartedAt", scheduler.currentJobStartedAt().toString());
+            }
+        } else {
+            result.put("jobRunning", false);
+        }
+        var jobs = mapper.createArrayNode();
+        if (jobStore != null) {
+            for (CronJob job : jobStore.all().stream()
+                    .sorted(java.util.Comparator.comparing(CronJob::id))
+                    .toList()) {
+                var jn = mapper.createObjectNode();
+                jn.put("id", job.id());
+                jn.put("name", job.name());
+                jn.put("expression", job.expression());
+                jn.put("enabled", job.enabled());
+                jn.put("heartbeat", job.id().startsWith(HeartbeatRunner.JOB_ID_PREFIX));
+                jn.put("kind", cronKind(job));
+                jn.put("description", summarizePrompt(job.prompt()));
+                if (job.lastRunAt() != null) {
+                    jn.put("lastRunAt", job.lastRunAt().toString());
+                }
+                if (job.lastError() != null && !job.lastError().isBlank()) {
+                    jn.put("lastError", job.lastError());
+                }
+                try {
+                    Instant lastRun = job.lastRunAt() != null ? job.lastRunAt() : Instant.EPOCH;
+                    Instant nextFire = dev.aceclaw.daemon.cron.CronExpression.parse(job.expression())
+                            .nextFireTime(lastRun);
+                    if (nextFire != null) {
+                        jn.put("nextFireAt", nextFire.toString());
+                    }
+                } catch (Exception ignored) {
+                    // Bad expression — surface the rest of the job, just no nextFireAt.
+                }
+                jobs.add(jn);
+            }
+        }
+        result.set("jobs", jobs);
+        return result;
+    }
+
+    /**
+     * Replies to a {@code scheduler.cron.status} inbound message from the
+     * dashboard with the same snapshot the CLI would get over JSON-RPC,
+     * wrapped as a one-shot point-to-point reply (NOT broadcast). Mirrors
+     * {@link #handleSessionsList}.
+     *
+     * <p>Reply shape:
+     * <pre>{@code
+     * {
+     *   "method": "scheduler.cron.status.result",
+     *   "schedulerRunning": <bool>,
+     *   "jobRunning": <bool>,
+     *   "jobs": [{ id, name, expression, enabled, lastRunAt?, nextFireAt?, ... }]
+     * }
+     * }</pre>
+     */
+    private static void handleSchedulerCronStatus(io.javalin.websocket.WsContext ctx,
+                                                   ObjectMapper mapper,
+                                                   dev.aceclaw.daemon.cron.JobStore jobStore,
+                                                   dev.aceclaw.daemon.cron.CronScheduler scheduler) {
+        try {
+            var body = buildCronStatusReply(mapper, jobStore, scheduler);
+            // Tag with the result method so the dashboard's hook can match it
+            // against the request it sent on connect.
+            body.put("method", "scheduler.cron.status.result");
+            ctx.send(mapper.writeValueAsString(body));
+        } catch (Exception e) {
+            log.warn("Failed to send scheduler.cron.status.result reply: {}", e.getMessage());
+        }
+    }
 
     private static String cronKind(CronJob job) {
         if (job.id() != null && job.id().startsWith(HeartbeatRunner.JOB_ID_PREFIX)) {

--- a/aceclaw-dashboard/src/App.tsx
+++ b/aceclaw-dashboard/src/App.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
+import { CronJobsList } from './components/CronJobsList';
 import { ExecutionTree } from './components/ExecutionTree';
 import { SessionList } from './components/SessionList';
+import { useCronJobs } from './hooks/useCronJobs';
 import { useExecutionTree } from './hooks/useExecutionTree';
 import { useSessions } from './hooks/useSessions';
 
@@ -60,6 +62,7 @@ export function App() {
   const [sessionId, setSessionId] = useState(initialSession);
   const [wsUrl] = useState(initialWs);
   const sessions = useSessions(wsUrl);
+  const cronJobs = useCronJobs(wsUrl);
 
   // Selecting a session in the sidebar replaces the URL so reload preserves
   // the selection — replaceState rather than pushState so the back button
@@ -79,6 +82,7 @@ export function App() {
         sessions={sessions}
         selectedSessionId={sessionId || null}
         onSelect={selectSession}
+        footer={<CronJobsList jobs={cronJobs} />}
       />
       <div className="flex flex-1 flex-col overflow-hidden">
         {sessionId ? (

--- a/aceclaw-dashboard/src/App.tsx
+++ b/aceclaw-dashboard/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { CronJobsList } from './components/CronJobsList';
+import { CronTimeline } from './components/CronTimeline';
 import { ExecutionTree } from './components/ExecutionTree';
 import { SessionList } from './components/SessionList';
 import { useCronJobs } from './hooks/useCronJobs';
@@ -62,7 +63,7 @@ export function App() {
   const [sessionId, setSessionId] = useState(initialSession);
   const [wsUrl] = useState(initialWs);
   const sessions = useSessions(wsUrl);
-  const cronJobs = useCronJobs(wsUrl);
+  const { jobs: cronJobs, recentEvents: cronRecentEvents } = useCronJobs(wsUrl);
 
   // Selecting a session in the sidebar replaces the URL so reload preserves
   // the selection — replaceState rather than pushState so the back button
@@ -85,6 +86,7 @@ export function App() {
         footer={<CronJobsList jobs={cronJobs} />}
       />
       <div className="flex flex-1 flex-col overflow-hidden">
+        <CronTimeline jobs={cronJobs} recentEvents={cronRecentEvents} />
         {sessionId ? (
           <DashboardConnected sessionId={sessionId.trim()} wsUrl={wsUrl} />
         ) : (

--- a/aceclaw-dashboard/src/components/CronJobsList.tsx
+++ b/aceclaw-dashboard/src/components/CronJobsList.tsx
@@ -1,0 +1,145 @@
+/**
+ * CronJobsList — sidebar section showing the daemon's cron jobs (#459 layer 2).
+ *
+ * Sourced from {@link useCronJobs}. Each row shows the job's name, cron
+ * expression, last-run status (icon + relative time), and the next
+ * scheduled fire time. Click handlers, history expansion, and
+ * jump-to-session are deferred to a follow-up — this layer's job is to
+ * make the daemon's scheduling layer simply *visible*.
+ */
+
+import type { CronJobInfo } from '../hooks/useCronJobs';
+
+interface CronJobsListProps {
+  jobs: CronJobInfo[];
+}
+
+export function CronJobsList({ jobs }: CronJobsListProps) {
+  return (
+    <section className="flex shrink-0 flex-col border-t border-zinc-800">
+      <header className="flex items-center justify-between border-b border-zinc-800 px-3 py-2 text-[11px] uppercase tracking-wider text-zinc-500">
+        <span>Scheduled jobs</span>
+        <span className="font-mono text-zinc-600">{jobs.length}</span>
+      </header>
+      {jobs.length === 0 ? (
+        <p className="px-3 py-4 text-xs text-zinc-500">
+          No cron jobs.{' '}
+          <span className="text-zinc-600">Add one with the CLI.</span>
+        </p>
+      ) : (
+        <ul className="max-h-72 overflow-y-auto">
+          {jobs.map((job) => (
+            <CronJobRow key={job.id} job={job} />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+interface CronJobRowProps {
+  job: CronJobInfo;
+}
+
+function CronJobRow({ job }: CronJobRowProps) {
+  const dotColor = statusDotColor(job);
+  const subtitle = subtitleFor(job);
+  return (
+    <li>
+      <div
+        className="flex w-full items-start gap-2 px-3 py-2 text-left text-xs"
+        title={job.lastError ?? job.description ?? job.id}
+      >
+        <span
+          className={`mt-1 h-2 w-2 shrink-0 rounded-full ${dotColor}`}
+          aria-label={`status: ${job.lastStatus ?? 'idle'}`}
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="truncate text-zinc-200">{job.name}</span>
+            {!job.enabled && (
+              <span className="rounded bg-zinc-800 px-1 py-px font-mono text-[9px] uppercase text-zinc-500">
+                disabled
+              </span>
+            )}
+          </div>
+          <div className="flex items-center gap-2 text-[10px] text-zinc-500">
+            <span className="truncate font-mono">{job.expression}</span>
+            <span>·</span>
+            <span className="whitespace-nowrap">{subtitle}</span>
+          </div>
+        </div>
+      </div>
+    </li>
+  );
+}
+
+/**
+ * Picks the dot colour from the most recent observed status, falling back
+ * to grey when nothing's happened since the dashboard connected.
+ */
+function statusDotColor(job: CronJobInfo): string {
+  if (!job.enabled) return 'bg-zinc-700';
+  switch (job.lastStatus) {
+    case 'running':
+      return 'bg-blue-500 animate-pulse';
+    case 'completed':
+      return 'bg-emerald-500';
+    case 'failed':
+      return 'bg-rose-500';
+    case 'skipped':
+      return 'bg-amber-500';
+    default:
+      // No event observed yet but the daemon may have run it pre-connect:
+      // surface failed-from-snapshot first, then last-run-at, else idle.
+      if (job.lastError) return 'bg-rose-500';
+      if (job.lastRunAt) return 'bg-emerald-700';
+      return 'bg-zinc-600';
+  }
+}
+
+/**
+ * Per-row second line. Prefer "next fires in Xm" when we have it (this is
+ * the unique value a scheduler dashboard adds over a generic log viewer);
+ * fall back to "ran Xm ago" so a job that's already past its last fire
+ * still surfaces something useful.
+ */
+function subtitleFor(job: CronJobInfo): string {
+  if (job.nextFireAt) {
+    const next = relativeFutureTime(job.nextFireAt);
+    if (next) return `next ${next}`;
+  }
+  if (job.lastRunAt) {
+    return `ran ${relativePastTime(job.lastRunAt)}`;
+  }
+  return 'never run';
+}
+
+/** "in 23m" / "in 2h" / "in 3d" — null when the timestamp is in the past. */
+function relativeFutureTime(iso: string): string | null {
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return null;
+  const seconds = Math.floor((t - Date.now()) / 1000);
+  if (seconds < 0) return null;
+  if (seconds < 60) return `in ${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `in ${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `in ${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `in ${days}d`;
+}
+
+/** "Xs ago" / "Xm ago" / "Xh ago" / "Xd ago" — same format as SessionList. */
+function relativePastTime(iso: string): string {
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return '—';
+  const seconds = Math.max(0, Math.floor((Date.now() - t) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}

--- a/aceclaw-dashboard/src/components/CronTimeline.tsx
+++ b/aceclaw-dashboard/src/components/CronTimeline.tsx
@@ -1,0 +1,297 @@
+/**
+ * CronTimeline (#459 layer 3) — compact horizontal timeline that turns
+ * the daemon's scheduling into a swimlane chart.
+ *
+ * One row per cron job. Past triggers render as filled rectangles
+ * coloured by outcome (green/red/blue/amber); the next scheduled fire
+ * for each job renders as an outlined rect at its predicted time. The
+ * "now" line slides right as wall-clock time advances.
+ *
+ * Sources its data from the same {@code useCronJobs} hook the sidebar
+ * uses — no second WebSocket. See #462 for the multi-connection
+ * trade-off.
+ */
+
+import { useEffect, useState } from 'react';
+import type { CronEventRecord, CronJobInfo } from '../hooks/useCronJobs';
+
+interface CronTimelineProps {
+  jobs: CronJobInfo[];
+  recentEvents: CronEventRecord[];
+  /** Width of the visible time window. Defaults to 1h. */
+  windowMs?: number;
+}
+
+const DEFAULT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+const LANE_HEIGHT_PX = 18;
+const LANE_GAP_PX = 4;
+const LEFT_GUTTER_PX = 96; // job-name column
+const RIGHT_PAD_PX = 16;
+const AXIS_HEIGHT_PX = 18;
+const NOW_TICK_INTERVAL_MS = 10_000;
+
+export function CronTimeline({
+  jobs,
+  recentEvents,
+  windowMs = DEFAULT_WINDOW_MS,
+}: CronTimelineProps) {
+  // Re-render every 10s so the "now" line drifts visibly without
+  // requiring user interaction. Heavier ticking would be a waste —
+  // events themselves trigger renders when something changes.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(Date.now()), NOW_TICK_INTERVAL_MS);
+    return () => window.clearInterval(id);
+  }, []);
+
+  // Hide entirely when no jobs are configured — keeps the dashboard
+  // chrome clean for users who don't use cron.
+  if (jobs.length === 0) return null;
+
+  const totalHeight =
+    AXIS_HEIGHT_PX + jobs.length * LANE_HEIGHT_PX + (jobs.length - 1) * LANE_GAP_PX;
+  const windowStart = now - windowMs;
+
+  return (
+    <div className="border-b border-zinc-800 bg-zinc-900/40 px-2 py-2">
+      <div className="mb-1 flex items-center gap-2 text-[10px] uppercase tracking-wider text-zinc-500">
+        <span>Schedule timeline</span>
+        <span className="font-mono text-zinc-600">last {Math.round(windowMs / 60_000)}m</span>
+      </div>
+      <svg
+        className="block w-full"
+        viewBox={`0 0 1000 ${totalHeight}`}
+        preserveAspectRatio="none"
+        style={{ height: totalHeight }}
+        role="img"
+        aria-label="Cron schedule timeline"
+      >
+        <Axis windowStart={windowStart} windowEnd={now} y={AXIS_HEIGHT_PX - 4} />
+        {jobs.map((job, idx) => {
+          const laneY = AXIS_HEIGHT_PX + idx * (LANE_HEIGHT_PX + LANE_GAP_PX);
+          const events = filterEventsForJob(recentEvents, job.id, windowStart, now);
+          return (
+            <JobLane
+              key={job.id}
+              job={job}
+              events={events}
+              y={laneY}
+              windowStart={windowStart}
+              windowEnd={now}
+            />
+          );
+        })}
+        <NowLine y={AXIS_HEIGHT_PX} height={totalHeight - AXIS_HEIGHT_PX} />
+      </svg>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+interface AxisProps {
+  windowStart: number;
+  windowEnd: number;
+  y: number;
+}
+
+function Axis({ windowStart, windowEnd, y }: AxisProps) {
+  // Ticks at -60m / -45m / -30m / -15m / now (assuming 1h window).
+  // Rendered on the SVG's own coordinate system (0..1000 + LEFT_GUTTER_PX).
+  const ticks: Array<{ label: string; t: number }> = [];
+  const span = windowEnd - windowStart;
+  for (let i = 0; i <= 4; i += 1) {
+    const t = windowStart + (span * i) / 4;
+    const minutesAgo = Math.round((windowEnd - t) / 60_000);
+    ticks.push({
+      t,
+      label: minutesAgo === 0 ? 'now' : `-${minutesAgo}m`,
+    });
+  }
+  return (
+    <g>
+      {ticks.map(({ t, label }) => {
+        const x = projectX(t, windowStart, windowEnd);
+        return (
+          <g key={`tick-${label}`}>
+            <line
+              x1={x}
+              x2={x}
+              y1={y - 2}
+              y2={y + 2}
+              stroke="#3f3f46"
+              strokeWidth={1}
+            />
+            <text
+              x={x}
+              y={y - 4}
+              fontSize={9}
+              fill="#71717a"
+              fontFamily="ui-monospace, 'JetBrains Mono', monospace"
+              textAnchor="middle"
+            >
+              {label}
+            </text>
+          </g>
+        );
+      })}
+    </g>
+  );
+}
+
+interface JobLaneProps {
+  job: CronJobInfo;
+  events: CronEventRecord[];
+  y: number;
+  windowStart: number;
+  windowEnd: number;
+}
+
+function JobLane({ job, events, y, windowStart, windowEnd }: JobLaneProps) {
+  const nextX =
+    job.nextFireAt && Date.parse(job.nextFireAt) <= windowEnd + (windowEnd - windowStart)
+      ? projectX(Date.parse(job.nextFireAt), windowStart, windowEnd)
+      : null;
+  return (
+    <g>
+      {/* Job name column */}
+      <text
+        x={LEFT_GUTTER_PX - 8}
+        y={y + LANE_HEIGHT_PX / 2 + 3}
+        fontSize={10}
+        fill="#a1a1aa"
+        fontFamily="ui-monospace, 'JetBrains Mono', monospace"
+        textAnchor="end"
+      >
+        {truncate(job.name, 14)}
+        <title>{job.id}</title>
+      </text>
+      {/* Lane background */}
+      <rect
+        x={LEFT_GUTTER_PX}
+        y={y}
+        width={1000 - LEFT_GUTTER_PX - RIGHT_PAD_PX}
+        height={LANE_HEIGHT_PX}
+        fill="#18181b"
+        rx={2}
+      />
+      {/* Past events */}
+      {events.map((evt, i) => {
+        const t = Date.parse(evt.timestamp);
+        if (Number.isNaN(t)) return null;
+        const x = projectX(t, windowStart, windowEnd);
+        const color = eventColor(evt.kind);
+        return (
+          <rect
+            key={`${evt.timestamp}-${i}`}
+            x={x - 2}
+            y={y + 2}
+            width={4}
+            height={LANE_HEIGHT_PX - 4}
+            fill={color}
+            rx={1}
+          >
+            <title>
+              {evt.kind} @ {evt.timestamp}
+              {evt.durationMs ? ` (${evt.durationMs}ms)` : ''}
+              {evt.error ? `\n${evt.error}` : ''}
+              {evt.reason ? `\n${evt.reason}` : ''}
+            </title>
+          </rect>
+        );
+      })}
+      {/* Next scheduled fire — only render when it falls in (or near) the window */}
+      {nextX !== null && nextX >= LEFT_GUTTER_PX && nextX <= 1000 - RIGHT_PAD_PX ? (
+        <rect
+          x={nextX - 2}
+          y={y + 2}
+          width={4}
+          height={LANE_HEIGHT_PX - 4}
+          fill="none"
+          stroke="#71717a"
+          strokeDasharray="2,1"
+          rx={1}
+        >
+          <title>next fire @ {job.nextFireAt}</title>
+        </rect>
+      ) : null}
+    </g>
+  );
+}
+
+interface NowLineProps {
+  y: number;
+  height: number;
+}
+
+function NowLine({ y, height }: NowLineProps) {
+  // "now" sits at the right edge of the window (we project windowEnd
+  // there) — drawing a line here gives the user a visual anchor for
+  // "everything left of this is past, everything right is forecast".
+  const x = 1000 - RIGHT_PAD_PX;
+  return (
+    <line
+      x1={x}
+      x2={x}
+      y1={y}
+      y2={y + height}
+      stroke="#3f3f46"
+      strokeDasharray="1,2"
+      strokeWidth={1}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for unit tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps a timestamp to an x-coordinate in the SVG's 0..1000 viewBox.
+ * Times outside the window are clamped to the gutter / right edge,
+ * so a caller still gets a sensible value when filtering's a thin slice.
+ */
+export function projectX(t: number, windowStart: number, windowEnd: number): number {
+  const span = windowEnd - windowStart;
+  if (span <= 0) return LEFT_GUTTER_PX;
+  const ratio = (t - windowStart) / span;
+  const drawWidth = 1000 - LEFT_GUTTER_PX - RIGHT_PAD_PX;
+  return LEFT_GUTTER_PX + Math.max(0, Math.min(1, ratio)) * drawWidth;
+}
+
+/** Filters and sorts events for a given job within [windowStart, windowEnd]. */
+export function filterEventsForJob(
+  events: CronEventRecord[],
+  jobId: string,
+  windowStart: number,
+  windowEnd: number,
+): CronEventRecord[] {
+  return events
+    .filter((e) => {
+      if (e.jobId !== jobId) return false;
+      const t = Date.parse(e.timestamp);
+      if (Number.isNaN(t)) return false;
+      return t >= windowStart && t <= windowEnd;
+    })
+    .sort((a, b) => Date.parse(a.timestamp) - Date.parse(b.timestamp));
+}
+
+/** Status palette mirrors the sidebar so the visual vocabulary stays consistent. */
+export function eventColor(kind: CronEventRecord['kind']): string {
+  switch (kind) {
+    case 'triggered':
+      return '#3b82f6'; // blue-500
+    case 'completed':
+      return '#10b981'; // emerald-500
+    case 'failed':
+      return '#f43f5e'; // rose-500
+    case 'skipped':
+      return '#f59e0b'; // amber-500
+  }
+}
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? `${s.slice(0, max - 1)}…` : s;
+}

--- a/aceclaw-dashboard/src/components/SessionList.tsx
+++ b/aceclaw-dashboard/src/components/SessionList.tsx
@@ -21,9 +21,21 @@ interface SessionListProps {
   sessions: SessionInfo[];
   selectedSessionId: string | null;
   onSelect: (sessionId: string) => void;
+  /**
+   * Optional content rendered at the bottom of the sidebar, beneath the
+   * session rows. Used by App to mount the CronJobsList panel (#459)
+   * without wrapping SessionList in another container — the parent
+   * &lt;aside&gt; here is already the dashboard's left rail.
+   */
+  footer?: React.ReactNode;
 }
 
-export function SessionList({ sessions, selectedSessionId, onSelect }: SessionListProps) {
+export function SessionList({
+  sessions,
+  selectedSessionId,
+  onSelect,
+  footer,
+}: SessionListProps) {
   return (
     <aside className="flex h-full w-60 shrink-0 flex-col border-r border-zinc-800 bg-zinc-900/40">
       <header className="flex items-center justify-between border-b border-zinc-800 px-3 py-2 text-[11px] uppercase tracking-wider text-zinc-500">
@@ -47,6 +59,7 @@ export function SessionList({ sessions, selectedSessionId, onSelect }: SessionLi
           ))}
         </ul>
       )}
+      {footer}
     </aside>
   );
 }

--- a/aceclaw-dashboard/src/hooks/useCronJobs.ts
+++ b/aceclaw-dashboard/src/hooks/useCronJobs.ts
@@ -122,7 +122,24 @@ export function useCronJobs(wsUrl: string | null): CronJobInfo[] {
         const jobId = typeof params['jobId'] === 'string' ? params['jobId'] : null;
         if (!jobId) return;
 
-        setJobs((prev) => applyEventDelta(prev, method, jobId, params));
+        setJobs((prev) => {
+          if (!hasJob(prev, jobId)) {
+            // Job was created after our snapshot — applyEventDelta would
+            // silently drop the event. Re-request the status so the new
+            // row appears (the snapshot reply will replace this state
+            // wholesale; returning `prev` here just keeps the UI stable
+            // for the few ms of round-trip). The send is idempotent so
+            // React's strict-mode double-invocation is harmless.
+            try {
+              ws?.send(STATUS_REQUEST);
+            } catch {
+              // Socket transitioning — next reconnect's onopen will
+              // re-fetch anyway.
+            }
+            return prev;
+          }
+          return applyEventDelta(prev, method, jobId, params);
+        });
       };
 
       ws.onclose = () => {
@@ -197,10 +214,21 @@ export function parseStatusResult(data: Record<string, unknown>): CronJobInfo[] 
 }
 
 /**
+ * True when {@code prev} contains a job with the given id. Exposed
+ * separately from {@link applyEventDelta} so the hook can fire a
+ * snapshot refresh BEFORE applying the delta when the event references
+ * a job created after our last snapshot — without that refresh the
+ * sidebar would silently drop events for newly-created jobs.
+ */
+export function hasJob(prev: CronJobInfo[], jobId: string): boolean {
+  return prev.some((j) => j.id === jobId);
+}
+
+/**
  * Folds a {@code scheduler.job_*} event into the existing job list. If
  * the event references a job we don't know about (e.g. a job created
- * after our snapshot), the call is a no-op — the next reconnect /
- * status refresh will pick it up.
+ * after our snapshot), the call is a no-op — the caller should fire
+ * a status refresh, see {@link hasJob}.
  *
  * Exported for unit tests so the four event types are pinned by name.
  */

--- a/aceclaw-dashboard/src/hooks/useCronJobs.ts
+++ b/aceclaw-dashboard/src/hooks/useCronJobs.ts
@@ -1,0 +1,241 @@
+/**
+ * useCronJobs — sidebar data source for the cron-jobs panel (#459 layer 2).
+ *
+ * Owns its OWN WebSocket connection (separate from
+ * {@link useExecutionTree} and {@link useSessions}) for the same reason
+ * sidebars do: a per-session reducer can't observe daemon-wide events.
+ * Three responsibilities:
+ *
+ *   1. On open, request {@code scheduler.cron.status} and seed the job
+ *      list from the one-shot reply (snapshot of state at request time).
+ *   2. Listen for live {@code scheduler.job_triggered/completed/failed/skipped}
+ *      envelopes — those carry the {@code __global__} sentinel sessionId
+ *      so {@link useExecutionTree} naturally ignores them. We apply each
+ *      as a delta so the list is fresh without re-fetching.
+ *   3. Reconnect with exponential backoff, mirroring {@link useSessions}.
+ *
+ * The wire shape from the daemon ({@code scheduler.cron.status.result}
+ * and {@code scheduler.job_*}) lives in
+ * {@code aceclaw-daemon/.../AceClawDaemon.java}.
+ */
+
+import { useEffect, useState } from 'react';
+
+/** One row in the cron-jobs sidebar. Mirrors the daemon's reply shape. */
+export interface CronJobInfo {
+  id: string;
+  name: string;
+  /** Five-field cron expression. */
+  expression: string;
+  enabled: boolean;
+  /** Best-effort kind hint from the daemon: "scheduled", "one-shot", … */
+  kind?: string;
+  description?: string;
+  /** ISO-8601 of the last run start, if any. */
+  lastRunAt?: string;
+  /** ISO-8601 of the next computed fire time, if the expression is valid. */
+  nextFireAt?: string;
+  /** Last error message — present only when the most recent run failed. */
+  lastError?: string;
+  /**
+   * Synthesised by the hook from the most recent {@code scheduler.job_*}
+   * envelope so the sidebar can render a status dot without re-fetching:
+   *   - {@code "running"}  while a triggered run hasn't completed
+   *   - {@code "completed"} after a clean run
+   *   - {@code "failed"}    after a failure (also see {@link lastError})
+   *   - {@code "skipped"}   when the daemon skipped a fire (e.g. previous run busy)
+   *   - {@code undefined}   when no event has been observed since connect
+   */
+  lastStatus?: 'running' | 'completed' | 'failed' | 'skipped';
+}
+
+const STATUS_REQUEST = JSON.stringify({ method: 'scheduler.cron.status' });
+const RECONNECT_INITIAL_MS = 500;
+const RECONNECT_MAX_MS = 30_000;
+
+/**
+ * Subscribes to the daemon's cron-job set. Returns a stable array sorted
+ * by job id (matching the daemon's wire order) so React's keyed children
+ * stay stable across re-renders.
+ *
+ * @param wsUrl daemon bridge URL — same as {@link useExecutionTree}.
+ *              Pass {@code null} to disable the connection.
+ */
+export function useCronJobs(wsUrl: string | null): CronJobInfo[] {
+  const [jobs, setJobs] = useState<CronJobInfo[]>([]);
+
+  useEffect(() => {
+    if (!wsUrl) {
+      // Drop any rows from a prior connection so the sidebar doesn't
+      // ghost stale jobs while the dashboard is detached.
+      setJobs([]);
+      return;
+    }
+    let ws: WebSocket | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let backoffMs = RECONNECT_INITIAL_MS;
+    let cancelled = false;
+
+    const connect = (): void => {
+      if (cancelled) return;
+      try {
+        ws = new WebSocket(wsUrl);
+      } catch {
+        return;
+      }
+
+      ws.onopen = () => {
+        if (cancelled) return;
+        backoffMs = RECONNECT_INITIAL_MS;
+        // Refresh on every reopen so a daemon restart doesn't leave us
+        // showing stale lastRunAt values.
+        ws?.send(STATUS_REQUEST);
+      };
+
+      ws.onmessage = (e: MessageEvent<string>) => {
+        if (cancelled) return;
+        let data: unknown;
+        try {
+          data = JSON.parse(e.data);
+        } catch {
+          return;
+        }
+        if (!isPlainObject(data)) return;
+
+        // Point-to-point reply to our STATUS_REQUEST. Snapshot of the
+        // current job set; replace local state.
+        if (data['method'] === 'scheduler.cron.status.result') {
+          const next = parseStatusResult(data);
+          if (next) setJobs(next);
+          return;
+        }
+
+        // Live envelope. Filter by the GLOBAL_SESSION_ID sentinel so we
+        // don't accidentally pick up stream.* events from any session.
+        if (data['sessionId'] !== '__global__') return;
+        const event = data['event'];
+        if (!isPlainObject(event)) return;
+        const method = typeof event['method'] === 'string' ? event['method'] : null;
+        if (!method || !method.startsWith('scheduler.job_')) return;
+        const rawParams = event['params'];
+        const params: Record<string, unknown> = isPlainObject(rawParams) ? rawParams : {};
+        const jobId = typeof params['jobId'] === 'string' ? params['jobId'] : null;
+        if (!jobId) return;
+
+        setJobs((prev) => applyEventDelta(prev, method, jobId, params));
+      };
+
+      ws.onclose = () => {
+        if (cancelled) return;
+        reconnectTimer = setTimeout(connect, backoffMs);
+        backoffMs = Math.min(backoffMs * 2, RECONNECT_MAX_MS);
+      };
+
+      ws.onerror = () => {
+        // onerror always precedes onclose for hard failures; the close
+        // handler reconnects, so no work needed here.
+      };
+    };
+
+    connect();
+
+    return () => {
+      cancelled = true;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      if (ws) {
+        ws.onopen = null;
+        ws.onmessage = null;
+        ws.onclose = null;
+        ws.onerror = null;
+        ws.close();
+      }
+    };
+  }, [wsUrl]);
+
+  return jobs;
+}
+
+// ---------------------------------------------------------------------------
+// Validation + delta helpers (exported for unit tests)
+// ---------------------------------------------------------------------------
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isString(v: unknown): v is string {
+  return typeof v === 'string';
+}
+
+/**
+ * Parses a {@code scheduler.cron.status.result} payload. Returns null when
+ * the shape is unusable (so the hook falls back to whatever it had).
+ *
+ * Exported so unit tests can pin the wire-format contract directly.
+ */
+export function parseStatusResult(data: Record<string, unknown>): CronJobInfo[] | null {
+  const jobs = data['jobs'];
+  if (!Array.isArray(jobs)) return null;
+  const out: CronJobInfo[] = [];
+  for (const j of jobs) {
+    if (!isPlainObject(j)) continue;
+    if (!isString(j['id']) || !isString(j['name']) || !isString(j['expression'])) continue;
+    const row: CronJobInfo = {
+      id: j['id'],
+      name: j['name'],
+      expression: j['expression'],
+      enabled: typeof j['enabled'] === 'boolean' ? j['enabled'] : true,
+    };
+    if (isString(j['kind'])) row.kind = j['kind'];
+    if (isString(j['description'])) row.description = j['description'];
+    if (isString(j['lastRunAt'])) row.lastRunAt = j['lastRunAt'];
+    if (isString(j['nextFireAt'])) row.nextFireAt = j['nextFireAt'];
+    if (isString(j['lastError'])) row.lastError = j['lastError'];
+    out.push(row);
+  }
+  return out;
+}
+
+/**
+ * Folds a {@code scheduler.job_*} event into the existing job list. If
+ * the event references a job we don't know about (e.g. a job created
+ * after our snapshot), the call is a no-op — the next reconnect /
+ * status refresh will pick it up.
+ *
+ * Exported for unit tests so the four event types are pinned by name.
+ */
+export function applyEventDelta(
+  prev: CronJobInfo[],
+  method: string,
+  jobId: string,
+  params: Record<string, unknown>,
+): CronJobInfo[] {
+  const ts = isString(params['timestamp']) ? params['timestamp'] : null;
+  return prev.map((j) => {
+    if (j.id !== jobId) return j;
+    switch (method) {
+      case 'scheduler.job_triggered': {
+        const next: CronJobInfo = { ...j, lastStatus: 'running' };
+        if (ts) next.lastRunAt = ts;
+        delete next.lastError;
+        return next;
+      }
+      case 'scheduler.job_completed': {
+        const next: CronJobInfo = { ...j, lastStatus: 'completed' };
+        if (ts) next.lastRunAt = ts;
+        delete next.lastError;
+        return next;
+      }
+      case 'scheduler.job_failed': {
+        const next: CronJobInfo = { ...j, lastStatus: 'failed' };
+        if (ts) next.lastRunAt = ts;
+        if (isString(params['error'])) next.lastError = params['error'];
+        return next;
+      }
+      case 'scheduler.job_skipped':
+        return { ...j, lastStatus: 'skipped' };
+      default:
+        return j;
+    }
+  });
+}

--- a/aceclaw-dashboard/src/hooks/useCronJobs.ts
+++ b/aceclaw-dashboard/src/hooks/useCronJobs.ts
@@ -21,6 +21,40 @@
 
 import { useEffect, useState } from 'react';
 
+/** Discriminator for {@link CronEventRecord}. */
+export type CronEventKind = 'triggered' | 'completed' | 'failed' | 'skipped';
+
+/**
+ * One scheduler-event record in the timeline buffer. Sourced from two
+ * places that share the same daemon-side typing:
+ *   - Backfill on connect via {@code scheduler.events.poll.result}
+ *   - Live deltas via {@code scheduler.job_*} envelopes
+ *
+ * Optional fields are present only for the kinds that carry them — the
+ * union is wide so the timeline component can render every variant
+ * without per-case schema gymnastics.
+ */
+export interface CronEventRecord {
+  jobId: string;
+  kind: CronEventKind;
+  /** ISO-8601 daemon timestamp — used to position the block on the time axis. */
+  timestamp: string;
+  /** completed only. */
+  durationMs?: number;
+  /** triggered only. */
+  cronExpression?: string;
+  /** failed only. */
+  error?: string;
+  /** failed only — current attempt number. */
+  attempt?: number;
+  /** failed only — retry budget. */
+  maxAttempts?: number;
+  /** skipped only. */
+  reason?: string;
+  /** completed only — daemon-summarised LLM output. */
+  summary?: string;
+}
+
 /** One row in the cron-jobs sidebar. Mirrors the daemon's reply shape. */
 export interface CronJobInfo {
   id: string;
@@ -50,25 +84,52 @@ export interface CronJobInfo {
 }
 
 const STATUS_REQUEST = JSON.stringify({ method: 'scheduler.cron.status' });
+/**
+ * On connect we ask for the most recent N events so the timeline isn't
+ * blank for the first minute. 100 covers ~1.5h of a per-minute job
+ * (typical) and ~1.7 days of an hourly job — enough to show meaningful
+ * history without bloating the wire payload.
+ */
+const EVENTS_BACKFILL_REQUEST = JSON.stringify({
+  method: 'scheduler.events.poll',
+  params: { afterSeq: 0, limit: 100 },
+});
+/**
+ * In-memory cap for the rolling event buffer. The timeline only
+ * renders events within its visible time window (default 1h), so this
+ * mostly bounds memory after a long-running tab — 200 is generous
+ * relative to the daemon-side ring's 256.
+ */
+const RECENT_EVENTS_CAP = 200;
 const RECONNECT_INITIAL_MS = 500;
 const RECONNECT_MAX_MS = 30_000;
 
+/** Combined return shape: the sidebar's job list AND the timeline's event window. */
+export interface UseCronJobsResult {
+  jobs: CronJobInfo[];
+  /** Rolling buffer of recent {@code scheduler.job_*} events, oldest → newest. */
+  recentEvents: CronEventRecord[];
+}
+
 /**
- * Subscribes to the daemon's cron-job set. Returns a stable array sorted
- * by job id (matching the daemon's wire order) so React's keyed children
- * stay stable across re-renders.
+ * Subscribes to the daemon's cron-job set AND the recent-event stream.
+ * Returns both because layer 3's timeline widget shares this hook's
+ * connection rather than opening its own — see #462 for the broader
+ * shared-connection plan.
  *
  * @param wsUrl daemon bridge URL — same as {@link useExecutionTree}.
  *              Pass {@code null} to disable the connection.
  */
-export function useCronJobs(wsUrl: string | null): CronJobInfo[] {
+export function useCronJobs(wsUrl: string | null): UseCronJobsResult {
   const [jobs, setJobs] = useState<CronJobInfo[]>([]);
+  const [recentEvents, setRecentEvents] = useState<CronEventRecord[]>([]);
 
   useEffect(() => {
     if (!wsUrl) {
       // Drop any rows from a prior connection so the sidebar doesn't
       // ghost stale jobs while the dashboard is detached.
       setJobs([]);
+      setRecentEvents([]);
       return;
     }
     let ws: WebSocket | null = null;
@@ -88,8 +149,9 @@ export function useCronJobs(wsUrl: string | null): CronJobInfo[] {
         if (cancelled) return;
         backoffMs = RECONNECT_INITIAL_MS;
         // Refresh on every reopen so a daemon restart doesn't leave us
-        // showing stale lastRunAt values.
+        // showing stale lastRunAt values + a stale event window.
         ws?.send(STATUS_REQUEST);
+        ws?.send(EVENTS_BACKFILL_REQUEST);
       };
 
       ws.onmessage = (e: MessageEvent<string>) => {
@@ -110,6 +172,20 @@ export function useCronJobs(wsUrl: string | null): CronJobInfo[] {
           return;
         }
 
+        // Point-to-point reply to our EVENTS_BACKFILL_REQUEST. Replace
+        // the entire recentEvents buffer with the daemon's snapshot.
+        // A tiny race window exists where a live event arrives between
+        // our request and the reply — that event would already be in
+        // recentEvents and would get clobbered here. Acceptable: the
+        // next live event will re-populate, and the timeline doesn't
+        // visually distinguish "happened 1.0s ago" from "happened 1.1s
+        // ago" anyway.
+        if (data['method'] === 'scheduler.events.poll.result') {
+          const next = parseEventsPollResult(data);
+          if (next) setRecentEvents(next);
+          return;
+        }
+
         // Live envelope. Filter by the GLOBAL_SESSION_ID sentinel so we
         // don't accidentally pick up stream.* events from any session.
         if (data['sessionId'] !== '__global__') return;
@@ -121,6 +197,13 @@ export function useCronJobs(wsUrl: string | null): CronJobInfo[] {
         const params: Record<string, unknown> = isPlainObject(rawParams) ? rawParams : {};
         const jobId = typeof params['jobId'] === 'string' ? params['jobId'] : null;
         if (!jobId) return;
+
+        // Append to the rolling event buffer for the timeline. This
+        // path runs alongside the sidebar's setJobs below.
+        const eventRecord = recordFromLiveEvent(method, jobId, params);
+        if (eventRecord) {
+          setRecentEvents((prev) => appendCapped(prev, eventRecord, RECENT_EVENTS_CAP));
+        }
 
         setJobs((prev) => {
           if (!hasJob(prev, jobId)) {
@@ -169,7 +252,7 @@ export function useCronJobs(wsUrl: string | null): CronJobInfo[] {
     };
   }, [wsUrl]);
 
-  return jobs;
+  return { jobs, recentEvents };
 }
 
 // ---------------------------------------------------------------------------
@@ -211,6 +294,109 @@ export function parseStatusResult(data: Record<string, unknown>): CronJobInfo[] 
     out.push(row);
   }
   return out;
+}
+
+/**
+ * Parses a {@code scheduler.events.poll.result} payload into the
+ * timeline's event-record shape. Returns null when the wire shape is
+ * unusable. Daemon-side type discriminator (`type`) is mapped to the
+ * dashboard's {@link CronEventKind}; events with unknown types are
+ * dropped silently so a future daemon adding a 5th kind doesn't crash
+ * older dashboards.
+ *
+ * Exported for unit tests so the wire-format mapping is pinned.
+ */
+export function parseEventsPollResult(
+  data: Record<string, unknown>,
+): CronEventRecord[] | null {
+  const events = data['events'];
+  if (!Array.isArray(events)) return null;
+  const out: CronEventRecord[] = [];
+  for (const e of events) {
+    if (!isPlainObject(e)) continue;
+    if (!isString(e['jobId']) || !isString(e['type']) || !isString(e['timestamp'])) continue;
+    const kind = parseEventKind(e['type']);
+    if (!kind) continue;
+    const rec: CronEventRecord = {
+      jobId: e['jobId'],
+      kind,
+      timestamp: e['timestamp'],
+    };
+    if (typeof e['durationMs'] === 'number') rec.durationMs = e['durationMs'];
+    if (isString(e['cronExpression'])) rec.cronExpression = e['cronExpression'];
+    if (isString(e['error'])) rec.error = e['error'];
+    if (typeof e['attempt'] === 'number') rec.attempt = e['attempt'];
+    if (typeof e['maxAttempts'] === 'number') rec.maxAttempts = e['maxAttempts'];
+    if (isString(e['reason'])) rec.reason = e['reason'];
+    if (isString(e['summary'])) rec.summary = e['summary'];
+    out.push(rec);
+  }
+  return out;
+}
+
+function parseEventKind(t: string): CronEventKind | null {
+  switch (t) {
+    case 'triggered':
+    case 'completed':
+    case 'failed':
+    case 'skipped':
+      return t;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Builds a {@link CronEventRecord} from a live {@code scheduler.job_*}
+ * envelope. Returns null when the method is unknown or critical fields
+ * are missing — same defensive shape as {@link parseEventsPollResult}.
+ *
+ * Exported for unit tests.
+ */
+export function recordFromLiveEvent(
+  method: string,
+  jobId: string,
+  params: Record<string, unknown>,
+): CronEventRecord | null {
+  const timestamp = isString(params['timestamp']) ? params['timestamp'] : null;
+  if (!timestamp) return null;
+  const kind = liveMethodToKind(method);
+  if (!kind) return null;
+  const rec: CronEventRecord = { jobId, kind, timestamp };
+  if (typeof params['durationMs'] === 'number') rec.durationMs = params['durationMs'];
+  if (isString(params['cronExpression'])) rec.cronExpression = params['cronExpression'];
+  if (isString(params['error'])) rec.error = params['error'];
+  if (typeof params['attempt'] === 'number') rec.attempt = params['attempt'];
+  if (typeof params['maxAttempts'] === 'number') rec.maxAttempts = params['maxAttempts'];
+  if (isString(params['reason'])) rec.reason = params['reason'];
+  if (isString(params['summary'])) rec.summary = params['summary'];
+  return rec;
+}
+
+function liveMethodToKind(method: string): CronEventKind | null {
+  switch (method) {
+    case 'scheduler.job_triggered':
+      return 'triggered';
+    case 'scheduler.job_completed':
+      return 'completed';
+    case 'scheduler.job_failed':
+      return 'failed';
+    case 'scheduler.job_skipped':
+      return 'skipped';
+    default:
+      return null;
+  }
+}
+
+/**
+ * Appends {@code item} to {@code prev}, dropping the oldest entries if
+ * the result would exceed {@code cap}. Pure / immutable so React state
+ * updates stay safe; exported so a unit test can pin the cap behavior.
+ */
+export function appendCapped<T>(prev: T[], item: T, cap: number): T[] {
+  const next = prev.length + 1 > cap ? prev.slice(prev.length + 1 - cap) : prev.slice();
+  next.push(item);
+  return next;
 }
 
 /**

--- a/aceclaw-dashboard/tests/cronTimeline.test.ts
+++ b/aceclaw-dashboard/tests/cronTimeline.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Pure-helper tests for {@link CronTimeline} (#459 layer 3).
+ *
+ * The component itself is mostly SVG glue; the layout math
+ * (projectX, filterEventsForJob) and the colour palette are the
+ * places typos would silently produce wrong-looking output. Each is
+ * exported for direct testing.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  eventColor,
+  filterEventsForJob,
+  projectX,
+} from '../src/components/CronTimeline';
+import type { CronEventRecord } from '../src/hooks/useCronJobs';
+
+describe('projectX', () => {
+  // The timeline's SVG viewBox is 0..1000. The left gutter (96px)
+  // hosts job-name labels; the right pad (16px) makes the now-line
+  // sit cleanly inside the frame.
+
+  it('maps windowEnd to the right edge minus the right pad', () => {
+    const x = projectX(1000, 0, 1000);
+    expect(x).toBe(1000 - 16);
+  });
+
+  it('maps windowStart to the left gutter', () => {
+    expect(projectX(0, 0, 1000)).toBe(96);
+  });
+
+  it('clamps a timestamp before windowStart to the left gutter', () => {
+    expect(projectX(-100, 0, 1000)).toBe(96);
+  });
+
+  it('clamps a timestamp after windowEnd to the right edge', () => {
+    expect(projectX(2000, 0, 1000)).toBe(1000 - 16);
+  });
+
+  it('handles a zero-span window without dividing by zero', () => {
+    expect(projectX(500, 500, 500)).toBe(96);
+  });
+});
+
+describe('filterEventsForJob', () => {
+  const ev = (jobId: string, ts: string): CronEventRecord => ({
+    jobId,
+    kind: 'completed',
+    timestamp: ts,
+  });
+
+  it('filters by jobId', () => {
+    const events = [ev('a', '2026-05-01T10:00:00Z'), ev('b', '2026-05-01T10:00:01Z')];
+    const out = filterEventsForJob(events, 'a',
+      Date.parse('2026-05-01T09:00:00Z'),
+      Date.parse('2026-05-01T11:00:00Z'));
+    expect(out).toHaveLength(1);
+    expect(out[0]!.jobId).toBe('a');
+  });
+
+  it('drops events outside the window', () => {
+    const events = [
+      ev('a', '2026-05-01T05:00:00Z'), // way before
+      ev('a', '2026-05-01T10:00:00Z'), // inside
+      ev('a', '2026-05-01T15:00:00Z'), // way after
+    ];
+    const out = filterEventsForJob(events, 'a',
+      Date.parse('2026-05-01T09:00:00Z'),
+      Date.parse('2026-05-01T11:00:00Z'));
+    expect(out).toHaveLength(1);
+    expect(out[0]!.timestamp).toBe('2026-05-01T10:00:00Z');
+  });
+
+  it('drops events with malformed timestamps', () => {
+    const events = [ev('a', 'not-a-date'), ev('a', '2026-05-01T10:00:00Z')];
+    const out = filterEventsForJob(events, 'a',
+      Date.parse('2026-05-01T09:00:00Z'),
+      Date.parse('2026-05-01T11:00:00Z'));
+    expect(out).toHaveLength(1);
+  });
+
+  it('returns events sorted by timestamp ascending', () => {
+    const events = [
+      ev('a', '2026-05-01T10:00:30Z'),
+      ev('a', '2026-05-01T10:00:00Z'),
+      ev('a', '2026-05-01T10:00:15Z'),
+    ];
+    const out = filterEventsForJob(events, 'a',
+      Date.parse('2026-05-01T09:00:00Z'),
+      Date.parse('2026-05-01T11:00:00Z'));
+    expect(out.map((e) => e.timestamp)).toEqual([
+      '2026-05-01T10:00:00Z',
+      '2026-05-01T10:00:15Z',
+      '2026-05-01T10:00:30Z',
+    ]);
+  });
+});
+
+describe('eventColor', () => {
+  // Pinning so a future palette refactor doesn't accidentally swap
+  // green for red and quietly invert the user's reading of "the job
+  // is healthy".
+  it('returns a distinct hex code per kind', () => {
+    const colors = new Set([
+      eventColor('triggered'),
+      eventColor('completed'),
+      eventColor('failed'),
+      eventColor('skipped'),
+    ]);
+    expect(colors.size).toBe(4);
+  });
+
+  it('uses green-ish for completed', () => {
+    expect(eventColor('completed')).toMatch(/^#10/i); // emerald-500 starts with #10
+  });
+
+  it('uses red-ish for failed', () => {
+    expect(eventColor('failed')).toMatch(/^#f4/i); // rose-500 starts with #f4
+  });
+});

--- a/aceclaw-dashboard/tests/useCronJobs.test.ts
+++ b/aceclaw-dashboard/tests/useCronJobs.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Unit tests for useCronJobs's pure helpers (#459 layer 2).
+ *
+ * The hook itself wires WebSocket plumbing — we test it via the helpers
+ * (parseStatusResult, applyEventDelta) so wire-format and delta logic
+ * have a fast safety net independent of a live socket.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  applyEventDelta,
+  parseStatusResult,
+  type CronJobInfo,
+} from '../src/hooks/useCronJobs';
+
+describe('parseStatusResult', () => {
+  it('returns null for non-array jobs', () => {
+    expect(parseStatusResult({})).toBeNull();
+    expect(parseStatusResult({ jobs: 'oops' })).toBeNull();
+  });
+
+  it('parses a minimal valid job', () => {
+    const out = parseStatusResult({
+      jobs: [{ id: 'a', name: 'Daily', expression: '0 2 * * *', enabled: true }],
+    });
+    expect(out).toEqual([
+      { id: 'a', name: 'Daily', expression: '0 2 * * *', enabled: true },
+    ]);
+  });
+
+  it('skips rows missing required fields', () => {
+    const out = parseStatusResult({
+      jobs: [
+        { id: 'a', name: 'ok', expression: '* * * * *', enabled: true },
+        { id: 42, name: 'bad-id', expression: '* * * * *' }, // bad: id not string
+        { id: 'c', name: 'no-expr' },                          // bad: missing expression
+        'not-an-object',                                       // bad: not object
+      ],
+    });
+    expect(out).toHaveLength(1);
+    expect(out![0]!.id).toBe('a');
+  });
+
+  it('passes through optional fields when present and valid', () => {
+    const out = parseStatusResult({
+      jobs: [{
+        id: 'a',
+        name: 'Daily',
+        expression: '0 2 * * *',
+        enabled: true,
+        kind: 'scheduled',
+        description: 'cleanup',
+        lastRunAt: '2026-05-01T10:00:00Z',
+        nextFireAt: '2026-05-02T02:00:00Z',
+        lastError: 'previous failure',
+      }],
+    });
+    expect(out![0]).toMatchObject({
+      kind: 'scheduled',
+      description: 'cleanup',
+      lastRunAt: '2026-05-01T10:00:00Z',
+      nextFireAt: '2026-05-02T02:00:00Z',
+      lastError: 'previous failure',
+    });
+  });
+
+  it('omits optional fields rather than assigning undefined (exactOptionalPropertyTypes)', () => {
+    const out = parseStatusResult({
+      jobs: [{ id: 'a', name: 'X', expression: '* * * * *', enabled: true }],
+    });
+    // Property must not exist, so consumers using `'kind' in row` style checks
+    // get truthful answers. (in undefined === false in JS, but the test
+    // documents the contract.)
+    expect(Object.prototype.hasOwnProperty.call(out![0], 'kind')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(out![0], 'lastRunAt')).toBe(false);
+  });
+
+  it('defaults enabled=true when the field is missing or non-boolean', () => {
+    const out = parseStatusResult({
+      jobs: [{ id: 'a', name: 'X', expression: '* * * * *' }],
+    });
+    expect(out![0]!.enabled).toBe(true);
+  });
+});
+
+describe('applyEventDelta', () => {
+  const baseJob = (over: Partial<CronJobInfo> = {}): CronJobInfo => ({
+    id: 'a',
+    name: 'Daily',
+    expression: '0 2 * * *',
+    enabled: true,
+    ...over,
+  });
+
+  it('marks the matching job running on triggered + clears prior error', () => {
+    const prev = [baseJob({ lastError: 'old failure' })];
+    const next = applyEventDelta(prev, 'scheduler.job_triggered', 'a', {
+      timestamp: '2026-05-01T10:00:00Z',
+    });
+    expect(next[0]).toEqual({
+      ...prev[0]!,
+      lastError: undefined, // delete leaves no own key — undefined access OK
+      lastRunAt: '2026-05-01T10:00:00Z',
+      lastStatus: 'running',
+    });
+    expect('lastError' in next[0]!).toBe(false); // delete removed the key
+  });
+
+  it('marks the matching job completed on completed', () => {
+    const prev = [baseJob()];
+    const next = applyEventDelta(prev, 'scheduler.job_completed', 'a', {
+      timestamp: '2026-05-01T10:01:00Z',
+    });
+    expect(next[0]!.lastStatus).toBe('completed');
+    expect(next[0]!.lastRunAt).toBe('2026-05-01T10:01:00Z');
+  });
+
+  it('marks failed and stamps the error text', () => {
+    // Field-swap regression guard: a copy-paste typo that put params.error
+    // into the wrong field would silently render an empty tooltip.
+    const prev = [baseJob()];
+    const next = applyEventDelta(prev, 'scheduler.job_failed', 'a', {
+      error: 'tool exec timeout',
+      attempt: 2,
+      maxAttempts: 5,
+      timestamp: '2026-05-01T10:02:00Z',
+    });
+    expect(next[0]!.lastStatus).toBe('failed');
+    expect(next[0]!.lastError).toBe('tool exec timeout');
+    expect(next[0]!.lastRunAt).toBe('2026-05-01T10:02:00Z');
+  });
+
+  it('marks skipped without disturbing lastRunAt', () => {
+    const prev = [baseJob({ lastRunAt: '2026-05-01T09:00:00Z' })];
+    const next = applyEventDelta(prev, 'scheduler.job_skipped', 'a', {
+      reason: 'previous run still active',
+    });
+    expect(next[0]!.lastStatus).toBe('skipped');
+    // skipped does not change lastRunAt — the previous run remains the
+    // most recent actual execution.
+    expect(next[0]!.lastRunAt).toBe('2026-05-01T09:00:00Z');
+  });
+
+  it('is a no-op when the jobId is unknown', () => {
+    const prev = [baseJob()];
+    const next = applyEventDelta(prev, 'scheduler.job_triggered', 'unknown-id', {
+      timestamp: '2026-05-01T10:00:00Z',
+    });
+    expect(next).toEqual(prev);
+  });
+
+  it('does not mutate the input array', () => {
+    const prev = [baseJob()];
+    applyEventDelta(prev, 'scheduler.job_completed', 'a', {
+      timestamp: '2026-05-01T10:01:00Z',
+    });
+    expect(prev[0]!.lastStatus).toBeUndefined();
+  });
+});

--- a/aceclaw-dashboard/tests/useCronJobs.test.ts
+++ b/aceclaw-dashboard/tests/useCronJobs.test.ts
@@ -9,6 +9,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   applyEventDelta,
+  hasJob,
   parseStatusResult,
   type CronJobInfo,
 } from '../src/hooks/useCronJobs';
@@ -142,6 +143,9 @@ describe('applyEventDelta', () => {
   });
 
   it('is a no-op when the jobId is unknown', () => {
+    // The hook's responsibility is to detect this case via `hasJob` and
+    // fire a status refresh — the delta itself stays a pure no-op so
+    // the function can keep its plain (prev → next) shape.
     const prev = [baseJob()];
     const next = applyEventDelta(prev, 'scheduler.job_triggered', 'unknown-id', {
       timestamp: '2026-05-01T10:00:00Z',
@@ -155,5 +159,30 @@ describe('applyEventDelta', () => {
       timestamp: '2026-05-01T10:01:00Z',
     });
     expect(prev[0]!.lastStatus).toBeUndefined();
+  });
+});
+
+describe('hasJob', () => {
+  // The hook uses hasJob to gate "apply delta vs fire snapshot refresh"
+  // — so a `scheduler.job_*` event for a job created after our snapshot
+  // triggers a re-fetch instead of being silently dropped. This is the
+  // counterpart to applyEventDelta's "no-op on unknown id" contract.
+  const baseJob = (id: string): CronJobInfo => ({
+    id,
+    name: 'X',
+    expression: '* * * * *',
+    enabled: true,
+  });
+
+  it('returns true for an id present in the list', () => {
+    expect(hasJob([baseJob('a'), baseJob('b')], 'b')).toBe(true);
+  });
+
+  it('returns false for an id missing from the list', () => {
+    expect(hasJob([baseJob('a')], 'unknown')).toBe(false);
+  });
+
+  it('returns false for an empty list', () => {
+    expect(hasJob([], 'a')).toBe(false);
   });
 });

--- a/aceclaw-dashboard/tests/useCronJobs.test.ts
+++ b/aceclaw-dashboard/tests/useCronJobs.test.ts
@@ -8,9 +8,12 @@
 
 import { describe, expect, it } from 'vitest';
 import {
+  appendCapped,
   applyEventDelta,
   hasJob,
+  parseEventsPollResult,
   parseStatusResult,
+  recordFromLiveEvent,
   type CronJobInfo,
 } from '../src/hooks/useCronJobs';
 
@@ -159,6 +162,123 @@ describe('applyEventDelta', () => {
       timestamp: '2026-05-01T10:01:00Z',
     });
     expect(prev[0]!.lastStatus).toBeUndefined();
+  });
+});
+
+describe('parseEventsPollResult', () => {
+  // Pins the wire-format mapping for the timeline backfill (#459 layer 3).
+  // A typo'd `cronExpression` vs `cronExpr` would silently render blank
+  // tooltips with no test failure — this guards.
+
+  it('returns null when events is not an array', () => {
+    expect(parseEventsPollResult({})).toBeNull();
+    expect(parseEventsPollResult({ events: 'oops' })).toBeNull();
+  });
+
+  it('parses each of the four event types with their kind-specific fields', () => {
+    const out = parseEventsPollResult({
+      events: [
+        { jobId: 'a', type: 'triggered', timestamp: '2026-05-01T10:00:00Z',
+          cronExpression: '* * * * *' },
+        { jobId: 'a', type: 'completed', timestamp: '2026-05-01T10:00:01Z',
+          durationMs: 1234, summary: 'done' },
+        { jobId: 'a', type: 'failed', timestamp: '2026-05-01T10:00:02Z',
+          error: 'boom', attempt: 2, maxAttempts: 5 },
+        { jobId: 'a', type: 'skipped', timestamp: '2026-05-01T10:00:03Z',
+          reason: 'previous run still active' },
+      ],
+    });
+    expect(out).toHaveLength(4);
+    expect(out![0]).toMatchObject({ kind: 'triggered', cronExpression: '* * * * *' });
+    expect(out![1]).toMatchObject({ kind: 'completed', durationMs: 1234, summary: 'done' });
+    expect(out![2]).toMatchObject({
+      kind: 'failed',
+      error: 'boom',
+      attempt: 2,
+      maxAttempts: 5,
+    });
+    expect(out![3]).toMatchObject({ kind: 'skipped', reason: 'previous run still active' });
+  });
+
+  it('skips events with unknown type so a future 5th kind doesn\'t crash old dashboards', () => {
+    const out = parseEventsPollResult({
+      events: [
+        { jobId: 'a', type: 'triggered', timestamp: '2026-05-01T10:00:00Z' },
+        { jobId: 'a', type: 'magicked-into-existence', timestamp: '2026-05-01T10:00:01Z' },
+      ],
+    });
+    expect(out).toHaveLength(1);
+    expect(out![0]!.kind).toBe('triggered');
+  });
+
+  it('skips events missing required fields', () => {
+    const out = parseEventsPollResult({
+      events: [
+        { jobId: 'a', type: 'triggered', timestamp: '2026-05-01T10:00:00Z' },
+        { type: 'triggered', timestamp: '2026-05-01T10:00:01Z' },     // missing jobId
+        { jobId: 'b', type: 'completed' },                            // missing timestamp
+      ],
+    });
+    expect(out).toHaveLength(1);
+  });
+});
+
+describe('recordFromLiveEvent', () => {
+  it('returns null on unknown method', () => {
+    expect(recordFromLiveEvent('scheduler.unrelated', 'a', { timestamp: 't' })).toBeNull();
+  });
+
+  it('returns null when timestamp is missing', () => {
+    expect(recordFromLiveEvent('scheduler.job_triggered', 'a', {})).toBeNull();
+  });
+
+  it('maps each live method to the right kind', () => {
+    expect(recordFromLiveEvent('scheduler.job_triggered', 'a',
+      { timestamp: 't' })?.kind).toBe('triggered');
+    expect(recordFromLiveEvent('scheduler.job_completed', 'a',
+      { timestamp: 't' })?.kind).toBe('completed');
+    expect(recordFromLiveEvent('scheduler.job_failed', 'a',
+      { timestamp: 't' })?.kind).toBe('failed');
+    expect(recordFromLiveEvent('scheduler.job_skipped', 'a',
+      { timestamp: 't' })?.kind).toBe('skipped');
+  });
+
+  it('preserves kind-specific fields', () => {
+    const r = recordFromLiveEvent('scheduler.job_failed', 'a', {
+      timestamp: '2026-05-01T10:00:00Z',
+      error: 'boom',
+      attempt: 1,
+      maxAttempts: 3,
+    });
+    expect(r).toMatchObject({
+      jobId: 'a',
+      kind: 'failed',
+      error: 'boom',
+      attempt: 1,
+      maxAttempts: 3,
+    });
+  });
+});
+
+describe('appendCapped', () => {
+  it('appends below the cap', () => {
+    expect(appendCapped([1, 2], 3, 5)).toEqual([1, 2, 3]);
+  });
+
+  it('drops oldest when at cap', () => {
+    expect(appendCapped([1, 2, 3], 4, 3)).toEqual([2, 3, 4]);
+  });
+
+  it('drops multiple when exceeding cap', () => {
+    // Edge case — we wouldn't normally hit this since the buffer is
+    // appended one item at a time, but the math has to be right.
+    expect(appendCapped([1, 2, 3, 4, 5], 6, 3)).toEqual([4, 5, 6]);
+  });
+
+  it('does not mutate the input array', () => {
+    const prev = [1, 2, 3];
+    appendCapped(prev, 4, 3);
+    expect(prev).toEqual([1, 2, 3]);
   });
 });
 


### PR DESCRIPTION
## ⚠️ Stacked PR

This branch (`feat/459-cron-timeline`) is **stacked on `feat/459-cron-sidebar-panel`** (PR #461, layer 2). The diff against `main` will include layer 2's changes; for a clean layer-3-only diff, compare against the layer 2 branch:

\`\`\`bash
git diff feat/459-cron-sidebar-panel..feat/459-cron-timeline
\`\`\`

I'll rebase + force-push to clean this up once #461 lands.

## Summary

Layer 3 of #459. Schedule timeline at the top of the main pane: one swimlane per cron job, past triggers as colour-coded blocks, next-fire as a dashed outline, "now" line drifting right every 10s.

- Daemon: extracted `scheduler.events.poll` body into `buildSchedulerEventsPollReply`; new WS inbound handler replies with `scheduler.events.poll.result` (same shape as CLI's RPC).
- `useCronJobs` now returns `{ jobs, recentEvents }` — backfilled from `scheduler.events.poll` on connect, then appended from live `scheduler.job_*` envelopes (cap 200, drop oldest).
- New `CronTimeline` SVG component: 1h default window (configurable), per-event tooltips, axis ticks every 15min. Hides itself when no jobs configured.
- **No second WebSocket** — timeline shares `useCronJobs`'s connection (see #462 for the broader multi-connection plan).

## What you should see

After rebuild + restart + `npm run dev`:
- A horizontal timeline strip appears at the top of the main pane (only when jobs are configured)
- Each row is a job; coloured blocks show past triggers; dashed outline shows next fire
- The "now" guide on the right edge advances every 10s
- Hover a block → tooltip with kind / timestamp / duration / error

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 27 new useCronJobs + 12 new cronTimeline tests, 178 total green
- [x] `npx vite build` clean
- [x] `./gradlew :aceclaw-daemon:test` green
- [ ] Manual: timeline renders correctly with a `* * * * *` cron job; blocks appear within seconds of each fire

## Out of scope (follow-ups in #459)

- Click a block → jump to the produced session (needs `sessionId` on SchedulerEvent records — daemon schema change)
- Window-zoom toggle (1h / 1d / 7d)
- Edit cron jobs from the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)