### PR TITLE
feat(security): signed capability audit log v1 (#465 Layer 8)

### DIFF
--- a/aceclaw-security/build.gradle.kts
+++ b/aceclaw-security/build.gradle.kts
@@ -4,5 +4,6 @@ dependencies {
     implementation(project(":aceclaw-core"))
 
     implementation("com.fasterxml.jackson.core:jackson-databind")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     implementation("org.slf4j:slf4j-api")
 }

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/PermissionManager.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/PermissionManager.java
@@ -1,8 +1,10 @@
 package dev.aceclaw.security;
 
+import dev.aceclaw.security.audit.CapabilityAuditLog;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -37,8 +39,26 @@ public final class PermissionManager {
      */
     private final Map<String, Set<String>> sessionApprovals = new ConcurrentHashMap<>();
 
+    /**
+     * Optional signed audit log of every decision (#465 Layer 8 v1).
+     * Null = audit disabled (default for unit tests that construct a
+     * manager without disk I/O setup). When non-null, every call to
+     * {@link #check} records one entry — best-effort, never throws.
+     */
+    private final CapabilityAuditLog auditLog;
+
     public PermissionManager(PermissionPolicy policy) {
+        this(policy, null);
+    }
+
+    /**
+     * Constructs a manager that signs and persists every decision to
+     * {@code auditLog}. Pass {@code null} to disable auditing (this is
+     * what the single-arg constructor does).
+     */
+    public PermissionManager(PermissionPolicy policy, CapabilityAuditLog auditLog) {
         this.policy = policy;
+        this.auditLog = auditLog;
     }
 
     /**
@@ -64,14 +84,50 @@ public final class PermissionManager {
             if (allow != null && allow.contains(request.toolName())) {
                 log.debug("Permission auto-approved (session blanket): tool={}, sessionId={}",
                         request.toolName(), sessionId);
-                return new PermissionDecision.Approved();
+                var decision = new PermissionDecision.Approved();
+                audit(request, sessionId, decision, "session-blanket-approval");
+                return decision;
             }
         }
         var decision = policy.evaluate(request);
         log.debug("Permission check: tool={}, level={}, sessionId={}, decision={}",
                 request.toolName(), request.level(), sessionId,
                 decision.getClass().getSimpleName());
+        audit(request, sessionId, decision, null);
         return decision;
+    }
+
+    /**
+     * Writes one entry to the audit log if one is attached. Flattens
+     * the sealed {@link PermissionDecision} into the on-disk string
+     * form ({@code APPROVED} / {@code DENIED} / {@code NEEDS_APPROVAL})
+     * and chooses the {@code reason} field: caller-supplied note
+     * (for the session-blanket branch), the denial reason (for
+     * Denied), the prompt (for NeedsUserApproval), or null.
+     */
+    private void audit(
+            PermissionRequest request,
+            String sessionId,
+            PermissionDecision decision,
+            String approvalNote) {
+        if (auditLog == null) return;
+        String kind;
+        String reason;
+        switch (decision) {
+            case PermissionDecision.Approved a -> {
+                kind = "APPROVED";
+                reason = approvalNote;
+            }
+            case PermissionDecision.Denied d -> {
+                kind = "DENIED";
+                reason = d.reason();
+            }
+            case PermissionDecision.NeedsUserApproval n -> {
+                kind = "NEEDS_APPROVAL";
+                reason = n.prompt();
+            }
+        }
+        auditLog.record(Instant.now(), sessionId, request.toolName(), request.level(), kind, reason);
     }
 
     /**

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/PermissionManager.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/PermissionManager.java
@@ -114,7 +114,7 @@ public final class PermissionManager {
         String kind;
         String reason;
         switch (decision) {
-            case PermissionDecision.Approved a -> {
+            case PermissionDecision.Approved _ -> {
                 kind = "APPROVED";
                 reason = approvalNote;
             }

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/audit/AuditLogSigner.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/audit/AuditLogSigner.java
@@ -1,0 +1,105 @@
+package dev.aceclaw.security.audit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.HexFormat;
+import java.util.Set;
+
+/**
+ * HMAC-SHA256 signer for capability audit entries (#465 Layer 8 v1).
+ *
+ * <p>Mirrors {@code MemorySigner}'s pattern but with its own per-
+ * installation key file at {@code ~/.aceclaw/audit/audit.key}. Two
+ * independent keys (one for memory, one for audit) means a leak of
+ * either doesn't compromise the other, and they can be rotated on
+ * different cadences. POSIX 600 on the key file by default; on
+ * non-POSIX filesystems we fall back to whatever default the JVM
+ * gives us and log a warning.
+ *
+ * <p>Verification uses constant-time comparison
+ * ({@link MessageDigest#isEqual}) to prevent timing side-channels —
+ * same protection {@code MemorySigner} provides.
+ */
+public final class AuditLogSigner {
+
+    private static final Logger log = LoggerFactory.getLogger(AuditLogSigner.class);
+    private static final String ALGORITHM = "HmacSHA256";
+    /** 32 bytes = 256 bits, matches HMAC-SHA256 native key size. */
+    private static final int KEY_BYTES = 32;
+
+    private final SecretKeySpec keySpec;
+
+    public AuditLogSigner(byte[] secret) {
+        if (secret == null || secret.length == 0) {
+            throw new IllegalArgumentException("secret must not be null or empty");
+        }
+        this.keySpec = new SecretKeySpec(secret, ALGORITHM);
+    }
+
+    /**
+     * Loads the signing key from {@code keyPath}, generating + persisting
+     * a fresh 32-byte random key if the file doesn't exist. The parent
+     * directory is created if needed; the key file is set to POSIX 600
+     * on filesystems that support it.
+     */
+    public static AuditLogSigner loadOrCreate(Path keyPath) throws IOException {
+        if (Files.exists(keyPath)) {
+            byte[] secret = Files.readAllBytes(keyPath);
+            if (secret.length == 0) {
+                throw new IOException("Audit key file is empty: " + keyPath);
+            }
+            return new AuditLogSigner(secret);
+        }
+        Files.createDirectories(keyPath.getParent());
+        byte[] freshKey = new byte[KEY_BYTES];
+        new SecureRandom().nextBytes(freshKey);
+        Files.write(keyPath, freshKey);
+        try {
+            Files.setPosixFilePermissions(keyPath, Set.of(
+                    PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE));
+        } catch (UnsupportedOperationException e) {
+            // Non-POSIX filesystem (Windows). Log so operators know the
+            // key file inherits whatever ACL the parent directory had.
+            log.warn("Audit key file at {} is not POSIX; inherited filesystem ACL applies.", keyPath);
+        }
+        return new AuditLogSigner(freshKey);
+    }
+
+    /** Computes the HMAC-SHA256 hex digest for {@code payload}. */
+    public String sign(String payload) {
+        try {
+            Mac mac = Mac.getInstance(ALGORITHM);
+            mac.init(keySpec);
+            byte[] hash = mac.doFinal(payload.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            throw new RuntimeException("HMAC-SHA256 signing failed", e);
+        }
+    }
+
+    /**
+     * Constant-time HMAC verification. {@code expectedHmac} is treated
+     * as the suspect value; {@code payload} is rehashed under our key
+     * and the two are compared byte-by-byte without short-circuiting.
+     */
+    public boolean verify(String payload, String expectedHmac) {
+        if (expectedHmac == null) return false;
+        String actual = sign(payload);
+        return MessageDigest.isEqual(
+                actual.getBytes(StandardCharsets.UTF_8),
+                expectedHmac.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/audit/CapabilityAuditEntry.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/audit/CapabilityAuditEntry.java
@@ -71,21 +71,45 @@ public record CapabilityAuditEntry(
     }
 
     /**
-     * Returns the canonical string used as the HMAC input. Field order
-     * is fixed and tab-separated to keep the encoding unambiguous;
-     * any rearrangement here MUST be matched on the verifier side.
+     * Returns the canonical string used as the HMAC input. Encoding
+     * is length-prefixed so that no choice of nullable / variable-width
+     * field values can collide:
      *
-     * <p>Null fields are encoded as the literal string {@code "null"}
-     * so a field that flips between null and present produces a
-     * different signature.
+     * <pre>
+     *   nullable string s → "-" if null, else "&lt;codeUnitLength&gt;:&lt;s&gt;"
+     *   non-null fields   → ":&lt;value&gt;" (length omitted, fixed shape)
+     *   joined with the literal pipe '|' character
+     * </pre>
+     *
+     * <p>The earlier scheme used tab-joined raw values with the
+     * literal string {@code "null"} for absent fields, which let
+     * {@code sessionId = null} collide with {@code sessionId = "null"},
+     * and let a tab inside a {@code reason} collide with the
+     * separator. The length prefix on each nullable field makes both
+     * collision classes impossible: an attacker can no longer forge
+     * one entry's signature into another.
+     *
+     * <p>Field order is fixed; any rearrangement here MUST be matched
+     * on the verifier side.
      */
     public String signablePayload() {
-        return String.join("\t",
-                timestamp.toString(),
-                sessionId == null ? "null" : sessionId,
-                toolName,
-                level.name(),
-                decisionKind,
-                reason == null ? "null" : reason);
+        return String.join("|",
+                ":" + timestamp.toString(),
+                encodeNullable(sessionId),
+                encodeLen(toolName),
+                ":" + level.name(),
+                ":" + decisionKind,
+                encodeNullable(reason));
+    }
+
+    private static String encodeNullable(String s) {
+        return s == null ? "-" : encodeLen(s);
+    }
+
+    private static String encodeLen(String s) {
+        // Length is char-count of the canonical string; HMAC then
+        // operates on the UTF-8 bytes of the whole joined payload,
+        // so any unicode in the value is folded in unchanged.
+        return s.length() + ":" + s;
     }
 }

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/audit/CapabilityAuditEntry.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/audit/CapabilityAuditEntry.java
@@ -1,0 +1,89 @@
+package dev.aceclaw.security.audit;
+
+import dev.aceclaw.security.PermissionLevel;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * One signed record in the capability audit log (#465 Layer 8 v1).
+ *
+ * <p>Today every {@link dev.aceclaw.security.PermissionManager#check} call
+ * produces an entry. When the runtime-governance epic later introduces
+ * {@code CapabilityRequest}, those richer requests will produce richer
+ * entries — but this v1 schema covers the single most-asked-for thing:
+ * a tamper-evident record of every permission decision the daemon made.
+ *
+ * <h3>Schema</h3>
+ *
+ * <ul>
+ *   <li>{@code timestamp} — wall-clock instant of the decision (ISO-8601
+ *       on the wire).</li>
+ *   <li>{@code sessionId} — owning session, or {@code null} for daemon-
+ *       internal checks that don't belong to any session.</li>
+ *   <li>{@code toolName} — the tool the request was for.</li>
+ *   <li>{@code level} — the request's {@link PermissionLevel} (READ / WRITE
+ *       / EXECUTE / DANGEROUS).</li>
+ *   <li>{@code decisionKind} — the resulting decision flattened to a
+ *       string ({@code "APPROVED"} / {@code "DENIED"} /
+ *       {@code "NEEDS_APPROVAL"}). Strings instead of the sealed type
+ *       so the on-disk format isn't tied to the JVM type identity.</li>
+ *   <li>{@code reason} — denial / approval reason, or {@code null}.</li>
+ *   <li>{@code signature} — HMAC-SHA256 hex of every other field,
+ *       computed via {@link AuditLogSigner}. Verified on read; an entry
+ *       with a bad signature has been tampered with (or written by a
+ *       different installation's key) and gets dropped from query
+ *       results.</li>
+ * </ul>
+ *
+ * <p>The signed payload is assembled by {@link #signablePayload()} —
+ * the same implementation must be used by signer and verifier. Field
+ * order matters for HMAC reproducibility; see that method's doc.
+ */
+public record CapabilityAuditEntry(
+        Instant timestamp,
+        String sessionId,
+        String toolName,
+        PermissionLevel level,
+        String decisionKind,
+        String reason,
+        String signature) {
+
+    public CapabilityAuditEntry {
+        Objects.requireNonNull(timestamp, "timestamp");
+        Objects.requireNonNull(toolName, "toolName");
+        Objects.requireNonNull(level, "level");
+        Objects.requireNonNull(decisionKind, "decisionKind");
+        Objects.requireNonNull(signature, "signature");
+        // sessionId and reason intentionally nullable — captured above.
+    }
+
+    /**
+     * Returns this entry with {@code signature} replaced. Used by the
+     * signer to populate the signature after building the unsigned
+     * shape of the entry.
+     */
+    public CapabilityAuditEntry withSignature(String newSignature) {
+        return new CapabilityAuditEntry(
+                timestamp, sessionId, toolName, level, decisionKind, reason, newSignature);
+    }
+
+    /**
+     * Returns the canonical string used as the HMAC input. Field order
+     * is fixed and tab-separated to keep the encoding unambiguous;
+     * any rearrangement here MUST be matched on the verifier side.
+     *
+     * <p>Null fields are encoded as the literal string {@code "null"}
+     * so a field that flips between null and present produces a
+     * different signature.
+     */
+    public String signablePayload() {
+        return String.join("\t",
+                timestamp.toString(),
+                sessionId == null ? "null" : sessionId,
+                toolName,
+                level.name(),
+                decisionKind,
+                reason == null ? "null" : reason);
+    }
+}

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/audit/CapabilityAuditEntry.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/audit/CapabilityAuditEntry.java
@@ -59,11 +59,13 @@ public record CapabilityAuditEntry(
     }
 
     /**
-     * Returns this entry with {@code signature} replaced. Used by the
-     * signer to populate the signature after building the unsigned
-     * shape of the entry.
+     * Returns this entry with {@code signature} replaced. Package-
+     * private on purpose — only {@link CapabilityAuditLog} should use
+     * it, as part of the build-then-sign flow. Exposing this publicly
+     * would let callers craft signed entries off-the-side, bypassing
+     * the audit log's lock and write path.
      */
-    public CapabilityAuditEntry withSignature(String newSignature) {
+    CapabilityAuditEntry withSignature(String newSignature) {
         return new CapabilityAuditEntry(
                 timestamp, sessionId, toolName, level, decisionKind, reason, newSignature);
     }

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/audit/CapabilityAuditLog.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/audit/CapabilityAuditLog.java
@@ -50,9 +50,11 @@ public final class CapabilityAuditLog {
 
     /**
      * Creates an audit log rooted at {@code auditDir}. The directory
-     * and key file are created lazily on first write — no disk side-
-     * effects from construction alone, so unit tests can build one
-     * with a tmp dir without requiring real filesystem state up front.
+     * and key file are materialised up front — {@code auditDir} is
+     * created if missing and the signing key is written to
+     * {@code audit.key} on first call (POSIX 600 where supported).
+     * Only the JSONL file itself is lazy: it appears on the first
+     * {@link #record} call.
      */
     public static CapabilityAuditLog create(Path auditDir) throws IOException {
         Objects.requireNonNull(auditDir, "auditDir");

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/audit/CapabilityAuditLog.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/audit/CapabilityAuditLog.java
@@ -1,0 +1,161 @@
+package dev.aceclaw.security.audit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import dev.aceclaw.security.PermissionLevel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Append-only signed audit log for capability decisions (#465 Layer 8 v1).
+ *
+ * <p>Mirrors the {@code InjectionAuditLog} pattern used for memory
+ * candidate injections — JSONL on disk, ReentrantLock around append
+ * for concurrent virtual threads, lazy directory creation. The
+ * differentiator vs. that log is signing: every entry is HMAC-SHA256
+ * signed at write time and verified on read. Tampered or wrong-key
+ * entries are dropped from query results with a warning so a corrupted
+ * file doesn't poison reporting.
+ *
+ * <p>On-disk location: {@code ~/.aceclaw/audit/capability-audit.jsonl}
+ * with the signing key at {@code ~/.aceclaw/audit/audit.key}.
+ *
+ * <p>This v1 attaches to the existing {@link dev.aceclaw.security.PermissionManager#check}
+ * path. When the runtime-governance epic introduces unified
+ * {@code CapabilityRequest}, the same log naturally extends to record
+ * those richer requests too — schema is forward-additive (new fields
+ * are added to {@link CapabilityAuditEntry}'s signable payload, old
+ * keys removed only by version bump).
+ */
+public final class CapabilityAuditLog {
+
+    private static final Logger log = LoggerFactory.getLogger(CapabilityAuditLog.class);
+    private static final String AUDIT_FILE = "capability-audit.jsonl";
+    private static final String KEY_FILE = "audit.key";
+
+    private final Path auditFile;
+    private final AuditLogSigner signer;
+    private final ObjectMapper mapper;
+    private final ReentrantLock writeLock = new ReentrantLock();
+
+    /**
+     * Creates an audit log rooted at {@code auditDir}. The directory
+     * and key file are created lazily on first write — no disk side-
+     * effects from construction alone, so unit tests can build one
+     * with a tmp dir without requiring real filesystem state up front.
+     */
+    public static CapabilityAuditLog create(Path auditDir) throws IOException {
+        Objects.requireNonNull(auditDir, "auditDir");
+        Files.createDirectories(auditDir);
+        AuditLogSigner signer = AuditLogSigner.loadOrCreate(auditDir.resolve(KEY_FILE));
+        return new CapabilityAuditLog(auditDir.resolve(AUDIT_FILE), signer);
+    }
+
+    /** Visible for testing — production code should use {@link #create}. */
+    CapabilityAuditLog(Path auditFile, AuditLogSigner signer) {
+        this.auditFile = Objects.requireNonNull(auditFile, "auditFile");
+        this.signer = Objects.requireNonNull(signer, "signer");
+        this.mapper = new ObjectMapper().registerModule(new JavaTimeModule());
+    }
+
+    /**
+     * Signs and appends one decision. The signature is computed over
+     * {@link CapabilityAuditEntry#signablePayload()}, then attached.
+     * Best-effort: an IO failure logs a warning rather than throwing,
+     * because the calling permission check has already produced its
+     * decision and the agent shouldn't be aborted by a degraded log.
+     */
+    public void record(
+            Instant timestamp,
+            String sessionId,
+            String toolName,
+            PermissionLevel level,
+            String decisionKind,
+            String reason) {
+        // Build with a placeholder signature, sign the canonical
+        // payload, then re-emit with the real signature attached.
+        // Two-step is necessary because the signature is a field of
+        // the entry but is also derived from its other fields.
+        var unsigned = new CapabilityAuditEntry(
+                timestamp, sessionId, toolName, level, decisionKind, reason, "unsigned");
+        var entry = unsigned.withSignature(signer.sign(unsigned.signablePayload()));
+        appendEntry(entry);
+    }
+
+    /**
+     * Returns all entries from the log whose signature verifies under
+     * the current key. Tampered, malformed, or wrong-key entries are
+     * skipped with a warning — they don't fail the read. Order matches
+     * disk order (append order = decision order).
+     *
+     * <p>Returns an empty list if the file doesn't exist yet.
+     */
+    public List<CapabilityAuditEntry> readVerified() {
+        if (!Files.isRegularFile(auditFile)) {
+            return List.of();
+        }
+        var verified = new ArrayList<CapabilityAuditEntry>();
+        try {
+            int lineNo = 0;
+            int dropped = 0;
+            for (String line : Files.readAllLines(auditFile)) {
+                lineNo++;
+                if (line.isBlank()) continue;
+                CapabilityAuditEntry entry;
+                try {
+                    entry = mapper.readValue(line, CapabilityAuditEntry.class);
+                } catch (IOException parseError) {
+                    log.warn("Audit log {} line {} is malformed; dropping. cause={}",
+                            auditFile, lineNo, parseError.getMessage());
+                    dropped++;
+                    continue;
+                }
+                if (!signer.verify(entry.signablePayload(), entry.signature())) {
+                    log.warn("Audit log {} line {} failed signature verification; dropping",
+                            auditFile, lineNo);
+                    dropped++;
+                    continue;
+                }
+                verified.add(entry);
+            }
+            if (dropped > 0) {
+                log.warn("Dropped {} of {} audit entries from {} due to verification failure",
+                        dropped, lineNo, auditFile);
+            }
+        } catch (IOException e) {
+            log.warn("Failed to read audit log {}: {}", auditFile, e.getMessage());
+        }
+        return verified;
+    }
+
+    /** Path to the audit file (may not exist yet if no entries written). */
+    public Path auditFile() {
+        return auditFile;
+    }
+
+    private void appendEntry(CapabilityAuditEntry entry) {
+        writeLock.lock();
+        try {
+            // Parent dir was created in factory but tolerate manual
+            // deletion between create() and first record() — a missing
+            // parent directory should not crash the daemon.
+            Files.createDirectories(auditFile.getParent());
+            Files.writeString(auditFile, mapper.writeValueAsString(entry) + "\n",
+                    StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+        } catch (IOException e) {
+            log.warn("Failed to write capability audit entry: {}", e.getMessage());
+        } finally {
+            writeLock.unlock();
+        }
+    }
+}

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/PermissionManagerAuditTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/PermissionManagerAuditTest.java
@@ -1,0 +1,139 @@
+package dev.aceclaw.security;
+
+import dev.aceclaw.security.audit.CapabilityAuditEntry;
+import dev.aceclaw.security.audit.CapabilityAuditLog;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Tests that {@link PermissionManager} writes one signed audit entry
+ * per {@code .check()} call when an audit log is attached, and that
+ * the three sealed {@link PermissionDecision} variants flatten to
+ * the right on-disk representation.
+ *
+ * <p>This is the integration boundary for #465 Layer 8 v1: every
+ * call site of permission checks goes through {@code PermissionManager},
+ * so this is the single point where audit coverage is enforced. If
+ * a future refactor removes the audit hook here, the audit log silently
+ * stops growing — these tests catch that regression.
+ */
+final class PermissionManagerAuditTest {
+
+    private static final PermissionRequest READ_REQ =
+            PermissionRequest.read("read_file", "read /tmp/foo");
+    private static final PermissionRequest WRITE_REQ =
+            PermissionRequest.write("write_file", "write /tmp/foo");
+    private static final PermissionRequest EXEC_REQ =
+            PermissionRequest.execute("bash", "rm /tmp/foo");
+
+    private static final PermissionPolicy APPROVE_POLICY = req ->
+            new PermissionDecision.Approved();
+    private static final PermissionPolicy DENY_POLICY = req ->
+            new PermissionDecision.Denied("policy denies");
+    private static final PermissionPolicy NEEDS_APPROVAL_POLICY = req ->
+            new PermissionDecision.NeedsUserApproval("approve write to /tmp/foo?");
+
+    @Test
+    void approvedDecisionIsRecordedAsApproved(@TempDir Path tmp) throws IOException {
+        var auditLog = CapabilityAuditLog.create(tmp);
+        var pm = new PermissionManager(APPROVE_POLICY, auditLog);
+
+        pm.check(READ_REQ, "sess-1");
+
+        List<CapabilityAuditEntry> entries = auditLog.readVerified();
+        assertThat(entries).hasSize(1);
+        var e = entries.getFirst();
+        assertThat(e.decisionKind()).isEqualTo("APPROVED");
+        assertThat(e.toolName()).isEqualTo("read_file");
+        assertThat(e.level()).isEqualTo(PermissionLevel.READ);
+        assertThat(e.sessionId()).isEqualTo("sess-1");
+        // No reason attached for plain policy-approved decisions.
+        assertThat(e.reason()).isNull();
+    }
+
+    @Test
+    void deniedDecisionRecordsTheDenialReason(@TempDir Path tmp) throws IOException {
+        var auditLog = CapabilityAuditLog.create(tmp);
+        var pm = new PermissionManager(DENY_POLICY, auditLog);
+
+        pm.check(EXEC_REQ, "sess-1");
+
+        var entry = auditLog.readVerified().getFirst();
+        assertThat(entry.decisionKind()).isEqualTo("DENIED");
+        // The reason from PermissionDecision.Denied makes it onto disk
+        // so post-mortem queries can group denials by cause.
+        assertThat(entry.reason()).isEqualTo("policy denies");
+    }
+
+    @Test
+    void needsUserApprovalRecordsThePromptText(@TempDir Path tmp) throws IOException {
+        var auditLog = CapabilityAuditLog.create(tmp);
+        var pm = new PermissionManager(NEEDS_APPROVAL_POLICY, auditLog);
+
+        pm.check(WRITE_REQ, "sess-1");
+
+        var entry = auditLog.readVerified().getFirst();
+        assertThat(entry.decisionKind()).isEqualTo("NEEDS_APPROVAL");
+        assertThat(entry.reason()).isEqualTo("approve write to /tmp/foo?");
+    }
+
+    @Test
+    void sessionBlanketApprovalIsTaggedInTheReasonField(@TempDir Path tmp) throws IOException {
+        // The session-blanket branch short-circuits before the policy
+        // — auditors need to be able to distinguish "user clicked
+        // Always Allow earlier" from "policy auto-approved", because
+        // the trust models differ.
+        var auditLog = CapabilityAuditLog.create(tmp);
+        var pm = new PermissionManager(DENY_POLICY, auditLog);
+        pm.approveForSession("sess-1", "write_file");
+
+        pm.check(WRITE_REQ, "sess-1");
+
+        var entry = auditLog.readVerified().getFirst();
+        assertThat(entry.decisionKind()).isEqualTo("APPROVED");
+        assertThat(entry.reason()).isEqualTo("session-blanket-approval");
+    }
+
+    @Test
+    void nullSessionIdIsRecordedAsNull(@TempDir Path tmp) throws IOException {
+        var auditLog = CapabilityAuditLog.create(tmp);
+        var pm = new PermissionManager(APPROVE_POLICY, auditLog);
+
+        pm.check(READ_REQ, null);
+
+        var entry = auditLog.readVerified().getFirst();
+        assertThat(entry.sessionId()).isNull();
+    }
+
+    @Test
+    void noAuditLogAttachedIsANoOp() {
+        // Single-arg constructor (or null) means audit is disabled.
+        // The check itself must still work end-to-end without throwing.
+        var pm = new PermissionManager(APPROVE_POLICY);
+
+        assertThatCode(() -> pm.check(READ_REQ, "sess-1")).doesNotThrowAnyException();
+        assertThat(pm.check(WRITE_REQ, "sess-1"))
+                .isInstanceOf(PermissionDecision.Approved.class);
+    }
+
+    @Test
+    void everyCheckCallProducesExactlyOneEntry(@TempDir Path tmp) throws IOException {
+        var auditLog = CapabilityAuditLog.create(tmp);
+        var pm = new PermissionManager(APPROVE_POLICY, auditLog);
+
+        for (int i = 0; i < 5; i++) {
+            pm.check(READ_REQ, "sess-" + i);
+        }
+
+        // Sanity: 5 calls in, 5 entries out — no dropping, no
+        // double-writing.
+        assertThat(auditLog.readVerified()).hasSize(5);
+    }
+}

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/audit/AuditLogSignerTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/audit/AuditLogSignerTest.java
@@ -1,0 +1,143 @@
+package dev.aceclaw.security.audit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link AuditLogSigner} — HMAC-SHA256 signing for capability
+ * audit entries (#465 Layer 8 v1).
+ *
+ * <p>Mirror coverage of the existing {@code MemorySignerTest} pattern.
+ * The audit log's tamper-evidence story rests entirely on this class:
+ * if signature roundtrip breaks, every entry past that release is
+ * indistinguishable from a forgery, so these are sentinel tests.
+ */
+final class AuditLogSignerTest {
+
+    @Test
+    void signAndVerifyRoundtrip() {
+        var signer = new AuditLogSigner("test-key-bytes".getBytes());
+        String payload = "tool=bash\tlevel=EXECUTE\tdecision=APPROVED";
+        String sig = signer.sign(payload);
+        assertThat(signer.verify(payload, sig)).isTrue();
+    }
+
+    @Test
+    void verifyRejectsTamperedPayload() {
+        var signer = new AuditLogSigner("test-key-bytes".getBytes());
+        String original = "tool=bash\tlevel=EXECUTE\tdecision=DENIED";
+        String tampered = "tool=bash\tlevel=EXECUTE\tdecision=APPROVED";
+        String sig = signer.sign(original);
+        assertThat(signer.verify(tampered, sig))
+                .as("flipping DENIED→APPROVED must invalidate the signature")
+                .isFalse();
+    }
+
+    @Test
+    void verifyRejectsWrongSignature() {
+        var signer = new AuditLogSigner("test-key-bytes".getBytes());
+        String payload = "anything";
+        assertThat(signer.verify(payload, "deadbeef")).isFalse();
+    }
+
+    @Test
+    void verifyHandlesNullSignatureWithoutThrowing() {
+        var signer = new AuditLogSigner("test-key-bytes".getBytes());
+        // A malformed line that's missing the signature field
+        // shouldn't crash the verifier — readVerified() relies on
+        // verify() being null-safe to drop those entries cleanly.
+        assertThat(signer.verify("payload", null)).isFalse();
+    }
+
+    @Test
+    void differentKeysProduceDifferentSignatures() {
+        var signerA = new AuditLogSigner("key-A-bytes".getBytes());
+        var signerB = new AuditLogSigner("key-B-bytes".getBytes());
+        String payload = "shared-payload";
+        // Each installation has its own key, so an entry signed by
+        // installation A must not verify under installation B's
+        // signer — confirming key isolation.
+        assertThat(signerA.sign(payload)).isNotEqualTo(signerB.sign(payload));
+        assertThat(signerB.verify(payload, signerA.sign(payload))).isFalse();
+    }
+
+    @Test
+    void constructorRejectsEmptySecret() {
+        assertThatThrownBy(() -> new AuditLogSigner(new byte[0]))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new AuditLogSigner(null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void loadOrCreateGeneratesFreshKeyWhenMissing(@TempDir Path tmp) throws IOException {
+        Path keyFile = tmp.resolve("audit.key");
+        assertThat(Files.exists(keyFile)).isFalse();
+
+        AuditLogSigner signer = AuditLogSigner.loadOrCreate(keyFile);
+
+        assertThat(Files.exists(keyFile)).isTrue();
+        // 32 bytes = HMAC-SHA256's native key size; we'd rather trip
+        // a test than silently downgrade the key strength.
+        assertThat(Files.size(keyFile)).isEqualTo(32);
+        // Smoke check the returned signer is usable.
+        String payload = "hello";
+        assertThat(signer.verify(payload, signer.sign(payload))).isTrue();
+    }
+
+    @Test
+    void loadOrCreateReusesExistingKey(@TempDir Path tmp) throws IOException {
+        Path keyFile = tmp.resolve("audit.key");
+        AuditLogSigner first = AuditLogSigner.loadOrCreate(keyFile);
+        String firstSig = first.sign("payload");
+
+        // Second load must reuse the on-disk key (otherwise a daemon
+        // restart would invalidate every prior audit entry).
+        AuditLogSigner second = AuditLogSigner.loadOrCreate(keyFile);
+        assertThat(second.sign("payload")).isEqualTo(firstSig);
+        assertThat(second.verify("payload", firstSig)).isTrue();
+    }
+
+    @Test
+    void loadOrCreateSetsPosixPermissionsOnFreshKey(@TempDir Path tmp) throws IOException {
+        Path keyFile = tmp.resolve("audit.key");
+        AuditLogSigner.loadOrCreate(keyFile);
+
+        // The key contains the only thing protecting the audit log
+        // from forgery — POSIX 600 keeps it out of reach of other
+        // local users on shared workstations.
+        try {
+            Set<PosixFilePermission> perms = Files.getPosixFilePermissions(keyFile);
+            assertThat(perms)
+                    .containsExactlyInAnyOrder(
+                            PosixFilePermission.OWNER_READ,
+                            PosixFilePermission.OWNER_WRITE);
+        } catch (UnsupportedOperationException nonPosix) {
+            // Windows test runner — the implementation logs a warning
+            // instead of failing; nothing to assert on that path.
+        }
+    }
+
+    @Test
+    void loadOrCreateRejectsZeroByteKeyFile(@TempDir Path tmp) throws IOException {
+        // A truncated-to-zero key file would silently work with an
+        // empty SecretKeySpec under some JDK versions and produce
+        // garbage signatures. Better to fail loudly so the operator
+        // knows the audit chain is broken.
+        Path keyFile = tmp.resolve("audit.key");
+        Files.createFile(keyFile);
+
+        assertThatThrownBy(() -> AuditLogSigner.loadOrCreate(keyFile))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("empty");
+    }
+}

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/audit/CapabilityAuditEntryTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/audit/CapabilityAuditEntryTest.java
@@ -1,0 +1,88 @@
+package dev.aceclaw.security.audit;
+
+import dev.aceclaw.security.PermissionLevel;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link CapabilityAuditEntry#signablePayload()} — the
+ * canonical HMAC input. Sentinel coverage for the encoding-collision
+ * class that the v1 PR's tab-joined scheme allowed (Codex P2 finding):
+ *
+ * <ul>
+ *   <li>null vs. literal {@code "null"} for the same field MUST sign
+ *       to different payloads;</li>
+ *   <li>a separator-character ({@code |}) inside a user-supplied field
+ *       MUST NOT bleed into the next field;</li>
+ *   <li>shifting characters between two adjacent variable-length
+ *       fields MUST produce a distinct payload (length-prefix
+ *       guarantees this).</li>
+ * </ul>
+ *
+ * <p>If any of these regress, an attacker who controls user-supplied
+ * fields (sessionId / toolName / reason) can craft two semantically
+ * distinct entries that share an HMAC — exactly the tamper-evidence
+ * break the audit log exists to prevent.
+ */
+final class CapabilityAuditEntryTest {
+
+    private static final Instant FIXED_TS = Instant.parse("2026-05-01T00:00:00Z");
+
+    private static CapabilityAuditEntry entry(String sessionId, String toolName, String reason) {
+        return new CapabilityAuditEntry(
+                FIXED_TS, sessionId, toolName, PermissionLevel.EXECUTE,
+                "APPROVED", reason, "unsigned");
+    }
+
+    @Test
+    void nullSessionIdDoesNotCollideWithLiteralNullString() {
+        // The pre-fix encoding wrote both as the bare string "null"
+        // separated by tabs, so an attacker editing JSON to swap
+        // sessionId between (real) null and the string "null" would
+        // not invalidate the signature. Length-prefix encoding with
+        // a dedicated null marker ("-") makes them distinguishable.
+        var withRealNull = entry(null, "bash", null);
+        var withStringNull = entry("null", "bash", "null");
+
+        assertThat(withRealNull.signablePayload())
+                .isNotEqualTo(withStringNull.signablePayload());
+    }
+
+    @Test
+    void separatorCharInUserFieldDoesNotCollideWithFieldBoundary() {
+        // sessionId="A|B" must not be signature-equivalent to two
+        // adjacent fields that happen to read "A" and "B". Without
+        // length prefixes, '|' inside a value would have aliased
+        // with the field separator.
+        var withPipeInside = entry("A|B", "bash", null);
+        var withDifferentSplit = entry("A", "B", null);
+
+        assertThat(withPipeInside.signablePayload())
+                .isNotEqualTo(withDifferentSplit.signablePayload());
+    }
+
+    @Test
+    void shiftingCharactersBetweenAdjacentNullableFieldsProducesDifferentPayload() {
+        // sessionId="AB", reason="" vs sessionId="A", reason="B".
+        // With raw concatenation these would alias; with length
+        // prefixes (2:AB vs 1:A...1:B) they don't.
+        var packedLeft = entry("AB", "bash", "");
+        var packedRight = entry("A", "bash", "B");
+
+        assertThat(packedLeft.signablePayload())
+                .isNotEqualTo(packedRight.signablePayload());
+    }
+
+    @Test
+    void identicalEntriesProduceIdenticalPayload() {
+        // Sanity baseline — without this the other tests prove
+        // nothing (everything could be different by accident).
+        var a = entry("sess-1", "bash", "blocked");
+        var b = entry("sess-1", "bash", "blocked");
+
+        assertThat(a.signablePayload()).isEqualTo(b.signablePayload());
+    }
+}

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/audit/CapabilityAuditLogTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/audit/CapabilityAuditLogTest.java
@@ -1,0 +1,158 @@
+package dev.aceclaw.security.audit;
+
+import dev.aceclaw.security.PermissionLevel;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link CapabilityAuditLog} — the signed JSONL append store
+ * that anchors #465 Layer 8 v1. These cover:
+ *
+ * <ul>
+ *   <li>round-trip: what we wrote is what we read, with the signature
+ *       intact and the schema fields preserved (timestamp, sessionId
+ *       nullable, tool, level, decision kind, reason);</li>
+ *   <li>tamper detection: a hand-edited line is dropped from the
+ *       verified read so reporting can't be poisoned;</li>
+ *   <li>missing-file behaviour: queries before any write don't crash;</li>
+ *   <li>concurrency: parallel virtual-thread appends produce one
+ *       valid line per call, none lost or interleaved.</li>
+ * </ul>
+ */
+final class CapabilityAuditLogTest {
+
+    @Test
+    void recordAndReadRoundtripPreservesAllFields(@TempDir Path tmp) throws IOException {
+        var auditLog = CapabilityAuditLog.create(tmp);
+
+        Instant ts = Instant.parse("2026-05-01T12:34:56Z");
+        auditLog.record(ts, "sess-A", "bash", PermissionLevel.EXECUTE, "APPROVED", null);
+
+        List<CapabilityAuditEntry> entries = auditLog.readVerified();
+        assertThat(entries).hasSize(1);
+        var e = entries.getFirst();
+        assertThat(e.timestamp()).isEqualTo(ts);
+        assertThat(e.sessionId()).isEqualTo("sess-A");
+        assertThat(e.toolName()).isEqualTo("bash");
+        assertThat(e.level()).isEqualTo(PermissionLevel.EXECUTE);
+        assertThat(e.decisionKind()).isEqualTo("APPROVED");
+        assertThat(e.reason()).isNull();
+        assertThat(e.signature()).isNotBlank();
+    }
+
+    @Test
+    void preservesAppendOrderAcrossMultipleWrites(@TempDir Path tmp) throws IOException {
+        var auditLog = CapabilityAuditLog.create(tmp);
+        auditLog.record(Instant.now(), "s", "read_file", PermissionLevel.READ, "APPROVED", null);
+        auditLog.record(Instant.now(), "s", "write_file", PermissionLevel.WRITE,
+                "NEEDS_APPROVAL", "Write to /tmp/foo?");
+        auditLog.record(Instant.now(), "s", "bash", PermissionLevel.EXECUTE,
+                "DENIED", "blocked by policy");
+
+        List<CapabilityAuditEntry> entries = auditLog.readVerified();
+        assertThat(entries).extracting(CapabilityAuditEntry::toolName)
+                .containsExactly("read_file", "write_file", "bash");
+        assertThat(entries).extracting(CapabilityAuditEntry::decisionKind)
+                .containsExactly("APPROVED", "NEEDS_APPROVAL", "DENIED");
+    }
+
+    @Test
+    void nullSessionIdSurvivesRoundtrip(@TempDir Path tmp) throws IOException {
+        // Daemon-internal checks pass null sessionId. The on-disk
+        // shape encodes this as JSON null and reads back as Java null.
+        var auditLog = CapabilityAuditLog.create(tmp);
+        auditLog.record(Instant.now(), null, "internal", PermissionLevel.READ, "APPROVED", null);
+
+        var entry = auditLog.readVerified().getFirst();
+        assertThat(entry.sessionId()).isNull();
+    }
+
+    @Test
+    void readVerifiedReturnsEmptyWhenFileMissing(@TempDir Path tmp) throws IOException {
+        // Construct an audit log whose file has not yet been written —
+        // first call from a daemon process would land in this state.
+        var auditLog = CapabilityAuditLog.create(tmp);
+        assertThat(auditLog.readVerified()).isEmpty();
+    }
+
+    @Test
+    void tamperedEntryIsDroppedOnRead(@TempDir Path tmp) throws IOException {
+        var auditLog = CapabilityAuditLog.create(tmp);
+        auditLog.record(Instant.now(), "s", "bash", PermissionLevel.EXECUTE, "DENIED", "no");
+        auditLog.record(Instant.now(), "s", "bash", PermissionLevel.EXECUTE, "APPROVED", null);
+
+        // Hand-edit the file: flip line 1's "DENIED" to "APPROVED"
+        // without re-signing — exactly the attack the signature
+        // exists to detect.
+        Path file = auditLog.auditFile();
+        String contents = Files.readString(file);
+        String tampered = contents.replaceFirst("DENIED", "APPROVED");
+        Files.writeString(file, tampered);
+
+        List<CapabilityAuditEntry> entries = auditLog.readVerified();
+        // The tampered line is dropped; the legitimate one survives.
+        assertThat(entries).hasSize(1);
+        assertThat(entries.getFirst().decisionKind()).isEqualTo("APPROVED");
+        assertThat(entries.getFirst().reason()).isNull();
+    }
+
+    @Test
+    void malformedJsonLineIsSkippedNotThrown(@TempDir Path tmp) throws IOException {
+        // A partial write or accidental edit could leave invalid JSON
+        // mid-file. The reader should skip those and return what's
+        // still verifiable rather than failing the whole query.
+        var auditLog = CapabilityAuditLog.create(tmp);
+        auditLog.record(Instant.now(), "s", "bash", PermissionLevel.EXECUTE, "APPROVED", null);
+
+        Path file = auditLog.auditFile();
+        Files.writeString(file, "this is not json\n" + Files.readString(file));
+
+        var entries = auditLog.readVerified();
+        assertThat(entries).hasSize(1);
+        assertThat(entries.getFirst().toolName()).isEqualTo("bash");
+    }
+
+    @Test
+    void concurrentAppendsAreSerialized(@TempDir Path tmp) throws Exception {
+        // PermissionManager.check() is called from many concurrent
+        // virtual threads. Two threads racing on Files.writeString
+        // could otherwise interleave bytes and produce a malformed
+        // line. The ReentrantLock around append guards against that.
+        var auditLog = CapabilityAuditLog.create(tmp);
+        int writers = 50;
+        var start = new CountDownLatch(1);
+        var done = new CountDownLatch(writers);
+
+        IntStream.range(0, writers).forEach(i -> Thread.ofVirtual().start(() -> {
+            try {
+                start.await();
+                auditLog.record(Instant.now(), "s-" + i, "bash",
+                        PermissionLevel.EXECUTE, "APPROVED", null);
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            } finally {
+                done.countDown();
+            }
+        }));
+        start.countDown();
+        assertThat(done.await(10, TimeUnit.SECONDS))
+                .as("all writers must finish within 10s")
+                .isTrue();
+
+        var entries = auditLog.readVerified();
+        // Every write produces exactly one verifiable entry — no
+        // dropped or corrupted lines.
+        assertThat(entries).hasSize(writers);
+    }
+}


### PR DESCRIPTION
## Summary

First concrete piece of the runtime-governance epic (#465). Adds a tamper-evident, on-disk record of every `PermissionManager.check()` decision, attached to the **existing** permission path — no API surface changes for callers who don't want auditing.

Closes the gap between the README's enterprise pitch ("the same record drives the audit trail") and reality, where capability decisions previously left no signed trail.

### What ships

- **`CapabilityAuditEntry`** — JSON record with `timestamp`, `sessionId` (nullable for daemon-internal checks), `toolName`, `level`, `decisionKind` (`APPROVED` / `DENIED` / `NEEDS_APPROVAL`), `reason`, and an HMAC-SHA256 hex `signature`.
- **`AuditLogSigner`** — HMAC-SHA256 with constant-time verify, mirroring `MemorySigner`. Loads or creates a 32-byte key at `~/.aceclaw/audit/audit.key` with POSIX 600.
- **`CapabilityAuditLog`** — append-only JSONL store at `~/.aceclaw/audit/capability-audit.jsonl`. `ReentrantLock` around append for the concurrent virtual-thread call sites. Tampered, malformed, or wrong-key entries are dropped on read with a warning so reporting can't be poisoned.
- **`PermissionManager`** — new two-arg constructor `(PermissionPolicy, CapabilityAuditLog)`. Existing single-arg constructor delegates with a `null` log (audit disabled — keeps unit tests free of disk I/O setup). Every `.check()` call records one entry; writes are best-effort and never throw.

### Why standalone (not blocked on #465 Layer 1)

Path C from the runtime-governance discussion: AuditLog v1 attaches to the existing permission path today and delivers immediate compliance-track value, without waiting for the broader `CapabilityRequest` unification. When that unification lands, the same log naturally extends to record the richer requests — schema is forward-additive.

### Files

| Path | Purpose |
|---|---|
| `aceclaw-security/src/main/java/dev/aceclaw/security/audit/CapabilityAuditEntry.java` | Signed entry record + canonical signable payload |
| `aceclaw-security/src/main/java/dev/aceclaw/security/audit/AuditLogSigner.java` | HMAC-SHA256 sign/verify + key load-or-create |
| `aceclaw-security/src/main/java/dev/aceclaw/security/audit/CapabilityAuditLog.java` | JSONL append store with verifying read |
| `aceclaw-security/src/main/java/dev/aceclaw/security/PermissionManager.java` | Wiring: optional log via new constructor, audit hook in `.check()` |
| `aceclaw-security/build.gradle.kts` | Add `jackson-datatype-jsr310` for `Instant` serialization |

## Test plan

- [x] Unit: `AuditLogSignerTest` — sign/verify roundtrip, tamper detection, wrong-key isolation, null-signature safety, key persistence across loads, POSIX 600 on fresh key, zero-byte key rejection
- [x] Unit: `CapabilityAuditLogTest` — roundtrip preserves all fields, append order, null sessionId roundtrip, missing-file safety, **tampered entry dropped on read**, malformed JSON skipped, **50-thread concurrent append produces 50 verifiable entries**
- [x] Integration: `PermissionManagerAuditTest` — each of `Approved` / `Denied` / `NeedsUserApproval` flattens correctly, session-blanket approval is tagged `session-blanket-approval` in `reason` (so auditors can distinguish it from policy-approved), null sessionId surfaces as null on disk, no-audit-log mode is a no-op, 5 calls produce exactly 5 entries
- [x] `./gradlew :aceclaw-security:test` — green
- [x] `./gradlew build` — green (full project)

## Refs
- Closes part of #465 (Layer 8)
- Builds on the `MemorySigner` pattern from the memory module

🤖 Generated with [Claude Code](https://claude.com/claude-code)