### PR TITLE
fix(dashboard): converge step subtree on plan_step_completed (#485 PR 1/3)

### DIFF
--- a/aceclaw-dashboard/src/reducers/treeReducer.ts
+++ b/aceclaw-dashboard/src/reducers/treeReducer.ts
@@ -208,6 +208,49 @@ function appendChild(
 }
 
 /**
+ * Walks {@code children} and returns a new forest where every descendant
+ * still in {@code 'running'} has been flipped to {@code terminal}. The
+ * {@code flippedTools} counter is mutated in place so the caller can update
+ * sidebar stats for tool nodes that were converged this way.
+ *
+ * Used at scope boundaries (plan step / plan completion — issue #485) to
+ * recover when an intermediate {@code stream.tool_completed} or
+ * {@code stream.thinking.complete} event was lost in transit. Without this,
+ * a dropped completion event leaves a perpetually pulsing tool/thinking node
+ * under a step or plan that has long since finished.
+ *
+ * The traversal preserves structural sharing — branches with no running
+ * descendants return the same array reference so React reconciliation skips
+ * them.
+ */
+function convergeRunningSubtree(
+  children: readonly ExecutionNode[],
+  terminal: ExecutionStatus,
+  flippedTools: { count: number },
+): ExecutionNode[] {
+  let changed = false;
+  const next = children.map((c) => {
+    const newGrandkids = convergeRunningSubtree(c.children, terminal, flippedTools);
+    const grandkidsChanged = newGrandkids !== c.children;
+    if (c.status === 'running') {
+      changed = true;
+      if (c.type === 'tool') flippedTools.count++;
+      return {
+        ...c,
+        status: terminal,
+        children: grandkidsChanged ? newGrandkids : c.children,
+      };
+    }
+    if (grandkidsChanged) {
+      changed = true;
+      return { ...c, children: newGrandkids };
+    }
+    return c;
+  });
+  return changed ? next : (children as ExecutionNode[]);
+}
+
+/**
  * Finds the natural parent for a new turn or plan: the deepest running step
  * (when a plan is mid-execution), else the deepest session ancestor of the
  * current active node, else any session matching {@code sessionId} at the
@@ -1047,16 +1090,38 @@ function completeStep(
     return state;
   }
 
+  // Step subtree convergence (#485): if intermediate completion events were
+  // lost, descendant tool/thinking/text nodes can be stuck running under a
+  // step that has just finished. Flip them to a terminal state along with
+  // the step itself, mirroring the step's outcome — success → completed,
+  // failure → cancelled (the step bailed, descendants were aborted, not
+  // independently successful).
+  const flippedTools = { count: 0 };
+  const subtreeTerminal: ExecutionStatus = params.success ? 'completed' : 'cancelled';
   const rootNodes = mapNode(state.rootNodes, stepId, (n) => ({
     ...n,
     status: params.success ? 'completed' : 'failed',
     duration: params.durationMs,
+    children: convergeRunningSubtree(n.children, subtreeTerminal, flippedTools),
   }));
+  // Stats: tools flipped via convergence have never gone through
+  // completeToolNode, so totalTools is already counted but completedTools /
+  // failedTools wasn't. Bump them now so the sidebar stays consistent with
+  // the converged subtree.
+  const stats = flippedTools.count > 0
+    ? {
+        ...state.stats,
+        completedTools:
+          state.stats.completedTools + (params.success ? flippedTools.count : 0),
+        failedTools:
+          state.stats.failedTools + (params.success ? 0 : flippedTools.count),
+      }
+    : state.stats;
   // Step done → next pending sibling inherits focus, else the plan, else
   // leave focus alone (plan was missing too).
   const planAfter = findNode(rootNodes, params.planId);
   if (!planAfter) {
-    return { ...state, rootNodes };
+    return { ...state, rootNodes, stats };
   }
   const nextPending = planAfter.children.find(
     (c) => c.type === 'step' && c.status === 'pending',
@@ -1064,6 +1129,7 @@ function completeStep(
   return {
     ...state,
     rootNodes,
+    stats,
     activeNodeId: nextPending ? nextPending.id : params.planId,
   };
 }

--- a/aceclaw-dashboard/tests/treeReducer.test.ts
+++ b/aceclaw-dashboard/tests/treeReducer.test.ts
@@ -2386,7 +2386,7 @@ describe('completeStep converges still-running descendants (#485)', () => {
   it('does not double-count a tool that already completed normally', () => {
     const before = runAll(
       planStartedWithToolRunning(),
-      envelope('stream.tool_completed', { id: 't1', isError: false, durationMs: 10 }),
+      envelope('stream.tool_completed', { id: 't1', name: 'read_file', isError: false, durationMs: 10 }),
     );
     expect(findById(before, 't1').status).toBe('completed');
     const beforeCompletedTools = before.stats.completedTools;

--- a/aceclaw-dashboard/tests/treeReducer.test.ts
+++ b/aceclaw-dashboard/tests/treeReducer.test.ts
@@ -2296,6 +2296,177 @@ describe('completeStep resolves replanned synthetic steps after focus moves', ()
 });
 
 // ---------------------------------------------------------------------------
+// Step subtree convergence (#485): when stream.tool_completed is lost in
+// transit, the tool node would otherwise stay 'running' under a step that
+// has long since finished. completeStep walks the step subtree and flips
+// any still-running descendants to a terminal state.
+// ---------------------------------------------------------------------------
+
+describe('completeStep converges still-running descendants (#485)', () => {
+  function planStartedWithToolRunning() {
+    return runAll(
+      freshTree(),
+      envelope('stream.session_started', {
+        sessionId: 'sess-1',
+        model: 'm',
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.turn_started', {
+        sessionId: 'sess-1',
+        requestId: 'req-1',
+        turnNumber: 1,
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.plan_created', {
+        planId: 'plan-1',
+        stepCount: 1,
+        goal: 'g',
+        steps: [{ index: 1, name: 's1', description: '' }],
+      }),
+      envelope('stream.plan_step_started', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        totalSteps: 1,
+        stepName: 's1',
+      }),
+      envelope('stream.tool_use', { id: 't1', name: 'read_file' }),
+    );
+  }
+
+  it('flips a running tool to completed and bumps completedTools when the step succeeds', () => {
+    const before = planStartedWithToolRunning();
+    expect(findById(before, 't1').status).toBe('running');
+    const beforeCompletedTools = before.stats.completedTools;
+
+    // Note: stream.tool_completed deliberately omitted to simulate event loss.
+    const after = runAll(
+      before,
+      envelope('stream.plan_step_completed', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        stepName: 's1',
+        success: true,
+        durationMs: 100,
+        tokensUsed: 50,
+      }),
+    );
+
+    const step = findById(after, stepNodeId('plan-1', 1));
+    expect(step.status).toBe('completed');
+    expect(findById(after, 't1').status).toBe('completed');
+    expect(after.stats.completedTools).toBe(beforeCompletedTools + 1);
+    expect(after.stats.failedTools).toBe(before.stats.failedTools);
+  });
+
+  it('flips a running tool to cancelled and bumps failedTools when the step fails', () => {
+    const before = planStartedWithToolRunning();
+    const beforeFailedTools = before.stats.failedTools;
+
+    const after = runAll(
+      before,
+      envelope('stream.plan_step_completed', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        stepName: 's1',
+        success: false,
+        durationMs: 100,
+        tokensUsed: 50,
+      }),
+    );
+
+    expect(findById(after, stepNodeId('plan-1', 1)).status).toBe('failed');
+    expect(findById(after, 't1').status).toBe('cancelled');
+    expect(after.stats.failedTools).toBe(beforeFailedTools + 1);
+    expect(after.stats.completedTools).toBe(before.stats.completedTools);
+  });
+
+  it('does not double-count a tool that already completed normally', () => {
+    const before = runAll(
+      planStartedWithToolRunning(),
+      envelope('stream.tool_completed', { id: 't1', isError: false, durationMs: 10 }),
+    );
+    expect(findById(before, 't1').status).toBe('completed');
+    const beforeCompletedTools = before.stats.completedTools;
+
+    const after = runAll(
+      before,
+      envelope('stream.plan_step_completed', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        stepName: 's1',
+        success: true,
+        durationMs: 100,
+        tokensUsed: 50,
+      }),
+    );
+
+    expect(findById(after, 't1').status).toBe('completed');
+    // Tool was already counted by completeToolNode; convergence must not
+    // bump completedTools again.
+    expect(after.stats.completedTools).toBe(beforeCompletedTools);
+  });
+
+  it('converges multiple parallel running tools under the same step', () => {
+    // Two parallel tool_use events from the same LLM response — neither
+    // tool_completed arrives, so both stay running. plan_step_completed
+    // must flip both and bump completedTools by 2.
+    const before = runAll(
+      freshTree(),
+      envelope('stream.session_started', {
+        sessionId: 'sess-1',
+        model: 'm',
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.turn_started', {
+        sessionId: 'sess-1',
+        requestId: 'req-1',
+        turnNumber: 1,
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.plan_created', {
+        planId: 'plan-1',
+        stepCount: 1,
+        goal: 'g',
+        steps: [{ index: 1, name: 's1', description: '' }],
+      }),
+      envelope('stream.plan_step_started', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        totalSteps: 1,
+        stepName: 's1',
+      }),
+      envelope('stream.tool_use', { id: 't1', name: 'read_file' }),
+      envelope('stream.tool_use', { id: 't2', name: 'read_file' }),
+    );
+    expect(findById(before, 't1').status).toBe('running');
+    expect(findById(before, 't2').status).toBe('running');
+    const beforeCompletedTools = before.stats.completedTools;
+
+    const after = runAll(
+      before,
+      envelope('stream.plan_step_completed', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        stepName: 's1',
+        success: true,
+        durationMs: 100,
+        tokensUsed: 50,
+      }),
+    );
+
+    expect(findById(after, 't1').status).toBe('completed');
+    expect(findById(after, 't2').status).toBe('completed');
+    expect(after.stats.completedTools).toBe(beforeCompletedTools + 2);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Step events arriving before plan_created — don't dangle activeNodeId
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `completeStep` now walks the step's descendants and flips any still-running tool/thinking/text node to a terminal state — `completed` when the step succeeded, `cancelled` when it failed.
- Sidebar stats are kept consistent: tools converged this way bump `completedTools` (success) or `failedTools` (failure), since they never went through `completeToolNode` which is the normal accounting path.
- Helper `convergeRunningSubtree` preserves structural sharing — branches with no running descendants return the same array reference.

Addresses the first failure mode in #485 ((B): "step is green but children are still running"). Plan-level convergence and `parentStepId` attribution are PR 2/3 and PR 3/3 of the same issue.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 204/204 pass (4 new tests in `treeReducer.test.ts`)
  - flips a running tool to `completed` and bumps `completedTools` when the step succeeds
  - flips a running tool to `cancelled` and bumps `failedTools` when the step fails
  - does not double-count a tool that already completed normally (regression guard)
  - converges multiple parallel running tools under the same step
- [ ] Manual: run a plan locally with a tool whose completion event is artificially dropped; confirm the dashboard shows the step as ✓ with all children also ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of plan step completion when intermediate tool completion events are missing in transit, ensuring descendant nodes properly transition to terminal states.
  * Fixed tool completion statistics tracking to prevent double-counting and ensure accurate counters.

* **Tests**
  * Added comprehensive test coverage for step completion scenarios with missing intermediate events.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xinhuagu/AceClaw/pull/486)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->