### PR TITLE
feat(daemon+dashboard): parentStepId on stream.tool_use (#485 PR 3/3)

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -710,9 +710,20 @@ public final class StreamingAgentHandler {
 
         // 3. Execute the plan
         var conversationHistory = toMessages(session.messages());
+        // Track the running plan step so stream.tool_use notifications can
+        // carry an explicit parentStepId (#485 PR 3/3). null when eventHandler
+        // is not the production StreamingNotificationHandler (e.g. test
+        // doubles) — in that case, parentStepId tagging is silently skipped.
+        StreamingNotificationHandler streamHandler =
+                eventHandler instanceof StreamingNotificationHandler h ? h : null;
         var listener = new SequentialPlanExecutor.PlanEventListener() {
             @Override
             public void onStepStarted(PlannedStep step, int stepIndex, int totalSteps) {
+                if (streamHandler != null) {
+                    // Composed form mirrors the dashboard's stepNodeId(planId, 1-based)
+                    // so the reducer can look up the step node by id directly.
+                    streamHandler.setCurrentStepId(plan.planId() + ":step:" + (stepIndex + 1));
+                }
                 try {
                     var p = objectMapper.createObjectNode();
                     p.put("planId", plan.planId());
@@ -745,6 +756,9 @@ public final class StreamingAgentHandler {
 
             @Override
             public void onPlanCompleted(TaskPlan completedPlan, boolean success, long totalDurationMs) {
+                if (streamHandler != null) {
+                    streamHandler.setCurrentStepId(null);
+                }
                 try {
                     var p = objectMapper.createObjectNode();
                     p.put("planId", completedPlan.planId());
@@ -774,6 +788,9 @@ public final class StreamingAgentHandler {
 
             @Override
             public void onPlanEscalated(TaskPlan escalatedPlan, String reason) {
+                if (streamHandler != null) {
+                    streamHandler.setCurrentStepId(null);
+                }
                 try {
                     var p = objectMapper.createObjectNode();
                     p.put("planId", escalatedPlan.planId());
@@ -2854,14 +2871,22 @@ public final class StreamingAgentHandler {
         }
 
         // 8. Create notification listener for the resumed plan
+        // Same parentStepId tagging as the fresh-plan path (#485 PR 3/3) — null
+        // when eventHandler isn't the production handler.
+        StreamingNotificationHandler resumedStreamHandler =
+                eventHandler instanceof StreamingNotificationHandler h ? h : null;
         var notificationListener = new SequentialPlanExecutor.PlanEventListener() {
             @Override
             public void onStepStarted(PlannedStep step, int stepIndex, int totalSteps) {
+                int oneBasedIndex = cp.nextStepIndex() + stepIndex + 1;
+                if (resumedStreamHandler != null) {
+                    resumedStreamHandler.setCurrentStepId(resumedPlanId + ":step:" + oneBasedIndex);
+                }
                 try {
                     var p = objectMapper.createObjectNode();
                     p.put("planId", resumedPlanId);
                     p.put("stepId", step.stepId());
-                    p.put("stepIndex", cp.nextStepIndex() + stepIndex + 1);
+                    p.put("stepIndex", oneBasedIndex);
                     p.put("totalSteps", cp.plan().steps().size());
                     p.put("stepName", step.name());
                     cancelContext.sendNotification("stream.plan_step_started", p);
@@ -2889,6 +2914,9 @@ public final class StreamingAgentHandler {
 
             @Override
             public void onPlanCompleted(TaskPlan completedPlan, boolean success, long totalDurationMs) {
+                if (resumedStreamHandler != null) {
+                    resumedStreamHandler.setCurrentStepId(null);
+                }
                 try {
                     var p = objectMapper.createObjectNode();
                     p.put("planId", resumedPlanId);
@@ -2920,6 +2948,9 @@ public final class StreamingAgentHandler {
 
             @Override
             public void onPlanEscalated(TaskPlan escalatedPlan, String reason) {
+                if (resumedStreamHandler != null) {
+                    resumedStreamHandler.setCurrentStepId(null);
+                }
                 try {
                     var p = objectMapper.createObjectNode();
                     p.put("planId", escalatedPlan.planId());
@@ -3341,10 +3372,31 @@ public final class StreamingAgentHandler {
 
         private final StreamContext context;
         private final ObjectMapper objectMapper;
+        /**
+         * Plan step id (in the dashboard's composed {@code planId:step:index}
+         * form) currently in scope, or {@code null} for non-plan ReAct turns.
+         * Set by the {@link SequentialPlanExecutor.PlanEventListener} on
+         * {@code onStepStarted} and cleared on plan termination — see #485
+         * PR 3/3. Read on {@code onContentBlockStart} for ToolUse so each
+         * {@code stream.tool_use} carries an explicit parent reference,
+         * removing the dashboard's reliance on event ordering for tool-to-step
+         * attribution.
+         */
+        private final java.util.concurrent.atomic.AtomicReference<String> currentStepId
+                = new java.util.concurrent.atomic.AtomicReference<>();
 
         StreamingNotificationHandler(StreamContext context, ObjectMapper objectMapper) {
             this.context = context;
             this.objectMapper = objectMapper;
+        }
+
+        /**
+         * Sets (or clears with {@code null}) the dashboard-form step id used
+         * to tag {@code stream.tool_use} notifications. Caller is responsible
+         * for setting on step start and clearing on plan termination.
+         */
+        void setCurrentStepId(String stepId) {
+            currentStepId.set(stepId);
         }
 
         @Override
@@ -3379,6 +3431,10 @@ public final class StreamingAgentHandler {
                     String summary = summarizeToolInput(toolUse.name(), toolUse.inputJson(), objectMapper);
                     if (!summary.isBlank()) {
                         params.put("summary", summary);
+                    }
+                    String stepId = currentStepId.get();
+                    if (stepId != null) {
+                        params.put("parentStepId", stepId);
                     }
                     context.sendNotification("stream.tool_use", params);
                 } catch (IOException e) {

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/DaemonIntegrationTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/DaemonIntegrationTest.java
@@ -1138,6 +1138,27 @@ class DaemonIntegrationTest {
                     .anyMatch(n -> "stream.plan_completed".equals(n.path("method").asText()));
             assertThat(hasPlanCompleted).isTrue();
 
+            // #485 PR 3/3: tool_use emitted from inside a plan step must
+            // carry parentStepId in the dashboard's composed form
+            // ({planId}:step:{1-based-index}). This proves the listener
+            // wired the StreamingNotificationHandler tracker on step start.
+            String planId = result.notifications().stream()
+                    .filter(n -> "stream.plan_created".equals(n.path("method").asText()))
+                    .findFirst()
+                    .map(n -> n.path("params").path("planId").asText())
+                    .orElseThrow(() -> new AssertionError("plan_created notification missing"));
+            var toolUseDuringStep = result.notifications().stream()
+                    .filter(n -> "stream.tool_use".equals(n.path("method").asText()))
+                    .filter(n -> "read_file".equals(n.path("params").path("name").asText()))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("tool_use notification missing"));
+            assertThat(toolUseDuringStep.path("params").has("parentStepId"))
+                    .as("tool_use during plan step must carry parentStepId")
+                    .isTrue();
+            assertThat(toolUseDuringStep.path("params").path("parentStepId").asText())
+                    .as("parentStepId must be the dashboard's composed step node id")
+                    .isEqualTo(planId + ":step:1");
+
             // Verify checkpoint files were created on disk
             List<Path> checkpointFiles;
             try (var files = Files.list(checkpointDir)) {

--- a/aceclaw-dashboard/src/reducers/treeReducer.ts
+++ b/aceclaw-dashboard/src/reducers/treeReducer.ts
@@ -463,7 +463,55 @@ function addToolNode(
   // continuity but the helper returns the nearest running turn OR
   // step, so plan-step agent loops anchor on the step (not the
   // enclosing turn) — see findCurrentAgentScope.
-  const turn = findCurrentAgentScope(state);
+  //
+  // #485 PR 3/3: when the daemon tags the tool_use with an explicit
+  // parentStepId, prefer that node over the heuristic. The heuristic
+  // walks up from activeNodeId — it can disagree with the explicit
+  // parent if an out-of-order plan_step_completed flipped the step out
+  // of 'running' before this tool_use arrived. The explicit field is
+  // authoritative because the daemon sets it from inside the listener
+  // for the actually-running step, not from a tree-walk over a
+  // potentially-stale snapshot.
+  const explicitParentNode = params.parentStepId
+    ? findNode(state.rootNodes, params.parentStepId)
+    : null;
+  // Skip override when the resolved step is a replan tombstone (status
+  // 'cancelled'): the composed id collides with the cancelled skeleton
+  // left behind by replacePlanSteps, but the actually-running step
+  // carries a synthetic `:r{n}` id under the same plan. Treating the
+  // tombstone as authoritative would attach all post-replan tools to
+  // the cancelled step. 'completed' / 'failed' are fine to attach to —
+  // late tools for a naturally-finished step are exactly what this PR
+  // exists to handle.
+  const explicitParentStep = explicitParentNode?.status === 'cancelled'
+    ? null
+    : explicitParentNode;
+  const heuristicScope = findCurrentAgentScope(state);
+  const turn = explicitParentStep ?? heuristicScope;
+  // When we override the heuristic, also bypass currentTextId /
+  // currentThinkingId below — those anchors may still belong to the
+  // enclosing-turn scope and would re-route the tool away from the
+  // explicit parent step.
+  // Compare by id rather than object reference — future helpers that wrap
+  // findNode (memoization, snapshot cloning, …) would silently break the
+  // override-detection if it relied on identity equality.
+  //
+  // Also force override when the candidate anchor (state.currentTextId or
+  // state.currentThinkingId) is NOT inside the explicit step's subtree.
+  // Step boundaries do not currently clear those anchors, so a step-1
+  // leftover text can capture step-2's first tool even when explicit and
+  // heuristic agree on the step (Codex feedback on #488). Override flips
+  // the anchor selection below to the step itself, bypassing the stale
+  // text/thinking.
+  const candidateAnchorId = state.currentTextId ?? state.currentThinkingId;
+  const candidateInsideExplicit = !explicitParentStep || !candidateAnchorId
+    ? true
+    : findNode(explicitParentStep.children, candidateAnchorId) !== null;
+  const explicitOverride = explicitParentStep !== null
+    && (
+      explicitParentStep.id !== (heuristicScope?.id ?? null)
+      || !candidateInsideExplicit
+    );
 
   // Iteration-boundary synthesis (mirrors appendTextToCurrentTurn):
   // when this tool_use is the FIRST event of a new iteration with no
@@ -478,8 +526,14 @@ function addToolNode(
   // Suppress the synthesis when there's a running sibling tool under
   // the current anchor — that signals parallel tools from the SAME LLM
   // call, which must keep sharing the existing anchor.
+  //
+  // Also suppress under explicitOverride (#485 PR 3/3): the anchor
+  // selection below will route this tool directly to the named step
+  // and bypass currentThinkingId entirely, so a freshly-minted thinking
+  // would just sit orphaned under the step with no children.
   let workingState = state;
   if (
+    !explicitOverride &&
     turn &&
     state.currentTextId === null &&
     (state.currentThinkingId === null || state.thinkingSealed)
@@ -507,9 +561,12 @@ function addToolNode(
   // share the same anchor. textIsOpen=false (after a tool closed the
   // text) keeps the anchor for parallel-tool grouping but signals to
   // the next text delta that it's a NEW iteration.
-  const anchorId =
-    state.currentTextId ?? state.currentThinkingId ?? (turn ? turn.id : null);
-  const narrationId = state.currentTextId;
+  const anchorId = explicitOverride
+    ? (turn ? turn.id : null)
+    : state.currentTextId ?? state.currentThinkingId ?? (turn ? turn.id : null);
+  // Narration anchor is also dropped under explicit override — the open
+  // text node belongs to a different scope's iteration.
+  const narrationId = explicitOverride ? null : state.currentTextId;
 
   const tool: ExecutionNode = {
     id: params.id,
@@ -550,7 +607,13 @@ function addToolNode(
   // for this iteration — both should stop pulsing immediately so the
   // visual state matches reality. Only flip 'running' → 'completed'
   // so a node that already failed/etc. isn't clobbered.
-  if (state.currentThinkingId) {
+  //
+  // Skip both flips under explicitOverride: those anchors belong to
+  // whatever step is actually running right now (the explicit-parent
+  // tool is for a different, possibly older, scope) — flipping them
+  // here would prematurely close the live step's thinking and force
+  // its next text/tool_use to mint a fresh iteration boundary.
+  if (!explicitOverride && state.currentThinkingId) {
     rootNodes = mapNode(rootNodes, state.currentThinkingId, (t) =>
       t.status === 'running' ? { ...t, status: 'completed' as const } : t,
     );
@@ -561,20 +624,31 @@ function addToolNode(
     );
   }
 
-  let next: ExecutionTree = {
-    ...state,
-    rootNodes,
-    activeNodeId: tool.id,
-    // Seal both anchors: a tool_use means the model has stopped
-    // thinking AND stopped talking; the next thinking OR text delta is
-    // from a NEW LLM call (next ReAct iteration). Parallel tool_use
-    // events that follow within the SAME call don't have a thinking
-    // or text delta between them, so currentThinkingId / currentTextId
-    // stay valid for parallel-tool grouping.
-    thinkingSealed: true,
-    textIsOpen: false,
-    stats: { ...state.stats, totalTools: state.stats.totalTools + 1 },
-  };
+  // Anchor mutation also gates on explicitOverride: a late tool_use
+  // for an older scope must not move activeNodeId, seal the live
+  // thinking, or close the live text. The tool inserts as a passive
+  // child of the explicit step; the live step's iteration bookkeeping
+  // continues uninterrupted.
+  let next: ExecutionTree = explicitOverride
+    ? {
+        ...state,
+        rootNodes,
+        stats: { ...state.stats, totalTools: state.stats.totalTools + 1 },
+      }
+    : {
+        ...state,
+        rootNodes,
+        activeNodeId: tool.id,
+        // Seal both anchors: a tool_use means the model has stopped
+        // thinking AND stopped talking; the next thinking OR text delta is
+        // from a NEW LLM call (next ReAct iteration). Parallel tool_use
+        // events that follow within the SAME call don't have a thinking
+        // or text delta between them, so currentThinkingId / currentTextId
+        // stay valid for parallel-tool grouping.
+        thinkingSealed: true,
+        textIsOpen: false,
+        stats: { ...state.stats, totalTools: state.stats.totalTools + 1 },
+      };
   // Drain any buffered permission.request that arrived BEFORE this
   // tool_use event (parallel virtual threads on the daemon dispatch
   // permission.request and stream.tool_use independently — wire order

--- a/aceclaw-dashboard/src/types/events.ts
+++ b/aceclaw-dashboard/src/types/events.ts
@@ -126,6 +126,19 @@ export interface ToolUseParams {
   name: string;
   /** Optional one-line summary of the input (path, command, etc.). */
   summary?: string;
+  /**
+   * Plan step that owns this tool call, when emitted from inside a
+   * SequentialPlanExecutor step. Optional for forward / backward compat:
+   * older daemons (and non-plan ReAct turns) omit it, and the reducer
+   * falls back to its anchor heuristic ({@code currentTextId} →
+   * {@code currentThinkingId} → enclosing turn).
+   *
+   * When present, the reducer prefers an explicit lookup of this step
+   * over the anchor heuristic, so that tools attribute correctly even
+   * when {@code stream.tool_use} arrives after {@code stream.plan_step_completed}
+   * for the step they belonged to (issue #485 PR 3/3).
+   */
+  parentStepId?: string;
 }
 
 /** stream.tool_completed — terminal event for a tool call. */

--- a/aceclaw-dashboard/tests/treeReducer.test.ts
+++ b/aceclaw-dashboard/tests/treeReducer.test.ts
@@ -2470,6 +2470,484 @@ describe('completeStep converges still-running descendants (#485)', () => {
 // Step events arriving before plan_created — don't dangle activeNodeId
 // ---------------------------------------------------------------------------
 
+
+// ---------------------------------------------------------------------------
+// parentStepId on stream.tool_use (#485 PR 3/3): the daemon tags each
+// tool_use with the composed step id ({planId}:step:{1-based-index}) so
+// the reducer can attribute the tool to the right step even when events
+// arrive out of order (e.g. plan_step_completed overtaking a late
+// tool_use).
+// ---------------------------------------------------------------------------
+
+describe('stepNodeId wire format guard (#485)', () => {
+  // The daemon hardcodes the same `${planId}:step:${1-based-index}` form
+  // when emitting parentStepId on stream.tool_use (see
+  // StreamingAgentHandler.java — the executePlannedPrompt and
+  // executeResumedPlan listeners both compose it inline). If this format
+  // ever changes here without a matching daemon change, every tool_use
+  // would silently stop attributing to its step. Lock the contract so a
+  // format change immediately fails CI on the dashboard side.
+  it('produces the exact form the daemon emits as parentStepId', () => {
+    expect(stepNodeId('plan-1', 1)).toBe('plan-1:step:1');
+    expect(stepNodeId('uuid-foo-bar', 42)).toBe('uuid-foo-bar:step:42');
+  });
+});
+
+describe('addToolNode honours parentStepId from daemon (#485)', () => {
+  it('attaches a tool to the explicit parent step even after step has flipped to completed', () => {
+    let state = runAll(
+      freshTree(),
+      envelope('stream.session_started', {
+        sessionId: 'sess-1',
+        model: 'm',
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.turn_started', {
+        sessionId: 'sess-1',
+        requestId: 'req-1',
+        turnNumber: 1,
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.plan_created', {
+        planId: 'plan-1',
+        stepCount: 1,
+        goal: 'g',
+        steps: [{ index: 1, name: 's1', description: '' }],
+      }),
+      envelope('stream.plan_step_started', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        totalSteps: 1,
+        stepName: 's1',
+      }),
+      envelope('stream.plan_step_completed', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        stepName: 's1',
+        success: true,
+        durationMs: 100,
+        tokensUsed: 50,
+      }),
+    );
+    const stepId = stepNodeId('plan-1', 1);
+    expect(findById(state, stepId).status).toBe('completed');
+    const childCountBefore = findById(state, stepId).children.length;
+
+    state = runAll(
+      state,
+      envelope('stream.tool_use', {
+        id: 't1',
+        name: 'read_file',
+        parentStepId: stepId,
+      }),
+    );
+
+    const stepAfter = findById(state, stepId);
+    expect(stepAfter.children.length).toBeGreaterThan(childCountBefore);
+    const tool = stepAfter.children.find((c) => c.id === 't1');
+    expect(tool).toBeDefined();
+    expect(tool?.type).toBe('tool');
+  });
+
+  it('falls back to the heuristic when parentStepId is missing (regression guard)', () => {
+    const before = runAll(
+      freshTree(),
+      envelope('stream.session_started', {
+        sessionId: 'sess-1',
+        model: 'm',
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.turn_started', {
+        sessionId: 'sess-1',
+        requestId: 'req-1',
+        turnNumber: 1,
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.plan_created', {
+        planId: 'plan-1',
+        stepCount: 1,
+        goal: 'g',
+        steps: [{ index: 1, name: 's1', description: '' }],
+      }),
+      envelope('stream.plan_step_started', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        totalSteps: 1,
+        stepName: 's1',
+      }),
+    );
+    const after = runAll(
+      before,
+      envelope('stream.tool_use', { id: 't1', name: 'read_file' }),
+    );
+    const step = findById(after, stepNodeId('plan-1', 1));
+    // Tool can sit directly under the step or under a synthesized
+    // thinking node beneath it — assert the subtree contains it.
+    function hasDescendant(node: ExecutionNode, id: string): boolean {
+      if (node.children.some((c) => c.id === id)) return true;
+      return node.children.some((c) => hasDescendant(c, id));
+    }
+    expect(hasDescendant(step, 't1')).toBe(true);
+  });
+
+  it('does not mint an orphan synthetic thinking under explicit override (CodeRabbit #488)', () => {
+    // Regression guard: when explicit parentStepId routes the tool
+    // directly to the step, the iteration-boundary synthesis above
+    // must NOT mint a thinking node — the tool would bypass it,
+    // leaving an empty completed thinking hanging off the step.
+    let state = runAll(
+      freshTree(),
+      envelope('stream.session_started', {
+        sessionId: 'sess-1',
+        model: 'm',
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.turn_started', {
+        sessionId: 'sess-1',
+        requestId: 'req-1',
+        turnNumber: 1,
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.plan_created', {
+        planId: 'plan-1',
+        stepCount: 1,
+        goal: 'g',
+        steps: [{ index: 1, name: 's1', description: '' }],
+      }),
+      envelope('stream.plan_step_started', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        totalSteps: 1,
+        stepName: 's1',
+      }),
+      envelope('stream.plan_step_completed', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        stepName: 's1',
+        success: true,
+        durationMs: 100,
+        tokensUsed: 50,
+      }),
+    );
+    const stepId = stepNodeId('plan-1', 1);
+    state = runAll(
+      state,
+      envelope('stream.tool_use', {
+        id: 't1',
+        name: 'read_file',
+        parentStepId: stepId,
+      }),
+    );
+
+    const stepAfter = findById(state, stepId);
+    const orphanThinking = stepAfter.children.find(
+      (c) => c.type === 'thinking' && c.children.length === 0,
+    );
+    expect(orphanThinking).toBeUndefined();
+    // Tool itself should be a direct child of the step under override.
+    expect(stepAfter.children.find((c) => c.id === 't1')).toBeDefined();
+  });
+
+  it('skips override when parentStepId resolves to a replan tombstone (Codex #488)', () => {
+    // After replan, the failed/cancelled skeleton at the composed id
+    // (e.g. plan-1:step:1) sticks around as a tombstone, and the new
+    // running step gets a synthetic `:r{n}` id under the same plan.
+    // The daemon still tags subsequent tool_use with the composed
+    // form. If the reducer naively trusted that, all post-replan
+    // tools would attach to the cancelled step. The fix: skip
+    // override when the resolved step is 'cancelled', falling back
+    // to the heuristic which finds the live synthetic step.
+    let state = runAll(
+      freshTree(),
+      envelope('stream.session_started', {
+        sessionId: 'sess-1',
+        model: 'm',
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.turn_started', {
+        sessionId: 'sess-1',
+        requestId: 'req-1',
+        turnNumber: 1,
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.plan_created', {
+        planId: 'plan-1',
+        stepCount: 1,
+        goal: 'g',
+        steps: [{ index: 1, name: 's1', description: '' }],
+      }),
+      envelope('stream.plan_step_started', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        totalSteps: 1,
+        stepName: 's1',
+      }),
+      envelope('stream.plan_replanned', {
+        planId: 'plan-1',
+        replanAttempt: 1,
+        newStepCount: 1,
+        rationale: 'changed approach',
+      }),
+      envelope('stream.plan_step_started', {
+        planId: 'plan-1',
+        stepId: 's1-replan',
+        stepIndex: 1,
+        totalSteps: 1,
+        stepName: 's1-replan',
+      }),
+    );
+    const tombstoneId = stepNodeId('plan-1', 1);
+    expect(findById(state, tombstoneId).status).toBe('cancelled');
+    const plan = state.rootNodes[0]!.children[0]!.children[0]!;
+    const liveStep = plan.children.find(
+      (c) => c.metadata?.['createdByReplan'] === true,
+    );
+    expect(liveStep?.status).toBe('running');
+
+    state = runAll(
+      state,
+      envelope('stream.tool_use', {
+        id: 't1',
+        name: 'read_file',
+        // Daemon's hardcoded composed form — collides with the tombstone.
+        parentStepId: tombstoneId,
+      }),
+    );
+
+    // Tombstone gets no children; live synthetic step gets the tool.
+    const tombstoneAfter = findById(state, tombstoneId);
+    expect(tombstoneAfter.children.find((c) => c.id === 't1')).toBeUndefined();
+    function hasDescendant(node: ExecutionNode, id: string): boolean {
+      if (node.children.some((c) => c.id === id)) return true;
+      return node.children.some((c) => hasDescendant(c, id));
+    }
+    const liveStepAfter = findById(state, liveStep!.id);
+    expect(hasDescendant(liveStepAfter, 't1')).toBe(true);
+  });
+
+  it('preserves live-scope anchors when an explicit-parent tool arrives late (Codex #488)', () => {
+    // Step 1 runs and emits a thinking + tool that completes. Step 2
+    // starts and emits its own thinking — currentThinkingId now points
+    // to step 2's live thinking. A delayed tool_use for step 1 arrives
+    // (parentStepId resolves to the completed step 1). Without the
+    // override-aware guards, this late event would flip step 2's
+    // running thinking to completed, seal thinkingSealed, and move
+    // activeNodeId — breaking the rendering of step 2's subsequent
+    // events. The fix: under explicitOverride, leave global anchors
+    // untouched.
+    let state = runAll(
+      freshTree(),
+      envelope('stream.session_started', {
+        sessionId: 'sess-1',
+        model: 'm',
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.turn_started', {
+        sessionId: 'sess-1',
+        requestId: 'req-1',
+        turnNumber: 1,
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.plan_created', {
+        planId: 'plan-1',
+        stepCount: 2,
+        goal: 'g',
+        steps: [
+          { index: 1, name: 's1', description: '' },
+          { index: 2, name: 's2', description: '' },
+        ],
+      }),
+      envelope('stream.plan_step_started', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        totalSteps: 2,
+        stepName: 's1',
+      }),
+      envelope('stream.plan_step_completed', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        stepName: 's1',
+        success: true,
+        durationMs: 50,
+        tokensUsed: 25,
+      }),
+      envelope('stream.plan_step_started', {
+        planId: 'plan-1',
+        stepId: 's2',
+        stepIndex: 2,
+        totalSteps: 2,
+        stepName: 's2',
+      }),
+      // Step 2's live iteration bookkeeping: thinking + first tool.
+      envelope('stream.thinking', { delta: 'planning step 2…' }),
+    );
+    const liveThinkingIdBefore = state.currentThinkingId;
+    const liveActiveBefore = state.activeNodeId;
+    const liveThinkingSealedBefore = state.thinkingSealed;
+    expect(liveThinkingIdBefore).not.toBeNull();
+
+    // Delayed tool_use for step 1 (completed). parentStepId routes it
+    // back to step 1. This must not disturb step 2's live anchors.
+    state = runAll(
+      state,
+      envelope('stream.tool_use', {
+        id: 't-late',
+        name: 'read_file',
+        parentStepId: stepNodeId('plan-1', 1),
+      }),
+    );
+
+    expect(state.currentThinkingId).toBe(liveThinkingIdBefore);
+    expect(state.activeNodeId).toBe(liveActiveBefore);
+    expect(state.thinkingSealed).toBe(liveThinkingSealedBefore);
+    // Step 2's live thinking must still be running.
+    const liveThinking = findById(state, liveThinkingIdBefore!);
+    expect(liveThinking.status).toBe('running');
+  });
+
+  it('forces override when explicit + heuristic agree but candidate anchor is stale (Codex #488)', () => {
+    // Step 1 ends with currentTextId set to its final-text node. Step 2
+    // starts (activateStep moves activeNodeId but does NOT clear the
+    // text/thinking anchors). Step 2's first tool_use arrives with
+    // parentStepId pointing at step 2.
+    //
+    // Without the candidate-inside-explicit guard, explicitParentStep
+    // and heuristicScope both resolve to step 2 → explicitOverride
+    // stays false → anchorId falls through to the leftover step-1
+    // currentTextId, and the step-2 tool attaches under step 1's text.
+    let state = runAll(
+      freshTree(),
+      envelope('stream.session_started', {
+        sessionId: 'sess-1',
+        model: 'm',
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.turn_started', {
+        sessionId: 'sess-1',
+        requestId: 'req-1',
+        turnNumber: 1,
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.plan_created', {
+        planId: 'plan-1',
+        stepCount: 2,
+        goal: 'g',
+        steps: [
+          { index: 1, name: 's1', description: '' },
+          { index: 2, name: 's2', description: '' },
+        ],
+      }),
+      envelope('stream.plan_step_started', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        totalSteps: 2,
+        stepName: 's1',
+      }),
+      // Step 1 emits text → currentTextId is set to a node under step 1.
+      envelope('stream.text', { delta: 'finished step 1' }),
+      envelope('stream.plan_step_completed', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        stepName: 's1',
+        success: true,
+        durationMs: 50,
+        tokensUsed: 25,
+      }),
+      envelope('stream.plan_step_started', {
+        planId: 'plan-1',
+        stepId: 's2',
+        stepIndex: 2,
+        totalSteps: 2,
+        stepName: 's2',
+      }),
+    );
+    // Confirm the leftover anchor really points into step 1's subtree.
+    function hasDescendant(node: ExecutionNode, id: string): boolean {
+      if (node.children.some((c) => c.id === id)) return true;
+      return node.children.some((c) => hasDescendant(c, id));
+    }
+    const step1Id = stepNodeId('plan-1', 1);
+    const step2Id = stepNodeId('plan-1', 2);
+    const step1 = findById(state, step1Id);
+    expect(state.currentTextId).not.toBeNull();
+    expect(hasDescendant(step1, state.currentTextId!)).toBe(true);
+
+    // Step 2's first tool_use, daemon-tagged with parentStepId=step 2.
+    state = runAll(
+      state,
+      envelope('stream.tool_use', {
+        id: 't1',
+        name: 'read_file',
+        parentStepId: step2Id,
+      }),
+    );
+
+    // Tool must end up in step 2's subtree, NOT under step 1's leftover text.
+    expect(hasDescendant(findById(state, step2Id), 't1')).toBe(true);
+    expect(hasDescendant(findById(state, step1Id), 't1')).toBe(false);
+  });
+
+  it('falls back to the heuristic when parentStepId references a non-existent node', () => {
+    const before = runAll(
+      freshTree(),
+      envelope('stream.session_started', {
+        sessionId: 'sess-1',
+        model: 'm',
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.turn_started', {
+        sessionId: 'sess-1',
+        requestId: 'req-1',
+        turnNumber: 1,
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.plan_created', {
+        planId: 'plan-1',
+        stepCount: 1,
+        goal: 'g',
+        steps: [{ index: 1, name: 's1', description: '' }],
+      }),
+      envelope('stream.plan_step_started', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        totalSteps: 1,
+        stepName: 's1',
+      }),
+    );
+    const after = runAll(
+      before,
+      envelope('stream.tool_use', {
+        id: 't1',
+        name: 'read_file',
+        parentStepId: 'plan-NEVER-EXISTED:step:99',
+      }),
+    );
+    const step = findById(after, stepNodeId('plan-1', 1));
+    // Tool can sit directly under the step or under a synthesized
+    // thinking node beneath it — assert the subtree contains it.
+    function hasDescendant(node: ExecutionNode, id: string): boolean {
+      if (node.children.some((c) => c.id === id)) return true;
+      return node.children.some((c) => hasDescendant(c, id));
+    }
+    expect(hasDescendant(step, 't1')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Step events arriving before plan_created — don't dangle activeNodeId
+// ---------------------------------------------------------------------------
+
 describe('plan/step events without plan skeleton', () => {
   it('plan_step_started without a plan is a state no-op', () => {
     const before = runAll(


### PR DESCRIPTION
## Summary

The dashboard's tool-to-step attribution depended on event ordering plus the `activeNodeId` heuristic in `findCurrentAgentScope`. When a `plan_step_completed` overtook a late `stream.tool_use` (or any out-of-order delivery), the heuristic could no longer find the running step and the tool would attach to the enclosing turn instead of the step it actually belonged to. PRs 1/3 and 2/3 reconcile the *symptom* at the step / plan boundary; this PR removes the *cause* by tagging each `stream.tool_use` with an explicit `parentStepId`.

### Daemon (`StreamingAgentHandler`)

- `StreamingNotificationHandler` tracks the active plan step via an `AtomicReference<String>`, set on `onStepStarted` and cleared on `onPlanCompleted` / `onPlanEscalated`.
- The id is composed in the dashboard's `stepNodeId` form (`{planId}:step:{1-based-index}`) so the reducer can look the step up directly without an extra mapping table.
- Both the fresh-plan listener and the resume-from-checkpoint listener are wired the same way. Non-`StreamingNotificationHandler` event handlers (test doubles, broadcast-only contexts used by cron / deferred actions) are silently skipped.
- `onContentBlockStart` for `ToolUse` reads the tracker and adds `parentStepId` to the params when present.

### Dashboard

- `ToolUseParams.parentStepId` added as optional. Older daemons omit it and the reducer falls back to the existing heuristic, so backward compat is preserved.
- `addToolNode` resolves an explicit parent step before consulting `findCurrentAgentScope`. When the explicit parent disagrees with the heuristic (the out-of-order case), the explicit field wins and the `currentTextId` / `currentThinkingId` anchors are bypassed — those anchors may belong to a different scope's iteration and would otherwise re-route the tool away from the named step.

> Independent of #486 (PR 1/3) and #487 (PR 2/3); branched from `main` because the change touches different surfaces. Can be reviewed and merged in any order.

## Test plan

### Dashboard

- [x] `npm run typecheck` clean
- [x] `npm test` — 203/203 pass (3 new tests in `treeReducer.test.ts`)
  - tool with `parentStepId` attaches to the named step even after the step has flipped to `completed`
  - missing `parentStepId` falls back to the heuristic (regression guard)
  - bogus `parentStepId` (no matching node) falls back to the heuristic (forward-compat hazard)

### Daemon

- [x] `./gradlew :aceclaw-daemon:compileJava` clean
- [x] `./gradlew :aceclaw-daemon:test --tests DaemonIntegrationTest.testCheckpointCreatedDuringPlanExecution` passes — augmented the existing plan-execution test to assert `stream.tool_use` during a step carries `parentStepId == {planId}:step:1`.

### Pre-existing failure not addressed by this PR

`AceClawConfigTest.webSocketGatedOffForNonLoopbackHostWithoutExplicitEnable` fails on `main` independently of this change (verified by running it on `main` with my changes stashed). Not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming tool-use events are now tagged with a parent-step identifier so tool outputs are anchored to the correct plan step and preserve live iteration state when applicable.
  * Event schemas accept an optional parent-step id to enable explicit anchoring during resumed or fresh plan execution.

* **Tests**
  * Added integration and unit tests validating parent-step attribution, resumed-execution offsets, and regression scenarios for explicit-parent tooling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xinhuagu/AceClaw/pull/488)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->