### PR TITLE
chore: restore planner threshold to 5 — /plan is the right escape hatch

### DIFF
--- a/aceclaw-core/src/main/java/dev/aceclaw/core/planner/ComplexityEstimator.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/planner/ComplexityEstimator.java
@@ -16,14 +16,12 @@ public final class ComplexityEstimator {
     /**
      * Default threshold for the no-arg constructor. Mirrors
      * {@code AceClawConfig.DEFAULT_PLANNER_THRESHOLD} — keep the
-     * two in sync. Settled at 4: too low (3) made every single
-     * "refactor X" / "extract Y" trigger a planner LLM call even on
-     * trivial prompts; too high (5) required two explicit signals
-     * which most prompts didn't hit. At 4, a single +3 signal alone
-     * stays as plain ReAct, but adding ANY second signal flips on
-     * planning.
+     * two in sync. Restored to 5 after live testing showed the
+     * planner's extra LLM call is material cost. The {@code /plan}
+     * slash command is the escape hatch for prompts that need
+     * planning but don't trip two heuristic signals.
      */
-    private static final int DEFAULT_THRESHOLD = 4;
+    private static final int DEFAULT_THRESHOLD = 5;
 
     // -- Heuristic patterns ---------------------------------------------------
 

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/planner/ComplexityEstimatorTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/planner/ComplexityEstimatorTest.java
@@ -41,13 +41,12 @@ class ComplexityEstimatorTest {
 
     @Test
     void refactoring_singleSignalDoesNotPlan_atDefaultThreshold() {
-        // The signal IS detected and contributes its 3 points, but at
-        // the default threshold (4) a single +3 signal alone is not
-        // enough to invoke the planner — the planner adds a real
+        // At the default threshold (5) a single +3 signal alone is
+        // not enough to invoke the planner — the planner adds a real
         // LLM-call cost, and "refactor X" can mean trivially small
         // work (REFACTORING regex matches "extract" too, etc.).
-        // Users who want planning on a borderline single-signal prompt
-        // can use the /plan slash command (forcePlan) instead.
+        // Users who want planning on a borderline single-signal
+        // prompt use the /plan slash command (forcePlan) instead.
         var score = estimator.estimate("Refactor the authentication module");
         assertTrue(score.signals().contains("refactoring"));
         assertEquals(3, score.score());
@@ -55,15 +54,15 @@ class ComplexityEstimatorTest {
     }
 
     @Test
-    void refactoring_plusSecondSignal_plans() {
-        // Adding ANY second signal pushes a +3 prompt over threshold 4.
-        // Pins the rule "single +3 signal → no plan; +3 with anything
-        // else → plan" so future threshold tweaks have to reckon with
-        // the assertion explicitly.
+    void refactoring_plusStrongSecondSignal_plans() {
+        // refactoring(3) + testing(2) = 5 hits the default threshold.
+        // Pins the rule "two distinct +2/+3 signals → plan" so future
+        // threshold tweaks have to update an explicit assertion
+        // rather than silently drift the policy.
         var withTesting = estimator.estimate("Refactor the auth module and add tests");
         assertTrue(withTesting.signals().contains("refactoring"));
         assertTrue(withTesting.signals().contains("testing"));
-        assertTrue(withTesting.score() >= 4);
+        assertTrue(withTesting.score() >= 5);
         assertTrue(withTesting.shouldPlan());
     }
 

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
@@ -75,27 +75,27 @@ public final class AceClawConfig {
     private static final boolean DEFAULT_HEARTBEAT_ENABLED = true;
     private static final boolean DEFAULT_PLANNER_ENABLED = true;
     /**
-     * Default complexity score for triggering the planner. Bumped
-     * from 5 → 4 (initially landed at 3, dialled back after review).
+     * Default complexity score for triggering the planner. Restored
+     * to 5 after live testing showed the planner's extra LLM call is
+     * material cost, and lower thresholds either over-triggered (3:
+     * every "extract", "refactor" fired the planner) or were a
+     * borderline middle (4: still triggered on common 3+1 prompts
+     * that didn't really need a separate planning pass).
      *
-     * <p>Threshold 5 required two explicit signals — most everyday
-     * agentic prompts hit at most one, so the planner essentially
-     * never fired. Threshold 3 went too far the other way: every
-     * single "refactor X" / "extract Y" (REFACTORING regex matches
-     * "extract" too) triggered a planner LLM call before any actual
-     * work, even on trivial prompts.
-     *
-     * <p>Threshold 4 is the middle ground: single-signal +3 prompts
-     * ("refactor X" alone) stay as plain ReAct, but adding ANY
-     * second signal (a long description, a second action, multiple
-     * files, testing, …) flips on planning. Users who explicitly
-     * want the planner on a borderline prompt can use
-     * {@code /plan <prompt>} as the escape hatch — that bypasses
-     * this heuristic entirely.
+     * <p>The new model is "explicit by default": at 5, only
+     * unambiguously compound work (two distinct +2/+3 signals)
+     * triggers the heuristic. Everything else stays as plain ReAct
+     * — which is what the agent loop is good at anyway. When the
+     * operator wants planning on a borderline prompt, the
+     * {@code /plan <prompt>} slash command (#467) bypasses the
+     * heuristic entirely. That escape hatch is what makes the
+     * conservative default acceptable: the user has explicit
+     * control on the cases where the heuristic would have been
+     * wrong either way.
      *
      * <p>See {@link ComplexityEstimator} for the score table.
      */
-    private static final int DEFAULT_PLANNER_THRESHOLD = 4;
+    private static final int DEFAULT_PLANNER_THRESHOLD = 5;
     private static final boolean DEFAULT_ADAPTIVE_REPLAN_ENABLED = true;
     private static final boolean DEFAULT_CANDIDATE_INJECTION_ENABLED = true;
     private static final boolean DEFAULT_CANDIDATE_PROMOTION_ENABLED = true;


### PR DESCRIPTION
## Summary

Live-testing follow-up. Planner = extra LLM call; lower thresholds proved either over-triggering (3) or borderline (4). Reverting to 5 with \`/plan <prompt>\` (#467) as the explicit escape hatch.

| Default behaviour | At T=5 |
|---|---|
| Implicit planning | Only on unambiguously compound work (two +2/+3 signals) |
| Borderline single-signal prompt | Plain ReAct |
| User wants planning anyway | \`/plan <prompt>\` |

## Test plan

- [x] \`refactoring_singleSignalDoesNotPlan_atDefaultThreshold\` still asserts \`shouldPlan() == false\` (score 3, threshold 5)
- [x] \`refactoring_plusStrongSecondSignal_plans\` (renamed) asserts \`shouldPlan() == true\` for refactoring + testing (score 5)
- [x] \`./gradlew :aceclaw-core:test :aceclaw-daemon:test :aceclaw-cli:test\` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)