### PR TITLE
chore(daemon): resolve injection-audit memory dir from homeDir

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -711,8 +711,12 @@ public final class AceClawDaemon {
             var runtimeMetricsExporter = new RuntimeMetricsExporter();
             agentHandler.setRuntimeMetricsExporter(runtimeMetricsExporter);
             if (cs != null) {
-                var memoryDir = Path.of(System.getProperty("user.home"), ".aceclaw", "memory");
-                agentHandler.setInjectionAuditLog(new dev.aceclaw.memory.InjectionAuditLog(memoryDir));
+                // Resolve from homeDir (NOT user.home) so AceClawDaemon.create(Path)
+                // overrides and test isolations write the injection audit log under
+                // the same root as every other persisted thing. Same fix shape as
+                // the capability audit dir at the top of wireAgentHandler (#475).
+                agentHandler.setInjectionAuditLog(
+                        new dev.aceclaw.memory.InjectionAuditLog(homeDir.resolve("memory")));
             }
 
             log.info("Self-improvement engine wired (with strategy refinement + candidate pipeline + runtime metrics)");


### PR DESCRIPTION
## Summary

Driveby cleanup of the same anti-pattern that #475 fixed at the capability-audit wiring. The InjectionAuditLog wiring (~340 lines down in the same method) was still using \`Path.of(System.getProperty("user.home"), ".aceclaw", "memory")\` instead of \`homeDir.resolve("memory")\`.

Concrete impact: \`AceClawDaemon.create(Path)\` overrides and test isolations under a custom home would write injection-audit data into the real user profile, breaking the home-scoping contract that pid lock, UDS socket, transcripts, checkpoints, candidate store and (post-#475) capability audit all already obey.

Same fix shape as #475 — flagged independently by both Codex and CodeRabbit on that PR; called out as out-of-scope at the time and saved for this small standalone PR.

### Files

| Path | Change |
|---|---|
| \`aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java\` | -2 / +6 (1-line fix + 4-line comment explaining the fix shape and pointing at #475) |

### No test added

InjectionAuditLog construction has no existing daemon-side test coverage (testing it would require booting \`AceClawDaemon\` end-to-end, which has no precedent in \`aceclaw-daemon/src/test/\`). The change just swaps one \`Path\` argument for another at the call site; \`AceClawDaemonAuditWiringTest\` (added in #475) already exercises the same Path-arg construction pattern through \`CapabilityAuditLog\`.

## Test plan

- [x] \`./gradlew :aceclaw-daemon:test\` — green
- [x] No new tests; mechanical 1-line fix mirroring tested pattern

## Refs

- Direct cleanup of the residual issue from #475 review
- Closes the daemon's home-scoping contract gap for #465 Layer 8 v1

🤖 Generated with [Claude Code](https://claude.com/claude-code)