### PR TITLE
fix(release): revert orphan v0.3.19 + honor bump input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,12 +35,25 @@ jobs:
       - name: Compute next version
         id: version
         run: |
-          # Read version from gradle.properties (source of truth).
-          # SNAPSHOT suffix is stripped; result is the release version.
+          # gradle.properties holds the in-progress SNAPSHOT (e.g. 0.3.19-SNAPSHOT).
+          # `patch` releases that version as-is; `minor` and `major` re-derive
+          # the release version from semver rules so the user can pick the bump
+          # type at trigger time without first hand-editing gradle.properties.
+          # The post-release "Bump to next SNAPSHOT" step always advances by
+          # patch+1 from whatever we publish here.
           CURRENT=$(grep '^version=' gradle.properties | cut -d= -f2)
           BARE="${CURRENT%-SNAPSHOT}"
-          echo "next=v${BARE}" >> "$GITHUB_OUTPUT"
-          echo "Next version: v${BARE}"
+          MAJOR=$(echo "$BARE" | cut -d. -f1)
+          MINOR=$(echo "$BARE" | cut -d. -f2)
+          PATCH=$(echo "$BARE" | cut -d. -f3)
+          case "${{ inputs.bump }}" in
+            major) NEXT="$((MAJOR + 1)).0.0" ;;
+            minor) NEXT="${MAJOR}.$((MINOR + 1)).0" ;;
+            patch) NEXT="${BARE}" ;;
+            *) echo "Invalid bump: ${{ inputs.bump }}"; exit 1 ;;
+          esac
+          echo "next=v${NEXT}" >> "$GITHUB_OUTPUT"
+          echo "Next version: v${NEXT} (bump=${{ inputs.bump }}, current=${CURRENT})"
 
       - name: Bump gradle.properties
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,52 +1,5 @@
 # Changelog
 
-## [0.3.19] - 2026-05-03
-
-### Bug Fixes
-
-- One text node per ReAct iteration, anchored on its thinking (#450)
-- Include projectPath in stream.session_started (#452) (#453)
-
-### Documentation
-
-- Pair each intro image with its section
-- Lead with the ReAct loop visualization, drop race detail
-- Add Node 20 LTS + React 19 badges, pin engines.node
-- Name it "runtime state visualization" in the harness intro
-- Visual-harness roadmap — debugger, decision graph, permission dashboard, learning viewer
-- Drop roadmap link from README
-- Tagline harness link as runtime's observability + control plane
-- Catch up with the WebSocket bridge
-- Position AceClaw as runtime-level governance
-- Lead with the thesis, drop "two things in one project"
-- Positive enterprise framing in README opener
-- Collapse the second paragraph back into one clean enumeration
-- Restore protocol/connector contrast as context for the "one ..." enumeration
-- Rewrite the architecture sentence — no comparisons, no "one one one"
-- Weave runtime + harness into the opener; runtime-level governance framing
-- Drop React mention; tighten "compliance captures" to "audit trail"
-- README opener says only what's actually shipped
-
-### Features
-
-- Execution event schema for browser clients (#439) (#440)
-- WebSocket bridge + EventMultiplexer + missing events (#431) (#441)
-- React + Vite + TS + Tailwind + Framer Motion + dagre scaffold (#434) (#442)
-- EventReducer + useExecutionTree hook (#435) (#443)
-- ExecutionTree component — animated SVG live tree (#436) (#444)
-- Multi-session discovery — sessions.list + sidebar (#445) (#447)
-- Snapshot.request endpoint for late-joining clients (#432) (#448)
-- Accept permission.response over WebSocket (#433) (#454)
-- Inline permission approve/deny panel (#437) (#455)
-- Bridge SchedulerEvent to WebSocket for cron viz (#459) (#460)
-- Cron jobs sidebar panel (#459 layer 2) (#461)
-- Cron-as-session — drill into a cron run as a tree (#459) (#464)
-- Replan as a first-class tree node + plan badge (#458) (#466)
-- Lower planner threshold 5→3 + /plan slash command (#467)
-- Nav controls + breadcrumb for the execution tree (#472)
-- Signed capability audit log v1 (#474)
-- Wire capability audit log into startup (#475)
-- Aceclaw dashboard subcommand — daemon serves bundled dist (#446)
 ## [0.3.18] - 2026-04-20
 
 ### Bug Fixes

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=dev.aceclaw
-version=0.3.19
+version=0.3.19-SNAPSHOT


### PR DESCRIPTION
Two fixes bundled because the release pipeline got into a half-broken state and we need to reset it cleanly.

## Background

- PR #477 was merged. I triggered a release with `bump=minor` to ship v0.4.0.
- The release workflow's `Compute next version` step **ignores the `bump` input** — it only strips `-SNAPSHOT` from gradle.properties. So `bump=minor` was a no-op.
- I cancelled the run, but the cancel signal arrived after the `Commit and tag` step had already pushed `chore(release): v0.3.19` (commit 421b15b) and tag v0.3.19 to main.
- The workflow was then cancelled during `gradlew clean build`, so no GitHub Release artifact was uploaded and the post-release `Bump to next SNAPSHOT` step was skipped.

Net result: main has an orphan release commit + tag pointing to nothing, gradle.properties is stuck at `0.3.19` (no -SNAPSHOT), and the bug that started this is still in place.

## What this PR does

1. Reverts `421b15b` so gradle.properties returns to `0.3.19-SNAPSHOT` and the spurious CHANGELOG entry is gone.
2. Fixes `Compute next version` to actually honor `inputs.bump`:
   - `patch` → release current SNAPSHOT (existing behavior)
   - `minor` → bump minor, reset patch to 0
   - `major` → bump major, reset minor and patch to 0

## Follow-up after merge

- Delete orphan tag: `git push origin :refs/tags/v0.3.19`
- Re-trigger release with `bump=minor` → publishes v0.4.0 (which will include the `aceclaw dashboard` subcommand from #446)

## Test plan

- [x] revert leaves gradle.properties at `0.3.19-SNAPSHOT`
- [x] release.yml YAML parses
- [ ] Re-triggered release publishes v0.4.0 cleanly (will verify after merge)