### PR TITLE
feat(security): Provenance + CapabilityAware + WriteFileTool migration (#480 PR 2/3)

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -49,13 +49,10 @@ import dev.aceclaw.memory.CandidateStore;
 import dev.aceclaw.memory.DailyJournal;
 import dev.aceclaw.memory.MarkdownMemoryStore;
 import dev.aceclaw.memory.MemoryEntry;
-import dev.aceclaw.security.Capability;
-import dev.aceclaw.security.CapabilityAware;
 import dev.aceclaw.security.PermissionDecision;
 import dev.aceclaw.security.PermissionLevel;
 import dev.aceclaw.security.PermissionManager;
 import dev.aceclaw.security.PermissionRequest;
-import dev.aceclaw.security.Provenance;
 import dev.aceclaw.tools.AppleScriptTool;
 import dev.aceclaw.tools.BashExecTool;
 import dev.aceclaw.tools.EditFileTool;
@@ -3983,54 +3980,14 @@ public final class StreamingAgentHandler {
             var toolDescription = buildToolDescription(delegate.name(), effectiveInputJson);
             final String finalInputJson = effectiveInputJson;
 
-            // #480 PR 2: tools that implement CapabilityAware advertise a
-            // structured Capability so PermissionManager / audit log see the
-            // real intent (e.g. FileWrite("/tmp/x", OVERWRITE)) rather than
-            // the flat tool name. The allowlist stays keyed by tool name
-            // (delegate.name()) so existing "always allow X" approvals keep
-            // working through migration; the rich human description carries
-            // through to the user's prompt unchanged. Falls back to the
-            // legacy PermissionRequest path for tools that haven't migrated
-            // yet — single audit/decision pipeline either way.
-            PermissionDecision decision;
-            if (delegate instanceof CapabilityAware capAware) {
-                // Three outcomes from the capability conversion, each
-                // handled distinctly:
-                //  - returns a capability   → take the structured path
-                //  - throws on bad args     → fall back to legacy (logged)
-                //  - returns null           → contract violation, fail fast
-                // The fallback is deliberately narrow. Errors from
-                // permissionManager.check itself (policy / audit) MUST
-                // surface — silently re-running the legacy path on those
-                // would mask real bugs and could downgrade the decision
-                // pipeline. (Codex + CodeRabbit reviews on #482.)
-                Capability capability;
-                boolean conversionThrew = false;
-                try {
-                    capability = capAware.toCapability(objectMapper.readTree(finalInputJson));
-                } catch (RuntimeException | java.io.IOException toCapErr) {
-                    log.warn("CapabilityAware tool {} rejected args; falling back to legacy permission path: {}",
-                            delegate.name(), toCapErr.getMessage());
-                    capability = null;
-                    conversionThrew = true;
-                }
-                if (capability == null && !conversionThrew) {
-                    throw new IllegalStateException(
-                            "CapabilityAware tool " + delegate.name()
-                                    + " returned null capability (contract violation)");
-                }
-                if (capability != null) {
-                    var provenance = Provenance.legacy(sessionId);
-                    decision = permissionManager.check(
-                            capability, provenance, delegate.name(), toolDescription);
-                } else {
-                    var permRequest = new PermissionRequest(delegate.name(), toolDescription, level);
-                    decision = permissionManager.check(permRequest, sessionId);
-                }
-            } else {
-                var permRequest = new PermissionRequest(delegate.name(), toolDescription, level);
-                decision = permissionManager.check(permRequest, sessionId);
-            }
+            // #480 PR 2: routing the call through ToolPermissionRouter keeps
+            // the structured-vs-legacy branching logic in one testable place.
+            // CapabilityAware tools take the structured path; everything else
+            // hits the legacy PermissionRequest entry point. Both ultimately
+            // share PermissionManager's single decision/audit pipeline.
+            var decision = ToolPermissionRouter.check(
+                    delegate, finalInputJson, sessionId, toolDescription, level,
+                    permissionManager, objectMapper);
             var overrideStatus = antiPatternOverrideSupplier != null
                     ? antiPatternOverrideSupplier.get()
                     : new AntiPatternGateOverrideStatus(sessionId, delegate.name(), false, 0L, "");

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -49,6 +49,7 @@ import dev.aceclaw.memory.CandidateStore;
 import dev.aceclaw.memory.DailyJournal;
 import dev.aceclaw.memory.MarkdownMemoryStore;
 import dev.aceclaw.memory.MemoryEntry;
+import dev.aceclaw.security.Capability;
 import dev.aceclaw.security.CapabilityAware;
 import dev.aceclaw.security.PermissionDecision;
 import dev.aceclaw.security.PermissionLevel;
@@ -3993,18 +3994,28 @@ public final class StreamingAgentHandler {
             // yet — single audit/decision pipeline either way.
             PermissionDecision decision;
             if (delegate instanceof CapabilityAware capAware) {
+                // Only the args-to-Capability conversion is allowed to fall
+                // back to the legacy path. A failure here means the tool's
+                // toCapability() refused malformed args (or JSON parse blew
+                // up); fallback gives the user the same "needs approval"
+                // prompt with description rather than an opaque crash.
+                // Errors raised by permissionManager.check itself (policy,
+                // audit, runtime) MUST surface — silently re-running the
+                // legacy path on those would mask real bugs and could
+                // downgrade the decision pipeline. (Codex review on #482.)
+                Capability capability;
                 try {
-                    var capability = capAware.toCapability(objectMapper.readTree(finalInputJson));
+                    capability = capAware.toCapability(objectMapper.readTree(finalInputJson));
+                } catch (RuntimeException | java.io.IOException toCapErr) {
+                    log.warn("CapabilityAware tool {} rejected args; falling back to legacy permission path: {}",
+                            delegate.name(), toCapErr.getMessage());
+                    capability = null;
+                }
+                if (capability != null) {
                     var provenance = Provenance.legacy(sessionId);
                     decision = permissionManager.check(
                             capability, provenance, delegate.name(), toolDescription);
-                } catch (RuntimeException | java.io.IOException toCapErr) {
-                    // Tool's toCapability() refused (bad args, etc.) — fall
-                    // back to legacy path so the user gets the same
-                    // "needs approval" prompt with description rather than
-                    // an opaque crash. Logged so the regression is visible.
-                    log.warn("CapabilityAware tool {} rejected args; falling back to legacy permission path: {}",
-                            delegate.name(), toCapErr.getMessage());
+                } else {
                     var permRequest = new PermissionRequest(delegate.name(), toolDescription, level);
                     decision = permissionManager.check(permRequest, sessionId);
                 }

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -49,10 +49,12 @@ import dev.aceclaw.memory.CandidateStore;
 import dev.aceclaw.memory.DailyJournal;
 import dev.aceclaw.memory.MarkdownMemoryStore;
 import dev.aceclaw.memory.MemoryEntry;
+import dev.aceclaw.security.CapabilityAware;
 import dev.aceclaw.security.PermissionDecision;
 import dev.aceclaw.security.PermissionLevel;
 import dev.aceclaw.security.PermissionManager;
 import dev.aceclaw.security.PermissionRequest;
+import dev.aceclaw.security.Provenance;
 import dev.aceclaw.tools.AppleScriptTool;
 import dev.aceclaw.tools.BashExecTool;
 import dev.aceclaw.tools.EditFileTool;
@@ -3980,8 +3982,36 @@ public final class StreamingAgentHandler {
             var toolDescription = buildToolDescription(delegate.name(), effectiveInputJson);
             final String finalInputJson = effectiveInputJson;
 
-            var permRequest = new PermissionRequest(delegate.name(), toolDescription, level);
-            var decision = permissionManager.check(permRequest, sessionId);
+            // #480 PR 2: tools that implement CapabilityAware advertise a
+            // structured Capability so PermissionManager / audit log see the
+            // real intent (e.g. FileWrite("/tmp/x", OVERWRITE)) rather than
+            // the flat tool name. The allowlist stays keyed by tool name
+            // (delegate.name()) so existing "always allow X" approvals keep
+            // working through migration; the rich human description carries
+            // through to the user's prompt unchanged. Falls back to the
+            // legacy PermissionRequest path for tools that haven't migrated
+            // yet — single audit/decision pipeline either way.
+            PermissionDecision decision;
+            if (delegate instanceof CapabilityAware capAware) {
+                try {
+                    var capability = capAware.toCapability(objectMapper.readTree(finalInputJson));
+                    var provenance = Provenance.legacy(sessionId);
+                    decision = permissionManager.check(
+                            capability, provenance, delegate.name(), toolDescription);
+                } catch (RuntimeException | java.io.IOException toCapErr) {
+                    // Tool's toCapability() refused (bad args, etc.) — fall
+                    // back to legacy path so the user gets the same
+                    // "needs approval" prompt with description rather than
+                    // an opaque crash. Logged so the regression is visible.
+                    log.warn("CapabilityAware tool {} rejected args; falling back to legacy permission path: {}",
+                            delegate.name(), toCapErr.getMessage());
+                    var permRequest = new PermissionRequest(delegate.name(), toolDescription, level);
+                    decision = permissionManager.check(permRequest, sessionId);
+                }
+            } else {
+                var permRequest = new PermissionRequest(delegate.name(), toolDescription, level);
+                decision = permissionManager.check(permRequest, sessionId);
+            }
             var overrideStatus = antiPatternOverrideSupplier != null
                     ? antiPatternOverrideSupplier.get()
                     : new AntiPatternGateOverrideStatus(sessionId, delegate.name(), false, 0L, "");

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -3994,22 +3994,30 @@ public final class StreamingAgentHandler {
             // yet — single audit/decision pipeline either way.
             PermissionDecision decision;
             if (delegate instanceof CapabilityAware capAware) {
-                // Only the args-to-Capability conversion is allowed to fall
-                // back to the legacy path. A failure here means the tool's
-                // toCapability() refused malformed args (or JSON parse blew
-                // up); fallback gives the user the same "needs approval"
-                // prompt with description rather than an opaque crash.
-                // Errors raised by permissionManager.check itself (policy,
-                // audit, runtime) MUST surface — silently re-running the
-                // legacy path on those would mask real bugs and could
-                // downgrade the decision pipeline. (Codex review on #482.)
+                // Three outcomes from the capability conversion, each
+                // handled distinctly:
+                //  - returns a capability   → take the structured path
+                //  - throws on bad args     → fall back to legacy (logged)
+                //  - returns null           → contract violation, fail fast
+                // The fallback is deliberately narrow. Errors from
+                // permissionManager.check itself (policy / audit) MUST
+                // surface — silently re-running the legacy path on those
+                // would mask real bugs and could downgrade the decision
+                // pipeline. (Codex + CodeRabbit reviews on #482.)
                 Capability capability;
+                boolean conversionThrew = false;
                 try {
                     capability = capAware.toCapability(objectMapper.readTree(finalInputJson));
                 } catch (RuntimeException | java.io.IOException toCapErr) {
                     log.warn("CapabilityAware tool {} rejected args; falling back to legacy permission path: {}",
                             delegate.name(), toCapErr.getMessage());
                     capability = null;
+                    conversionThrew = true;
+                }
+                if (capability == null && !conversionThrew) {
+                    throw new IllegalStateException(
+                            "CapabilityAware tool " + delegate.name()
+                                    + " returned null capability (contract violation)");
                 }
                 if (capability != null) {
                     var provenance = Provenance.legacy(sessionId);

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/ToolPermissionRouter.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/ToolPermissionRouter.java
@@ -57,7 +57,9 @@ final class ToolPermissionRouter {
      * Routes a tool call to the structured or legacy permission entry point.
      *
      * @param delegate        the tool being invoked (may or may not be {@link CapabilityAware})
-     * @param inputJson       the JSON args the LLM supplied to the tool
+     * @param inputJson       the JSON args the LLM supplied to the tool, or {@code null}
+     *                        / malformed if upstream couldn't produce a payload — those
+     *                        cases fall back to the legacy permission path (no crash)
      * @param sessionId       the owning session id, or {@code null} for daemon-internal calls
      * @param description     rich human-readable description for the approval prompt
      * @param fallbackLevel   risk level used when going through the legacy path
@@ -76,11 +78,15 @@ final class ToolPermissionRouter {
             PermissionManager permissionManager,
             ObjectMapper mapper) {
         Objects.requireNonNull(delegate, "delegate");
-        Objects.requireNonNull(inputJson, "inputJson");
         Objects.requireNonNull(description, "description");
         Objects.requireNonNull(fallbackLevel, "fallbackLevel");
         Objects.requireNonNull(permissionManager, "permissionManager");
         Objects.requireNonNull(mapper, "mapper");
+        // inputJson is intentionally NOT null-guarded — upstream (e.g.
+        // ContentBlock.ToolUse, PermissionAwareTool's parse path) tolerates
+        // missing/invalid arguments and the dispatcher previously absorbed
+        // them in the try-catch below. Hard-failing here would convert a
+        // recoverable flow into an unhandled crash. (Codex review on #482.)
 
         if (!(delegate instanceof CapabilityAware capAware)) {
             return checkLegacy(delegate, description, fallbackLevel, sessionId, permissionManager);
@@ -90,6 +96,9 @@ final class ToolPermissionRouter {
         try {
             capability = capAware.toCapability(mapper.readTree(inputJson));
         } catch (RuntimeException | IOException toCapErr) {
+            // Catches NPE from mapper.readTree(null), IOException from
+            // malformed JSON, IllegalArgumentException from toCapability's
+            // own arg validation — all fall back to the legacy prompt path.
             log.warn("CapabilityAware tool {} rejected args; falling back to legacy permission path: {}",
                     delegate.name(), toCapErr.getMessage());
             return checkLegacy(delegate, description, fallbackLevel, sessionId, permissionManager);

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/ToolPermissionRouter.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/ToolPermissionRouter.java
@@ -1,0 +1,112 @@
+package dev.aceclaw.daemon;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.aceclaw.core.agent.Tool;
+import dev.aceclaw.security.Capability;
+import dev.aceclaw.security.CapabilityAware;
+import dev.aceclaw.security.PermissionDecision;
+import dev.aceclaw.security.PermissionLevel;
+import dev.aceclaw.security.PermissionManager;
+import dev.aceclaw.security.PermissionRequest;
+import dev.aceclaw.security.Provenance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Picks the right entry point on {@link PermissionManager} for a given tool
+ * call (#480 PR 2). Extracted from {@link StreamingAgentHandler} so the
+ * branching contract — "tools that implement {@link CapabilityAware} take
+ * the structured path; everything else takes legacy" — is testable without
+ * standing up the full agent loop.
+ *
+ * <h3>Three outcomes for a {@link CapabilityAware} tool</h3>
+ *
+ * <ol>
+ *   <li>{@code toCapability(...)} returns a non-null {@link Capability} →
+ *       call {@link PermissionManager#check(Capability, Provenance, String, String)}.
+ *       The originating tool's name is the allowlist key (so historical
+ *       "always allow {@code write_file}" approvals keep applying), and the
+ *       caller-supplied human description carries through to the user prompt.</li>
+ *   <li>{@code toCapability(...)} throws {@link RuntimeException} or
+ *       {@link IOException} (parse failure, bad args) → log a warning and
+ *       fall back to the legacy {@link PermissionRequest} path so the user
+ *       still gets a meaningful approval prompt instead of an opaque crash.</li>
+ *   <li>{@code toCapability(...)} returns {@code null} → contract violation;
+ *       throw {@link IllegalStateException}. Silently downgrading to legacy
+ *       here would mask a broken migration and drop structured policy/audit
+ *       data. (Codex + CodeRabbit reviews on #482.)</li>
+ * </ol>
+ *
+ * <h3>What does NOT trigger the fallback</h3>
+ *
+ * Errors raised by {@code permissionManager.check} itself (policy / audit /
+ * runtime) are propagated as-is. Re-running the legacy path on those would
+ * mask real bugs and could change the decision pipeline behind the user's
+ * back. The fallback is strictly for the args-to-Capability conversion step.
+ */
+final class ToolPermissionRouter {
+
+    private static final Logger log = LoggerFactory.getLogger(ToolPermissionRouter.class);
+
+    private ToolPermissionRouter() { /* static-only */ }
+
+    /**
+     * Routes a tool call to the structured or legacy permission entry point.
+     *
+     * @param delegate        the tool being invoked (may or may not be {@link CapabilityAware})
+     * @param inputJson       the JSON args the LLM supplied to the tool
+     * @param sessionId       the owning session id, or {@code null} for daemon-internal calls
+     * @param description     rich human-readable description for the approval prompt
+     * @param fallbackLevel   risk level used when going through the legacy path
+     * @param permissionManager the manager that evaluates policy
+     * @param mapper          Jackson mapper, used to parse {@code inputJson} for capability conversion
+     * @return the manager's decision
+     * @throws IllegalStateException if a {@link CapabilityAware} tool's
+     *         {@code toCapability(...)} returns {@code null} (contract violation)
+     */
+    static PermissionDecision check(
+            Tool delegate,
+            String inputJson,
+            String sessionId,
+            String description,
+            PermissionLevel fallbackLevel,
+            PermissionManager permissionManager,
+            ObjectMapper mapper) {
+        Objects.requireNonNull(delegate, "delegate");
+        Objects.requireNonNull(inputJson, "inputJson");
+        Objects.requireNonNull(description, "description");
+        Objects.requireNonNull(fallbackLevel, "fallbackLevel");
+        Objects.requireNonNull(permissionManager, "permissionManager");
+        Objects.requireNonNull(mapper, "mapper");
+
+        if (!(delegate instanceof CapabilityAware capAware)) {
+            var legacyRequest = new PermissionRequest(delegate.name(), description, fallbackLevel);
+            return permissionManager.check(legacyRequest, sessionId);
+        }
+
+        Capability capability;
+        boolean conversionThrew = false;
+        try {
+            capability = capAware.toCapability(mapper.readTree(inputJson));
+        } catch (RuntimeException | IOException toCapErr) {
+            log.warn("CapabilityAware tool {} rejected args; falling back to legacy permission path: {}",
+                    delegate.name(), toCapErr.getMessage());
+            capability = null;
+            conversionThrew = true;
+        }
+        if (capability == null && !conversionThrew) {
+            throw new IllegalStateException(
+                    "CapabilityAware tool " + delegate.name()
+                            + " returned null capability (contract violation)");
+        }
+        if (capability != null) {
+            var provenance = Provenance.fromNullableSessionId(sessionId);
+            return permissionManager.check(capability, provenance, delegate.name(), description);
+        }
+        var legacyRequest = new PermissionRequest(delegate.name(), description, fallbackLevel);
+        return permissionManager.check(legacyRequest, sessionId);
+    }
+}

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/ToolPermissionRouter.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/ToolPermissionRouter.java
@@ -83,29 +83,32 @@ final class ToolPermissionRouter {
         Objects.requireNonNull(mapper, "mapper");
 
         if (!(delegate instanceof CapabilityAware capAware)) {
-            var legacyRequest = new PermissionRequest(delegate.name(), description, fallbackLevel);
-            return permissionManager.check(legacyRequest, sessionId);
+            return checkLegacy(delegate, description, fallbackLevel, sessionId, permissionManager);
         }
 
         Capability capability;
-        boolean conversionThrew = false;
         try {
             capability = capAware.toCapability(mapper.readTree(inputJson));
         } catch (RuntimeException | IOException toCapErr) {
             log.warn("CapabilityAware tool {} rejected args; falling back to legacy permission path: {}",
                     delegate.name(), toCapErr.getMessage());
-            capability = null;
-            conversionThrew = true;
+            return checkLegacy(delegate, description, fallbackLevel, sessionId, permissionManager);
         }
-        if (capability == null && !conversionThrew) {
+        if (capability == null) {
             throw new IllegalStateException(
                     "CapabilityAware tool " + delegate.name()
                             + " returned null capability (contract violation)");
         }
-        if (capability != null) {
-            var provenance = Provenance.fromNullableSessionId(sessionId);
-            return permissionManager.check(capability, provenance, delegate.name(), description);
-        }
+        var provenance = Provenance.fromNullableSessionId(sessionId);
+        return permissionManager.check(capability, provenance, delegate.name(), description);
+    }
+
+    private static PermissionDecision checkLegacy(
+            Tool delegate,
+            String description,
+            PermissionLevel fallbackLevel,
+            String sessionId,
+            PermissionManager permissionManager) {
         var legacyRequest = new PermissionRequest(delegate.name(), description, fallbackLevel);
         return permissionManager.check(legacyRequest, sessionId);
     }

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/ToolPermissionRouterTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/ToolPermissionRouterTest.java
@@ -1,0 +1,211 @@
+package dev.aceclaw.daemon;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.aceclaw.core.agent.Tool;
+import dev.aceclaw.security.Capability;
+import dev.aceclaw.security.CapabilityAware;
+import dev.aceclaw.security.PermissionDecision;
+import dev.aceclaw.security.PermissionLevel;
+import dev.aceclaw.security.PermissionManager;
+import dev.aceclaw.security.PermissionPolicy;
+import dev.aceclaw.security.PermissionRequest;
+import dev.aceclaw.security.WriteMode;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Pins the dispatcher branching contract for #480 PR 2: tools that implement
+ * {@link CapabilityAware} are routed through the structured
+ * {@link Capability} path; everything else takes the legacy
+ * {@link PermissionRequest} path. Both paths land in the same
+ * {@link PermissionManager} decision pipeline.
+ *
+ * <p>Without this test, a regression that hides {@code CapabilityAware} (e.g.
+ * a tool decorator that delegates {@code execute} but not the marker
+ * interface) would silently drop the structured policy/audit benefit and
+ * never fail in CI.
+ */
+final class ToolPermissionRouterTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /** Capturing policy: records the {@link PermissionRequest} so the test can pin what was sent. */
+    private static final class CapturingPolicy implements PermissionPolicy {
+        final AtomicReference<PermissionRequest> last = new AtomicReference<>();
+        final AtomicInteger calls = new AtomicInteger();
+
+        @Override
+        public PermissionDecision evaluate(PermissionRequest request) {
+            last.set(request);
+            calls.incrementAndGet();
+            return new PermissionDecision.Approved();
+        }
+    }
+
+    /** Plain tool, NOT CapabilityAware — must take the legacy path. */
+    private static final class LegacyOnlyTool implements Tool {
+        @Override public String name() { return "legacy_tool"; }
+        @Override public String description() { return ""; }
+        @Override public JsonNode inputSchema() { return MAPPER.createObjectNode(); }
+        @Override public ToolResult execute(String inputJson) { return new ToolResult("ok", false); }
+    }
+
+    /** CapabilityAware tool that records whether toCapability was called. */
+    private static final class SpyCapabilityAwareTool implements Tool, CapabilityAware {
+        final AtomicInteger toCapabilityCalls = new AtomicInteger();
+        Capability capabilityToReturn = new Capability.FileWrite(Path.of("/tmp/x"), WriteMode.OVERWRITE);
+        boolean throwOnConvert = false;
+        boolean returnNull = false;
+
+        @Override public String name() { return "spy_tool"; }
+        @Override public String description() { return ""; }
+        @Override public JsonNode inputSchema() { return MAPPER.createObjectNode(); }
+        @Override public ToolResult execute(String inputJson) { return new ToolResult("ok", false); }
+        @Override public Capability toCapability(JsonNode args) {
+            toCapabilityCalls.incrementAndGet();
+            if (throwOnConvert) {
+                throw new IllegalArgumentException("simulated bad args");
+            }
+            if (returnNull) {
+                return null;
+            }
+            return capabilityToReturn;
+        }
+    }
+
+    @Test
+    void capabilityAwareToolTakesStructuredPath() {
+        // The whole point of CapabilityAware: when the tool can produce a
+        // structured Capability, the router uses it instead of the flat
+        // legacy PermissionRequest. Pin both: toCapability was called, AND
+        // the policy received a request derived from the capability.
+        var policy = new CapturingPolicy();
+        var pm = new PermissionManager(policy);
+        var tool = new SpyCapabilityAwareTool();
+
+        ToolPermissionRouter.check(
+                tool, "{\"file_path\":\"/tmp/x\"}", "sess-1", "Write /tmp/x",
+                PermissionLevel.WRITE, pm, MAPPER);
+
+        assertThat(tool.toCapabilityCalls.get())
+                .as("structured path must call toCapability")
+                .isEqualTo(1);
+        assertThat(policy.last.get().toolName())
+                .as("router passes the originating tool name as allowlist key")
+                .isEqualTo("spy_tool");
+        assertThat(policy.last.get().description())
+                .as("router passes the rich caller-supplied description, not displayLabel")
+                .isEqualTo("Write /tmp/x");
+        assertThat(policy.last.get().level())
+                .as("level comes from the capability variant, not the fallback level")
+                .isEqualTo(PermissionLevel.WRITE);
+    }
+
+    @Test
+    void plainToolTakesLegacyPath() {
+        // A non-CapabilityAware tool must not reach toCapability (there's
+        // nothing to call) and must produce the same legacy
+        // PermissionRequest the dispatcher built before #480.
+        var policy = new CapturingPolicy();
+        var pm = new PermissionManager(policy);
+        var tool = new LegacyOnlyTool();
+
+        ToolPermissionRouter.check(
+                tool, "{}", "sess-1", "describe me", PermissionLevel.EXECUTE, pm, MAPPER);
+
+        assertThat(policy.last.get().toolName()).isEqualTo("legacy_tool");
+        assertThat(policy.last.get().description()).isEqualTo("describe me");
+        assertThat(policy.last.get().level()).isEqualTo(PermissionLevel.EXECUTE);
+    }
+
+    @Test
+    void toCapabilityThrowFallsBackToLegacy() {
+        // A tool that throws from toCapability (bad args, parse error)
+        // should not crash the dispatcher — fall back to the legacy path
+        // so the user gets a normal approval prompt. Pin: toCapability was
+        // attempted, then the legacy path produced a request with the
+        // dispatcher-supplied fallback level (not the variant's risk).
+        var policy = new CapturingPolicy();
+        var pm = new PermissionManager(policy);
+        var tool = new SpyCapabilityAwareTool();
+        tool.throwOnConvert = true;
+
+        var decision = ToolPermissionRouter.check(
+                tool, "{}", "sess-1", "fallback prompt", PermissionLevel.WRITE, pm, MAPPER);
+
+        assertThat(decision).isInstanceOf(PermissionDecision.Approved.class);
+        assertThat(tool.toCapabilityCalls.get()).isEqualTo(1);
+        assertThat(policy.last.get().level())
+                .as("fallback uses the caller-supplied level, not a derived risk")
+                .isEqualTo(PermissionLevel.WRITE);
+    }
+
+    @Test
+    void toCapabilityReturningNullFailsFast() {
+        // Contract violation: CapabilityAware.toCapability is documented
+        // non-null. Silently downgrading to legacy here would mask a broken
+        // tool and drop structured policy/audit data. Verify the router
+        // throws IllegalStateException naming the offending tool.
+        var policy = new CapturingPolicy();
+        var pm = new PermissionManager(policy);
+        var tool = new SpyCapabilityAwareTool();
+        tool.returnNull = true;
+
+        assertThatThrownBy(() -> ToolPermissionRouter.check(
+                tool, "{}", "sess-1", "any", PermissionLevel.WRITE, pm, MAPPER))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("spy_tool")
+                .hasMessageContaining("null capability");
+
+        assertThat(policy.calls.get())
+                .as("policy must NOT be consulted when the contract is violated")
+                .isZero();
+    }
+
+    @Test
+    void permissionManagerErrorPropagates() {
+        // The narrow fallback intentionally does NOT cover errors from
+        // permissionManager.check itself — those would be policy/audit
+        // bugs. Re-running the legacy path on them would mask real
+        // failures and could change the decision behind the user's back.
+        // Pin: a policy that throws bubbles up through the structured path.
+        PermissionPolicy crashingPolicy = req -> {
+            throw new IllegalStateException("policy bug");
+        };
+        var pm = new PermissionManager(crashingPolicy);
+        var tool = new SpyCapabilityAwareTool();
+
+        assertThatThrownBy(() -> ToolPermissionRouter.check(
+                tool, "{}", "sess-1", "any", PermissionLevel.WRITE, pm, MAPPER))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("policy bug");
+    }
+
+    @Test
+    void daemonInternalCallNullSessionIdGoesThroughBothPaths() {
+        // Cron, boot scripts, and other daemon-internal callers pass
+        // sessionId == null. The router must accept it (no NPE) and
+        // produce a Provenance.daemonInternal()-shaped check via the
+        // structured path, falling back unchanged through the legacy
+        // path otherwise.
+        var policy = new CapturingPolicy();
+        var pm = new PermissionManager(policy);
+
+        ToolPermissionRouter.check(
+                new SpyCapabilityAwareTool(), "{}", null, "no session",
+                PermissionLevel.WRITE, pm, MAPPER);
+        assertThat(policy.last.get().toolName()).isEqualTo("spy_tool");
+
+        ToolPermissionRouter.check(
+                new LegacyOnlyTool(), "{}", null, "no session",
+                PermissionLevel.READ, pm, MAPPER);
+        assertThat(policy.last.get().toolName()).isEqualTo("legacy_tool");
+    }
+}

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/ToolPermissionRouterTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/ToolPermissionRouterTest.java
@@ -189,6 +189,33 @@ final class ToolPermissionRouterTest {
     }
 
     @Test
+    void nullInputJsonFallsBackToLegacyInsteadOfCrashing() {
+        // Upstream (ContentBlock.ToolUse, PermissionAwareTool's parse
+        // path) can deliver a tool call with no arguments payload. The
+        // router must treat that as "couldn't build a Capability, prompt
+        // via legacy" rather than throw NPE — otherwise a recoverable
+        // upstream flow becomes an unhandled crash. (Codex review on
+        // #482, second pass.)
+        var policy = new CapturingPolicy();
+        var pm = new PermissionManager(policy);
+        var tool = new SpyCapabilityAwareTool();
+
+        var decision = ToolPermissionRouter.check(
+                tool, null, "sess-1", "fallback prompt", PermissionLevel.WRITE, pm, MAPPER);
+
+        assertThat(decision).isInstanceOf(PermissionDecision.Approved.class);
+        assertThat(tool.toCapabilityCalls.get())
+                .as("null input never reaches toCapability — readTree fails first, caught, legacy fallback")
+                .isZero();
+        assertThat(policy.last.get().toolName())
+                .as("legacy fallback was used")
+                .isEqualTo("spy_tool");
+        assertThat(policy.last.get().level())
+                .as("legacy fallback uses caller-supplied level")
+                .isEqualTo(PermissionLevel.WRITE);
+    }
+
+    @Test
     void daemonInternalCallNullSessionIdGoesThroughBothPaths() {
         // Cron, boot scripts, and other daemon-internal callers pass
         // sessionId == null. The router must accept it (no NPE) and

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/Capability.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/Capability.java
@@ -71,6 +71,31 @@ public sealed interface Capability {
     String displayLabel();
 
     /**
+     * Default allowlist key used by {@link PermissionManager#check(Capability, Provenance)}
+     * — the convenience overload — when no explicit key is supplied. Returns
+     * the variant's simple class name (e.g. {@code "FileRead"}); useful for
+     * daemon-internal callers that have no originating tool name.
+     *
+     * <p><strong>Tool dispatchers must NOT rely on this default.</strong>
+     * They should call
+     * {@link PermissionManager#check(Capability, Provenance, String, String)}
+     * with the originating tool's name as the allowlist key, so that user
+     * approvals granted before #480 (keyed by tool name like
+     * {@code "write_file"}) keep auto-approving the migrated structured
+     * path. Two different tools producing the same capability variant
+     * intentionally remain separate allowlist entries — "always allow this
+     * tool" is a per-tool decision, while capability-level rules belong in
+     * PolicyEngine (#465 Scope #2).
+     *
+     * <p>{@link LegacyToolUse} overrides this to return its recorded
+     * {@code toolName} so the convenience overload also stays compatible
+     * for that bridge variant.
+     */
+    default String allowlistKey() {
+        return getClass().getSimpleName();
+    }
+
+    /**
      * Renders a {@link Path} with forward slashes regardless of the host OS.
      * Audit logs and dashboard labels are observed across platforms (a Linux
      * operator viewing a Windows daemon's events shouldn't see backslashes
@@ -265,5 +290,15 @@ public sealed interface Capability {
             };
         }
         @Override public String displayLabel() { return "legacy:" + toolName; }
+
+        /**
+         * Preserves the existing tool-name keyed allowlist semantics: a user
+         * who clicked "always allow {@code write_file}" before #480 must
+         * keep being auto-approved even after their tool dispatch goes
+         * through the {@link LegacyToolUse} bridge. Returning the recorded
+         * {@code toolName} (instead of the default {@code "LegacyToolUse"})
+         * makes that work without touching the allowlist storage format.
+         */
+        @Override public String allowlistKey() { return toolName; }
     }
 }

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/Capability.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/Capability.java
@@ -181,11 +181,15 @@ public sealed interface Capability {
 
         @Override public PermissionLevel risk() { return PermissionLevel.EXECUTE; }
         @Override public DataFlow dataFlow() {
-            // GET/HEAD are read-only request bodies; everything else can
-            // ship payload, so DataFlow.BOTH is the safe default.
-            return ("GET".equalsIgnoreCase(method) || "HEAD".equalsIgnoreCase(method))
-                    ? DataFlow.INGRESS
-                    : DataFlow.BOTH;
+            // ALL HTTP methods are EGRESS-capable, including GET/HEAD: URL
+            // query strings, headers, cookies, and (in some clients) bodies
+            // ship data outbound regardless of the verb. Classifying GET as
+            // INGRESS-only would let a "block-egress" policy be bypassed by
+            // exfiltrating via querystring — a real-world attack pattern.
+            // Keeping a single answer (BOTH) avoids that whole class of
+            // bypass; per-payload inspection belongs in PolicyEngine
+            // (#465 Scope #2). (Codex review on #481, addressed in #482.)
+            return DataFlow.BOTH;
         }
         @Override public String displayLabel() { return method + " " + url; }
     }

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/CapabilityAware.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/CapabilityAware.java
@@ -1,0 +1,39 @@
+package dev.aceclaw.security;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Optional companion to {@code dev.aceclaw.core.agent.Tool}: a tool
+ * implements this when it can describe its requested operation as a
+ * structured {@link Capability} variant rather than the flat
+ * {@link PermissionRequest} (#480 — runtime governance Scope #1).
+ *
+ * <p>The dispatcher checks {@code instanceof CapabilityAware} before
+ * calling {@link PermissionManager}; if present, the structured capability
+ * goes into the audit log and the policy decision; otherwise the legacy
+ * path with {@link Capability.LegacyToolUse} bridges. This lets tools
+ * migrate one-at-a-time without a flag-day sweep.
+ *
+ * <p>Lives in {@code aceclaw-security} (not {@code aceclaw-core}) because
+ * it's specifically about the security pipeline; {@code aceclaw-core}'s
+ * {@code Tool} stays general-purpose. Tools in {@code aceclaw-tools}
+ * already depend on both modules so they can implement both interfaces.
+ */
+public interface CapabilityAware {
+
+    /**
+     * Builds the {@link Capability} this tool will exercise on the given
+     * input. Called <em>before</em> the tool runs, so the policy can make
+     * a decision against a structured request.
+     *
+     * <p>Implementations should return a {@code Capability} variant whose
+     * fields match what the tool will actually do — e.g.
+     * {@code WriteFileTool} returns {@link Capability.FileWrite} with the
+     * path and write mode it intends to use.
+     *
+     * @param args the JSON args the LLM (or caller) passed to the tool
+     * @return the structured capability the tool will request, never null
+     * @throws IllegalArgumentException if args are missing required fields
+     */
+    Capability toCapability(JsonNode args);
+}

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/PermissionManager.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/PermissionManager.java
@@ -63,37 +63,100 @@ public final class PermissionManager {
 
     /**
      * Checks whether the given request is permitted within the given
-     * session.
+     * session. <strong>Legacy entry point</strong> retained for callers that
+     * still construct flat {@link PermissionRequest}s; under the hood it
+     * wraps the request as a {@link Capability.LegacyToolUse} and delegates
+     * to {@link #check(Capability, Provenance)}, so legacy and structured
+     * paths share one decision-and-audit pipeline (#480 Layer 1, PR 2).
      *
-     * <p>Order: session-level blanket approval → policy. The
-     * blanket-approval lookup is per-session — a tool approved in
-     * session A is NOT auto-approved in session B (issue #456).
+     * <p>Order is unchanged: session-level blanket approval → policy. The
+     * blanket-approval lookup is per-session — a tool approved in session A
+     * is NOT auto-approved in session B (issue #456).
      *
      * @param request   the permission request
      * @param sessionId the session this check belongs to. {@code null}
-     *                  skips the per-session allow-list lookup and
-     *                  goes straight to the policy — useful for
-     *                  daemon-internal checks where no session owns
-     *                  the request.
+     *                  skips the per-session allow-list lookup — daemon-
+     *                  internal checks (cron, boot scripts) use this.
      * @return the decision
      */
     public PermissionDecision check(PermissionRequest request, String sessionId) {
         Objects.requireNonNull(request, "request");
-        if (sessionId != null) {
-            var allow = sessionApprovals.get(sessionId);
-            if (allow != null && allow.contains(request.toolName())) {
-                log.debug("Permission auto-approved (session blanket): tool={}, sessionId={}",
-                        request.toolName(), sessionId);
+        var capability = new Capability.LegacyToolUse(request.toolName(), request.level());
+        var provenance = Provenance.legacy(sessionId);
+        // Legacy callers' allowlist key is already the tool name — pass it
+        // through unchanged so existing "always allow X" approvals stay valid.
+        return check(capability, provenance, request.toolName(), request.description());
+    }
+
+    /**
+     * Structured-capability entry point introduced by #480 PR 2. Takes a
+     * {@link Capability} (one of the sealed variants) plus the
+     * {@link Provenance} that records how the agent arrived at this check,
+     * and returns the same decision the legacy method does.
+     *
+     * <p>This convenience overload uses the capability's
+     * {@link Capability#allowlistKey() default allowlist key} (the variant
+     * class name) and {@link Capability#displayLabel()} as the prompt
+     * description. Tool dispatchers should prefer
+     * {@link #check(Capability, Provenance, String, String)} so existing
+     * tool-name-keyed allowlists keep working through migration and the
+     * user sees a richer prompt than the synthetic {@code displayLabel()}.
+     */
+    public PermissionDecision check(Capability capability, Provenance provenance) {
+        return check(capability, provenance, capability.allowlistKey(), capability.displayLabel());
+    }
+
+    /**
+     * Full structured-capability entry point. Caller supplies an explicit
+     * {@code allowlistKey} (typically the originating tool's name) and a
+     * {@code description} (typically the dispatcher's rich human-readable
+     * tool summary). Used by the dispatcher in {@code StreamingAgentHandler}
+     * so that:
+     *
+     * <ul>
+     *   <li>"Always allow {@code write_file}" approvals granted before #480
+     *       keep auto-approving even after {@code WriteFileTool} migrates
+     *       to {@code CapabilityAware} — the allowlist is keyed by tool
+     *       name, not by capability variant.</li>
+     *   <li>The user sees the same prompt for both legacy and migrated
+     *       tools — no UX regression during migration.</li>
+     * </ul>
+     *
+     * <p>Pipeline is unchanged: session allowlist first, then policy.
+     * PolicyEngine (#465 Scope #2) will eventually consume the structured
+     * {@link Capability} directly; until then this method bridges by
+     * constructing a {@link PermissionRequest} on the fly.
+     */
+    public PermissionDecision check(
+            Capability capability,
+            Provenance provenance,
+            String allowlistKey,
+            String description) {
+        Objects.requireNonNull(capability, "capability");
+        Objects.requireNonNull(provenance, "provenance");
+        Objects.requireNonNull(allowlistKey, "allowlistKey");
+        Objects.requireNonNull(description, "description");
+
+        String sessionIdOrNull = provenance.sessionId().map(s -> s.value()).orElse(null);
+        if (sessionIdOrNull != null) {
+            var allow = sessionApprovals.get(sessionIdOrNull);
+            if (allow != null && allow.contains(allowlistKey)) {
+                log.debug("Permission auto-approved (session blanket): key={}, sessionId={}",
+                        allowlistKey, sessionIdOrNull);
                 var decision = new PermissionDecision.Approved();
-                audit(request, sessionId, decision, "session-blanket-approval");
+                audit(allowlistKey, capability.risk(), sessionIdOrNull, decision, "session-blanket-approval");
                 return decision;
             }
         }
+
+        // PolicyEngine is still PermissionRequest-shaped today (#465 Scope
+        // #2 will change that). Build a request from the capability.
+        var request = new PermissionRequest(allowlistKey, description, capability.risk());
         var decision = policy.evaluate(request);
-        log.debug("Permission check: tool={}, level={}, sessionId={}, decision={}",
-                request.toolName(), request.level(), sessionId,
+        log.debug("Permission check: key={}, level={}, sessionId={}, decision={}",
+                allowlistKey, capability.risk(), sessionIdOrNull,
                 decision.getClass().getSimpleName());
-        audit(request, sessionId, decision, null);
+        audit(allowlistKey, capability.risk(), sessionIdOrNull, decision, null);
         return decision;
     }
 
@@ -104,9 +167,15 @@ public final class PermissionManager {
      * and chooses the {@code reason} field: caller-supplied note
      * (for the session-blanket branch), the denial reason (for
      * Denied), the prompt (for NeedsUserApproval), or null.
+     *
+     * <p>Audit shape is still v1 (flat fields) in PR 2 — PR 3 will swap
+     * in a structured form that carries the {@link Capability} and
+     * {@link Provenance} directly. For now we project them down to the
+     * v1 fields {@code (toolName, level)}.
      */
     private void audit(
-            PermissionRequest request,
+            String allowlistKey,
+            PermissionLevel risk,
             String sessionId,
             PermissionDecision decision,
             String approvalNote) {
@@ -127,7 +196,7 @@ public final class PermissionManager {
                 reason = n.prompt();
             }
         }
-        auditLog.record(Instant.now(), sessionId, request.toolName(), request.level(), kind, reason);
+        auditLog.record(Instant.now(), sessionId, allowlistKey, risk, kind, reason);
     }
 
     /**

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/PermissionManager.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/PermissionManager.java
@@ -82,7 +82,7 @@ public final class PermissionManager {
     public PermissionDecision check(PermissionRequest request, String sessionId) {
         Objects.requireNonNull(request, "request");
         var capability = new Capability.LegacyToolUse(request.toolName(), request.level());
-        var provenance = Provenance.legacy(sessionId);
+        var provenance = Provenance.fromNullableSessionId(sessionId);
         // Legacy callers' allowlist key is already the tool name — pass it
         // through unchanged so existing "always allow X" approvals stay valid.
         return check(capability, provenance, request.toolName(), request.description());

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/PermissionManager.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/PermissionManager.java
@@ -103,6 +103,8 @@ public final class PermissionManager {
      * user sees a richer prompt than the synthetic {@code displayLabel()}.
      */
     public PermissionDecision check(Capability capability, Provenance provenance) {
+        Objects.requireNonNull(capability, "capability");
+        Objects.requireNonNull(provenance, "provenance");
         return check(capability, provenance, capability.allowlistKey(), capability.displayLabel());
     }
 

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/Provenance.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/Provenance.java
@@ -1,0 +1,104 @@
+package dev.aceclaw.security;
+
+import dev.aceclaw.security.ids.PlanStepId;
+import dev.aceclaw.security.ids.PromptId;
+import dev.aceclaw.security.ids.SessionId;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * "How did we get here" for a {@link Capability} check (#480). Every
+ * capability use carries a {@link Provenance} so the audit log can answer
+ * questions like "what user prompt eventually triggered this {@code rm
+ * -rf}?", which sub-agent did it, which plan step, after how many retries.
+ *
+ * <h3>Field semantics</h3>
+ *
+ * <ul>
+ *   <li>{@code rootPrompt} — the user prompt at the root of this chain.
+ *       Optional because PR 2 does not yet thread {@link PromptId} through
+ *       {@code StreamingAgentLoop}; PR 3 wires it. The legacy shim
+ *       ({@link PermissionManager#check(PermissionRequest, String)}) leaves
+ *       it empty.</li>
+ *   <li>{@code sessionId} — owning session, or empty for daemon-internal
+ *       checks (cron triggers, boot scripts). Not all capability uses
+ *       belong to a user-facing session.</li>
+ *   <li>{@code planStepId} — current plan step, or empty when not running
+ *       inside a plan. PR 3 wires the planner to populate this.</li>
+ *   <li>{@code subAgentDepth} — 0 for top-level agent; N for an agent
+ *       spawned N levels deep. Policies can refuse spawns past a depth.</li>
+ *   <li>{@code chain} — ordered list of {@link ProvenanceLink}s root-first.
+ *       Empty in PR 2 (no chain wiring yet). PR 3 will populate it.</li>
+ * </ul>
+ *
+ * <h3>Why all the {@code Optional} fields</h3>
+ *
+ * Because pretending we know what we don't is worse than admitting it.
+ * PR 2 introduces the shape; PR 3 wires the data. An honest empty is
+ * easier to spot in the audit log than a synthetic placeholder; future
+ * code can pattern-match on {@code Optional.isEmpty()} to know "this
+ * capability was checked through the legacy path before full provenance
+ * tracking landed."
+ */
+public record Provenance(
+        Optional<PromptId> rootPrompt,
+        Optional<SessionId> sessionId,
+        Optional<PlanStepId> planStepId,
+        int subAgentDepth,
+        List<ProvenanceLink> chain
+) {
+    public Provenance {
+        Objects.requireNonNull(rootPrompt, "rootPrompt");
+        Objects.requireNonNull(sessionId, "sessionId");
+        Objects.requireNonNull(planStepId, "planStepId");
+        if (subAgentDepth < 0) {
+            throw new IllegalArgumentException("subAgentDepth must be non-negative; got " + subAgentDepth);
+        }
+        chain = chain != null ? List.copyOf(chain) : List.of();
+    }
+
+    /**
+     * Top-level provenance for a session, with no plan step / prompt-id
+     * wiring (yet). Used by tools that have a session but haven't been
+     * threaded through PR 3's full chain yet.
+     */
+    public static Provenance forSession(SessionId sessionId) {
+        Objects.requireNonNull(sessionId, "sessionId");
+        return new Provenance(
+                Optional.empty(),
+                Optional.of(sessionId),
+                Optional.empty(),
+                0,
+                List.of());
+    }
+
+    /**
+     * Provenance for a daemon-internal capability check that doesn't
+     * belong to any user session — boot scripts, cron triggers,
+     * background maintenance.
+     */
+    public static Provenance daemonInternal() {
+        return new Provenance(
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                0,
+                List.of());
+    }
+
+    /**
+     * Compatibility bridge for {@link PermissionManager#check(PermissionRequest, String)}
+     * — the legacy entry point that only knows {@code (request, sessionId)}.
+     * Constructs the same shape {@link #forSession} produces, but is named
+     * differently so a grep for {@code Provenance.legacy} finds every site
+     * that hasn't yet been migrated to the structured API.
+     */
+    public static Provenance legacy(String sessionId) {
+        if (sessionId == null) {
+            return daemonInternal();
+        }
+        return forSession(new SessionId(sessionId));
+    }
+}

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/Provenance.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/Provenance.java
@@ -89,13 +89,19 @@ public record Provenance(
     }
 
     /**
-     * Compatibility bridge for {@link PermissionManager#check(PermissionRequest, String)}
-     * — the legacy entry point that only knows {@code (request, sessionId)}.
-     * Constructs the same shape {@link #forSession} produces, but is named
-     * differently so a grep for {@code Provenance.legacy} finds every site
-     * that hasn't yet been migrated to the structured API.
+     * Convenience for callers that have a {@code String} sessionId from a
+     * pre-#480 surface (legacy {@code PermissionRequest} shim) or from the
+     * dispatcher (which doesn't yet have a {@link PromptId} or
+     * {@link PlanStepId} to thread — those land in PR 3). Maps {@code null}
+     * to {@link #daemonInternal()} and a non-null value to {@link #forSession}.
+     *
+     * <p>Named {@code fromNullableSessionId} (rather than {@code legacy})
+     * so the call sites describe what they actually have — a possibly-null
+     * raw string id — without implying the path is legacy-only. A grep for
+     * this name finds every site that lacks the full PR 3 chain wiring,
+     * which is the migration signal we actually care about.
      */
-    public static Provenance legacy(String sessionId) {
+    public static Provenance fromNullableSessionId(String sessionId) {
         if (sessionId == null) {
             return daemonInternal();
         }

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/ProvenanceLink.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/ProvenanceLink.java
@@ -1,0 +1,65 @@
+package dev.aceclaw.security;
+
+import dev.aceclaw.security.ids.PlanStepId;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * One step in a {@link Provenance} chain (#480) — what happened to the agent
+ * between the root prompt and the current capability check. Modeled as a
+ * sealed interface so audit replay and dashboard timelines can pattern-match
+ * exhaustively on the kind of event.
+ *
+ * <p>Variants are intentionally narrow: each kind of step has its own
+ * record with the fields that step needs. PolicyEngine (#465 Scope #2) and
+ * the audit-log viewer (planned for PR 3) both consume this via
+ * {@code switch} with no default — adding a new kind of link forces every
+ * consumer to update.
+ */
+public sealed interface ProvenanceLink {
+
+    /** Wall-clock instant the link was recorded. */
+    Instant at();
+
+    /** Single-line human-readable summary, used in the dashboard timeline. */
+    String displayLabel();
+
+    /** Agent entered a plan step. {@code stepId} identifies which step. */
+    record PlanStepEntered(PlanStepId stepId, Instant at) implements ProvenanceLink {
+        public PlanStepEntered {
+            Objects.requireNonNull(stepId, "stepId");
+            Objects.requireNonNull(at, "at");
+        }
+        @Override public String displayLabel() { return "plan-step " + stepId; }
+    }
+
+    /**
+     * A sub-agent was spawned. {@code role} is a free-form descriptor (e.g.
+     * {@code "planner"}, {@code "reviewer"}); the new sub-agent's depth is
+     * {@code parent.subAgentDepth + 1}, recorded on the new {@link Provenance}
+     * rather than on the link.
+     */
+    record SubAgentSpawned(String role, Instant at) implements ProvenanceLink {
+        public SubAgentSpawned {
+            Objects.requireNonNull(role, "role");
+            Objects.requireNonNull(at, "at");
+        }
+        @Override public String displayLabel() { return "spawn role=" + role; }
+    }
+
+    /**
+     * A retry of a previously-failed action. {@code attempt} is 1-indexed
+     * (a fresh attempt is 1, the first retry is 2, …) so log lines read
+     * naturally as {@code "retry attempt 3"}.
+     */
+    record RetryAttempt(int attempt, Instant at) implements ProvenanceLink {
+        public RetryAttempt {
+            Objects.requireNonNull(at, "at");
+            if (attempt < 1) {
+                throw new IllegalArgumentException("attempt must be >= 1; got " + attempt);
+            }
+        }
+        @Override public String displayLabel() { return "retry attempt " + attempt; }
+    }
+}

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/CapabilityTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/CapabilityTest.java
@@ -78,21 +78,19 @@ final class CapabilityTest {
     }
 
     @Test
-    void httpFetchGetIsIngressOnly() {
-        var cap = new Capability.HttpFetch(URI.create("https://example.com"), "GET");
-
-        assertThat(cap.risk()).isEqualTo(PermissionLevel.EXECUTE);
-        assertThat(cap.dataFlow())
-                .as("safe HTTP methods upload no body")
-                .isEqualTo(DataFlow.INGRESS);
-    }
-
-    @Test
-    void httpFetchPostIsBidirectional() {
-        var cap = new Capability.HttpFetch(URI.create("https://example.com"), "POST");
-
-        assertThat(cap.risk()).isEqualTo(PermissionLevel.EXECUTE);
-        assertThat(cap.dataFlow()).isEqualTo(DataFlow.BOTH);
+    void httpFetchAllMethodsAreBidirectional() {
+        // Even GET/HEAD ship URL query strings, headers, and cookies
+        // outbound — those are exfiltration vectors. Classify every HTTP
+        // method as BOTH so a "block-egress" policy cannot be bypassed by
+        // hiding payload in a GET querystring. Per-payload inspection
+        // belongs in PolicyEngine (#465 Scope #2).
+        for (var method : java.util.List.of("GET", "HEAD", "POST", "PUT", "DELETE", "PATCH")) {
+            var cap = new Capability.HttpFetch(URI.create("https://example.com"), method);
+            assertThat(cap.risk()).isEqualTo(PermissionLevel.EXECUTE);
+            assertThat(cap.dataFlow())
+                    .as("HTTP %s must be BOTH (URL/headers are egress vectors)", method)
+                    .isEqualTo(DataFlow.BOTH);
+        }
     }
 
     @Test

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/PermissionManagerCapabilityTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/PermissionManagerCapabilityTest.java
@@ -21,10 +21,6 @@ final class PermissionManagerCapabilityTest {
     private static final PermissionPolicy DENY = req ->
             new PermissionDecision.Denied("test policy denies");
 
-    /** Always-approve policy. */
-    private static final PermissionPolicy APPROVE = req ->
-            new PermissionDecision.Approved();
-
     @Test
     void structuredCheckUsesCapabilityRiskInPolicyRequest() {
         // PolicyEngine doesn't yet consume Capability directly (#465 Scope
@@ -120,17 +116,21 @@ final class PermissionManagerCapabilityTest {
     void daemonInternalProvenanceSkipsAllowlistLookup() {
         // Provenance.daemonInternal() leaves sessionId empty. Without a
         // session, the manager falls straight through to the policy — same
-        // semantics as the legacy path's null-sessionId case.
-        var pm = new PermissionManager(APPROVE);
-        // Even with an approval in some session, daemon-internal goes
-        // straight to policy.
+        // semantics as the legacy path's null-sessionId case. Use DENY here
+        // (not APPROVE) so the assertion actually proves the bypass: if
+        // daemonInternal accidentally reused the session approval, this
+        // test would now wrongly approve. With DENY, only the bypass path
+        // can produce the expected Denied outcome.
+        var pm = new PermissionManager(DENY);
         pm.approveForSession("sess-X", "FileRead");
 
         var decision = pm.check(
                 new Capability.FileRead(Path.of("/etc/hosts")),
                 Provenance.daemonInternal());
 
-        assertThat(decision).isInstanceOf(PermissionDecision.Approved.class);
+        assertThat(decision)
+                .as("daemon-internal must skip the session allowlist and hit policy")
+                .isInstanceOf(PermissionDecision.Denied.class);
     }
 
     @Test

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/PermissionManagerCapabilityTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/PermissionManagerCapabilityTest.java
@@ -1,0 +1,151 @@
+package dev.aceclaw.security;
+
+import dev.aceclaw.security.ids.SessionId;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the new {@link PermissionManager#check(Capability, Provenance)}
+ * pipeline (#480 PR 2): structured capability + provenance go in, a
+ * decision compatible with the legacy path comes out, and the legacy
+ * {@link PermissionManager#check(PermissionRequest, String)} keeps working
+ * by routing through the same code via the {@link Capability.LegacyToolUse}
+ * shim.
+ */
+final class PermissionManagerCapabilityTest {
+
+    /** Always-deny policy so any Approved result must come from the session blanket. */
+    private static final PermissionPolicy DENY = req ->
+            new PermissionDecision.Denied("test policy denies");
+
+    /** Always-approve policy. */
+    private static final PermissionPolicy APPROVE = req ->
+            new PermissionDecision.Approved();
+
+    @Test
+    void structuredCheckUsesCapabilityRiskInPolicyRequest() {
+        // PolicyEngine doesn't yet consume Capability directly (#465 Scope
+        // #2 lands later); for now the manager builds a PermissionRequest
+        // from the capability so DefaultPermissionPolicy etc. keep working
+        // unchanged. Confirm the level passed in is the variant's derived
+        // risk, not something a caller could lie about.
+        var captured = new java.util.concurrent.atomic.AtomicReference<PermissionRequest>();
+        PermissionPolicy capturing = req -> {
+            captured.set(req);
+            return new PermissionDecision.Approved();
+        };
+        var pm = new PermissionManager(capturing);
+        var fileWrite = new Capability.FileWrite(Path.of("/tmp/x"), WriteMode.OVERWRITE);
+
+        pm.check(fileWrite, Provenance.forSession(new SessionId("s")));
+
+        assertThat(captured.get().level()).isEqualTo(PermissionLevel.WRITE);
+        assertThat(captured.get().toolName())
+                .as("toolName uses the capability's allowlistKey, not a stringly-typed name")
+                .isEqualTo("FileWrite");
+    }
+
+    @Test
+    void sessionBlanketApprovalSurvivesToolMigrationViaDispatcherKey() {
+        // Critical compatibility test: a user who clicked "always allow
+        // write_file" via the LEGACY path MUST still be auto-approved when
+        // the tool migrates to CapabilityAware. The dispatcher passes the
+        // originating tool's name as the explicit allowlist key, so the
+        // existing approval keeps applying — no UX regression on migration.
+        var pm = new PermissionManager(DENY);
+        pm.approveForSession("sess-A", "write_file");
+
+        // Legacy entry — same shape as before #480.
+        var legacyDecision = pm.check(PermissionRequest.write("write_file", "/tmp/x"), "sess-A");
+        assertThat(legacyDecision).isInstanceOf(PermissionDecision.Approved.class);
+
+        // Migrated path: dispatcher calls the 4-arg form with the tool name
+        // as the allowlist key. The pre-existing "write_file" approval
+        // applies, just as it did via the legacy path.
+        var migratedDecision = pm.check(
+                new Capability.FileWrite(Path.of("/tmp/x"), WriteMode.OVERWRITE),
+                Provenance.forSession(new SessionId("sess-A")),
+                "write_file",
+                "write /tmp/x");
+        assertThat(migratedDecision)
+                .as("tool-name allowlist survives migration to CapabilityAware")
+                .isInstanceOf(PermissionDecision.Approved.class);
+    }
+
+    @Test
+    void twoArgConvenienceUsesCapabilityClassNameKey() {
+        // The 2-arg form is for daemon-internal callers that have no
+        // originating tool name (cron, boot scripts). It uses the variant's
+        // class name as the allowlist key — pin that so a future change to
+        // the default doesn't silently widen daemon-internal approvals.
+        var pm = new PermissionManager(DENY);
+        pm.approveForSession("sess-A", "FileWrite");
+
+        var decision = pm.check(
+                new Capability.FileWrite(Path.of("/tmp/x"), WriteMode.OVERWRITE),
+                Provenance.forSession(new SessionId("sess-A")));
+        assertThat(decision).isInstanceOf(PermissionDecision.Approved.class);
+    }
+
+    @Test
+    void fourArgPathPassesCallerSuppliedDescriptionToPolicy() {
+        // The dispatcher computes a rich human-readable description via
+        // buildToolDescription(...) and passes it through. Pin that the
+        // policy sees that string rather than the synthetic displayLabel
+        // — losing it would regress the user's permission prompt UX.
+        var captured = new java.util.concurrent.atomic.AtomicReference<PermissionRequest>();
+        PermissionPolicy capturing = req -> {
+            captured.set(req);
+            return new PermissionDecision.NeedsUserApproval(req.description());
+        };
+        var pm = new PermissionManager(capturing);
+
+        pm.check(
+                new Capability.FileWrite(Path.of("/tmp/x"), WriteMode.OVERWRITE),
+                Provenance.forSession(new SessionId("sess")),
+                "write_file",
+                "Write /tmp/x (123 chars of new content)");
+
+        assertThat(captured.get().description())
+                .isEqualTo("Write /tmp/x (123 chars of new content)");
+        assertThat(captured.get().toolName())
+                .as("4-arg form uses the caller's allowlist key, not the variant class name")
+                .isEqualTo("write_file");
+    }
+
+    @Test
+    void daemonInternalProvenanceSkipsAllowlistLookup() {
+        // Provenance.daemonInternal() leaves sessionId empty. Without a
+        // session, the manager falls straight through to the policy — same
+        // semantics as the legacy path's null-sessionId case.
+        var pm = new PermissionManager(APPROVE);
+        // Even with an approval in some session, daemon-internal goes
+        // straight to policy.
+        pm.approveForSession("sess-X", "FileRead");
+
+        var decision = pm.check(
+                new Capability.FileRead(Path.of("/etc/hosts")),
+                Provenance.daemonInternal());
+
+        assertThat(decision).isInstanceOf(PermissionDecision.Approved.class);
+    }
+
+    @Test
+    void legacyShimDelegatesToStructuredPath() {
+        // The old check(PermissionRequest, sessionId) is now a thin shim
+        // — confirmed by the absence of a separate decision-and-audit
+        // pipeline. This test pins that legacy callers see no behavior
+        // change: the same DefaultPermissionPolicy answers in the same
+        // way regardless of which entry point is used.
+        var pm = new PermissionManager(new DefaultPermissionPolicy(DefaultPermissionPolicy.MODE_NORMAL));
+
+        var legacyDecision = pm.check(PermissionRequest.read("read_file", "x"), "sess");
+        assertThat(legacyDecision).isInstanceOf(PermissionDecision.Approved.class); // READ auto-approved
+
+        var legacyWrite = pm.check(PermissionRequest.write("write_file", "/tmp/x"), "sess");
+        assertThat(legacyWrite).isInstanceOf(PermissionDecision.NeedsUserApproval.class);
+    }
+}

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/ProvenanceLinkTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/ProvenanceLinkTest.java
@@ -1,0 +1,83 @@
+package dev.aceclaw.security;
+
+import dev.aceclaw.security.ids.PlanStepId;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Pins each {@link ProvenanceLink} variant's contract — null-guards, range
+ * checks, and the {@code displayLabel} format the dashboard timeline will
+ * render (#480 PR 2). The exhaustiveness sentinel below has no
+ * {@code default} branch: adding a new variant without updating it fails
+ * compilation.
+ */
+final class ProvenanceLinkTest {
+
+    @Test
+    void planStepEnteredCarriesStepId() {
+        var step = new PlanStepId("s-1");
+        var now = Instant.now();
+        var link = new ProvenanceLink.PlanStepEntered(step, now);
+
+        assertThat(link.stepId()).isEqualTo(step);
+        assertThat(link.at()).isEqualTo(now);
+        assertThat(link.displayLabel()).contains("s-1");
+    }
+
+    @Test
+    void subAgentSpawnedCarriesRole() {
+        var link = new ProvenanceLink.SubAgentSpawned("planner", Instant.now());
+
+        assertThat(link.role()).isEqualTo("planner");
+        assertThat(link.displayLabel()).contains("planner");
+    }
+
+    @Test
+    void retryAttemptIsOneIndexed() {
+        // 1-indexed so log lines read naturally — "retry attempt 1" is a
+        // first retry, not a fresh attempt.
+        var link = new ProvenanceLink.RetryAttempt(3, Instant.now());
+
+        assertThat(link.attempt()).isEqualTo(3);
+        assertThat(link.displayLabel()).contains("3");
+    }
+
+    @Test
+    void retryAttemptRejectsZeroOrNegative() {
+        assertThatThrownBy(() -> new ProvenanceLink.RetryAttempt(0, Instant.now()))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new ProvenanceLink.RetryAttempt(-1, Instant.now()))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void allVariantsRejectNullTimestamp() {
+        var step = new PlanStepId("s");
+        assertThatThrownBy(() -> new ProvenanceLink.PlanStepEntered(step, null))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new ProvenanceLink.SubAgentSpawned("r", null))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new ProvenanceLink.RetryAttempt(1, null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void exhaustivenessSentinelCoversEveryVariant() {
+        // No default branch — adding a new ProvenanceLink variant without
+        // updating this switch fails compilation.
+        ProvenanceLink l = new ProvenanceLink.RetryAttempt(1, Instant.now());
+        assertThat(exhaustivenessSentinel(l)).isNotBlank();
+    }
+
+    private static String exhaustivenessSentinel(ProvenanceLink l) {
+        return switch (l) {
+            case ProvenanceLink.PlanStepEntered p -> p.displayLabel();
+            case ProvenanceLink.SubAgentSpawned s -> s.displayLabel();
+            case ProvenanceLink.RetryAttempt r -> r.displayLabel();
+        };
+    }
+}

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/ProvenanceTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/ProvenanceTest.java
@@ -1,0 +1,139 @@
+package dev.aceclaw.security;
+
+import dev.aceclaw.security.ids.PlanStepId;
+import dev.aceclaw.security.ids.PromptId;
+import dev.aceclaw.security.ids.SessionId;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Pins the construction contract for {@link Provenance} — the "how did we
+ * get here" record threaded through every capability check (#480 PR 2).
+ *
+ * <p>Two factory methods carry semantic intent — {@link Provenance#forSession}
+ * vs {@link Provenance#daemonInternal} — so callers don't accidentally pass
+ * empty {@code Optional}s where they meant the daemon-internal sentinel.
+ * Tests pin those factory shapes so a future refactor can't silently drop
+ * the distinction.
+ */
+final class ProvenanceTest {
+
+    @Test
+    void forSessionWrapsSessionIdAndLeavesOtherFieldsEmpty() {
+        // PR 2 doesn't yet thread rootPrompt or planStepId through the agent
+        // loop — those land in PR 3. forSession admits that explicitly with
+        // empty Optionals rather than synthesizing fake values.
+        var sid = new SessionId("sess-1");
+        var p = Provenance.forSession(sid);
+
+        assertThat(p.sessionId()).contains(sid);
+        assertThat(p.rootPrompt()).isEmpty();
+        assertThat(p.planStepId()).isEmpty();
+        assertThat(p.subAgentDepth()).isZero();
+        assertThat(p.chain()).isEmpty();
+    }
+
+    @Test
+    void daemonInternalLeavesSessionIdEmpty() {
+        // Cron triggers, boot scripts, and other daemon-internal capability
+        // checks have no session. The factory makes that distinct from
+        // "forgot to pass a session" — empty Optional, not null.
+        var p = Provenance.daemonInternal();
+
+        assertThat(p.sessionId()).isEmpty();
+        assertThat(p.rootPrompt()).isEmpty();
+        assertThat(p.planStepId()).isEmpty();
+        assertThat(p.subAgentDepth()).isZero();
+    }
+
+    @Test
+    void legacyFactoryDispatchesByNullability() {
+        // The legacy bridge from PermissionManager.check(PermissionRequest,
+        // sessionId) lands here. null sessionId means daemon-internal;
+        // non-null wraps as a SessionId.
+        assertThat(Provenance.legacy(null).sessionId()).isEmpty();
+        assertThat(Provenance.legacy("sess-x").sessionId())
+                .map(SessionId::value)
+                .contains("sess-x");
+    }
+
+    @Test
+    void canonicalConstructorRequiresEveryOptionalArgument() {
+        // Optional fields rejecting null is intentional: callers must say
+        // explicitly "I have nothing here" (Optional.empty()) rather than
+        // accidentally passing null. That eliminates a class of NPE bugs
+        // downstream.
+        assertThatThrownBy(() -> new Provenance(
+                null, Optional.empty(), Optional.empty(), 0, List.of()))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("rootPrompt");
+        assertThatThrownBy(() -> new Provenance(
+                Optional.empty(), null, Optional.empty(), 0, List.of()))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("sessionId");
+        assertThatThrownBy(() -> new Provenance(
+                Optional.empty(), Optional.empty(), null, 0, List.of()))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("planStepId");
+    }
+
+    @Test
+    void rejectsNegativeSubAgentDepth() {
+        assertThatThrownBy(() -> new Provenance(
+                Optional.empty(), Optional.empty(), Optional.empty(), -1, List.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("subAgentDepth");
+    }
+
+    @Test
+    void chainIsDefensivelyCopied() {
+        // Caller mutates their list AFTER constructing Provenance — the
+        // record's chain must not change. List.copyOf in the canonical
+        // constructor enforces this.
+        var mutable = new java.util.ArrayList<ProvenanceLink>();
+        mutable.add(new ProvenanceLink.RetryAttempt(1, Instant.now()));
+        var p = new Provenance(
+                Optional.empty(), Optional.empty(), Optional.empty(), 0, mutable);
+
+        mutable.add(new ProvenanceLink.RetryAttempt(2, Instant.now()));
+        assertThat(p.chain()).hasSize(1);
+    }
+
+    @Test
+    void chainAcceptsNullAsEmpty() {
+        // Caller convenience — null in canonical constructor becomes List.of().
+        // Same pattern as records elsewhere in the codebase.
+        var p = new Provenance(
+                Optional.empty(), Optional.empty(), Optional.empty(), 0, null);
+        assertThat(p.chain()).isEmpty();
+    }
+
+    @Test
+    void canCarryFullChain() {
+        // Full population test — PR 3 will populate this through the agent
+        // loop; PR 2 just guarantees the shape works.
+        var sid = new SessionId("s");
+        var promptId = new PromptId("p1");
+        var stepId = new PlanStepId("step-1");
+        var now = Instant.now();
+        var p = new Provenance(
+                Optional.of(promptId),
+                Optional.of(sid),
+                Optional.of(stepId),
+                2,
+                List.of(
+                        new ProvenanceLink.PlanStepEntered(stepId, now),
+                        new ProvenanceLink.SubAgentSpawned("planner", now),
+                        new ProvenanceLink.RetryAttempt(2, now)));
+
+        assertThat(p.rootPrompt()).contains(promptId);
+        assertThat(p.subAgentDepth()).isEqualTo(2);
+        assertThat(p.chain()).hasSize(3);
+    }
+}

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/ProvenanceTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/ProvenanceTest.java
@@ -53,12 +53,13 @@ final class ProvenanceTest {
     }
 
     @Test
-    void legacyFactoryDispatchesByNullability() {
-        // The legacy bridge from PermissionManager.check(PermissionRequest,
-        // sessionId) lands here. null sessionId means daemon-internal;
-        // non-null wraps as a SessionId.
-        assertThat(Provenance.legacy(null).sessionId()).isEmpty();
-        assertThat(Provenance.legacy("sess-x").sessionId())
+    void fromNullableSessionIdDispatchesByNullability() {
+        // The bridge from callers that have a possibly-null raw String id
+        // (PermissionManager legacy shim, dispatcher pre-PR-3) lands here.
+        // null sessionId means daemon-internal; non-null wraps as a
+        // SessionId.
+        assertThat(Provenance.fromNullableSessionId(null).sessionId()).isEmpty();
+        assertThat(Provenance.fromNullableSessionId("sess-x").sessionId())
                 .map(SessionId::value)
                 .contains("sess-x");
     }

--- a/aceclaw-tools/src/main/java/dev/aceclaw/tools/WriteFileTool.java
+++ b/aceclaw-tools/src/main/java/dev/aceclaw/tools/WriteFileTool.java
@@ -3,6 +3,9 @@ package dev.aceclaw.tools;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.aceclaw.core.agent.Tool;
+import dev.aceclaw.security.Capability;
+import dev.aceclaw.security.CapabilityAware;
+import dev.aceclaw.security.WriteMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,7 +26,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * it can be overwritten. This prevents accidental data loss from blind writes.
  * New files (that don't exist yet) are exempt from this check.
  */
-public final class WriteFileTool implements Tool {
+public final class WriteFileTool implements Tool, CapabilityAware {
 
     private static final Logger log = LoggerFactory.getLogger(WriteFileTool.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -139,5 +142,31 @@ public final class WriteFileTool implements Tool {
 
     private Path resolveFilePath(String raw) {
         return PathResolver.resolve(raw, workingDir);
+    }
+
+    /**
+     * #480 PR 2: advertise this tool's intent as a structured
+     * {@link Capability.FileWrite} so PermissionManager / audit log /
+     * dashboard see the actual path and write mode rather than the flat
+     * {@code "write_file"} string.
+     *
+     * <p>Distinguishes {@link WriteMode#CREATE_NEW} from
+     * {@link WriteMode#OVERWRITE} via {@link Files#exists(Path, java.nio.file.LinkOption...)}
+     * at check time. This lets a "create-only" policy refuse overwrites
+     * without re-inspecting filesystem state. The tool's
+     * read-before-write gate in {@link #execute(String)} also catches
+     * blind overwrites at the execution layer; the two together keep the
+     * snapshot-vs-execute window safe — even if the file appears between
+     * the capability check and the write, the read-tracking set will
+     * reject it.
+     */
+    @Override
+    public Capability toCapability(JsonNode args) {
+        if (args == null || !args.has("file_path") || args.get("file_path").asText().isBlank()) {
+            throw new IllegalArgumentException("write_file requires a non-blank file_path");
+        }
+        var filePath = resolveFilePath(args.get("file_path").asText());
+        var mode = Files.exists(filePath) ? WriteMode.OVERWRITE : WriteMode.CREATE_NEW;
+        return new Capability.FileWrite(filePath, mode);
     }
 }

--- a/aceclaw-tools/src/main/java/dev/aceclaw/tools/WriteFileTool.java
+++ b/aceclaw-tools/src/main/java/dev/aceclaw/tools/WriteFileTool.java
@@ -151,14 +151,21 @@ public final class WriteFileTool implements Tool, CapabilityAware {
      * {@code "write_file"} string.
      *
      * <p>Distinguishes {@link WriteMode#CREATE_NEW} from
-     * {@link WriteMode#OVERWRITE} via {@link Files#exists(Path, java.nio.file.LinkOption...)}
-     * at check time. This lets a "create-only" policy refuse overwrites
-     * without re-inspecting filesystem state. The tool's
-     * read-before-write gate in {@link #execute(String)} also catches
-     * blind overwrites at the execution layer; the two together keep the
-     * snapshot-vs-execute window safe — even if the file appears between
-     * the capability check and the write, the read-tracking set will
-     * reject it.
+     * {@link WriteMode#OVERWRITE} by checking both
+     * {@link Files#exists(Path, java.nio.file.LinkOption...)} and
+     * {@link Files#notExists(Path, java.nio.file.LinkOption...)}. Both
+     * return {@code false} when existence cannot be determined (permission
+     * denied, broken symlink, …); collapsing that case to {@code CREATE_NEW}
+     * would let a "create-only" policy approve a request that may actually
+     * overwrite an existing-but-unreadable file. Reject indeterminate state
+     * explicitly — the dispatcher's catch-and-fall-back to the legacy path
+     * will still surface a normal user-approval prompt.
+     *
+     * <p>The tool's read-before-write gate in {@link #execute(String)} also
+     * catches blind overwrites at the execution layer; the two together
+     * keep the snapshot-vs-execute window safe — even if the file appears
+     * between the capability check and the write, the read-tracking set
+     * will reject it.
      */
     @Override
     public Capability toCapability(JsonNode args) {
@@ -166,7 +173,16 @@ public final class WriteFileTool implements Tool, CapabilityAware {
             throw new IllegalArgumentException("write_file requires a non-blank file_path");
         }
         var filePath = resolveFilePath(args.get("file_path").asText());
-        var mode = Files.exists(filePath) ? WriteMode.OVERWRITE : WriteMode.CREATE_NEW;
+        final WriteMode mode;
+        if (Files.exists(filePath)) {
+            mode = WriteMode.OVERWRITE;
+        } else if (Files.notExists(filePath)) {
+            mode = WriteMode.CREATE_NEW;
+        } else {
+            throw new IllegalArgumentException(
+                    "write_file cannot determine whether target exists (permission denied or broken link?): "
+                            + filePath);
+        }
         return new Capability.FileWrite(filePath, mode);
     }
 }

--- a/aceclaw-tools/src/test/java/dev/aceclaw/tools/WriteFileToolCapabilityTest.java
+++ b/aceclaw-tools/src/test/java/dev/aceclaw/tools/WriteFileToolCapabilityTest.java
@@ -1,0 +1,87 @@
+package dev.aceclaw.tools;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.aceclaw.security.Capability;
+import dev.aceclaw.security.WriteMode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Pins the {@link dev.aceclaw.security.CapabilityAware} migration of
+ * {@link WriteFileTool} (#480 PR 2): the dispatcher in
+ * {@code StreamingAgentHandler} calls {@code toCapability} before
+ * {@code PermissionManager.check}, so this is the bridge that turns
+ * LLM-supplied JSON args into a structured {@link Capability.FileWrite}
+ * the policy and audit log can reason about.
+ *
+ * <p>If a future change accidentally drops the {@code CapabilityAware}
+ * implementation or returns the wrong variant, this test fails — and
+ * production silently falls back to the legacy {@code LegacyToolUse}
+ * path without anyone noticing in code review.
+ */
+final class WriteFileToolCapabilityTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @TempDir
+    Path workDir;
+
+    @Test
+    void toCapabilityForNonExistentPathProducesCreateNew() throws Exception {
+        // Distinguishing CREATE_NEW from OVERWRITE at check time lets a
+        // create-only policy refuse overwrites without re-stat'ing the
+        // filesystem. Pin: a path that doesn't exist yet must come back
+        // as CREATE_NEW.
+        var tool = new WriteFileTool(workDir, ConcurrentHashMap.newKeySet());
+        var args = MAPPER.readTree("{\"file_path\":\"new.txt\",\"content\":\"hi\"}");
+
+        var cap = tool.toCapability(args);
+
+        var fw = assertInstanceOf(Capability.FileWrite.class, cap,
+                "WriteFileTool must produce FileWrite, not LegacyToolUse");
+        assertEquals(workDir.resolve("new.txt").toAbsolutePath().normalize(),
+                fw.path().toAbsolutePath().normalize(),
+                "relative paths resolve against the tool's workingDir");
+        assertEquals(WriteMode.CREATE_NEW, fw.mode(),
+                "non-existent path -> CREATE_NEW so policies can refuse overwrites");
+    }
+
+    @Test
+    void toCapabilityForExistingPathProducesOverwrite() throws Exception {
+        // The other half of the pair: an existing file means the write
+        // will overwrite, and the capability must say so.
+        var existing = workDir.resolve("existing.txt");
+        Files.writeString(existing, "old");
+        var tool = new WriteFileTool(workDir, ConcurrentHashMap.newKeySet());
+        var args = MAPPER.readTree("{\"file_path\":\"existing.txt\",\"content\":\"new\"}");
+
+        var cap = tool.toCapability(args);
+
+        var fw = assertInstanceOf(Capability.FileWrite.class, cap);
+        assertEquals(WriteMode.OVERWRITE, fw.mode(),
+                "existing file -> OVERWRITE");
+    }
+
+    @Test
+    void toCapabilityRejectsMissingOrBlankFilePath() throws Exception {
+        var tool = new WriteFileTool(workDir, ConcurrentHashMap.newKeySet());
+        // The dispatcher catches IllegalArgumentException and falls back to
+        // the legacy permission path, so the user still sees a meaningful
+        // prompt rather than a half-formed FileWrite hitting the policy.
+        var noPath = MAPPER.readTree("{\"content\":\"hi\"}");
+        var blankPath = MAPPER.readTree("{\"file_path\":\"  \",\"content\":\"hi\"}");
+        var nullArgs = (com.fasterxml.jackson.databind.JsonNode) null;
+
+        assertThrows(IllegalArgumentException.class, () -> tool.toCapability(noPath));
+        assertThrows(IllegalArgumentException.class, () -> tool.toCapability(blankPath));
+        assertThrows(IllegalArgumentException.class, () -> tool.toCapability(nullArgs));
+    }
+}


### PR DESCRIPTION
## Summary

Second of three PRs for #480 (runtime governance Layer 1, foundation for #465).

- New `CapabilityAware` interface — opt-in companion to `Tool`. A tool implements it to advertise structured `Capability` variants instead of the flat `(toolName, level)` shape.
- New `Provenance` + `ProvenanceLink` records — the "how did we get here" chain (root prompt, plan step, sub-agent depth, retry history). Optional fields are empty in PR 2; PR 3 wires them through the agent loop.
- `PermissionManager.check(...)` now has three entry points sharing one decision/audit pipeline:
  - `check(PermissionRequest, String)` — legacy shim, unchanged callers see no behavior change.
  - `check(Capability, Provenance)` — convenience overload for daemon-internal callers that have no originating tool name.
  - `check(Capability, Provenance, String allowlistKey, String description)` — dispatcher form. Caller passes the originating tool's name as the allowlist key + the rich human description, so existing "always allow X" approvals survive migration and the user prompt stays as detailed as before.
- `StreamingAgentHandler` dispatcher uses the 4-arg form when the tool is `CapabilityAware`; falls back to the legacy `PermissionRequest` path on bad args (logged) or for non-migrated tools.
- `WriteFileTool` is the first tool migrated. Its `toCapability(...)` checks `Files.exists` to pick `WriteMode.CREATE_NEW` vs `OVERWRITE`, so a create-only policy can refuse overwrites without re-stat'ing the filesystem.

## Migration safety

- Existing per-session "always allow `write_file`" approvals continue to auto-approve after the tool migrates — pinned by `PermissionManagerCapabilityTest.sessionBlanketApprovalSurvivesToolMigrationViaDispatcherKey`.
- Sub-agent path (`hasAnySessionApproval(toolName)`) keeps working because the dispatcher passes the tool name as the allowlist key.
- User prompts for migrated tools keep the same rich description that `buildToolDescription(...)` produces — pinned by `fourArgPathPassesCallerSuppliedDescriptionToPolicy`.

## Test plan

- [x] `:aceclaw-security:test` — new `PermissionManagerCapabilityTest`, `ProvenanceTest`, `ProvenanceLinkTest`
- [x] `:aceclaw-tools:test` — new `WriteFileToolCapabilityTest` (CREATE_NEW vs OVERWRITE pair, blank-args rejection)
- [x] `:aceclaw-daemon:test` — existing dispatcher integration tests still pass

## Out of scope (PR 3)

- Threading real `PromptId` / `PlanStepId` through the agent loop (Provenance optional fields stay empty in PR 2).
- Audit log v2 with structured `Capability` / `Provenance` payloads.
- Migrating `ReadFileTool`, `EditFileTool`, `BashExecTool`, `GlobSearchTool`, `GrepSearchTool` — done piecemeal in follow-ups.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Structured capability declarations for tools and a capability-aware routing path.
  * Provenance and provenance-link events for richer audit/context (sessions, plan steps, retries).

* **Refactor**
  * Permission pipeline migrated to use structured capability checks while preserving legacy fallbacks.
  * HTTP capability data-flow standardized to bidirectional for all methods.
  * File-write tool moved to capability-based permission reporting.

* **Tests**
  * Extensive tests added covering capability routing, provenance, and tool-to-capability translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->