### PR TITLE
feat: cron-as-session — drill into a cron run as a tree (#459)

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -2351,6 +2351,12 @@ public final class AceClawDaemon {
                         bootModel, bootSystemPrompt,
                         config.maxTokens(), config.thinkingBudget(),
                         eventBus, config.schedulerTickSeconds());
+                // #459: dashboard sees a cron run as a session ("cron-{jobId}")
+                // with one turn per fire. The bridge ref is null when WS is
+                // disabled, in which case the scheduler falls back to the
+                // existing SilentStreamHandler — CLI-only deployments
+                // unchanged.
+                cronScheduler.setWebSocketBridge(this.webSocketBridge);
                 cronScheduler.start();
 
                 shutdownManager.register(new ShutdownManager.ShutdownParticipant() {

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/BroadcastOnlyStreamContext.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/BroadcastOnlyStreamContext.java
@@ -1,0 +1,51 @@
+package dev.aceclaw.daemon;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * {@link StreamContext} for daemon-internal subsystems that need to emit
+ * dashboard events but have no inbound channel. Used by the cron
+ * scheduler (#459): a cron run has no CLI client to talk back to, but
+ * the dashboard still wants to see {@code stream.thinking} /
+ * {@code stream.tool_use} / {@code stream.text} as the run unfolds.
+ *
+ * <p>The "session" identity for these events is conceptual — for cron
+ * it's {@code "cron-" + jobId}, deterministic across runs of the same
+ * job so all triggers stack into the same ExecutionTree (each run
+ * becomes a new turn under the same session).
+ *
+ * <p>{@link #readMessage()} always returns {@code null}: there is no
+ * inbound channel, and any caller that blocks on it would hang
+ * forever. The intended use is one-way notification only.
+ */
+final class BroadcastOnlyStreamContext implements StreamContext {
+
+    private final WebSocketBridge bridge;
+    private final String sessionId;
+
+    BroadcastOnlyStreamContext(WebSocketBridge bridge, String sessionId) {
+        if (bridge == null) {
+            throw new IllegalArgumentException("bridge must not be null");
+        }
+        if (sessionId == null || sessionId.isBlank()) {
+            throw new IllegalArgumentException("sessionId must not be blank");
+        }
+        this.bridge = bridge;
+        this.sessionId = sessionId;
+    }
+
+    @Override
+    public void sendNotification(String method, Object params) {
+        bridge.broadcast(sessionId, method, params);
+    }
+
+    @Override
+    public JsonNode readMessage() {
+        // Daemon-internal subsystems have no client to read from. Returning
+        // null tells callers "no message; treat as closed" — the agent
+        // loop won't block waiting for a permission response that can
+        // never arrive (cron paths run with their own permission checker
+        // that auto-decides per the job's allowedTools set).
+        return null;
+    }
+}

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -3240,11 +3240,79 @@ public final class StreamingAgentHandler {
      *
      * <p>Returns the SAME translation logic the user-session path uses
      * so both surfaces speak literally one wire format.
+     *
+     * <p>Note: this handler only carries the LOW-LEVEL agent-loop events
+     * (thinking, tool_use, text, tool_completed). Callers must emit the
+     * lifecycle wrapper events ({@link #emitSessionStarted},
+     * {@link #emitTurnStarted}, {@link #emitTurnCompleted}) themselves at
+     * the run boundaries — without those, the dashboard reducer has no
+     * session/turn parent to attach the inner nodes to and tools end up
+     * floating at the tree root.
      */
     public static StreamEventHandler newBroadcastingStreamHandler(
             WebSocketBridge bridge, String sessionId, ObjectMapper mapper) {
         var ctx = new BroadcastOnlyStreamContext(bridge, sessionId);
         return new StreamingNotificationHandler(ctx, mapper);
+    }
+
+    /**
+     * Broadcasts {@code stream.session_started} for a daemon-internal
+     * session (cron, deferred action, …). Idempotency is the caller's
+     * responsibility — emit once per session lifetime (e.g., dedupe
+     * against a {@code Set<String>} of already-signaled ids).
+     *
+     * <p>Same wire shape as the user-session path uses, so the dashboard
+     * reducer creates the session root node identically.
+     */
+    public static void emitSessionStarted(WebSocketBridge bridge, String sessionId,
+                                          String model, ObjectMapper mapper) {
+        if (bridge == null) return;
+        var p = mapper.createObjectNode();
+        p.put("sessionId", sessionId);
+        p.put("model", model);
+        p.put("timestamp", java.time.Instant.now().toString());
+        bridge.broadcast(sessionId, "stream.session_started", p);
+    }
+
+    /**
+     * Broadcasts {@code stream.turn_started} for a daemon-internal
+     * session. Call once before each {@code agentLoop.runTurn(...)} so
+     * the reducer creates a fresh turn node and the agent-loop events
+     * that follow attach under it.
+     */
+    public static void emitTurnStarted(WebSocketBridge bridge, String sessionId,
+                                       String requestId, int turnNumber, ObjectMapper mapper) {
+        if (bridge == null) return;
+        var ts = mapper.createObjectNode();
+        ts.put("sessionId", sessionId);
+        ts.put("requestId", requestId);
+        ts.put("turnNumber", turnNumber);
+        ts.put("timestamp", java.time.Instant.now().toString());
+        bridge.broadcast(sessionId, "stream.turn_started", ts);
+    }
+
+    /**
+     * Broadcasts {@code stream.turn_completed} for a daemon-internal
+     * session. Call once after each {@code agentLoop.runTurn(...)}
+     * (success OR failure path) so the reducer can mark the turn
+     * complete and stop drawing it as in-progress.
+     */
+    public static void emitTurnCompleted(WebSocketBridge bridge, String sessionId,
+                                         String requestId, int turnNumber,
+                                         long durationMs, int toolCount,
+                                         String stopReason, ObjectMapper mapper) {
+        if (bridge == null) return;
+        var tc = mapper.createObjectNode();
+        tc.put("sessionId", sessionId);
+        tc.put("requestId", requestId);
+        tc.put("turnNumber", turnNumber);
+        tc.put("durationMs", durationMs);
+        tc.put("toolCount", toolCount);
+        tc.put("timestamp", java.time.Instant.now().toString());
+        if (stopReason != null) {
+            tc.put("stopReason", stopReason);
+        }
+        bridge.broadcast(sessionId, "stream.turn_completed", tc);
     }
 
     /**

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -3229,6 +3229,25 @@ public final class StreamingAgentHandler {
     // -- StreamEventHandler that forwards events as JSON-RPC notifications --
 
     /**
+     * Builds a {@link StreamEventHandler} for daemon-internal subsystems
+     * (cron scheduler, deferred actions, …) that need to push their
+     * agent-loop events to the dashboard but have no CLI client to
+     * funnel through. The handler translates raw LLM stream events into
+     * the same {@code stream.*} JSON-RPC notifications a normal user
+     * session would emit, and broadcasts them under {@code sessionId} via
+     * the WS bridge so the dashboard's existing ExecutionTree picks them
+     * up — a cron run becomes a session with one turn per fire (#459).
+     *
+     * <p>Returns the SAME translation logic the user-session path uses
+     * so both surfaces speak literally one wire format.
+     */
+    public static StreamEventHandler newBroadcastingStreamHandler(
+            WebSocketBridge bridge, String sessionId, ObjectMapper mapper) {
+        var ctx = new BroadcastOnlyStreamContext(bridge, sessionId);
+        return new StreamingNotificationHandler(ctx, mapper);
+    }
+
+    /**
      * Forwards stream events from the agent loop to the client as JSON-RPC notifications.
      */
     private static final class StreamingNotificationHandler implements StreamEventHandler {

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/cron/CronScheduler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/cron/CronScheduler.java
@@ -75,6 +75,12 @@ public final class CronScheduler {
      */
     private volatile WebSocketBridge webSocketBridge;
     private final ObjectMapper objectMapper;
+    /** Cron-sessionIds for which {@code stream.session_started} has been emitted in this JVM. */
+    private final java.util.Set<String> cronSessionStartedSignaled =
+            java.util.concurrent.ConcurrentHashMap.newKeySet();
+    /** Per-cron-session turn counter (1-based). Each fire becomes a new turn. */
+    private final java.util.concurrent.ConcurrentHashMap<String, java.util.concurrent.atomic.AtomicInteger>
+            cronTurnCounters = new java.util.concurrent.ConcurrentHashMap<>();
 
     private ScheduledExecutorService scheduler;
     private final AtomicBoolean running = new AtomicBoolean(false);
@@ -367,10 +373,36 @@ public final class CronScheduler {
         // Falls back to the no-op SilentStreamHandler when the bridge
         // is disabled — CLI deployments are unaffected.
         var bridgeRef = this.webSocketBridge;
+        String sessionId = "cron-" + job.id();
+        int turnNumber = cronTurnCounters
+                .computeIfAbsent(sessionId, k -> new java.util.concurrent.atomic.AtomicInteger(0))
+                .incrementAndGet();
+        String requestId = sessionId + "-turn-" + turnNumber;
         StreamEventHandler streamHandler = bridgeRef != null
                 ? StreamingAgentHandler.newBroadcastingStreamHandler(
-                        bridgeRef, "cron-" + job.id(), objectMapper)
+                        bridgeRef, sessionId, objectMapper)
                 : new SilentStreamHandler();
+
+        // Lifecycle wrappers (#459): the inner StreamEventHandler emits
+        // only the LOW-LEVEL agent-loop events (thinking, tool_use, …).
+        // Without an enclosing session_started + turn_started, the
+        // reducer has no parent to attach those nodes to and tools
+        // float at the tree root. We emit the wrappers here at the run
+        // boundaries, the same way StreamingAgentHandler does for user
+        // sessions — one wire format, no drift.
+        if (bridgeRef != null) {
+            if (cronSessionStartedSignaled.add(sessionId)) {
+                StreamingAgentHandler.emitSessionStarted(bridgeRef, sessionId, model, objectMapper);
+            }
+            StreamingAgentHandler.emitTurnStarted(
+                    bridgeRef, sessionId, requestId, turnNumber, objectMapper);
+        }
+        long turnStartNanos = System.nanoTime();
+        // turnEndStopReason flips to ERROR on any failure path so the
+        // turn_completed event sent in `finally` accurately reflects
+        // why the run ended. Without this, a timed-out cron run would
+        // silently render as "END_TURN" on the dashboard.
+        String turnEndStopReason = "END_TURN";
         try {
             var future = CompletableFuture.supplyAsync(() -> {
                 try {
@@ -385,11 +417,13 @@ public final class CronScheduler {
             try {
                 return future.get(job.timeoutSeconds(), TimeUnit.SECONDS);
             } catch (TimeoutException e) {
+                turnEndStopReason = "ERROR";
                 cancellationToken.cancel();
                 future.cancel(true);
                 throw new TimeoutException("Cron job '" + job.id() + "' timed out after "
                         + job.timeoutSeconds() + "s");
             } catch (ExecutionException e) {
+                turnEndStopReason = "ERROR";
                 Throwable cause = e.getCause();
                 if (cause instanceof Exception ex) {
                     throw ex;
@@ -398,6 +432,14 @@ public final class CronScheduler {
             }
         } finally {
             executor.close();
+            // Always close out the turn so the dashboard tree marks it
+            // completed (or failed) — never leave it in-progress.
+            if (bridgeRef != null) {
+                long durationMs = (System.nanoTime() - turnStartNanos) / 1_000_000L;
+                StreamingAgentHandler.emitTurnCompleted(
+                        bridgeRef, sessionId, requestId, turnNumber,
+                        durationMs, /* toolCount = */ 0, turnEndStopReason, objectMapper);
+            }
         }
     }
 

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/cron/CronScheduler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/cron/CronScheduler.java
@@ -11,8 +11,11 @@ import dev.aceclaw.core.llm.LlmException;
 import dev.aceclaw.core.llm.Message;
 import dev.aceclaw.core.llm.StreamEventHandler;
 import dev.aceclaw.core.util.WaitSupport;
+import dev.aceclaw.daemon.StreamingAgentHandler;
+import dev.aceclaw.daemon.WebSocketBridge;
 import dev.aceclaw.infra.event.EventBus;
 import dev.aceclaw.infra.event.SchedulerEvent;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,6 +64,17 @@ public final class CronScheduler {
     private final int thinkingBudget;
     private final EventBus eventBus;
     private final int tickSeconds;
+    /**
+     * Optional dashboard sink (#459). When non-null, each cron run's
+     * agent-loop events ({@code stream.thinking}, {@code stream.tool_use},
+     * etc.) are broadcast to the WS bridge under
+     * {@code "cron-" + jobId}, so the dashboard's ExecutionTree can
+     * render the run live — each fire becomes a turn under the same
+     * cron-as-session tree. Null disables the broadcast (CLI-only
+     * deployments fall back to the no-op SilentStreamHandler).
+     */
+    private volatile WebSocketBridge webSocketBridge;
+    private final ObjectMapper objectMapper;
 
     private ScheduledExecutorService scheduler;
     private final AtomicBoolean running = new AtomicBoolean(false);
@@ -94,6 +108,18 @@ public final class CronScheduler {
         this.thinkingBudget = thinkingBudget;
         this.eventBus = eventBus;
         this.tickSeconds = tickSeconds > 0 ? tickSeconds : 60;
+        this.objectMapper = new ObjectMapper();
+    }
+
+    /**
+     * Sets the dashboard sink. Idempotent. Pass {@code null} to disable
+     * dashboard broadcasting (a CLI-only deployment will keep working
+     * via the existing scheduler.* event feed). Setter rather than
+     * constructor param so daemon startup ordering doesn't constrain
+     * either side.
+     */
+    public void setWebSocketBridge(WebSocketBridge bridge) {
+        this.webSocketBridge = bridge;
     }
 
     /**
@@ -334,11 +360,22 @@ public final class CronScheduler {
 
         var cancellationToken = new CancellationToken();
         var executor = Executors.newVirtualThreadPerTaskExecutor();
+        // #459: when the dashboard's WS bridge is available, broadcast
+        // every agent-loop event under sessionId="cron-{jobId}" so
+        // operators can drill into the run live (and see history as
+        // accumulated turns under the same cron-as-session tree).
+        // Falls back to the no-op SilentStreamHandler when the bridge
+        // is disabled — CLI deployments are unaffected.
+        var bridgeRef = this.webSocketBridge;
+        StreamEventHandler streamHandler = bridgeRef != null
+                ? StreamingAgentHandler.newBroadcastingStreamHandler(
+                        bridgeRef, "cron-" + job.id(), objectMapper)
+                : new SilentStreamHandler();
         try {
             var future = CompletableFuture.supplyAsync(() -> {
                 try {
                     var turn = agentLoop.runTurn(cronPrompt, new ArrayList<>(),
-                            new SilentStreamHandler(), cancellationToken);
+                            streamHandler, cancellationToken);
                     return summarizeTurnOutput(turn);
                 } catch (LlmException e) {
                     throw new CompletionException(e);

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/cron/CronScheduler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/cron/CronScheduler.java
@@ -54,6 +54,21 @@ public final class CronScheduler {
     private static final int DEFAULT_EVENT_SUMMARY_MAX_CHARS = 8192;
     private static final int EVENT_SUMMARY_MAX_CHARS = parseEventSummaryMaxChars();
     private static final int TOOL_RESULT_FALLBACK_MAX_CHARS = 1600;
+    /**
+     * SessionId prefix used when broadcasting cron run events to the
+     * dashboard (#459 cron-as-session). The full sessionId is
+     * {@code CRON_SESSION_PREFIX + jobId}, deterministic across runs of
+     * the same job so all triggers stack as turns under one tree.
+     *
+     * <p><b>Cross-language coupling</b>: the dashboard's
+     * {@code isCronSessionId} (in {@code aceclaw-dashboard/src/hooks/useSessions.ts})
+     * and {@code cronSessionId} (in {@code components/CronJobsList.tsx})
+     * hard-code the same {@code "cron-"} string. Changing this constant
+     * silently breaks both — the sentinel test
+     * {@code CronScheduler.cronSessionPrefixIsStableForDashboardCompat}
+     * exists to surface that loudly at build time.
+     */
+    public static final String CRON_SESSION_PREFIX = "cron-";
 
     private final JobStore jobStore;
     private final LlmClient llmClient;
@@ -68,7 +83,7 @@ public final class CronScheduler {
      * Optional dashboard sink (#459). When non-null, each cron run's
      * agent-loop events ({@code stream.thinking}, {@code stream.tool_use},
      * etc.) are broadcast to the WS bridge under
-     * {@code "cron-" + jobId}, so the dashboard's ExecutionTree can
+     * {@code CRON_SESSION_PREFIX + jobId}, so the dashboard's ExecutionTree can
      * render the run live — each fire becomes a turn under the same
      * cron-as-session tree. Null disables the broadcast (CLI-only
      * deployments fall back to the no-op SilentStreamHandler).
@@ -343,7 +358,7 @@ public final class CronScheduler {
         // Build per-job permission checker
         var permChecker = new CronPermissionChecker(job.id(), job.allowedTools());
         var loopConfig = AgentLoopConfig.builder()
-                .sessionId("cron-" + job.id())
+                .sessionId(CRON_SESSION_PREFIX + job.id())
                 .permissionChecker(permChecker)
                 .maxIterations(job.maxIterations())
                 .build();
@@ -373,11 +388,18 @@ public final class CronScheduler {
         // Falls back to the no-op SilentStreamHandler when the bridge
         // is disabled — CLI deployments are unaffected.
         var bridgeRef = this.webSocketBridge;
-        String sessionId = "cron-" + job.id();
+        String sessionId = CRON_SESSION_PREFIX + job.id();
         int turnNumber = cronTurnCounters
                 .computeIfAbsent(sessionId, k -> new java.util.concurrent.atomic.AtomicInteger(0))
                 .incrementAndGet();
-        String requestId = sessionId + "-turn-" + turnNumber;
+        // requestId is the dashboard-side node id for this turn. Including
+        // epochMillis means a daemon restart can't accidentally reuse an
+        // id that's still in a long-lived dashboard tab's local state —
+        // post-restart counter resets to 1, but the timestamp differs, so
+        // there's no collision between the old turn-1 node and the new
+        // one. Display label keeps using turnNumber, the millis are
+        // opaque to the renderer.
+        String requestId = sessionId + "-turn-" + System.currentTimeMillis() + "-" + turnNumber;
         StreamEventHandler streamHandler = bridgeRef != null
                 ? StreamingAgentHandler.newBroadcastingStreamHandler(
                         bridgeRef, sessionId, objectMapper)

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/BroadcastOnlyStreamContextTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/BroadcastOnlyStreamContextTest.java
@@ -1,0 +1,119 @@
+package dev.aceclaw.daemon;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.WebSocket;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link BroadcastOnlyStreamContext} (#459 cron-as-session).
+ *
+ * The point of this context: cron runs (and any other daemon-internal
+ * subsystem with no CLI client) get a {@link StreamContext} that
+ * fans events out to the WS bridge as if they were a normal session,
+ * AND has a no-op inbound channel so the agent loop can never block
+ * on a permission response that won't arrive.
+ */
+final class BroadcastOnlyStreamContextTest {
+
+    private static final long AWAIT_TIMEOUT_MS = 5_000;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private WebSocketBridge bridge;
+
+    @AfterEach
+    void tearDown() {
+        if (bridge != null) bridge.stop();
+    }
+
+    @Test
+    void sendNotificationBroadcastsViaBridgeUnderTheGivenSessionId() throws Exception {
+        bridge = new WebSocketBridge("127.0.0.1", 0, mapper);
+        bridge.start();
+        var connected = new CountDownLatch(1);
+        bridge.addConnectionListener(_ -> connected.countDown());
+        var queue = new LinkedBlockingQueue<String>();
+        var ws = connect(queue::add);
+        assertThat(connected.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS)).isTrue();
+
+        var ctx = new BroadcastOnlyStreamContext(bridge, "cron-daily-backup");
+        ctx.sendNotification("stream.thinking", Map.of("delta", "considering options"));
+
+        var msg = queue.poll(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertThat(msg).isNotNull();
+        var node = mapper.readTree(msg);
+        // sessionId on the wire is the cron-as-session id, which the
+        // dashboard uses to route the events into the matching tree.
+        assertThat(node.get("sessionId").asText()).isEqualTo("cron-daily-backup");
+        assertThat(node.get("event").get("method").asText()).isEqualTo("stream.thinking");
+        assertThat(node.get("event").get("params").get("delta").asText()).isEqualTo("considering options");
+
+        ws.sendClose(WebSocket.NORMAL_CLOSURE, "bye").get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    void readMessageReturnsNullSoCallersDontBlockForever() throws Exception {
+        // Cron has no client to read from. The agent loop's
+        // permission-response read path checks for null and treats it
+        // as "no client" — without this the cron run would hang
+        // forever waiting for a stdin that doesn't exist.
+        bridge = new WebSocketBridge("127.0.0.1", 0, mapper);
+        bridge.start();
+        var ctx = new BroadcastOnlyStreamContext(bridge, "cron-x");
+        assertThat(ctx.readMessage()).isNull();
+        assertThat(ctx.readMessage(50)).isNull();
+    }
+
+    @Test
+    void rejectsNullBridgeAtConstruction() {
+        // Defense in depth: a daemon with WS disabled must NOT pass a
+        // null bridge here — CronScheduler is responsible for falling
+        // back to SilentStreamHandler in that case.
+        assertThatThrownBy(() -> new BroadcastOnlyStreamContext(null, "cron-x"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void rejectsBlankSessionIdAtConstruction() {
+        bridge = new WebSocketBridge("127.0.0.1", 0, mapper);
+        assertThatThrownBy(() -> new BroadcastOnlyStreamContext(bridge, ""))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new BroadcastOnlyStreamContext(bridge, "   "))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new BroadcastOnlyStreamContext(bridge, null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private WebSocket connect(java.util.function.Consumer<String> onText) throws Exception {
+        return HttpClient.newHttpClient().newWebSocketBuilder()
+                .buildAsync(URI.create("ws://127.0.0.1:" + bridge.port() + "/ws"),
+                        new java.net.http.WebSocket.Listener() {
+                            private final StringBuilder partial = new StringBuilder();
+
+                            @Override
+                            public CompletableFuture<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
+                                partial.append(data);
+                                if (last) {
+                                    onText.accept(partial.toString());
+                                    partial.setLength(0);
+                                }
+                                webSocket.request(1);
+                                return null;
+                            }
+                        })
+                .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    }
+}

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/cron/CronSchedulerTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/cron/CronSchedulerTest.java
@@ -323,6 +323,20 @@ class CronSchedulerTest {
         assertThat(updatedJob.get().lastError()).isNotNull();
     }
 
+    @Test
+    void cronSessionPrefixIsStableForDashboardCompat() {
+        // Sentinel: this constant is mirrored on the dashboard side as a
+        // hard-coded string in two places —
+        //   - aceclaw-dashboard/src/hooks/useSessions.ts (isCronSessionId)
+        //   - aceclaw-dashboard/src/components/CronJobsList.tsx (cronSessionId)
+        // Renaming CRON_SESSION_PREFIX without updating those would
+        // silently break the dashboard's filter (cron sessions would
+        // leak into SessionList) and the row-click navigation. The
+        // assertion is intentionally tautological — it exists to fire
+        // a build-time speed bump that says "go update the dashboard".
+        assertThat(CronScheduler.CRON_SESSION_PREFIX).isEqualTo("cron-");
+    }
+
     // -- Helpers --
 
     private static String extractUserPrompt(LlmRequest request) {

--- a/aceclaw-dashboard/src/App.tsx
+++ b/aceclaw-dashboard/src/App.tsx
@@ -82,7 +82,13 @@ export function App() {
         sessions={sessions}
         selectedSessionId={sessionId || null}
         onSelect={selectSession}
-        footer={<CronJobsList jobs={cronJobs} />}
+        footer={
+          <CronJobsList
+            jobs={cronJobs}
+            selectedSessionId={sessionId || null}
+            onSelect={selectSession}
+          />
+        }
       />
       <div className="flex flex-1 flex-col overflow-hidden">
         {sessionId ? (

--- a/aceclaw-dashboard/src/components/CronJobsList.tsx
+++ b/aceclaw-dashboard/src/components/CronJobsList.tsx
@@ -27,7 +27,15 @@ interface CronJobsListProps {
   onSelect: (sessionId: string) => void;
 }
 
-/** Maps a job id to the deterministic sessionId the daemon broadcasts under. */
+/**
+ * Maps a job id to the deterministic sessionId the daemon broadcasts under.
+ *
+ * <p><b>Daemon coupling</b>: the {@code 'cron-'} prefix mirrors
+ * {@code CronScheduler.CRON_SESSION_PREFIX} on the Java side. The sentinel
+ * test {@code cronSessionPrefixIsStableForDashboardCompat} (in
+ * CronSchedulerTest) fires if the daemon constant changes without a
+ * paired update here.
+ */
 export function cronSessionId(jobId: string): string {
   return `cron-${jobId}`;
 }

--- a/aceclaw-dashboard/src/components/CronJobsList.tsx
+++ b/aceclaw-dashboard/src/components/CronJobsList.tsx
@@ -1,20 +1,38 @@
 /**
- * CronJobsList — sidebar section showing the daemon's cron jobs (#459 layer 2).
+ * CronJobsList — sidebar section showing the daemon's cron jobs (#459).
  *
- * Sourced from {@link useCronJobs}. Each row shows the job's name, cron
- * expression, last-run status (icon + relative time), and the next
- * scheduled fire time. Click handlers, history expansion, and
- * jump-to-session are deferred to a follow-up — this layer's job is to
- * make the daemon's scheduling layer simply *visible*.
+ * Each row is clickable: selecting a job navigates the main pane to the
+ * cron's session tree (sessionId = {@code "cron-" + jobId}). The mental
+ * model is **a cron job IS a session, each fire IS a turn** — so the
+ * existing ExecutionTree component renders cron history naturally as
+ * accumulated turns under one tree, no new visualization needed.
  */
 
 import type { CronJobInfo } from '../hooks/useCronJobs';
 
 interface CronJobsListProps {
   jobs: CronJobInfo[];
+  /**
+   * Currently-selected sessionId from the main pane. Used to highlight
+   * the active row when the user is viewing a cron's tree. Pass the
+   * same value the SessionList receives — App keeps a single
+   * selectedSessionId for both lists.
+   */
+  selectedSessionId: string | null;
+  /**
+   * Invoked with the cron's sessionId ({@code "cron-" + jobId}) when
+   * the user clicks a row. App routes this through the same
+   * selectSession handler the SessionList uses.
+   */
+  onSelect: (sessionId: string) => void;
 }
 
-export function CronJobsList({ jobs }: CronJobsListProps) {
+/** Maps a job id to the deterministic sessionId the daemon broadcasts under. */
+export function cronSessionId(jobId: string): string {
+  return `cron-${jobId}`;
+}
+
+export function CronJobsList({ jobs, selectedSessionId, onSelect }: CronJobsListProps) {
   return (
     <section className="flex shrink-0 flex-col border-t border-zinc-800">
       <header className="flex items-center justify-between border-b border-zinc-800 px-3 py-2 text-[11px] uppercase tracking-wider text-zinc-500">
@@ -29,7 +47,12 @@ export function CronJobsList({ jobs }: CronJobsListProps) {
       ) : (
         <ul className="max-h-72 overflow-y-auto">
           {jobs.map((job) => (
-            <CronJobRow key={job.id} job={job} />
+            <CronJobRow
+              key={job.id}
+              job={job}
+              selected={selectedSessionId === cronSessionId(job.id)}
+              onSelect={onSelect}
+            />
           ))}
         </ul>
       )}
@@ -39,15 +62,24 @@ export function CronJobsList({ jobs }: CronJobsListProps) {
 
 interface CronJobRowProps {
   job: CronJobInfo;
+  selected: boolean;
+  onSelect: (sessionId: string) => void;
 }
 
-function CronJobRow({ job }: CronJobRowProps) {
+function CronJobRow({ job, selected, onSelect }: CronJobRowProps) {
   const dotColor = statusDotColor(job);
   const subtitle = subtitleFor(job);
+  // Mirror the SessionRow visual contract: left border + lighter bg
+  // when active, hover state otherwise. Same vocabulary across both
+  // lists keeps the sidebar coherent.
+  const baseBg = selected ? 'bg-zinc-800/60' : 'hover:bg-zinc-800/40';
+  const accent = selected ? 'border-l-2 border-blue-500' : 'border-l-2 border-transparent';
   return (
     <li>
-      <div
-        className="flex w-full items-start gap-2 px-3 py-2 text-left text-xs"
+      <button
+        type="button"
+        onClick={() => onSelect(cronSessionId(job.id))}
+        className={`flex w-full items-start gap-2 px-3 py-2 text-left text-xs transition-colors ${baseBg} ${accent}`}
         title={job.lastError ?? job.description ?? job.id}
       >
         <span
@@ -69,7 +101,7 @@ function CronJobRow({ job }: CronJobRowProps) {
             <span className="whitespace-nowrap">{subtitle}</span>
           </div>
         </div>
-      </div>
+      </button>
     </li>
   );
 }

--- a/aceclaw-dashboard/src/hooks/useSessions.ts
+++ b/aceclaw-dashboard/src/hooks/useSessions.ts
@@ -262,8 +262,12 @@ export function parseSessionsListResult(
 
 /**
  * True when {@code sessionId} belongs to a cron-as-session (#459).
- * Mirrors the daemon-side prefix in {@code CronScheduler.runJobOnce}.
- * Exported so unit tests pin the convention.
+ *
+ * <p><b>Daemon coupling</b>: the {@code 'cron-'} prefix mirrors
+ * {@code CronScheduler.CRON_SESSION_PREFIX} on the Java side. The
+ * sentinel test {@code cronSessionPrefixIsStableForDashboardCompat}
+ * (in CronSchedulerTest) fires if the daemon constant changes without
+ * a paired update here.
  */
 export function isCronSessionId(sessionId: string): boolean {
   return sessionId.startsWith('cron-');

--- a/aceclaw-dashboard/src/hooks/useSessions.ts
+++ b/aceclaw-dashboard/src/hooks/useSessions.ts
@@ -100,7 +100,13 @@ export function useSessions(wsUrl: string | null): SessionInfo[] {
         // resurrect a just-ended session or drop one we just learned about.
         if (data['method'] === 'sessions.list.result') {
           const list = parseSessionsListResult(data);
-          if (list) setSessions((prev) => mergeSnapshot(prev, list));
+          if (list) {
+            // Defensive cron filter — the daemon's SessionManager doesn't
+            // hold cron sessions today, but if it ever does we still
+            // don't want them in the user-facing sidebar. (#459)
+            const userOnly = list.filter((s) => !isCronSessionId(s.sessionId));
+            setSessions((prev) => mergeSnapshot(prev, userOnly));
+          }
           return;
         }
 
@@ -118,6 +124,14 @@ export function useSessions(wsUrl: string | null): SessionInfo[] {
         if (method === 'stream.session_started') {
           const row = sessionInfoFromSessionStarted(params);
           if (!row) return;
+          // #459: cron jobs reuse the session_started/turn_started
+          // events to scaffold their tree (each fire becomes a new
+          // turn under "cron-{jobId}"), but they aren't user sessions
+          // and shouldn't appear in the SessionList sidebar — they
+          // already have their own CronJobsList row. Filter by the
+          // sessionId prefix so cron events don't leak into the user
+          // session list.
+          if (isCronSessionId(row.sessionId)) return;
           setSessions((prev) =>
             prev.some((s) => s.sessionId === row.sessionId)
               ? prev
@@ -126,6 +140,7 @@ export function useSessions(wsUrl: string | null): SessionInfo[] {
         } else if (method === 'stream.session_ended') {
           const sessionId = typeof params['sessionId'] === 'string' ? params['sessionId'] : null;
           if (!sessionId) return;
+          if (isCronSessionId(sessionId)) return;
           setSessions((prev) =>
             prev.map((s) => (s.sessionId === sessionId ? { ...s, active: false } : s)),
           );
@@ -243,6 +258,15 @@ export function parseSessionsListResult(
     });
   }
   return out;
+}
+
+/**
+ * True when {@code sessionId} belongs to a cron-as-session (#459).
+ * Mirrors the daemon-side prefix in {@code CronScheduler.runJobOnce}.
+ * Exported so unit tests pin the convention.
+ */
+export function isCronSessionId(sessionId: string): boolean {
+  return sessionId.startsWith('cron-');
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/aceclaw-dashboard/tests/cronSessionId.test.ts
+++ b/aceclaw-dashboard/tests/cronSessionId.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Pins the {@code "cron-{jobId}"} sessionId convention (#459).
+ *
+ * Both sides of the wire need to agree on this string — daemon
+ * broadcasts cron-run events under it (CronScheduler.runJobOnce →
+ * BroadcastOnlyStreamContext), and the dashboard navigates to it when
+ * the user clicks a row in CronJobsList. A drift between the two
+ * would silently produce an empty ExecutionTree.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { cronSessionId } from '../src/components/CronJobsList';
+
+describe('cronSessionId', () => {
+  it('prefixes the job id with "cron-"', () => {
+    expect(cronSessionId('daily-backup')).toBe('cron-daily-backup');
+  });
+
+  it('matches the daemon-side prefix exactly', () => {
+    // The daemon constructs this string at CronScheduler.runJobOnce:
+    //   "cron-" + job.id()
+    // Any drift here breaks the dashboard's session navigation.
+    expect(cronSessionId('x')).toBe('cron-x');
+  });
+});

--- a/aceclaw-dashboard/tests/useSessions.test.ts
+++ b/aceclaw-dashboard/tests/useSessions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  isCronSessionId,
   mergeSnapshot,
   parseSessionsListResult,
   sessionInfoFromSessionStarted,
@@ -247,5 +248,22 @@ describe('sessionInfoFromSessionStarted (issue #452)', () => {
     // the wall-clock window the call ran in.
     expect(stamped).toBeGreaterThanOrEqual(before);
     expect(stamped).toBeLessThanOrEqual(after);
+  });
+});
+
+describe('isCronSessionId', () => {
+  // The hook filters cron-as-session events out of the user-facing
+  // SessionList (#459). Daemon emits cron run events under
+  // "cron-{jobId}" so the dashboard's reducer can scaffold the tree
+  // properly — but we don't want them showing up as user sessions.
+  it('returns true for cron-prefixed sessionIds', () => {
+    expect(isCronSessionId('cron-daily-backup')).toBe(true);
+    expect(isCronSessionId('cron-x')).toBe(true);
+  });
+
+  it('returns false for regular sessionIds', () => {
+    expect(isCronSessionId('s1')).toBe(false);
+    expect(isCronSessionId('a-cron-prefix-but-not-at-start')).toBe(false);
+    expect(isCronSessionId('Cron-uppercase')).toBe(false);
   });
 });


### PR DESCRIPTION
## ⚠️ Stacked PR

Branch is **stacked on `feat/459-cron-sidebar-panel`** (PR #461, layer 2). Layer-3-only diff:

\`\`\`bash
git diff feat/459-cron-sidebar-panel..feat/459-cron-as-session
\`\`\`

Replaces the scrapped #463 (timeline) with the right model.

## Summary

A cron job **is** a session. Each fire **is** a turn. With that mental model, no new visualisation is needed — clicking a cron job in the sidebar navigates to its `ExecutionTree` exactly like clicking a regular session, and history accumulates as turns under the same cron-as-session tree.

### Daemon

- `BroadcastOnlyStreamContext` — a `StreamContext` implementation for daemon-internal subsystems with no CLI client. `sendNotification` fans out to `WebSocketBridge.broadcast`; `readMessage` returns null so the agent loop never blocks for a response that can't arrive.
- `StreamingAgentHandler.newBroadcastingStreamHandler(...)` factory that wires the new context + the existing `StreamingNotificationHandler`. Cron uses the **same** translation logic user sessions use — one wire format, zero drift.
- `CronScheduler` swaps `SilentStreamHandler` for the broadcasting one when a bridge is available. CLI-only deployments still get `SilentStreamHandler` (graceful degradation).

### Dashboard

- `CronJobsList` rows become clickable buttons → `onSelect("cron-" + jobId)`, routed through the same `selectSession` handler the SessionList uses. Selected row highlights with the same border + bg vocabulary as a SessionRow.
- New `cronSessionId` helper pins the `"cron-{jobId}"` convention — daemon and dashboard string can't drift silently.

## Why this beats the timeline (PR #463, closed)

- Click a cron → see its tree, same as clicking a user session — zero new mental model
- History is free (multiple fires → multiple turns under one tree)
- All existing tree features apply: permission panels, error highlighting, auto-scroll, comfort-zone camera, …
- ~310 LOC total, vs ~700+ LOC for the timeline + daemon plumbing

## Test plan

- [x] `./gradlew :aceclaw-daemon:test` — green (incl. new `BroadcastOnlyStreamContextTest`)
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 156 tests green (incl. new `cronSessionId.test.ts`)
- [x] `npx vite build` clean
- [ ] Manual: add a `* * * * *` cron job, click it in the sidebar, watch a tree grow with thinking → tool_use → text on each fire

## Out of scope

- Cron sessions don't appear in `SessionList` — they live exclusively in `CronJobsList`. Unifying both into one "everything happening" panel is a separate UX call.
- Per-fire sessionId (so users can see historical runs side-by-side as separate trees) — current "one session, N turns" covers the live debugging story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cron jobs sidebar in the dashboard displaying job status, next run time, and last run time
  * Users can click cron jobs to view real-time execution logs and streaming output
  * Cron job status now updates live as jobs are triggered, completed, failed, or skipped

* **Chores**
  * Refactored scheduler cron status handling for WebSocket integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->