### PR TITLE
feat(security): Capability sealed type + ID record wrappers (#480 PR 1/3)

### DIFF
--- a/aceclaw-security/src/main/java/dev/aceclaw/security/Capability.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/Capability.java
@@ -70,6 +70,18 @@ public sealed interface Capability {
      */
     String displayLabel();
 
+    /**
+     * Renders a {@link Path} with forward slashes regardless of the host OS.
+     * Audit logs and dashboard labels are observed across platforms (a Linux
+     * operator viewing a Windows daemon's events shouldn't see backslashes
+     * that confuse readers and break grep). Native path semantics are
+     * preserved at the API boundary; this function only affects the
+     * <em>display</em> form.
+     */
+    private static String renderPath(Path path) {
+        return path.toString().replace('\\', '/');
+    }
+
     // -- Filesystem -----------------------------------------------------
 
     record FileRead(Path path) implements Capability {
@@ -79,7 +91,7 @@ public sealed interface Capability {
 
         @Override public PermissionLevel risk() { return PermissionLevel.READ; }
         @Override public DataFlow dataFlow() { return DataFlow.INGRESS; }
-        @Override public String displayLabel() { return "read " + path; }
+        @Override public String displayLabel() { return "read " + renderPath(path); }
     }
 
     record FileWrite(Path path, WriteMode mode) implements Capability {
@@ -90,17 +102,26 @@ public sealed interface Capability {
 
         @Override public PermissionLevel risk() { return PermissionLevel.WRITE; }
         @Override public DataFlow dataFlow() { return DataFlow.EGRESS; }
-        @Override public String displayLabel() { return "write " + path + " (" + mode + ")"; }
+        @Override public String displayLabel() { return "write " + renderPath(path) + " (" + mode + ")"; }
     }
 
+    /**
+     * Deletion is classified as {@link PermissionLevel#DANGEROUS} rather than
+     * {@code WRITE} so that {@code accept-edits} mode (which auto-approves
+     * {@code WRITE}) does NOT silently delete files — operators expect that
+     * mode to remove the prompt for "edit a file", not "rm -rf the project".
+     * Only {@code DANGEROUS} requires explicit approval in every mode except
+     * {@code yolo}, matching the existing {@link DefaultPermissionPolicy}
+     * behaviour for destructive ops.
+     */
     record FileDelete(Path path) implements Capability {
         public FileDelete {
             Objects.requireNonNull(path, "path");
         }
 
-        @Override public PermissionLevel risk() { return PermissionLevel.WRITE; }
+        @Override public PermissionLevel risk() { return PermissionLevel.DANGEROUS; }
         @Override public DataFlow dataFlow() { return DataFlow.EGRESS; }
-        @Override public String displayLabel() { return "delete " + path; }
+        @Override public String displayLabel() { return "delete " + renderPath(path); }
     }
 
     // -- Process --------------------------------------------------------
@@ -128,6 +149,9 @@ public sealed interface Capability {
         public HttpFetch {
             Objects.requireNonNull(url, "url");
             Objects.requireNonNull(method, "method");
+            if (method.isBlank()) {
+                throw new IllegalArgumentException("method must not be blank");
+            }
         }
 
         @Override public PermissionLevel risk() { return PermissionLevel.EXECUTE; }
@@ -229,11 +253,15 @@ public sealed interface Capability {
 
         @Override public PermissionLevel risk() { return declaredLevel; }
         @Override public DataFlow dataFlow() {
-            // Read-vs-write is the only thing a flat record reliably implied;
-            // anything finer-grained is unknowable from v1 fields.
+            // Best-effort mapping from the v1 flat-record level. EXECUTE and
+            // DANGEROUS go to BOTH (matching {@link BashExec}, the canonical
+            // EXECUTE-level capability) — those operations typically read and
+            // write at the same time. Pure WRITE → EGRESS; READ → INGRESS.
+            // Anything finer-grained is unknowable from v1 fields.
             return switch (declaredLevel) {
                 case READ -> DataFlow.INGRESS;
-                case WRITE, EXECUTE, DANGEROUS -> DataFlow.EGRESS;
+                case WRITE -> DataFlow.EGRESS;
+                case EXECUTE, DANGEROUS -> DataFlow.BOTH;
             };
         }
         @Override public String displayLabel() { return "legacy:" + toolName; }

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/Capability.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/Capability.java
@@ -1,0 +1,241 @@
+package dev.aceclaw.security;
+
+import dev.aceclaw.security.ids.MemoryKey;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * One concrete capability the agent loop wants to use, in a shape that makes
+ * invalid combinations <em>unrepresentable</em> rather than runtime-checked
+ * (#480, foundation for the runtime-governance epic #465).
+ *
+ * <p>Every variant carries exactly the fields its operation needs — and
+ * nothing else. That means:
+ *
+ * <ul>
+ *   <li>{@link FileRead} can only describe a path; you cannot accidentally
+ *       set its {@link DataFlow} to {@code EGRESS} or its {@link PermissionLevel}
+ *       to {@code DANGEROUS}, because those attributes are derived methods,
+ *       not constructor fields.</li>
+ *   <li>The cross-product nonsense states the older flat schema permitted
+ *       (e.g. "Operation.Read on a Process", "HttpFetch with DataFlow.Ingress
+ *       only") cannot be constructed at all.</li>
+ *   <li>PolicyEngine (#465 Scope #2) consumes a {@code Capability} via
+ *       exhaustive {@code switch}; the compiler enforces that adding a new
+ *       variant updates every consumer.</li>
+ * </ul>
+ *
+ * <h3>Adapter is intentionally absent</h3>
+ *
+ * Two different adapters (built-in {@code WriteFileTool} and an MCP server
+ * that happens to also offer file write) producing the same
+ * {@code FileWrite("/etc/hosts", OVERWRITE)} should get the <em>same</em>
+ * policy answer — that is the whole point of capability-style governance.
+ * "Who requested this" is recorded in {@code Provenance}, not in the
+ * Capability itself, so policies cannot fork by adapter.
+ *
+ * <h3>{@link #risk()} is derived, not declared</h3>
+ *
+ * Callers cannot lie about a capability's risk class. {@link FileRead} is
+ * always {@code READ}; {@link BashExec} is {@code EXECUTE} (PR-1 baseline);
+ * future patch will let {@code BashExec} self-escalate to {@code DANGEROUS}
+ * for known destructive patterns. Either way, the escalation lives in the
+ * variant — not at the call site.
+ *
+ * <h3>{@link LegacyToolUse}</h3>
+ *
+ * Exists to keep historical {@code CapabilityAuditEntry} v1 records readable
+ * after the audit log migrates (#480 PR 3). Never produced by current code;
+ * present so the legacy deserializer has a {@code Capability} variant to
+ * land on.
+ */
+public sealed interface Capability {
+
+    /**
+     * Risk classification for this capability. Derived from the variant —
+     * never user-supplied. Existing {@link PermissionLevel} enum is reused.
+     */
+    PermissionLevel risk();
+
+    /**
+     * Direction of data flow for this capability. See {@link DataFlow}.
+     */
+    DataFlow dataFlow();
+
+    /**
+     * Single-line human-readable summary, suitable for permission prompts
+     * and dashboard event labels. Example: {@code "write /tmp/x (OVERWRITE)"}.
+     */
+    String displayLabel();
+
+    // -- Filesystem -----------------------------------------------------
+
+    record FileRead(Path path) implements Capability {
+        public FileRead {
+            Objects.requireNonNull(path, "path");
+        }
+
+        @Override public PermissionLevel risk() { return PermissionLevel.READ; }
+        @Override public DataFlow dataFlow() { return DataFlow.INGRESS; }
+        @Override public String displayLabel() { return "read " + path; }
+    }
+
+    record FileWrite(Path path, WriteMode mode) implements Capability {
+        public FileWrite {
+            Objects.requireNonNull(path, "path");
+            Objects.requireNonNull(mode, "mode");
+        }
+
+        @Override public PermissionLevel risk() { return PermissionLevel.WRITE; }
+        @Override public DataFlow dataFlow() { return DataFlow.EGRESS; }
+        @Override public String displayLabel() { return "write " + path + " (" + mode + ")"; }
+    }
+
+    record FileDelete(Path path) implements Capability {
+        public FileDelete {
+            Objects.requireNonNull(path, "path");
+        }
+
+        @Override public PermissionLevel risk() { return PermissionLevel.WRITE; }
+        @Override public DataFlow dataFlow() { return DataFlow.EGRESS; }
+        @Override public String displayLabel() { return "delete " + path; }
+    }
+
+    // -- Process --------------------------------------------------------
+
+    /**
+     * Shell command execution. {@link #risk()} returns {@code EXECUTE} in
+     * this PR; #465 Scope #2 (PolicyEngine) is where DANGEROUS escalation
+     * for destructive command patterns will live, so the rule set is in
+     * one place rather than scattered across capability variants.
+     */
+    record BashExec(String command, Path cwd) implements Capability {
+        public BashExec {
+            Objects.requireNonNull(command, "command");
+            Objects.requireNonNull(cwd, "cwd");
+        }
+
+        @Override public PermissionLevel risk() { return PermissionLevel.EXECUTE; }
+        @Override public DataFlow dataFlow() { return DataFlow.BOTH; }
+        @Override public String displayLabel() { return "exec: " + command; }
+    }
+
+    // -- Network --------------------------------------------------------
+
+    record HttpFetch(URI url, String method) implements Capability {
+        public HttpFetch {
+            Objects.requireNonNull(url, "url");
+            Objects.requireNonNull(method, "method");
+        }
+
+        @Override public PermissionLevel risk() { return PermissionLevel.EXECUTE; }
+        @Override public DataFlow dataFlow() {
+            // GET/HEAD are read-only request bodies; everything else can
+            // ship payload, so DataFlow.BOTH is the safe default.
+            return ("GET".equalsIgnoreCase(method) || "HEAD".equalsIgnoreCase(method))
+                    ? DataFlow.INGRESS
+                    : DataFlow.BOTH;
+        }
+        @Override public String displayLabel() { return method + " " + url; }
+    }
+
+    // -- MCP ------------------------------------------------------------
+
+    /**
+     * Invocation of an MCP server's named method. The args payload is
+     * intentionally <em>not</em> stored here — args can be huge, can carry
+     * secrets, and live with the audit entry only when the policy chose
+     * to retain them. PolicyEngine sees {@code (server, method)} and decides
+     * whether further inspection is warranted.
+     */
+    record McpInvoke(String server, String method) implements Capability {
+        public McpInvoke {
+            Objects.requireNonNull(server, "server");
+            Objects.requireNonNull(method, "method");
+        }
+
+        @Override public PermissionLevel risk() { return PermissionLevel.EXECUTE; }
+        @Override public DataFlow dataFlow() { return DataFlow.BOTH; }
+        @Override public String displayLabel() { return "mcp " + server + "." + method; }
+    }
+
+    // -- Memory ---------------------------------------------------------
+
+    /**
+     * {@code tier} is a string rather than a {@code MemoryTier} reference
+     * to avoid a cross-module dependency from {@code aceclaw-security} to
+     * {@code aceclaw-memory}. The memory subsystem maps it back when
+     * applying the write.
+     */
+    record MemoryWrite(MemoryKey key, String tier) implements Capability {
+        public MemoryWrite {
+            Objects.requireNonNull(key, "key");
+            Objects.requireNonNull(tier, "tier");
+        }
+
+        @Override public PermissionLevel risk() { return PermissionLevel.WRITE; }
+        @Override public DataFlow dataFlow() { return DataFlow.EGRESS; }
+        @Override public String displayLabel() { return "memory.write " + tier + ":" + key; }
+    }
+
+    record MemoryRead(MemoryKey key) implements Capability {
+        public MemoryRead {
+            Objects.requireNonNull(key, "key");
+        }
+
+        @Override public PermissionLevel risk() { return PermissionLevel.READ; }
+        @Override public DataFlow dataFlow() { return DataFlow.INGRESS; }
+        @Override public String displayLabel() { return "memory.read " + key; }
+    }
+
+    // -- Sub-agent ------------------------------------------------------
+
+    /**
+     * Spawning a sub-agent is itself a capability, so the audit chain
+     * captures the moment of delegation. {@code parentDepth} is the
+     * spawning agent's depth — the new sub-agent runs at
+     * {@code parentDepth + 1}. Policies can refuse spawns past a depth.
+     */
+    record SubAgentSpawn(String role, int parentDepth) implements Capability {
+        public SubAgentSpawn {
+            Objects.requireNonNull(role, "role");
+            if (parentDepth < 0) {
+                throw new IllegalArgumentException("parentDepth must be non-negative; got " + parentDepth);
+            }
+        }
+
+        @Override public PermissionLevel risk() { return PermissionLevel.EXECUTE; }
+        @Override public DataFlow dataFlow() { return DataFlow.BOTH; }
+        @Override public String displayLabel() {
+            return "spawn sub-agent role=" + role + " depth=" + (parentDepth + 1);
+        }
+    }
+
+    // -- Legacy ---------------------------------------------------------
+
+    /**
+     * Bridge variant for reading historical {@link audit.CapabilityAuditEntry}
+     * v1 records, which carried only {@code (toolName, level)}. Never produced
+     * by current code; lives here so the legacy deserializer (#480 PR 3) has
+     * a typed landing pad.
+     */
+    record LegacyToolUse(String toolName, PermissionLevel declaredLevel) implements Capability {
+        public LegacyToolUse {
+            Objects.requireNonNull(toolName, "toolName");
+            Objects.requireNonNull(declaredLevel, "declaredLevel");
+        }
+
+        @Override public PermissionLevel risk() { return declaredLevel; }
+        @Override public DataFlow dataFlow() {
+            // Read-vs-write is the only thing a flat record reliably implied;
+            // anything finer-grained is unknowable from v1 fields.
+            return switch (declaredLevel) {
+                case READ -> DataFlow.INGRESS;
+                case WRITE, EXECUTE, DANGEROUS -> DataFlow.EGRESS;
+            };
+        }
+        @Override public String displayLabel() { return "legacy:" + toolName; }
+    }
+}

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/DataFlow.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/DataFlow.java
@@ -1,0 +1,24 @@
+package dev.aceclaw.security;
+
+/**
+ * Direction of data movement for a {@link Capability}. Derived from the
+ * variant — never set independently, never lied about by callers.
+ *
+ * <ul>
+ *   <li>{@code INGRESS} — data flows IN from a resource (e.g.
+ *       {@link Capability.FileRead}).</li>
+ *   <li>{@code EGRESS} — data flows OUT to a resource (e.g.
+ *       {@link Capability.FileWrite}).</li>
+ *   <li>{@code BOTH} — a single op moves data both ways (e.g. an HTTP
+ *       request that uploads a body and reads a response).</li>
+ * </ul>
+ *
+ * <p>Modeled as an enum because {@code DataFlow} carries no per-variant
+ * fields. PolicyEngine (#465 Scope #2) will use this to express rules like
+ * "no EGRESS in plan mode" uniformly across adapters.
+ */
+public enum DataFlow {
+    INGRESS,
+    EGRESS,
+    BOTH
+}

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/WriteMode.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/WriteMode.java
@@ -1,0 +1,16 @@
+package dev.aceclaw.security;
+
+/**
+ * Distinguishes the three flavors of {@link Capability.FileWrite} so a
+ * "create only" policy can refuse overwrites without inspecting filesystem
+ * state, and an audit reader can tell at a glance whether a write replaced
+ * existing content.
+ */
+public enum WriteMode {
+    /** Fail if the path already exists. */
+    CREATE_NEW,
+    /** Replace the file's content if it exists; create otherwise. */
+    OVERWRITE,
+    /** Append to existing content; create if missing. */
+    APPEND
+}

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/ids/MemoryKey.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/ids/MemoryKey.java
@@ -1,0 +1,24 @@
+package dev.aceclaw.security.ids;
+
+import java.util.Objects;
+
+/**
+ * Typed wrapper for a memory-tier key used in
+ * {@link dev.aceclaw.security.Capability.MemoryRead} /
+ * {@link dev.aceclaw.security.Capability.MemoryWrite} variants.
+ *
+ * <p>Lives in {@code aceclaw-security} (rather than {@code aceclaw-memory})
+ * so the security module can describe memory capabilities without taking a
+ * compile-time dependency on the memory module. The memory subsystem maps
+ * this back to its own {@code MemoryEntry} keys.
+ */
+public record MemoryKey(String value) {
+    public MemoryKey {
+        Objects.requireNonNull(value, "value");
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/ids/PlanStepId.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/ids/PlanStepId.java
@@ -1,0 +1,20 @@
+package dev.aceclaw.security.ids;
+
+import java.util.Objects;
+
+/**
+ * Typed wrapper for a plan step identifier. Today the planner uses bare
+ * {@code String} stepIds — wrapping them in a record at API boundaries (#480)
+ * lets the compiler catch the easy bug of mixing them with sessionIds or
+ * promptIds in capability/audit code.
+ */
+public record PlanStepId(String value) {
+    public PlanStepId {
+        Objects.requireNonNull(value, "value");
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/ids/PromptId.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/ids/PromptId.java
@@ -1,0 +1,19 @@
+package dev.aceclaw.security.ids;
+
+import java.util.Objects;
+
+/**
+ * Typed wrapper for a user-prompt identifier. The root of every provenance
+ * chain (#480) — every capability the agent eventually requests can be traced
+ * back to one of these via the {@code Provenance.rootPrompt()} field.
+ */
+public record PromptId(String value) {
+    public PromptId {
+        Objects.requireNonNull(value, "value");
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/ids/SessionId.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/ids/SessionId.java
@@ -1,0 +1,23 @@
+package dev.aceclaw.security.ids;
+
+import java.util.Objects;
+
+/**
+ * Typed wrapper for a session identifier. Replacing bare {@code String} use at
+ * API boundaries (#480 Layer 1) prevents the easy bug of passing a sessionId
+ * where a {@link PromptId} or {@link PlanStepId} was expected — the compiler
+ * catches it instead of a runtime mis-routing.
+ *
+ * <p>Construction null-guards the value so audit-log queries and dashboard
+ * envelopes can rely on the field being present.
+ */
+public record SessionId(String value) {
+    public SessionId {
+        Objects.requireNonNull(value, "value");
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/CapabilityTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/CapabilityTest.java
@@ -30,6 +30,8 @@ final class CapabilityTest {
 
         assertThat(cap.risk()).isEqualTo(PermissionLevel.READ);
         assertThat(cap.dataFlow()).isEqualTo(DataFlow.INGRESS);
+        // displayLabel uses forward slashes regardless of host OS so audit
+        // logs and dashboard text stay platform-independent.
         assertThat(cap.displayLabel()).isEqualTo("read /etc/hosts");
     }
 
@@ -39,15 +41,31 @@ final class CapabilityTest {
 
         assertThat(cap.risk()).isEqualTo(PermissionLevel.WRITE);
         assertThat(cap.dataFlow()).isEqualTo(DataFlow.EGRESS);
-        assertThat(cap.displayLabel()).contains("/tmp/x").contains("OVERWRITE");
+        assertThat(cap.displayLabel()).isEqualTo("write /tmp/x (OVERWRITE)");
     }
 
     @Test
-    void fileDeleteDerivesWriteEgress() {
+    void fileDeleteIsDangerousNotPlainWrite() {
+        // Deletion must NOT be auto-approved by accept-edits mode. WRITE
+        // would be — DANGEROUS is the level that always prompts.
         var cap = new Capability.FileDelete(Path.of("/tmp/x"));
 
-        assertThat(cap.risk()).isEqualTo(PermissionLevel.WRITE);
+        assertThat(cap.risk())
+                .as("rm-style ops must require explicit approval, not be auto-edited")
+                .isEqualTo(PermissionLevel.DANGEROUS);
         assertThat(cap.dataFlow()).isEqualTo(DataFlow.EGRESS);
+        assertThat(cap.displayLabel()).isEqualTo("delete /tmp/x");
+    }
+
+    @Test
+    void filePathDisplayUsesForwardSlashesOnAnyOS() {
+        // The Java NIO Path's native separator is '\' on Windows. We render
+        // it as '/' so audit logs and the dashboard look the same to a
+        // Linux operator viewing a Windows daemon and vice versa.
+        var winStyle = Path.of("C:\\tmp\\x");
+        var label = new Capability.FileRead(winStyle).displayLabel();
+        assertThat(label).doesNotContain("\\");
+        assertThat(label).contains("/");
     }
 
     @Test
@@ -63,6 +81,7 @@ final class CapabilityTest {
     void httpFetchGetIsIngressOnly() {
         var cap = new Capability.HttpFetch(URI.create("https://example.com"), "GET");
 
+        assertThat(cap.risk()).isEqualTo(PermissionLevel.EXECUTE);
         assertThat(cap.dataFlow())
                 .as("safe HTTP methods upload no body")
                 .isEqualTo(DataFlow.INGRESS);
@@ -72,7 +91,20 @@ final class CapabilityTest {
     void httpFetchPostIsBidirectional() {
         var cap = new Capability.HttpFetch(URI.create("https://example.com"), "POST");
 
+        assertThat(cap.risk()).isEqualTo(PermissionLevel.EXECUTE);
         assertThat(cap.dataFlow()).isEqualTo(DataFlow.BOTH);
+    }
+
+    @Test
+    void httpFetchRejectsBlankMethod() {
+        // Blank method would silently fall through to BOTH and look like a
+        // POST. Make it surface at construction so the bug doesn't get
+        // recorded in the audit log under a misleading data-flow.
+        assertThatThrownBy(() -> new Capability.HttpFetch(URI.create("https://x"), ""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("method");
+        assertThatThrownBy(() -> new Capability.HttpFetch(URI.create("https://x"), "  "))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
@@ -130,6 +162,23 @@ final class CapabilityTest {
                 .isEqualTo(PermissionLevel.WRITE);
         assertThat(cap.dataFlow()).isEqualTo(DataFlow.EGRESS);
         assertThat(cap.displayLabel()).startsWith("legacy:");
+    }
+
+    @Test
+    void legacyExecuteAndDangerousMapToBothLikeBashExec() {
+        // EXECUTE-class operations are usually bidirectional (read output +
+        // write side effects). Match BashExec's BOTH so audit-replay
+        // statistics aren't skewed compared to current entries.
+        assertThat(new Capability.LegacyToolUse("bash", PermissionLevel.EXECUTE).dataFlow())
+                .isEqualTo(DataFlow.BOTH);
+        assertThat(new Capability.LegacyToolUse("force_push", PermissionLevel.DANGEROUS).dataFlow())
+                .isEqualTo(DataFlow.BOTH);
+    }
+
+    @Test
+    void legacyReadMapsToIngress() {
+        assertThat(new Capability.LegacyToolUse("read_file", PermissionLevel.READ).dataFlow())
+                .isEqualTo(DataFlow.INGRESS);
     }
 
     @Test

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/CapabilityTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/CapabilityTest.java
@@ -1,0 +1,178 @@
+package dev.aceclaw.security;
+
+import dev.aceclaw.security.ids.MemoryKey;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Pins the derived attributes ({@code risk}, {@code dataFlow},
+ * {@code displayLabel}) for every {@link Capability} variant — so a refactor
+ * that accidentally changes the risk class of, say, {@code FileWrite} from
+ * {@code WRITE} to {@code READ} fails this test instead of silently turning
+ * off auto-prompting in production.
+ *
+ * <p>The {@link #exhaustivenessSentinel} switch has no {@code default} branch:
+ * if a new {@link Capability} variant is added without updating the sentinel,
+ * the build fails before this test runs. That's the compile-time half of
+ * "every consumer must handle every variant" — runtime half is each consumer's
+ * own switch.
+ */
+final class CapabilityTest {
+
+    @Test
+    void fileReadDerivesReadIngress() {
+        var cap = new Capability.FileRead(Path.of("/etc/hosts"));
+
+        assertThat(cap.risk()).isEqualTo(PermissionLevel.READ);
+        assertThat(cap.dataFlow()).isEqualTo(DataFlow.INGRESS);
+        assertThat(cap.displayLabel()).isEqualTo("read /etc/hosts");
+    }
+
+    @Test
+    void fileWriteDerivesWriteEgressIncludingMode() {
+        var cap = new Capability.FileWrite(Path.of("/tmp/x"), WriteMode.OVERWRITE);
+
+        assertThat(cap.risk()).isEqualTo(PermissionLevel.WRITE);
+        assertThat(cap.dataFlow()).isEqualTo(DataFlow.EGRESS);
+        assertThat(cap.displayLabel()).contains("/tmp/x").contains("OVERWRITE");
+    }
+
+    @Test
+    void fileDeleteDerivesWriteEgress() {
+        var cap = new Capability.FileDelete(Path.of("/tmp/x"));
+
+        assertThat(cap.risk()).isEqualTo(PermissionLevel.WRITE);
+        assertThat(cap.dataFlow()).isEqualTo(DataFlow.EGRESS);
+    }
+
+    @Test
+    void bashExecDerivesExecuteBoth() {
+        var cap = new Capability.BashExec("ls -la", Path.of("/tmp"));
+
+        assertThat(cap.risk()).isEqualTo(PermissionLevel.EXECUTE);
+        assertThat(cap.dataFlow()).isEqualTo(DataFlow.BOTH);
+        assertThat(cap.displayLabel()).contains("ls -la");
+    }
+
+    @Test
+    void httpFetchGetIsIngressOnly() {
+        var cap = new Capability.HttpFetch(URI.create("https://example.com"), "GET");
+
+        assertThat(cap.dataFlow())
+                .as("safe HTTP methods upload no body")
+                .isEqualTo(DataFlow.INGRESS);
+    }
+
+    @Test
+    void httpFetchPostIsBidirectional() {
+        var cap = new Capability.HttpFetch(URI.create("https://example.com"), "POST");
+
+        assertThat(cap.dataFlow()).isEqualTo(DataFlow.BOTH);
+    }
+
+    @Test
+    void mcpInvokeDerivesExecute() {
+        var cap = new Capability.McpInvoke("filesystem", "read_file");
+
+        assertThat(cap.risk()).isEqualTo(PermissionLevel.EXECUTE);
+        assertThat(cap.displayLabel()).isEqualTo("mcp filesystem.read_file");
+    }
+
+    @Test
+    void memoryWriteDerivesWriteEgress() {
+        var cap = new Capability.MemoryWrite(new MemoryKey("user/preferences"), "user");
+
+        assertThat(cap.risk()).isEqualTo(PermissionLevel.WRITE);
+        assertThat(cap.dataFlow()).isEqualTo(DataFlow.EGRESS);
+        assertThat(cap.displayLabel())
+                .as("label includes both tier and key for at-a-glance readability")
+                .contains("user").contains("user/preferences");
+    }
+
+    @Test
+    void memoryReadDerivesReadIngress() {
+        var cap = new Capability.MemoryRead(new MemoryKey("user/preferences"));
+
+        assertThat(cap.risk()).isEqualTo(PermissionLevel.READ);
+        assertThat(cap.dataFlow()).isEqualTo(DataFlow.INGRESS);
+    }
+
+    @Test
+    void subAgentSpawnRecordsParentDepth() {
+        var cap = new Capability.SubAgentSpawn("planner", 2);
+
+        assertThat(cap.risk()).isEqualTo(PermissionLevel.EXECUTE);
+        assertThat(cap.displayLabel())
+                .contains("role=planner")
+                .contains("depth=3"); // parent depth + 1
+    }
+
+    @Test
+    void subAgentSpawnRejectsNegativeDepth() {
+        // Negative parentDepth is impossible in real code — guard catches
+        // bugs that would otherwise silently produce nonsense audit entries.
+        assertThatThrownBy(() -> new Capability.SubAgentSpawn("planner", -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("parentDepth");
+    }
+
+    @Test
+    void legacyToolUseInheritsDeclaredLevel() {
+        var cap = new Capability.LegacyToolUse("write_file", PermissionLevel.WRITE);
+
+        assertThat(cap.risk())
+                .as("legacy entries can't re-derive risk; they replay what was recorded")
+                .isEqualTo(PermissionLevel.WRITE);
+        assertThat(cap.dataFlow()).isEqualTo(DataFlow.EGRESS);
+        assertThat(cap.displayLabel()).startsWith("legacy:");
+    }
+
+    @Test
+    void allVariantsRejectNullFields() {
+        // Sample one field per variant — the canonical pattern is the same
+        // (Objects.requireNonNull in the canonical constructor) so spot-check
+        // is enough; pinning every field × variant is just typing.
+        assertThatThrownBy(() -> new Capability.FileRead(null))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new Capability.FileWrite(null, WriteMode.OVERWRITE))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new Capability.FileWrite(Path.of("/x"), null))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new Capability.BashExec(null, Path.of("/")))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new Capability.HttpFetch(null, "GET"))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new Capability.MemoryWrite(null, "user"))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void exhaustivenessSentinelHandlesEveryVariant() {
+        // The sentinel switch below has NO default branch. Adding a new
+        // Capability variant without updating it fails compilation before
+        // this test runs — that's the foundation guarantee. The test merely
+        // exercises one path so the method stays live.
+        Capability c = new Capability.FileRead(Path.of("/x"));
+        assertThat(exhaustivenessSentinel(c)).isNotBlank();
+    }
+
+    private static String exhaustivenessSentinel(Capability c) {
+        return switch (c) {
+            case Capability.FileRead r -> r.displayLabel();
+            case Capability.FileWrite w -> w.displayLabel();
+            case Capability.FileDelete d -> d.displayLabel();
+            case Capability.BashExec b -> b.displayLabel();
+            case Capability.HttpFetch h -> h.displayLabel();
+            case Capability.McpInvoke m -> m.displayLabel();
+            case Capability.MemoryWrite mw -> mw.displayLabel();
+            case Capability.MemoryRead mr -> mr.displayLabel();
+            case Capability.SubAgentSpawn s -> s.displayLabel();
+            case Capability.LegacyToolUse l -> l.displayLabel();
+        };
+    }
+}

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/ids/IdRecordsTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/ids/IdRecordsTest.java
@@ -1,0 +1,56 @@
+package dev.aceclaw.security.ids;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Pins the null-guard + {@code toString} contract for the typed-ID record
+ * wrappers (#480). The whole point of these wrappers is that mixing a
+ * {@code SessionId} and a {@code PromptId} fails at compile time —
+ * runtime tests can only check the bits that aren't compile-checked, namely
+ * "null becomes a clear error, not a downstream NPE."
+ */
+final class IdRecordsTest {
+
+    @Test
+    void sessionIdRejectsNull() {
+        assertThatThrownBy(() -> new SessionId(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void sessionIdToStringIsTheValue() {
+        // Audit log + dashboard envelope serialize the wrapper as the bare
+        // value. Confirm toString matches so log lines stay readable.
+        assertThat(new SessionId("sess-1").toString()).isEqualTo("sess-1");
+    }
+
+    @Test
+    void promptIdRejectsNull() {
+        assertThatThrownBy(() -> new PromptId(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void planStepIdRejectsNull() {
+        assertThatThrownBy(() -> new PlanStepId(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void memoryKeyRejectsNull() {
+        assertThatThrownBy(() -> new MemoryKey(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void recordsImplementValueEquality() {
+        // Records get equals/hashCode for free; the test pins that no one
+        // accidentally overrode them away.
+        assertThat(new SessionId("a")).isEqualTo(new SessionId("a"));
+        assertThat(new SessionId("a")).isNotEqualTo(new SessionId("b"));
+        assertThat(new SessionId("a")).hasSameHashCodeAs(new SessionId("a"));
+    }
+}


### PR DESCRIPTION
First of three PRs implementing #480 (Layer 1 of #465). Pure additions — no existing call sites change, nothing wired into the runtime yet. Point: nail down the data model in isolation so PR 2 (PermissionManager overload + tool migration) and PR 3 (audit migration + agent-loop wiring) have a stable foundation.

## What ships

- `Capability` sealed interface with 10 variants (`FileRead`, `FileWrite`, `FileDelete`, `BashExec`, `HttpFetch`, `McpInvoke`, `MemoryWrite`, `MemoryRead`, `SubAgentSpawn`, `LegacyToolUse`)
- `risk()`, `dataFlow()`, `displayLabel()` as derived methods — callers cannot lie about a capability's risk class
- `DataFlow` enum (INGRESS / EGRESS / BOTH)
- `WriteMode` enum (CREATE_NEW / OVERWRITE / APPEND)
- ID record wrappers under `ids/`: `SessionId`, `PromptId`, `PlanStepId`, `MemoryKey`
- Tests pinning every variant's derived attributes + null-guard contracts
- Exhaustiveness sentinel (a switch with no default) so adding a new variant without updating consumers fails compilation

## Why these axes are derived, not free fields

The previous draft (#479, closed) put Operation, ResourceRef, DataFlow, Adapter, and risk as five independent record fields, letting callers construct nonsense states (Operation.Network on a ResourceRef.File; FileRead declared with DataFlow.Egress). This redesign uses Java 21 sealed types to make those states unrepresentable: each variant carries only the fields that mean something for it.

Adapter is gone entirely — same FileWrite gets the same policy answer regardless of which tool requested it. "Who requested" lives in Provenance (PR 2).

## What this PR doesn't do

- No Provenance type yet (PR 2)
- No PermissionManager.check(Capability, Provenance) overload (PR 2)
- No audit-entry migration (PR 3)
- No agent-loop wiring (PR 3)
- LegacyToolUse exists so PR 3's legacy deserializer has a typed landing pad; never produced by current code

## Test plan

- [x] ./gradlew :aceclaw-security:test green, including new CapabilityTest and IdRecordsTest
- [x] ./gradlew build -x test full module graph still compiles, no regressions
- [x] Exhaustiveness sentinel switch has no default
- [x] All record canonical constructors null-guard their args

## Refs

- Issue #480 (Layer 1 of #465)
- Replaces design from closed #479

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a comprehensive security capability framework for agent operations (file, network, process, memory, sub-agent) with human-readable labels and risk/data-flow classification.
  * Introduced data-flow categories (ingress/egress/both) and configurable write modes (create-only/overwrite/append).
  * Added typed identifiers to improve audit logging and visibility.

* **Tests**
  * Added unit tests validating capability attributes, constructor guards, and ID wrapper behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->