### PR TITLE
chore(planner): default to 4-6 steps, anti over-decomposition

### DIFF
--- a/aceclaw-core/src/main/java/dev/aceclaw/core/planner/PlanningPromptBuilder.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/planner/PlanningPromptBuilder.java
@@ -25,8 +25,9 @@ public final class PlanningPromptBuilder {
             - Order steps logically: research first, then implement, then verify.
             - Keep steps focused: one logical unit of work per step.
             - Default to 4-6 steps. Use 2-3 for narrowly-scoped tasks; only exceed 6 \
-              when the task has genuinely distinct phases (e.g., research → design → \
-              implement → test → deploy). Hard cap is 15.
+              when the task has many genuinely distinct phases \
+              (research, design, implementation, testing, deployment, monitoring, etc. \
+              — and only when each phase is substantively different work). Stay under 15.
             - Do NOT over-decompose. A single step covers "read context, decide, call \
               tools, summarise" as one ReAct iteration. Splitting "read X" and "use X" \
               across separate steps is wrong — they are one step. Trivial bookkeeping \

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/planner/PlanningPromptBuilder.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/planner/PlanningPromptBuilder.java
@@ -13,8 +13,9 @@ public final class PlanningPromptBuilder {
 
     static final String SYSTEM_PROMPT = """
             You are a task planning agent. Your job is to break down a complex goal into \
-            a sequence of concrete, actionable steps. Each step should be achievable in a single \
-            agent turn (one ReAct loop iteration with tool calls).
+            a sequence of concrete, actionable steps. Each step is one full ReAct iteration \
+            — the agent can read context, reason, call several tools, and produce output, \
+            all within ONE step.
 
             Rules:
             - Output ONLY valid JSON. No markdown, no explanation, no preamble.
@@ -23,7 +24,14 @@ public final class PlanningPromptBuilder {
               "requiredTools" (list of tool names), "fallbackApproach" (alternative if primary fails, or null).
             - Order steps logically: research first, then implement, then verify.
             - Keep steps focused: one logical unit of work per step.
-            - Use 2-15 steps. Fewer for simpler tasks, more for complex ones.
+            - Default to 4-6 steps. Use 2-3 for narrowly-scoped tasks; only exceed 6 \
+              when the task has genuinely distinct phases (e.g., research → design → \
+              implement → test → deploy). Hard cap is 15.
+            - Do NOT over-decompose. A single step covers "read context, decide, call \
+              tools, summarise" as one ReAct iteration. Splitting "read X" and "use X" \
+              across separate steps is wrong — they are one step. Trivial bookkeeping \
+              steps ("save the result", "report what happened") are also not steps; \
+              they are part of the surrounding step.
             - Reference actual tool names from the available tools list.
             """;
 

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/planner/PlanningPromptBuilderTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/planner/PlanningPromptBuilderTest.java
@@ -1,0 +1,54 @@
+package dev.aceclaw.core.planner;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Sentinel tests for the planner system prompt. The prompt content
+ * itself is a behaviour-tuning surface — full correctness can only
+ * be verified against a real LLM — but a few key calibration phrases
+ * are worth pinning so a future reverting edit fires a loud build-
+ * time signal instead of silently reintroducing over-decomposition.
+ *
+ * <p>The history that motivates these pins:
+ *   - The original prompt said "Use 2-15 steps. Fewer for simpler
+ *     tasks, more for complex ones." That was too vague — Claude
+ *     gravitated toward the upper-middle (8-12 steps) by default,
+ *     which over-decomposed simple work and ballooned plan-mode
+ *     token cost. Real complaint, real cost.
+ *   - Tightened to default 4-6 with explicit anti-over-decomposition
+ *     language. These tests pin those two anchors.
+ */
+final class PlanningPromptBuilderTest {
+
+    @Test
+    void systemPrompt_anchorsDefaultStepCountAt4to6() {
+        // Without an explicit anchor the LLM falls back to its own
+        // "round-medium-list" bias (≈8-12 items). The "4-6" anchor is
+        // load-bearing for the over-planning fix.
+        assertThat(PlanningPromptBuilder.SYSTEM_PROMPT)
+                .contains("Default to 4-6 steps");
+    }
+
+    @Test
+    void systemPrompt_callsOutAntiOverDecomposition() {
+        // The keyword "over-decompose" is the explicit instruction
+        // against splitting "read X / use X" into separate steps.
+        // Without it the model tends to expand a 3-step task into 8
+        // by adding bookkeeping steps (save, report, summarise).
+        assertThat(PlanningPromptBuilder.SYSTEM_PROMPT)
+                .contains("over-decompose");
+    }
+
+    @Test
+    void systemPrompt_clarifiesOneStepEqualsOneReActIteration() {
+        // The original wording said "achievable in a single agent
+        // turn (one ReAct loop iteration)" — too terse. The model
+        // read "one ReAct iteration" as "one tool call". Now spells
+        // out that a single iteration includes reading, reasoning,
+        // multiple tool calls, and summarising — all within ONE step.
+        assertThat(PlanningPromptBuilder.SYSTEM_PROMPT)
+                .contains("ONE step");
+    }
+}


### PR DESCRIPTION
## Summary

Planner prompt was producing 8-12 step plans for tasks where 3-4 would have done. Cause: original prompt said "Use 2-15 steps. Fewer for simpler tasks, more for complex ones." — too vague, Claude defaulted to its own "round-medium-list" bias.

Cost: every extra unneeded step is an extra ReAct loop = real LLM tokens + real wall time. This was the structural reason \`/plan\` mode felt expensive.

## Changes

System prompt now anchors at **4-6 default** with explicit anti-over-decomposition language:

| Before | After |
|---|---|
| "Use 2-15 steps. Fewer for simpler tasks, more for complex ones." | "Default to 4-6 steps. Use 2-3 for narrowly-scoped tasks; only exceed 6 when the task has genuinely distinct phases (e.g., research → design → implement → test → deploy). Hard cap is 15." |
| (no anti-decomposition guidance) | "Do NOT over-decompose. A single step covers 'read context, decide, call tools, summarise' as one ReAct iteration. Splitting 'read X' and 'use X' across separate steps is wrong — they are one step. Trivial bookkeeping steps ('save the result', 'report what happened') are also not steps; they are part of the surrounding step." |
| "Each step should be achievable in a single agent turn (one ReAct loop iteration with tool calls)." | "Each step is one full ReAct iteration — the agent can read context, reason, call several tools, and produce output, all within ONE step." |

\`TaskPlanParser.MAX_STEPS\` (20) stays as the absolute truncation guard — only behavioural soft-defaults changed.

## Test plan

- [x] 3 new sentinel tests in \`PlanningPromptBuilderTest\` pin the load-bearing phrases ("Default to 4-6 steps", "over-decompose", "ONE step"). A future revert that softens these would fire a build-time signal.
- [x] \`./gradlew :aceclaw-core:test :aceclaw-daemon:test\` — all green
- [ ] Manual: run a few \`/plan\` prompts of varying complexity; observe step counts cluster around 4-6 instead of 8-12

## Out of scope

- Changing the planner threshold (stays at 5; this PR only affects what the planner outputs ONCE it fires)
- Few-shot examples in the prompt — possible follow-up if 4-6 anchor alone isn't enough
- Per-task-complexity step-count heuristics (would need structured task classification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Refined AI task decomposition guidelines to establish clearer constraints on step definitions and execution models, supporting more reliable planning.

* **Tests**
  * Added validation tests to verify planning system prompt maintains accurate decomposition guidance and critical execution constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->