### PR TITLE
feat: lower planner threshold 5→3 + /plan slash command

### DIFF
--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/TaskManager.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/TaskManager.java
@@ -55,6 +55,19 @@ public final class TaskManager {
     public TaskHandle submit(String prompt, DaemonConnection connection, String sessionId,
                              OutputSink outputSink, PermissionBridge permissionBridge,
                              int contextWindow) {
+        return submit(prompt, connection, sessionId, outputSink, permissionBridge,
+                contextWindow, false);
+    }
+
+    /**
+     * Submits a task with an optional {@code forcePlan} flag — when true,
+     * the daemon bypasses its complexity heuristic and runs the planner
+     * regardless of the prompt's apparent complexity. Wired to the CLI's
+     * /plan slash command (TerminalRepl).
+     */
+    public TaskHandle submit(String prompt, DaemonConnection connection, String sessionId,
+                             OutputSink outputSink, PermissionBridge permissionBridge,
+                             int contextWindow, boolean forcePlan) {
         Objects.requireNonNull(prompt, "prompt");
         Objects.requireNonNull(connection, "connection");
         Objects.requireNonNull(sessionId, "sessionId");
@@ -67,7 +80,7 @@ public final class TaskManager {
 
         // TaskStreamReader reads sink from handle.outputSink() — supports /bg and /fg swaps
         var reader = new TaskStreamReader(handle, connection, sessionId,
-                prompt, permissionBridge, this::handleTaskComplete);
+                prompt, permissionBridge, this::handleTaskComplete, forcePlan);
 
         Thread thread = Thread.ofVirtual()
                 .name("aceclaw-task-" + taskId)

--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/TaskStreamReader.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/TaskStreamReader.java
@@ -33,17 +33,33 @@ public final class TaskStreamReader implements Runnable {
     private final String fullPrompt;
     private final PermissionBridge permissionBridge;
     private final Consumer<TaskHandle> onComplete;
+    /**
+     * When true, the daemon's complexity heuristic is bypassed and the
+     * planner always runs. Wired to the CLI's /plan slash command —
+     * lets users force planning on prompts that don't trip the
+     * estimator's keyword patterns.
+     */
+    private final boolean forcePlan;
 
     public TaskStreamReader(TaskHandle handle, DaemonConnection connection,
                             String sessionId, String fullPrompt,
                             PermissionBridge permissionBridge,
                             Consumer<TaskHandle> onComplete) {
+        this(handle, connection, sessionId, fullPrompt, permissionBridge, onComplete, false);
+    }
+
+    public TaskStreamReader(TaskHandle handle, DaemonConnection connection,
+                            String sessionId, String fullPrompt,
+                            PermissionBridge permissionBridge,
+                            Consumer<TaskHandle> onComplete,
+                            boolean forcePlan) {
         this.handle = Objects.requireNonNull(handle, "handle");
         this.connection = Objects.requireNonNull(connection, "connection");
         this.sessionId = Objects.requireNonNull(sessionId, "sessionId");
         this.fullPrompt = Objects.requireNonNull(fullPrompt, "fullPrompt");
         this.permissionBridge = Objects.requireNonNull(permissionBridge, "permissionBridge");
         this.onComplete = onComplete;
+        this.forcePlan = forcePlan;
     }
 
     @Override
@@ -73,15 +89,34 @@ public final class TaskStreamReader implements Runnable {
 
     private void sendPromptRequest() throws IOException {
         long id = connection.nextRequestId();
-        ObjectNode request = connection.objectMapper().createObjectNode();
+        var request = buildPromptRequest(connection.objectMapper(), sessionId, fullPrompt, id, forcePlan);
+        connection.writeLine(connection.objectMapper().writeValueAsString(request));
+    }
+
+    /**
+     * Builds the JSON-RPC envelope for an {@code agent.prompt} request.
+     * Pure / static so the wire shape can be unit-tested without
+     * mocking the {@link DaemonConnection}. Visible for tests.
+     *
+     * <p>{@code forcePlan} is only emitted when {@code true} so older
+     * daemons (without the field) see the same payload they always
+     * have — keeping the change strictly additive.
+     */
+    static ObjectNode buildPromptRequest(com.fasterxml.jackson.databind.ObjectMapper mapper,
+                                          String sessionId, String fullPrompt,
+                                          long id, boolean forcePlan) {
+        ObjectNode request = mapper.createObjectNode();
         request.put("jsonrpc", "2.0");
         request.put("method", "agent.prompt");
-        ObjectNode params = connection.objectMapper().createObjectNode();
+        ObjectNode params = mapper.createObjectNode();
         params.put("sessionId", sessionId);
         params.put("prompt", fullPrompt);
+        if (forcePlan) {
+            params.put("forcePlan", true);
+        }
         request.set("params", params);
         request.put("id", id);
-        connection.writeLine(connection.objectMapper().writeValueAsString(request));
+        return request;
     }
 
     private void readStreamLoop() throws IOException {

--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
@@ -604,7 +604,12 @@ public final class TerminalRepl {
                 // remainder as a regular prompt with forcePlan=true so
                 // the daemon always runs the planner (#458 follow-up).
                 // Empty /plan is a no-op (no prompt to send).
-                if (trimmed.equals("/plan") || trimmed.startsWith("/plan ")) {
+                // Case-insensitive on the command itself to match how
+                // handleSlashCommand normalises the rest of /help, /status
+                // etc. — `/PLAN refactor X` should not surprise the user
+                // with "Unknown command".
+                String lowered = trimmed.toLowerCase();
+                if (lowered.equals("/plan") || lowered.startsWith("/plan ")) {
                     String rest = trimmed.length() > 5 ? trimmed.substring(5).trim() : "";
                     if (rest.isEmpty()) {
                         out.println(WARNING + "/plan needs a prompt — try /plan <your task>" + RESET);

--- a/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
+++ b/aceclaw-cli/src/main/java/dev/aceclaw/cli/TerminalRepl.java
@@ -600,7 +600,19 @@ public final class TerminalRepl {
                 }
 
                 String trimmed = line.trim();
-                if (trimmed.startsWith("/")) {
+                // /plan <prompt> bypasses the heuristic — submit the
+                // remainder as a regular prompt with forcePlan=true so
+                // the daemon always runs the planner (#458 follow-up).
+                // Empty /plan is a no-op (no prompt to send).
+                if (trimmed.equals("/plan") || trimmed.startsWith("/plan ")) {
+                    String rest = trimmed.length() > 5 ? trimmed.substring(5).trim() : "";
+                    if (rest.isEmpty()) {
+                        out.println(WARNING + "/plan needs a prompt — try /plan <your task>" + RESET);
+                        out.flush();
+                    } else {
+                        submitAndWait(out, reader, rest, /* forcePlan = */ true);
+                    }
+                } else if (trimmed.startsWith("/")) {
                     if (handleSlashCommand(out, trimmed, reader)) {
                         break;
                     }
@@ -1120,6 +1132,17 @@ public final class TerminalRepl {
      * uses JLine's {@code printAbove()} to display the result above the prompt.
      */
     private void submitAndWait(PrintWriter out, LineReader reader, String input) {
+        submitAndWait(out, reader, input, false);
+    }
+
+    /**
+     * Submits a prompt for execution. When {@code forcePlan} is true, the
+     * daemon's complexity heuristic is bypassed and the planner always
+     * runs — wired to the {@code /plan} slash command for users who want
+     * planning on prompts that don't trip the keyword patterns.
+     */
+    private void submitAndWait(PrintWriter out, LineReader reader, String input,
+                                boolean forcePlan) {
         try {
             String effectiveInput = input == null ? "" : input.trim();
             if (!effectiveInput.isBlank()) {
@@ -1132,7 +1155,8 @@ public final class TerminalRepl {
 
             promptStartNanos = System.nanoTime();
 
-            var handle = taskManager.submit(effectiveInput, conn, sessionId, fgSink, permissionBridge, ctxWindow);
+            var handle = taskManager.submit(effectiveInput, conn, sessionId, fgSink,
+                    permissionBridge, ctxWindow, forcePlan);
             taskManager.setForeground(handle.taskId());
             resumeCheckpointStore.recordTaskSubmitted(
                     sessionId,
@@ -3186,6 +3210,7 @@ public final class TerminalRepl {
                 out.println(INFO + "  /compact" + RESET + "  Trigger context compaction");
                 out.println(INFO + "  /context" + RESET + "  Inspect context composition (/context list | /context detail <key>)");
                 out.println(INFO + "  /model" + RESET + "    Show current model (or /model <name> to switch)");
+                out.println(INFO + "  /plan <task>" + RESET + " Force the planner on this prompt (skips the complexity heuristic)");
                 out.println(INFO + "  /tools" + RESET + "    List available tools");
                 out.println(INFO + "  /status" + RESET + "   Show session status");
                 out.println(INFO + "  /learning" + RESET + " Show learning summary");

--- a/aceclaw-cli/src/test/java/dev/aceclaw/cli/TaskStreamReaderTest.java
+++ b/aceclaw-cli/src/test/java/dev/aceclaw/cli/TaskStreamReaderTest.java
@@ -1,0 +1,67 @@
+package dev.aceclaw.cli;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the {@code agent.prompt} JSON-RPC envelope built by
+ * {@link TaskStreamReader#buildPromptRequest}. The CLI's /plan slash
+ * command passes {@code forcePlan=true} all the way down to here; the
+ * daemon-side branch in {@code StreamingAgentHandler.handlePrompt}
+ * checks for the same field. These tests pin the wire shape so a
+ * field rename on either side fails loudly at unit-test time instead
+ * of silently disabling forced planning.
+ */
+final class TaskStreamReaderTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void buildPromptRequest_omitsForcePlanByDefault() {
+        // Older daemons don't know about forcePlan. Make sure we don't
+        // gratuitously emit the field for normal prompts — keeps the
+        // wire shape backward-compatible.
+        var req = TaskStreamReader.buildPromptRequest(
+                mapper, "sess-1", "hello", 7L, false);
+
+        assertThat(req.get("jsonrpc").asText()).isEqualTo("2.0");
+        assertThat(req.get("method").asText()).isEqualTo("agent.prompt");
+        assertThat(req.get("id").asLong()).isEqualTo(7L);
+
+        var params = req.get("params");
+        assertThat(params.get("sessionId").asText()).isEqualTo("sess-1");
+        assertThat(params.get("prompt").asText()).isEqualTo("hello");
+        assertThat(params.has("forcePlan"))
+                .as("default request must not carry forcePlan")
+                .isFalse();
+    }
+
+    @Test
+    void buildPromptRequest_emitsForcePlanWhenTrue() {
+        // /plan slash command path: the field MUST be present and true
+        // so the daemon's handlePrompt skips the ComplexityEstimator
+        // and runs the planner unconditionally.
+        var req = TaskStreamReader.buildPromptRequest(
+                mapper, "sess-1", "refactor X", 8L, true);
+
+        var params = req.get("params");
+        assertThat(params.get("forcePlan").asBoolean())
+                .as("forcePlan must be true on the wire when CLI requested it")
+                .isTrue();
+    }
+
+    @Test
+    void buildPromptRequest_fieldNameIsExactlyForcePlan() {
+        // Pin the exact field name. Daemon-side handlePrompt reads
+        // params.get("forcePlan") — any rename here would silently
+        // disable the feature without breaking anything else.
+        var req = TaskStreamReader.buildPromptRequest(
+                mapper, "s", "p", 1L, true);
+
+        var fieldNames = new java.util.ArrayList<String>();
+        req.get("params").fieldNames().forEachRemaining(fieldNames::add);
+        assertThat(fieldNames).contains("forcePlan");
+    }
+}

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/planner/ComplexityEstimator.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/planner/ComplexityEstimator.java
@@ -13,7 +13,14 @@ import java.util.regex.Pattern;
  */
 public final class ComplexityEstimator {
 
-    private static final int DEFAULT_THRESHOLD = 5;
+    /**
+     * Default threshold for the no-arg constructor. Mirrors
+     * {@code AceClawConfig.DEFAULT_PLANNER_THRESHOLD} — keep the two
+     * in sync. Lowered from 5 to 3 because single-signal compound
+     * prompts ("refactor X", "extract Y", "do A and then B") are
+     * already plannable but were never triggering the planner.
+     */
+    private static final int DEFAULT_THRESHOLD = 3;
 
     // -- Heuristic patterns ---------------------------------------------------
 

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/planner/ComplexityEstimatorTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/planner/ComplexityEstimatorTest.java
@@ -12,7 +12,9 @@ class ComplexityEstimatorTest {
     void simpleQuestion_lowScore() {
         var score = estimator.estimate("What is 2+2?");
         assertFalse(score.shouldPlan());
-        assertTrue(score.score() < 5);
+        // Score is 0 here — no signals fire for a plain question. The
+        // threshold (now 3) doesn't matter for this case.
+        assertEquals(0, score.score());
     }
 
     @Test
@@ -42,6 +44,11 @@ class ComplexityEstimatorTest {
         var score = estimator.estimate("Refactor the authentication module");
         assertTrue(score.signals().contains("refactoring"));
         assertTrue(score.score() >= 3);
+        // After the threshold drop (5 → 3), a single 'refactoring'
+        // signal is enough to plan. Pinning so a future revert can't
+        // silently restore the old "single signal never plans"
+        // behavior without updating this test.
+        assertTrue(score.shouldPlan());
     }
 
     @Test

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
@@ -74,7 +74,18 @@ public final class AceClawConfig {
     private static final int DEFAULT_SCHEDULER_TICK_SECONDS = 60;
     private static final boolean DEFAULT_HEARTBEAT_ENABLED = true;
     private static final boolean DEFAULT_PLANNER_ENABLED = true;
-    private static final int DEFAULT_PLANNER_THRESHOLD = 5;
+    /**
+     * Default complexity score for triggering the planner. Lowered
+     * from 5 → 3 so single-signal compound prompts ("refactor X",
+     * "rename across", "do A and then B") trigger a plan instead of
+     * being treated as plain ReAct turns. Empirically, threshold=5
+     * required two explicit signals which most everyday agentic
+     * prompts don't hit, so the planner essentially never fired for
+     * typical work. See {@link ComplexityEstimator} for the score
+     * table. Users can still override via config to restore older
+     * behavior.
+     */
+    private static final int DEFAULT_PLANNER_THRESHOLD = 3;
     private static final boolean DEFAULT_ADAPTIVE_REPLAN_ENABLED = true;
     private static final boolean DEFAULT_CANDIDATE_INJECTION_ENABLED = true;
     private static final boolean DEFAULT_CANDIDATE_PROMOTION_ENABLED = true;

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -372,6 +372,11 @@ public final class StreamingAgentHandler {
     private Object handlePrompt(JsonNode params, StreamContext context) throws Exception {
         var sessionId = requireString(params, "sessionId");
         var prompt = requireString(params, "prompt");
+        // Optional escape hatch for users who want to bypass the
+        // ComplexityEstimator and always run the planner — wired to the
+        // CLI's /plan slash command. When true, skips the heuristic
+        // entirely and goes straight to executePlannedPrompt below.
+        var forcePlan = params.has("forcePlan") && params.get("forcePlan").asBoolean(false);
 
         var session = sessionManager.getSession(sessionId);
         if (session == null) {
@@ -543,14 +548,28 @@ public final class StreamingAgentHandler {
                 }
             }
 
-            // Check if this task warrants upfront planning
+            // Check if this task warrants upfront planning. Two paths
+            // can trigger the planner:
+            //   1. forcePlan param (from CLI's /plan slash command) —
+            //      user explicitly asked for planning, skip the
+            //      heuristic. plannerEnabled still gates this so a
+            //      daemon configured with planner turned off entirely
+            //      still respects that.
+            //   2. ComplexityEstimator heuristic — score >= threshold.
             if (plannerEnabled) {
-                var estimator = new ComplexityEstimator(plannerThreshold);
-                var complexityScore = estimator.estimate(prompt);
-
-                if (complexityScore.shouldPlan()) {
-                    log.info("Complex task detected (score={}, signals={}), generating plan",
-                            complexityScore.score(), complexityScore.signals());
+                boolean shouldPlan = forcePlan;
+                if (forcePlan) {
+                    log.info("Forced planning requested via forcePlan=true, generating plan");
+                } else {
+                    var estimator = new ComplexityEstimator(plannerThreshold);
+                    var complexityScore = estimator.estimate(prompt);
+                    shouldPlan = complexityScore.shouldPlan();
+                    if (shouldPlan) {
+                        log.info("Complex task detected (score={}, signals={}), generating plan",
+                                complexityScore.score(), complexityScore.signals());
+                    }
+                }
+                if (shouldPlan) {
                     var planResult = executePlannedPrompt(prompt, session, sessionId, cancelContext,
                             eventHandler, permissionAwareLoop, cancellationToken,
                             metricsCollector, watchdog, requestToolNames);

--- a/aceclaw-dashboard/src/hooks/useTreeLayout.ts
+++ b/aceclaw-dashboard/src/hooks/useTreeLayout.ts
@@ -71,18 +71,27 @@ function populateGraph(
  * True iff the {@code child}'s containment edge from {@code parent} is
  * redundant with a flow edge that {@link addReActFlowEdges} will add.
  *
- * - A non-first {@code thinking} child of a turn: the chain enters via
- *   the previous thinking's tool outputs.
+ * - A non-first {@code thinking} child of a turn OR step: the chain
+ *   enters via the previous thinking's tool outputs, so a direct
+ *   parent → thinking edge would visually fan out from the parent
+ *   when the semantic is a linear chain.
  *
  * Text nodes are now anchored to their iteration's thinking (so they're
  * never direct children of the turn), and the redundant-containment
  * skip for them is no longer relevant.
+ *
+ * Steps are included alongside turns because each plan step runs its
+ * own ReAct loop with the same multi-iteration shape — without this,
+ * a step with N iterations would draw N containment edges (one to each
+ * thinking) on top of the flow chain, producing the same visual
+ * "everything fans out from the step" effect that this skip exists to
+ * prevent on turns.
  */
 function shouldSkipContainment(
   parent: ExecutionNode,
   child: ExecutionNode,
 ): boolean {
-  if (parent.type !== 'turn') return false;
+  if (parent.type !== 'turn' && parent.type !== 'step') return false;
   if (child.type === 'thinking') {
     const firstThinking = parent.children.find((c) => c.type === 'thinking');
     return firstThinking !== child;

--- a/aceclaw-dashboard/src/hooks/useTreeLayout.ts
+++ b/aceclaw-dashboard/src/hooks/useTreeLayout.ts
@@ -120,7 +120,13 @@ function addReActFlowEdges(
   nodes: ExecutionNode[],
 ): void {
   for (const parent of nodes) {
-    if (parent.type === 'turn') {
+    // Plan steps each run their own ReAct loop (see
+    // SequentialPlanExecutor.runStep on the daemon side), so a step
+    // with N iterations needs the same productive-tool → next-thinking
+    // flow edges that turns get. Without this, multiple thinkings
+    // under a step render as visually parallel siblings even though
+    // they're sequential in time.
+    if (parent.type === 'turn' || parent.type === 'step') {
       const thinkings = parent.children.filter((c) => c.type === 'thinking');
 
       for (let i = 0; i < thinkings.length - 1; i += 1) {

--- a/aceclaw-dashboard/src/reducers/treeReducer.ts
+++ b/aceclaw-dashboard/src/reducers/treeReducer.ts
@@ -146,6 +146,30 @@ function findNearestAncestor(
 }
 
 /**
+ * Returns the active scope under which agent-loop events (thinking,
+ * text, tool_use, sub-agent) should nest — the nearest running
+ * {@code 'turn'} OR {@code 'step'} ancestor of the active node.
+ *
+ * <p>A running plan step takes precedence over the enclosing turn.
+ * Without this, every step's agent-loop events would walk up past the
+ * step and re-attach to the user's original turn, producing one long
+ * undifferentiated chain across all steps instead of grouping each
+ * step's reasoning under itself. Each plan step is its own ReAct
+ * sub-loop (see SequentialPlanExecutor.runStep on the daemon side),
+ * so the step IS the right anchor when one is active.
+ *
+ * <p>Falls back to the running turn when no step is active (plain
+ * ReAct with no plan), preserving the historical behavior.
+ */
+function findCurrentAgentScope(state: ExecutionTree): ExecutionNode | null {
+  return findNearestAncestor(
+    state.rootNodes,
+    state.activeNodeId,
+    (n) => (n.type === 'turn' || n.type === 'step') && n.status === 'running',
+  );
+}
+
+/**
  * Replaces a node anywhere in the forest by id. Returns a new forest with
  * structural sharing for branches that did not change.
  */
@@ -392,12 +416,11 @@ function addToolNode(
   // Parallel tools from one LLM response don't get a thinking delta or
   // a text delta between them, so they share the same anchor — they
   // attach as siblings to whichever anchor was selected for the first
-  // tool of the call.
-  const turn = findNearestAncestor(
-    state.rootNodes,
-    state.activeNodeId,
-    (n) => n.type === 'turn' && n.status === 'running',
-  );
+  // tool of the call. Variable still named `turn` for historical
+  // continuity but the helper returns the nearest running turn OR
+  // step, so plan-step agent loops anchor on the step (not the
+  // enclosing turn) — see findCurrentAgentScope.
+  const turn = findCurrentAgentScope(state);
 
   // Iteration-boundary synthesis (mirrors appendTextToCurrentTurn):
   // when this tool_use is the FIRST event of a new iteration with no
@@ -623,11 +646,9 @@ function appendTextToCurrentTurn(
   // skips its thinking block (model went straight from tool result to
   // final response) would silently merge into the previous iter's
   // text node, because both ids would key on the same currentThinkingId.
-  const turn = findNearestAncestor(
-    state.rootNodes,
-    state.activeNodeId,
-    (n) => n.type === 'turn' && n.status === 'running',
-  );
+  // findCurrentAgentScope returns running step if one is active,
+  // else running turn — so step-scoped agent loops anchor correctly.
+  const turn = findCurrentAgentScope(state);
   if (!turn) return state;
 
   // If we're starting a new iteration's text without a fresh
@@ -801,12 +822,10 @@ function appendThinkingToCurrentTurn(
   // current thinking node, so the next thinking delta starts a fresh one.
   // Parallel tool_use events from a single LLM response don't seal the
   // anchor between themselves (no thinking delta arrives between them), so
-  // they correctly attach to the same parent.
-  const turn = findNearestAncestor(
-    state.rootNodes,
-    state.activeNodeId,
-    (n) => n.type === 'turn' && n.status === 'running',
-  );
+  // they correctly attach to the same parent. findCurrentAgentScope
+  // returns the running step when one is active so each plan step's
+  // thinking lands under itself rather than on the enclosing turn.
+  const turn = findCurrentAgentScope(state);
   if (!turn) return state;
 
   // Same iteration: append the delta to the existing thinking node.
@@ -1188,11 +1207,9 @@ function addSubAgentNode(
   state: ExecutionTree,
   params: SubAgentStartParams,
 ): ExecutionTree {
-  const turn = findNearestAncestor(
-    state.rootNodes,
-    state.activeNodeId,
-    (n) => n.type === 'turn' && n.status === 'running',
-  );
+  // Anchor on the running step when one is active (so a sub-agent
+  // spawned mid-step nests under that step), else the running turn.
+  const turn = findCurrentAgentScope(state);
   // Sub-agent ids in the daemon are not unique across the same agentType
   // running twice in one turn (#439). Mint a synthetic id from the per-tree
   // monotonic counter so two subagent.start events back-to-back with the

--- a/aceclaw-dashboard/tests/treeReducer.test.ts
+++ b/aceclaw-dashboard/tests/treeReducer.test.ts
@@ -345,6 +345,189 @@ describe('replan', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Plan-step agent-loop scoping — agent-loop events that fire while a plan
+// step is running must nest UNDER that step, not on the enclosing turn.
+// Without this, every step's thinking/tool/text would walk up past the
+// step and chain off the original prompt's turn, producing one long
+// undifferentiated agent-loop chain across all steps.
+// ---------------------------------------------------------------------------
+
+describe('agent-loop events anchor on the running plan step', () => {
+  function freshTurnWithPlan() {
+    return runAll(
+      freshTree(),
+      envelope('stream.session_started', {
+        sessionId: 'sess-1',
+        model: 'm',
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.turn_started', {
+        sessionId: 'sess-1',
+        requestId: 'req-1',
+        turnNumber: 1,
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.plan_created', {
+        planId: 'plan-1',
+        stepCount: 2,
+        goal: 'g',
+        steps: [
+          { index: 1, name: 's1', description: '' },
+          { index: 2, name: 's2', description: '' },
+        ],
+      }),
+    );
+  }
+
+  it('thinking inside a running step nests under the step, not the turn', () => {
+    const state = runAll(
+      freshTurnWithPlan(),
+      envelope('stream.plan_step_started', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        totalSteps: 2,
+        stepName: 's1',
+      }),
+      envelope('stream.thinking', { delta: 'considering options' }),
+    );
+    const turn = state.rootNodes[0]!.children[0]!;
+    const plan = turn.children[0]!;
+    const step = plan.children.find(
+      (c) => c.id === stepNodeId('plan-1', 1),
+    )!;
+    // Step is the parent of the thinking node, NOT the turn.
+    const thinking = step.children.find((c) => c.type === 'thinking');
+    expect(thinking).toBeDefined();
+    expect(thinking!.text).toBe('considering options');
+    // The turn must NOT have a thinking child of its own — only the
+    // plan it spawned and nothing else from the agent loop.
+    expect(turn.children.filter((c) => c.type === 'thinking')).toHaveLength(0);
+  });
+
+  it('tool_use inside a running step nests under the step', () => {
+    const state = runAll(
+      freshTurnWithPlan(),
+      envelope('stream.plan_step_started', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        totalSteps: 2,
+        stepName: 's1',
+      }),
+      envelope('stream.thinking', { delta: 'plan to read' }),
+      envelope('stream.tool_use', { id: 'tu-1', name: 'read_file' }),
+    );
+    const step = state.rootNodes[0]!.children[0]!.children[0]!.children.find(
+      (c) => c.id === stepNodeId('plan-1', 1),
+    )!;
+    // Tool nests under the step's thinking node (which itself nests
+    // under the step) — the whole sub-tree stays inside the step.
+    const stepThinking = step.children.find((c) => c.type === 'thinking');
+    const toolUse = stepThinking?.children.find((c) => c.type === 'tool');
+    expect(toolUse).toBeDefined();
+    expect(toolUse!.id).toBe('tu-1');
+    // The turn must not have any tool as a DIRECT child — the only
+    // child of the turn should be the plan, which contains the step,
+    // which contains the agent-loop subtree. Pre-fix, the tool would
+    // have appeared as a direct sibling of the plan under the turn.
+    const turn = state.rootNodes[0]!.children[0]!;
+    expect(turn.children.filter((c) => c.type === 'tool')).toHaveLength(0);
+  });
+
+  it('two consecutive steps each get their own agent-loop subtree', () => {
+    // The original bug: events from BOTH steps walked up past the step
+    // and chained on the user's turn, producing one giant agent-loop
+    // chain instead of two separate per-step subtrees.
+    const state = runAll(
+      freshTurnWithPlan(),
+      // Step 1: 1 thinking + 1 tool
+      envelope('stream.plan_step_started', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        totalSteps: 2,
+        stepName: 's1',
+      }),
+      envelope('stream.thinking', { delta: 's1 thinking' }),
+      envelope('stream.tool_use', { id: 'tu-1', name: 'read_file' }),
+      envelope('stream.tool_completed', {
+        id: 'tu-1',
+        name: 'read_file',
+        durationMs: 1,
+        isError: false,
+      }),
+      envelope('stream.plan_step_completed', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        stepName: 's1',
+        success: true,
+        durationMs: 1,
+        tokensUsed: 1,
+      }),
+      // Step 2: 1 thinking + 1 tool
+      envelope('stream.plan_step_started', {
+        planId: 'plan-1',
+        stepId: 's2',
+        stepIndex: 2,
+        totalSteps: 2,
+        stepName: 's2',
+      }),
+      envelope('stream.thinking', { delta: 's2 thinking' }),
+      envelope('stream.tool_use', { id: 'tu-2', name: 'edit_file' }),
+    );
+
+    const turn = state.rootNodes[0]!.children[0]!;
+    const plan = turn.children[0]!;
+    const step1 = plan.children.find((c) => c.id === stepNodeId('plan-1', 1))!;
+    const step2 = plan.children.find((c) => c.id === stepNodeId('plan-1', 2))!;
+
+    // Each step has its OWN thinking subtree (with its OWN tool nested inside).
+    const t1 = step1.children.find((c) => c.type === 'thinking');
+    const t2 = step2.children.find((c) => c.type === 'thinking');
+    expect(t1?.text).toBe('s1 thinking');
+    expect(t2?.text).toBe('s2 thinking');
+    expect(t1?.children.find((c) => c.type === 'tool')?.id).toBe('tu-1');
+    expect(t2?.children.find((c) => c.type === 'tool')?.id).toBe('tu-2');
+
+    // The turn must NOT have any thinking/tool children of its own
+    // outside the plan — those would be the symptom of the original
+    // anchoring bug (events chaining off the turn instead of the steps).
+    const turnDirectAgentLoop = turn.children.filter(
+      (c) => c.type === 'thinking' || c.type === 'tool' || c.type === 'text',
+    );
+    expect(turnDirectAgentLoop).toHaveLength(0);
+  });
+
+  it('falls back to the turn when no step is active (plain ReAct)', () => {
+    // Regression guard: the new helper must NOT break the no-plan path.
+    // Without this assertion, a future "step-only" interpretation of
+    // findCurrentAgentScope would silently break every non-plan
+    // session.
+    const state = runAll(
+      freshTree(),
+      envelope('stream.session_started', {
+        sessionId: 'sess-1',
+        model: 'm',
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.turn_started', {
+        sessionId: 'sess-1',
+        requestId: 'req-1',
+        turnNumber: 1,
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.thinking', { delta: 'no plan, just react' }),
+    );
+    const turn = state.rootNodes[0]!.children[0]!;
+    const thinking = turn.children.find((c) => c.type === 'thinking');
+    expect(thinking).toBeDefined();
+    expect(thinking!.text).toBe('no plan, just react');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Replan as a first-class node (#458)
 // ---------------------------------------------------------------------------
 

--- a/aceclaw-dashboard/tests/useTreeLayout.test.ts
+++ b/aceclaw-dashboard/tests/useTreeLayout.test.ts
@@ -345,6 +345,81 @@ describe('useTreeLayout', () => {
     expect(sequence).toHaveLength(0);
   });
 
+  it('emits ReAct flow edges between iterations under a STEP, not just a turn', () => {
+    // Plan steps each run their own ReAct loop; a step with N
+    // iterations needs the same productive-tool → next-thinking flow
+    // edges that a turn gets. Without these edges, multiple thinkings
+    // under the same step render as visually parallel siblings even
+    // though they're sequential in time. (#458 follow-up — caught
+    // when the user saw "parallel thinkings under a step".)
+    const tool1: ExecutionNode = {
+      id: 'tool-1',
+      type: 'tool',
+      status: 'completed',
+      label: 'read_file',
+      children: [],
+    };
+    const thinking1: ExecutionNode = {
+      id: 'think-1',
+      type: 'thinking',
+      status: 'completed',
+      label: 'iter 1',
+      children: [tool1],
+    };
+    const thinking2: ExecutionNode = {
+      id: 'think-2',
+      type: 'thinking',
+      status: 'completed',
+      label: 'iter 2',
+      children: [],
+    };
+    const step: ExecutionNode = {
+      id: 'step-1',
+      type: 'step',
+      status: 'running',
+      label: 'extract',
+      children: [thinking1, thinking2],
+    };
+    const { result } = renderHook(() => useTreeLayout(tree([step])));
+    // Flow edges are rendered as kind='sequence' (dashed) on the
+    // layout output. At least one should connect the productive tool
+    // of iter 1 to the start of iter 2.
+    const flowEdges = result.current.edges.filter((e) => e.kind === 'sequence');
+    expect(flowEdges.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('does not emit ReAct flow edges between thinkings under a non-loop parent', () => {
+    // Regression guard: only turns and steps host ReAct loops. A
+    // generic node with multiple thinking children (sub-agent here)
+    // shouldn't get flow edges synthesized — those would be wrong
+    // semantically since sub-agents aren't running their own ReAct
+    // loop in the parent's namespace.
+    const thinking1: ExecutionNode = {
+      id: 't1',
+      type: 'thinking',
+      status: 'completed',
+      label: 't1',
+      children: [],
+    };
+    const thinking2: ExecutionNode = {
+      id: 't2',
+      type: 'thinking',
+      status: 'completed',
+      label: 't2',
+      children: [],
+    };
+    const subagent: ExecutionNode = {
+      id: 'sa',
+      type: 'subagent',
+      status: 'running',
+      label: 'sub',
+      children: [thinking1, thinking2],
+    };
+    const { result } = renderHook(() => useTreeLayout(tree([subagent])));
+    const flowEdges = result.current.edges.filter((e) => e.kind === 'sequence');
+    expect(flowEdges).toHaveLength(0);
+  });
+
   it('attaches the dagre coordinates while preserving every ExecutionNode field', () => {
     const root: ExecutionNode = {
       id: 'r',

--- a/aceclaw-dashboard/tests/useTreeLayout.test.ts
+++ b/aceclaw-dashboard/tests/useTreeLayout.test.ts
@@ -388,6 +388,62 @@ describe('useTreeLayout', () => {
     expect(flowEdges.length).toBeGreaterThanOrEqual(1);
   });
 
+  it('skips containment edges from a step to its non-first thinkings', () => {
+    // Pinning the visual contract from the layout's
+    // shouldSkipContainment helper: a step with N iterations should
+    // draw exactly ONE containment edge to its FIRST thinking;
+    // subsequent thinkings reach the user via the flow chain through
+    // the previous iteration's productive tool. Without this skip
+    // the step would visually fan out into N parallel branches even
+    // when the flow edges are also drawn, undoing the chain-shape
+    // that #458 follow-up established.
+    const tool1: ExecutionNode = {
+      id: 'tool-a',
+      type: 'tool',
+      status: 'completed',
+      label: 'read_file',
+      children: [],
+    };
+    const thinking1: ExecutionNode = {
+      id: 'think-1',
+      type: 'thinking',
+      status: 'completed',
+      label: 'iter 1',
+      children: [tool1],
+    };
+    const thinking2: ExecutionNode = {
+      id: 'think-2',
+      type: 'thinking',
+      status: 'completed',
+      label: 'iter 2',
+      children: [],
+    };
+    const thinking3: ExecutionNode = {
+      id: 'think-3',
+      type: 'thinking',
+      status: 'completed',
+      label: 'iter 3',
+      children: [],
+    };
+    const step: ExecutionNode = {
+      id: 'step-1',
+      type: 'step',
+      status: 'running',
+      label: 'extract',
+      children: [thinking1, thinking2, thinking3],
+    };
+    const { result } = renderHook(() => useTreeLayout(tree([step])));
+    // Containment edges from step → thinking should exist for ONLY
+    // the first thinking. The other two are reached via flow edges.
+    const containmentFromStep = result.current.edges.filter(
+      (e) => e.kind === 'containment' && e.id.startsWith('step-1->'),
+    );
+    const stepToThinkingTargets = containmentFromStep
+      .map((e) => e.id.split('->')[1])
+      .filter((target) => target?.startsWith('think-'));
+    expect(stepToThinkingTargets).toEqual(['think-1']);
+  });
+
   it('does not emit ReAct flow edges between thinkings under a non-loop parent', () => {
     // Regression guard: only turns and steps host ReAct loops. A
     // generic node with multiple thinking children (sub-agent here)


### PR DESCRIPTION
## Summary

The task planner was effectively never firing — threshold 5 required two distinct signals, most everyday prompts hit at most one. Two complementary fixes:

### A. Lower the default threshold from 5 → 3

Single-signal compound prompts now plan:
| Prompt | Score | Old (≥5) | New (≥3) |
|---|---|---|---|
| "refactor PermissionBridge" | 3 | ❌ | ✅ |
| "extract validator" | 3 | ❌ | ✅ |
| "do A and then B" | 3 | ❌ | ✅ |
| "fix this bug" | 0 | ❌ | ❌ |
| "what does X do?" | 0 | ❌ | ❌ |

Lowered in two places (kept in sync): `AceClawConfig.DEFAULT_PLANNER_THRESHOLD` (production), `ComplexityEstimator.DEFAULT_THRESHOLD` (no-arg). Updated `ComplexityEstimatorTest.refactoring_highScore` to also assert `shouldPlan() == true` so a future revert is loud.

### B. `/plan <prompt>` slash command

Escape hatch for prompts that don't trip the heuristic but the user knows are plannable.

- **Daemon**: `agent.prompt` params gain optional `forcePlan: boolean`. When `true`, `StreamingAgentHandler.handlePrompt` skips the `ComplexityEstimator` and goes straight to `executePlannedPrompt`. Still gated by `plannerEnabled` so a daemon explicitly turning planning off keeps that behavior. Strictly additive — older daemons see the same payload.
- **CLI**: `TerminalRepl` detects `/plan` prefix, strips it, calls `submitAndWait(..., forcePlan=true)`. Threaded through `TaskManager.submit` and `TaskStreamReader`. The single-arg `submit` path is unchanged for non-/plan callers (zero blast radius).
- Field on the wire is omitted when `false` so the JSON shape doesn't change for normal prompts.
- Help listing (`/help`) now lists `/plan`.

## Test plan

- [x] `ComplexityEstimatorTest`: 12 tests pass with new threshold; refactoring case explicitly pins `shouldPlan() = true`.
- [x] `TaskStreamReaderTest` (new, 3 tests): pins exact `"forcePlan"` field name, that it's omitted by default, and emitted only when `true`.
- [x] `./gradlew :aceclaw-cli:test :aceclaw-core:test :aceclaw-daemon:test` — green
- [x] Dashboard `npx vitest run` — 166 green (no dashboard changes, sanity)
- [ ] Manual: `aceclaw> refactor PermissionBridge` → planner fires. `aceclaw> /plan investigate the cron flow` → planner fires even though "investigate" alone scored only 2.

## Out of scope

- LLM classifier fallback for prompts the heuristic + threshold don't catch (option C from the design discussion). Defer until we see whether A + B together is enough.
- Per-session threshold override. Not yet asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `/plan` command to CLI for explicitly requesting planning on any task, bypassing the automatic complexity check.
  * Improved dashboard visualization of nested planning steps in multi-step task execution flows.

* **Improvements**
  * Lowered planning complexity threshold to trigger planning more frequently for complex tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->