### PR TITLE
fix(dashboard): converge plan subtree on plan_completed/plan_escalated (#485 PR 2/3)

### DIFF
--- a/aceclaw-dashboard/src/reducers/treeReducer.ts
+++ b/aceclaw-dashboard/src/reducers/treeReducer.ts
@@ -1240,33 +1240,59 @@ function completePlan(
   state: ExecutionTree,
   params: PlanCompletedParams,
 ): ExecutionTree {
-  return {
-    ...state,
-    rootNodes: mapNode(state.rootNodes, params.planId, (n) => ({
-      ...n,
-      status: params.success ? 'completed' : 'failed',
-      duration: params.totalDurationMs,
-      metadata: {
-        ...(n.metadata ?? {}),
-        stepsCompleted: params.stepsCompleted,
-        totalSteps: params.totalSteps,
-      },
-    })),
-  };
+  // Plan subtree convergence (#485 PR 2/3): a step-level completion event
+  // that was lost in transit would otherwise leave a step (and its tool
+  // descendants) stuck running under a plan that just finished. Apply the
+  // same subtree flip that completeStep does, but at the plan boundary —
+  // success → completed, failure → cancelled (descendants that never
+  // reported completion are treated as aborted, not independently
+  // successful).
+  const flippedTools = { count: 0 };
+  const subtreeTerminal: ExecutionStatus = params.success ? 'completed' : 'cancelled';
+  const rootNodes = mapNode(state.rootNodes, params.planId, (n) => ({
+    ...n,
+    status: params.success ? 'completed' : 'failed',
+    duration: params.totalDurationMs,
+    metadata: {
+      ...(n.metadata ?? {}),
+      stepsCompleted: params.stepsCompleted,
+      totalSteps: params.totalSteps,
+    },
+    children: convergeRunningSubtree(n.children, subtreeTerminal, flippedTools),
+  }));
+  const stats = flippedTools.count > 0
+    ? {
+        ...state.stats,
+        completedTools:
+          state.stats.completedTools + (params.success ? flippedTools.count : 0),
+        failedTools:
+          state.stats.failedTools + (params.success ? 0 : flippedTools.count),
+      }
+    : state.stats;
+  return { ...state, rootNodes, stats };
 }
 
 function failPlan(
   state: ExecutionTree,
   params: PlanEscalatedParams,
 ): ExecutionTree {
-  return {
-    ...state,
-    rootNodes: mapNode(state.rootNodes, params.planId, (n) => ({
-      ...n,
-      status: 'failed',
-      error: params.reason,
-    })),
-  };
+  // Plan escalation is unconditionally a failure path — converge any still-
+  // running descendants to 'cancelled' and account them as failed tools so
+  // the sidebar reflects the abort, not a phantom in-flight tool count.
+  const flippedTools = { count: 0 };
+  const rootNodes = mapNode(state.rootNodes, params.planId, (n) => ({
+    ...n,
+    status: 'failed',
+    error: params.reason,
+    children: convergeRunningSubtree(n.children, 'cancelled', flippedTools),
+  }));
+  const stats = flippedTools.count > 0
+    ? {
+        ...state.stats,
+        failedTools: state.stats.failedTools + flippedTools.count,
+      }
+    : state.stats;
+  return { ...state, rootNodes, stats };
 }
 
 function addSubAgentNode(

--- a/aceclaw-dashboard/tests/treeReducer.test.ts
+++ b/aceclaw-dashboard/tests/treeReducer.test.ts
@@ -2467,6 +2467,152 @@ describe('completeStep converges still-running descendants (#485)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Plan subtree convergence (#485 PR 2/3): when a step-level completion event
+// is lost entirely, completeStep never runs but the plan's terminal event
+// still arrives. completePlan / failPlan walk the plan subtree to converge
+// any still-running step (and its still-running tool children) so the plan
+// node and its descendants render a coherent terminal state.
+// ---------------------------------------------------------------------------
+
+describe('completePlan / failPlan converge still-running descendants (#485)', () => {
+  function planWithRunningStepAndTool() {
+    return runAll(
+      freshTree(),
+      envelope('stream.session_started', {
+        sessionId: 'sess-1',
+        model: 'm',
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.turn_started', {
+        sessionId: 'sess-1',
+        requestId: 'req-1',
+        turnNumber: 1,
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.plan_created', {
+        planId: 'plan-1',
+        stepCount: 1,
+        goal: 'g',
+        steps: [{ index: 1, name: 's1', description: '' }],
+      }),
+      envelope('stream.plan_step_started', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        totalSteps: 1,
+        stepName: 's1',
+      }),
+      envelope('stream.tool_use', { id: 't1', name: 'read_file' }),
+    );
+  }
+
+  it('completePlan(success=true) converges a still-running step + tool to completed', () => {
+    const before = planWithRunningStepAndTool();
+    const beforeCompletedTools = before.stats.completedTools;
+    expect(findById(before, stepNodeId('plan-1', 1)).status).toBe('running');
+    expect(findById(before, 't1').status).toBe('running');
+
+    // Step-level completion deliberately omitted — only the plan-level event
+    // arrives, simulating a lost stream.plan_step_completed.
+    const after = runAll(
+      before,
+      envelope('stream.plan_completed', {
+        planId: 'plan-1',
+        success: true,
+        totalDurationMs: 200,
+        stepsCompleted: 1,
+        totalSteps: 1,
+      }),
+    );
+
+    expect(findById(after, 'plan-1').status).toBe('completed');
+    expect(findById(after, stepNodeId('plan-1', 1)).status).toBe('completed');
+    expect(findById(after, 't1').status).toBe('completed');
+    expect(after.stats.completedTools).toBe(beforeCompletedTools + 1);
+  });
+
+  it('completePlan(success=false) flips descendants to cancelled and bumps failedTools', () => {
+    const before = planWithRunningStepAndTool();
+    const beforeFailedTools = before.stats.failedTools;
+
+    const after = runAll(
+      before,
+      envelope('stream.plan_completed', {
+        planId: 'plan-1',
+        success: false,
+        totalDurationMs: 200,
+        stepsCompleted: 0,
+        totalSteps: 1,
+      }),
+    );
+
+    expect(findById(after, 'plan-1').status).toBe('failed');
+    expect(findById(after, stepNodeId('plan-1', 1)).status).toBe('cancelled');
+    expect(findById(after, 't1').status).toBe('cancelled');
+    expect(after.stats.failedTools).toBe(beforeFailedTools + 1);
+  });
+
+  it('failPlan (escalation) converges descendants to cancelled and bumps failedTools', () => {
+    const before = planWithRunningStepAndTool();
+    const beforeFailedTools = before.stats.failedTools;
+
+    const after = runAll(
+      before,
+      envelope('stream.plan_escalated', {
+        planId: 'plan-1',
+        reason: 'replanner gave up',
+      }),
+    );
+
+    const plan = findById(after, 'plan-1');
+    expect(plan.status).toBe('failed');
+    expect(plan.error).toBe('replanner gave up');
+    expect(findById(after, stepNodeId('plan-1', 1)).status).toBe('cancelled');
+    expect(findById(after, 't1').status).toBe('cancelled');
+    expect(after.stats.failedTools).toBe(beforeFailedTools + 1);
+  });
+
+  it('completePlan does not double-count tools whose step already completed normally', () => {
+    const before = runAll(
+      planWithRunningStepAndTool(),
+      envelope('stream.tool_completed', {
+        id: 't1',
+        name: 'read_file',
+        isError: false,
+        durationMs: 10,
+      }),
+      envelope('stream.plan_step_completed', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        stepName: 's1',
+        success: true,
+        durationMs: 100,
+        tokensUsed: 50,
+      }),
+    );
+    expect(findById(before, stepNodeId('plan-1', 1)).status).toBe('completed');
+    expect(findById(before, 't1').status).toBe('completed');
+    const beforeCompletedTools = before.stats.completedTools;
+
+    const after = runAll(
+      before,
+      envelope('stream.plan_completed', {
+        planId: 'plan-1',
+        success: true,
+        totalDurationMs: 200,
+        stepsCompleted: 1,
+        totalSteps: 1,
+      }),
+    );
+
+    // Step + tool already terminal before plan_completed, so the convergence
+    // walk finds nothing to flip and stats stay put.
+    expect(after.stats.completedTools).toBe(beforeCompletedTools);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Step events arriving before plan_created — don't dangle activeNodeId
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `completePlan` walks the plan's children with the `convergeRunningSubtree` helper from PR 1/3, flipping any still-running step (and its still-running tool descendants) to a terminal state when the plan terminates.
- `failPlan` (escalation path) does the same with `cancelled` as the terminal status — escalated plans are unconditionally a failure mode.
- Sidebar stats (`completedTools` / `failedTools`) are bumped for tool nodes converged this way; tools that already went through `completeToolNode` are not double-counted.

Addresses failure mode (A) in #485: the dashboard could render a green plan with a still-pulsing step beneath it whenever a `stream.plan_step_completed` event was lost.

> **Stacked on #486 (PR 1/3).** Reviewing this PR alone shows only the incremental diff; once #486 lands, GitHub will auto-retarget this PR's base to `main`.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 208/208 pass (4 new tests in `treeReducer.test.ts`)
  - `completePlan(success=true)` converges step + tool to `completed` and bumps `completedTools`
  - `completePlan(success=false)` flips descendants to `cancelled` and bumps `failedTools`
  - `failPlan` (escalation) flips descendants to `cancelled` and bumps `failedTools`
  - `completePlan` does not double-count tools whose step already completed normally (regression guard)
- [ ] Manual: drop a `plan_step_completed` event in flight (or run a plan that escalates after replan); confirm the dashboard shows the plan as ✓/✗ with all descendants also terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)