### PR TITLE
feat(daemon): wire capability audit log into startup (#465 Layer 8 wiring)

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -36,6 +36,7 @@ import dev.aceclaw.memory.TrendDetector;
 import dev.aceclaw.memory.WorkspacePaths;
 import dev.aceclaw.security.DefaultPermissionPolicy;
 import dev.aceclaw.security.PermissionManager;
+import dev.aceclaw.security.audit.CapabilityAuditLog;
 import dev.aceclaw.mcp.McpClientManager;
 import dev.aceclaw.mcp.McpServerConfig;
 import dev.aceclaw.tools.*;
@@ -376,7 +377,11 @@ public final class AceClawDaemon {
 
         // 3. Permission manager — mode from config (default: "normal")
         //    Created early because sub-agent permission checker references it.
-        var permissionManager = new PermissionManager(new DefaultPermissionPolicy(config.permissionMode()));
+        //    Audit log mirrors the memory dir convention (~/.aceclaw/audit/).
+        var auditDir = Path.of(System.getProperty("user.home"), ".aceclaw", "audit");
+        var permissionManager = new PermissionManager(
+                new DefaultPermissionPolicy(config.permissionMode()),
+                buildCapabilityAuditLog(auditDir));
 
         // 4. Sub-agent infrastructure (task delegation) and skills
         var agentTypeRegistry = AgentTypeRegistry.load(workingDir);
@@ -1780,6 +1785,29 @@ public final class AceClawDaemon {
 
         log.info("Agent handler wired: provider={}, model={}, tools={}",
                 config.provider(), model, toolRegistry.size());
+    }
+
+    /**
+     * Builds the capability audit log for {@link #wireAgentHandler}, or
+     * returns {@code null} if setup fails. Best-effort by design: a
+     * read-only {@code $HOME} or a permission error on the audit
+     * directory degrades the daemon to "no audit" rather than
+     * preventing startup. The agent must keep running even if the
+     * audit subsystem is unavailable.
+     *
+     * <p>Package-private for testing — production callers go through
+     * {@link #wireAgentHandler}.
+     */
+    static CapabilityAuditLog buildCapabilityAuditLog(Path auditDir) {
+        try {
+            var auditLog = CapabilityAuditLog.create(auditDir);
+            log.info("Capability audit log initialized at {}", auditDir);
+            return auditLog;
+        } catch (IOException e) {
+            log.warn("Failed to initialize capability audit log at {}: {}. Auditing disabled.",
+                    auditDir, e.getMessage());
+            return null;
+        }
     }
 
     private static String summarizePrompt(String prompt) {

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -377,11 +377,14 @@ public final class AceClawDaemon {
 
         // 3. Permission manager — mode from config (default: "normal")
         //    Created early because sub-agent permission checker references it.
-        //    Audit log mirrors the memory dir convention (~/.aceclaw/audit/).
-        var auditDir = Path.of(System.getProperty("user.home"), ".aceclaw", "audit");
+        //    Audit dir is resolved against the daemon's configured homeDir
+        //    (NOT user.home) so AceClawDaemon.create(Path) overrides and
+        //    test isolations write audit artifacts under the same root as
+        //    every other persisted thing (pid, sock, transcripts,
+        //    checkpoints, ...).
         var permissionManager = new PermissionManager(
                 new DefaultPermissionPolicy(config.permissionMode()),
-                buildCapabilityAuditLog(auditDir));
+                buildCapabilityAuditLog(homeDir.resolve("audit")));
 
         // 4. Sub-agent infrastructure (task delegation) and skills
         var agentTypeRegistry = AgentTypeRegistry.load(workingDir);

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/AceClawDaemonAuditWiringTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/AceClawDaemonAuditWiringTest.java
@@ -1,0 +1,94 @@
+package dev.aceclaw.daemon;
+
+import dev.aceclaw.security.DefaultPermissionPolicy;
+import dev.aceclaw.security.PermissionManager;
+import dev.aceclaw.security.PermissionRequest;
+import dev.aceclaw.security.audit.CapabilityAuditEntry;
+import dev.aceclaw.security.audit.CapabilityAuditLog;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies the daemon-startup wiring that connects {@link CapabilityAuditLog}
+ * into {@link PermissionManager} (#465 Layer 8 wiring; Codex P1 follow-up
+ * from #474).
+ *
+ * <p>Two paths matter:
+ * <ul>
+ *   <li><b>Happy path</b> — the helper builds an audit log and the resulting
+ *       PermissionManager actually writes a verifiable entry on every
+ *       {@link PermissionManager#check} call. Without this, the audit
+ *       subsystem produces no on-disk records in production even though
+ *       all the pieces compile and load.</li>
+ *   <li><b>Degraded path</b> — if the audit directory can't be created
+ *       (read-only home dir, permission error), the helper returns
+ *       {@code null} rather than throwing. The daemon must keep starting
+ *       up even when auditing is unavailable; treating audit setup as
+ *       fatal would turn a compliance feature into a denial-of-service
+ *       on the agent itself.</li>
+ * </ul>
+ *
+ * <p>Uses {@link TempDir} for the audit directory throughout — never
+ * touches the real {@code ~/.aceclaw/}.
+ */
+final class AceClawDaemonAuditWiringTest {
+
+    @Test
+    void buildCapabilityAuditLog_returnsWorkingLogWhenDirIsWritable(@TempDir Path tmp) {
+        // End-to-end: helper builds → PermissionManager records → entry
+        // appears verified on disk. This is the wiring path the daemon
+        // takes on a fresh install.
+        CapabilityAuditLog auditLog = AceClawDaemon.buildCapabilityAuditLog(tmp);
+
+        assertThat(auditLog)
+                .as("writable dir must yield a non-null audit log")
+                .isNotNull();
+
+        var pm = new PermissionManager(new DefaultPermissionPolicy("normal"), auditLog);
+        pm.check(PermissionRequest.execute("bash", "rm /tmp/test"), "session-1");
+
+        List<CapabilityAuditEntry> entries = auditLog.readVerified();
+        assertThat(entries).hasSize(1);
+        var entry = entries.getFirst();
+        assertThat(entry.toolName()).isEqualTo("bash");
+        assertThat(entry.sessionId()).isEqualTo("session-1");
+        // "normal" policy treats EXECUTE as needs-user-approval; the
+        // exact decision is the policy's call, but it must surface in
+        // the entry rather than being skipped.
+        assertThat(entry.decisionKind()).isNotBlank();
+        assertThat(entry.signature()).isNotBlank();
+    }
+
+    @Test
+    void buildCapabilityAuditLog_returnsNullWhenDirCannotBeCreated(@TempDir Path tmp) throws IOException {
+        // Stage a regular file at the path we're about to ask Files.
+        // createDirectories to materialise as a directory. POSIX won't
+        // turn a file into a directory, so create() throws IOException
+        // and the helper must return null instead of letting the
+        // daemon crash.
+        Path blocked = tmp.resolve("audit-collision");
+        Files.writeString(blocked, "this is a regular file, not a directory");
+
+        CapabilityAuditLog auditLog = AceClawDaemon.buildCapabilityAuditLog(blocked);
+
+        assertThat(auditLog)
+                .as("unwritable audit dir must downgrade to null, never throw")
+                .isNull();
+
+        // Sanity: a PermissionManager built with the null result still
+        // works (audit silently disabled). Mirrors what the daemon
+        // actually does — the PermissionManager 2-arg constructor
+        // accepts null for "audit off".
+        var pm = new PermissionManager(new DefaultPermissionPolicy("normal"), auditLog);
+        // Should not throw — proves the degraded path is genuinely
+        // benign rather than masking a downstream NPE.
+        pm.check(PermissionRequest.read("read_file", "x"), "session-1");
+    }
+}


### PR DESCRIPTION
## Summary

Daemon-side follow-up to #474. The audit subsystem (`CapabilityAuditEntry` + `AuditLogSigner` + `CapabilityAuditLog`) landed on main, but the daemon still constructed `PermissionManager` with the single-arg constructor — so production agents wrote zero audit entries even though the code paths existed. This PR turns the feature on.

This is **the Codex P1 follow-up** from #474 review:
> The single-argument constructor hard-disables auditing by always passing `null`, and existing runtime wiring still uses that constructor [...] this change adds audit code paths but does not actually produce signed capability records in production.

### What changed

- **`AceClawDaemon.wireAgentHandler`** — now builds the audit log and passes it to `PermissionManager`'s two-arg constructor. Audit dir at `~/.aceclaw/audit/`, mirroring the existing `~/.aceclaw/memory/` convention (already used ~340 lines below at the InjectionAuditLog wiring).

- **`AceClawDaemon.buildCapabilityAuditLog(Path)`** — new package-private static helper. Try/catch around `CapabilityAuditLog.create()`; on `IOException` returns `null` and logs a warning. Auditing is opt-in by side effect (works if the home dir is writable, silently disabled otherwise) — never fatal to daemon startup. A compliance feature must not become a denial-of-service on the agent itself.

### Why a helper instead of inline try/catch

Wiring is 3 lines; testability is the helper. Without it, the only test target is "boot the whole daemon," which has no precedent in `aceclaw-daemon/src/test/`. The helper keeps the test surface narrow and the production logic identical.

### Files

| Path | Change |
|---|---|
| `aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java` | +1 import, +3 lines at construction site, +20 lines for static helper |
| `aceclaw-daemon/src/test/java/dev/aceclaw/daemon/AceClawDaemonAuditWiringTest.java` | New — 2 tests covering happy + degraded paths |

## Test plan

- [x] `AceClawDaemonAuditWiringTest.buildCapabilityAuditLog_returnsWorkingLogWhenDirIsWritable` — helper builds → PermissionManager records → entry appears verified on disk. End-to-end through the wiring path.
- [x] `AceClawDaemonAuditWiringTest.buildCapabilityAuditLog_returnsNullWhenDirCannotBeCreated` — staged a regular file at the audit-dir path so `Files.createDirectories` throws; verifies helper returns null AND the resulting PermissionManager still answers `.check()` (degraded path is genuinely benign, not masking a downstream NPE).
- [x] Both tests use `@TempDir` — no real `~/.aceclaw/` access.
- [x] `./gradlew :aceclaw-daemon:test --tests "*.AceClawDaemonAuditWiringTest"` — green
- [x] `./gradlew build` — green (full project)

## Refs
- Closes the Layer 8 v1 milestone for #465 (subsystem from #474 + this wiring)
- Direct follow-up to #474 review feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability audit logging to track permission decisions and daemon activity.
  * Audit logs are automatically stored locally for review and compliance purposes.
  * System gracefully continues operation if audit log initialization fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->