### PR TITLE
feat(daemon+dashboard): parentStepId on stream.thinking + stream.text (#485 follow-up)

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -3404,6 +3404,10 @@ public final class StreamingAgentHandler {
             try {
                 var params = objectMapper.createObjectNode();
                 params.put("delta", event.text());
+                String stepId = currentStepId.get();
+                if (stepId != null) {
+                    params.put("parentStepId", stepId);
+                }
                 context.sendNotification("stream.thinking", params);
             } catch (IOException e) {
                 log.warn("Failed to send thinking delta notification: {}", e.getMessage());
@@ -3415,6 +3419,10 @@ public final class StreamingAgentHandler {
             try {
                 var params = objectMapper.createObjectNode();
                 params.put("delta", event.text());
+                String stepId = currentStepId.get();
+                if (stepId != null) {
+                    params.put("parentStepId", stepId);
+                }
                 context.sendNotification("stream.text", params);
             } catch (IOException e) {
                 log.warn("Failed to send text delta notification: {}", e.getMessage());

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/DaemonIntegrationTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/DaemonIntegrationTest.java
@@ -1159,6 +1159,23 @@ class DaemonIntegrationTest {
                     .as("parentStepId must be the dashboard's composed step node id")
                     .isEqualTo(planId + ":step:1");
 
+            // #485 follow-up: stream.thinking and stream.text emitted from
+            // inside a plan step must also carry parentStepId so the
+            // reducer can route iteration anchors (currentThinkingId /
+            // currentTextId) to the right step. The MockLlmClient response
+            // for step 1 includes a final text ("Found the API."), so we
+            // expect at least one stream.text envelope tagged for step 1.
+            var textInsideStep = result.notifications().stream()
+                    .filter(n -> "stream.text".equals(n.path("method").asText()))
+                    .filter(n -> n.path("params").has("parentStepId"))
+                    .findFirst();
+            assertThat(textInsideStep)
+                    .as("at least one stream.text during a plan step must carry parentStepId")
+                    .isPresent();
+            assertThat(textInsideStep.get().path("params").path("parentStepId").asText())
+                    .as("text parentStepId must be the dashboard's composed step node id")
+                    .startsWith(planId + ":step:");
+
             // Verify checkpoint files were created on disk
             List<Path> checkpointFiles;
             try (var files = Files.list(checkpointDir)) {

--- a/aceclaw-dashboard/src/reducers/treeReducer.ts
+++ b/aceclaw-dashboard/src/reducers/treeReducer.ts
@@ -191,7 +191,17 @@ function findCurrentAgentScope(state: ExecutionTree): ExecutionNode | null {
 function resolveAgentScope(
   state: ExecutionTree,
   parentStepId: string | undefined,
-): { turn: ExecutionNode | null; override: boolean } {
+): {
+  turn: ExecutionNode | null;
+  /** Explicit step diverges from the activeNodeId-based heuristic OR a
+   *  stale iteration anchor lives outside the explicit step's subtree. */
+  override: boolean;
+  /** Stronger flavour: explicit step is a *different* live scope than the
+   *  heuristic. Late events for an OLDER step land here — handlers must
+   *  not provisionally complete the live step's running children or
+   *  rotate iteration anchors, since those belong to a different scope. */
+  scopeChanged: boolean;
+} {
   const explicitNode = parentStepId
     ? findNode(state.rootNodes, parentStepId)
     : null;
@@ -199,16 +209,16 @@ function resolveAgentScope(
   const heuristic = findCurrentAgentScope(state);
   const turn = explicit ?? heuristic;
   if (!explicit) {
-    return { turn, override: false };
+    return { turn, override: false, scopeChanged: false };
   }
   if (explicit.id !== (heuristic?.id ?? null)) {
-    return { turn, override: true };
+    return { turn, override: true, scopeChanged: true };
   }
   const candidate = state.currentTextId ?? state.currentThinkingId;
   const candidateInside = !candidate
     ? true
     : findNode(explicit.children, candidate) !== null;
-  return { turn, override: !candidateInside };
+  return { turn, override: !candidateInside, scopeChanged: false };
 }
 
 /**
@@ -809,8 +819,19 @@ function appendTextToCurrentTurn(
   // (#485 follow-up) so a text delta routes to the right step even
   // when activeNodeId / currentTextId / currentThinkingId belong to a
   // previous step's iteration.
-  const { turn, override } = resolveAgentScope(state, params.parentStepId);
+  const { turn, override, scopeChanged } = resolveAgentScope(
+    state,
+    params.parentStepId,
+  );
   if (!turn) return state;
+
+  // Same scopeChanged rule as appendThinkingToCurrentTurn: late text
+  // for a different step must NOT mintIterationThinking against the
+  // live currentThinkingId. Accumulate under a stable per-step late
+  // text anchor instead.
+  if (scopeChanged) {
+    return appendLateText(state, turn, params.delta);
+  }
 
   // If we're starting a new iteration's text without a fresh
   // stream.thinking event, mint a SYNTHETIC thinking node to anchor
@@ -922,6 +943,82 @@ function appendTextToCurrentTurn(
  *   synthetic placeholders (the "model didn't think" case is already
  *   over by the time we infer the iteration boundary from a text delta)
  */
+/**
+ * Appends a late thinking delta under {@code step} when
+ * {@link resolveAgentScope} flagged scopeChanged: the event targets a
+ * step that is not the live scope. Accumulates onto a stable
+ * {@code {stepId}:late:thinking} node so multi-chunk late responses
+ * don't fragment into one synthetic thinking per delta.
+ *
+ * Critical: this path must NOT touch the live step's iteration anchors
+ * (currentThinkingId / currentTextId / activeNodeId / thinkingSealed /
+ * textIsOpen) — those belong to a different scope. mintIterationThinking
+ * would also walk currentThinkingId's subtree and provisionally-complete
+ * its running children, which is wrong when the live step is mid-flight.
+ */
+function appendLateThinking(
+  state: ExecutionTree,
+  step: ExecutionNode,
+  delta: string,
+): ExecutionTree {
+  const lateId = `${step.id}:late:thinking`;
+  const existing = findNode(state.rootNodes, lateId);
+  if (existing) {
+    return {
+      ...state,
+      rootNodes: mapNode(state.rootNodes, lateId, (t) => ({
+        ...t,
+        text: (t.text ?? '') + delta,
+      })),
+    };
+  }
+  const node: ExecutionNode = {
+    id: lateId,
+    type: 'thinking',
+    status: 'running',
+    label: 'thinking',
+    children: [],
+    text: delta,
+  };
+  return {
+    ...state,
+    rootNodes: appendChild(state.rootNodes, step.id, node),
+  };
+}
+
+/** Late-text twin of {@link appendLateThinking}. */
+function appendLateText(
+  state: ExecutionTree,
+  step: ExecutionNode,
+  delta: string,
+): ExecutionTree {
+  const lateId = `${step.id}:late:text`;
+  const existing = findNode(state.rootNodes, lateId);
+  const accumulated = (existing?.text ?? '') + delta;
+  if (existing) {
+    return {
+      ...state,
+      rootNodes: mapNode(state.rootNodes, lateId, (t) => ({
+        ...t,
+        text: accumulated,
+        label: previewLabel(accumulated),
+      })),
+    };
+  }
+  const node: ExecutionNode = {
+    id: lateId,
+    type: 'text',
+    status: 'running',
+    label: previewLabel(accumulated),
+    children: [],
+    text: accumulated,
+  };
+  return {
+    ...state,
+    rootNodes: appendChild(state.rootNodes, step.id, node),
+  };
+}
+
 function mintIterationThinking(
   state: ExecutionTree,
   turn: ExecutionNode,
@@ -993,8 +1090,22 @@ function appendThinkingToCurrentTurn(
   // (#485 follow-up) so a thinking delta routes to the right step even
   // when activeNodeId is stale or the leftover currentThinkingId
   // belongs to a previous step's iteration.
-  const { turn, override } = resolveAgentScope(state, params.parentStepId);
+  const { turn, override, scopeChanged } = resolveAgentScope(
+    state,
+    params.parentStepId,
+  );
   if (!turn) return state;
+
+  // scopeChanged: the late event targets a DIFFERENT step than the
+  // live one. mintIterationThinking would (a) provisionally-complete
+  // the live step's running tools/text via the still-current
+  // currentThinkingId, and (b) fragment a multi-chunk late response
+  // into one synthetic thinking per delta because the next chunk
+  // would not find a "running" parent. Instead, accumulate late
+  // chunks under a stable per-step late-anchor node.
+  if (scopeChanged) {
+    return appendLateThinking(state, turn, params.delta);
+  }
 
   // Same iteration: append the delta to the existing thinking node.
   // Skip under override — the live thinking belongs to a different

--- a/aceclaw-dashboard/src/reducers/treeReducer.ts
+++ b/aceclaw-dashboard/src/reducers/treeReducer.ts
@@ -213,21 +213,32 @@ function resolveExplicitStep(
   const node = findNode(state.rootNodes, parentStepId);
   if (!node) return null;
   if (node.status === 'cancelled') return null;
-  if (node.status === 'running') return node;
-  // Non-running, non-cancelled (completed / failed / paused). Could be
-  // a legitimate late-delivery target or a replan tombstone — sibling
-  // search disambiguates.
+  // Replan-replacement detection: when activateStep saw the composed
+  // id was already taken, it preserved the tombstone and minted a
+  // {composedId}:r{n} synthetic replacement under the same plan. The
+  // daemon's currentStepId tracker still emits the composed form, so
+  // any late delta naming the composed id should redirect to the
+  // *latest* synthetic — irrespective of its own status. Without the
+  // status-agnostic redirect, a delta arriving after the synthetic
+  // replacement has also completed would land back on the original
+  // tombstone (Codex feedback on PR #490).
   const path = findPath(state.rootNodes, parentStepId);
   const planNode = path?.find((n) => n.type === 'plan');
-  if (!planNode) return node;
-  const replacementPrefix = `${parentStepId}:r`;
-  const tombstoned = planNode.children.some(
-    (c) =>
-      c.type === 'step' &&
-      c.status === 'running' &&
-      c.id.startsWith(replacementPrefix),
-  );
-  return tombstoned ? null : node;
+  if (planNode) {
+    const replacementPrefix = `${parentStepId}:r`;
+    const replacements = planNode.children.filter(
+      (c) => c.type === 'step' && c.id.startsWith(replacementPrefix),
+    );
+    if (replacements.length > 0) {
+      const latest = replacements.reduce((acc, c) => {
+        const n = parseInt(acc.id.slice(replacementPrefix.length), 10);
+        const m = parseInt(c.id.slice(replacementPrefix.length), 10);
+        return Number.isFinite(m) && m > n ? c : acc;
+      });
+      return latest.status === 'cancelled' ? null : latest;
+    }
+  }
+  return node;
 }
 
 function resolveAgentScope(

--- a/aceclaw-dashboard/src/reducers/treeReducer.ts
+++ b/aceclaw-dashboard/src/reducers/treeReducer.ts
@@ -188,6 +188,48 @@ function findCurrentAgentScope(state: ExecutionTree): ExecutionNode | null {
  * skeleton, but the actually-running step under the same plan carries
  * a synthetic {@code :r{n}} id (issue #485).
  */
+/**
+ * Resolves an explicit {@code parentStepId} to a usable step node, or
+ * {@code null} when the lookup hits a replan tombstone that the daemon
+ * still names by its composed id.
+ *
+ * <p>Background: when {@link activateStep} sees the composed id is
+ * already taken by a non-pending step (replan reused the index after
+ * the original step was cancelled / completed / failed / paused),
+ * it preserves the tombstone and mints the live replacement at a
+ * {@code `:r{n}`} id under the same plan. The daemon's
+ * {@code currentStepId} tracker still emits the composed form, so a
+ * naive lookup of {@code parentStepId} returns the dead step. Detect
+ * this by sibling search: if the plan has a running step whose id
+ * starts with {@code `{parentStepId}:r`}, the explicit lookup is
+ * dead — return null so callers fall back to {@link findCurrentAgentScope}
+ * which finds the live synthetic replacement via activeNodeId.
+ */
+function resolveExplicitStep(
+  state: ExecutionTree,
+  parentStepId: string | undefined,
+): ExecutionNode | null {
+  if (!parentStepId) return null;
+  const node = findNode(state.rootNodes, parentStepId);
+  if (!node) return null;
+  if (node.status === 'cancelled') return null;
+  if (node.status === 'running') return node;
+  // Non-running, non-cancelled (completed / failed / paused). Could be
+  // a legitimate late-delivery target or a replan tombstone — sibling
+  // search disambiguates.
+  const path = findPath(state.rootNodes, parentStepId);
+  const planNode = path?.find((n) => n.type === 'plan');
+  if (!planNode) return node;
+  const replacementPrefix = `${parentStepId}:r`;
+  const tombstoned = planNode.children.some(
+    (c) =>
+      c.type === 'step' &&
+      c.status === 'running' &&
+      c.id.startsWith(replacementPrefix),
+  );
+  return tombstoned ? null : node;
+}
+
 function resolveAgentScope(
   state: ExecutionTree,
   parentStepId: string | undefined,
@@ -202,10 +244,7 @@ function resolveAgentScope(
    *  rotate iteration anchors, since those belong to a different scope. */
   scopeChanged: boolean;
 } {
-  const explicitNode = parentStepId
-    ? findNode(state.rootNodes, parentStepId)
-    : null;
-  const explicit = explicitNode?.status === 'cancelled' ? null : explicitNode;
+  const explicit = resolveExplicitStep(state, parentStepId);
   const heuristic = findCurrentAgentScope(state);
   const turn = explicit ?? heuristic;
   if (!explicit) {
@@ -524,20 +563,12 @@ function addToolNode(
   // authoritative because the daemon sets it from inside the listener
   // for the actually-running step, not from a tree-walk over a
   // potentially-stale snapshot.
-  const explicitParentNode = params.parentStepId
-    ? findNode(state.rootNodes, params.parentStepId)
-    : null;
-  // Skip override when the resolved step is a replan tombstone (status
-  // 'cancelled'): the composed id collides with the cancelled skeleton
-  // left behind by replacePlanSteps, but the actually-running step
-  // carries a synthetic `:r{n}` id under the same plan. Treating the
-  // tombstone as authoritative would attach all post-replan tools to
-  // the cancelled step. 'completed' / 'failed' are fine to attach to —
-  // late tools for a naturally-finished step are exactly what this PR
-  // exists to handle.
-  const explicitParentStep = explicitParentNode?.status === 'cancelled'
-    ? null
-    : explicitParentNode;
+  // resolveExplicitStep handles replan tombstone detection: a composed
+  // id whose plan has a sibling running synthetic `:r{n}` step is
+  // tombstoned and falls through to the heuristic. Late tools for
+  // legitimately-finished steps (no synthetic replacement) still take
+  // the override path — that's the PR's whole point.
+  const explicitParentStep = resolveExplicitStep(state, params.parentStepId);
   const heuristicScope = findCurrentAgentScope(state);
   const turn = explicitParentStep ?? heuristicScope;
   // When we override the heuristic, also bypass currentTextId /

--- a/aceclaw-dashboard/src/reducers/treeReducer.ts
+++ b/aceclaw-dashboard/src/reducers/treeReducer.ts
@@ -245,13 +245,24 @@ function resolveAgentScope(
   scopeChanged: boolean;
 } {
   const explicit = resolveExplicitStep(state, parentStepId);
+  // 'pending' = plan_step_started hasn't been reduced yet but
+  // plan_created already minted the skeleton. The daemon ALWAYS sets
+  // currentStepId from its own listener for the running step, so a
+  // pending explicit means we lost an event-ordering race — the step
+  // is about to become live. Treat it as live: override but NOT
+  // scopeChanged, so the handler mints a fresh iteration under it
+  // and rotates anchors normally. Otherwise the first delta lands in
+  // a `:late:*` node and the rest, after plan_step_started arrives,
+  // mint a new iteration node — splitting one streamed response.
+  const explicitIsLive =
+    explicit?.status === 'pending' || explicit?.status === 'running';
   const heuristic = findCurrentAgentScope(state);
   const turn = explicit ?? heuristic;
   if (!explicit) {
     return { turn, override: false, scopeChanged: false };
   }
   if (explicit.id !== (heuristic?.id ?? null)) {
-    return { turn, override: true, scopeChanged: true };
+    return { turn, override: true, scopeChanged: !explicitIsLive };
   }
   const candidate = state.currentTextId ?? state.currentThinkingId;
   const candidateInside = !candidate
@@ -987,18 +998,42 @@ function appendTextToCurrentTurn(
  * would also walk currentThinkingId's subtree and provisionally-complete
  * its running children, which is wrong when the live step is mid-flight.
  */
+/**
+ * Inherits the late node's status from its owning step so a node under
+ * a terminal step doesn't render as a perpetually pulsing 'running'
+ * leaf (CodeRabbit feedback on PR #490). 'failed' / 'paused' steps
+ * map to 'cancelled' (the late content was orphaned by the failure
+ * rather than naturally completing); 'completed' inherits as
+ * 'completed'; 'running' / 'pending' (live or about-to-be-live) keep
+ * 'running' so future deltas can extend.
+ */
+function lateNodeStatusFor(step: ExecutionNode): ExecutionStatus {
+  switch (step.status) {
+    case 'completed':
+      return 'completed';
+    case 'failed':
+    case 'cancelled':
+    case 'paused':
+      return 'cancelled';
+    default:
+      return 'running';
+  }
+}
+
 function appendLateThinking(
   state: ExecutionTree,
   step: ExecutionNode,
   delta: string,
 ): ExecutionTree {
   const lateId = `${step.id}:late:thinking`;
+  const status = lateNodeStatusFor(step);
   const existing = findNode(state.rootNodes, lateId);
   if (existing) {
     return {
       ...state,
       rootNodes: mapNode(state.rootNodes, lateId, (t) => ({
         ...t,
+        status,
         text: (t.text ?? '') + delta,
       })),
     };
@@ -1006,7 +1041,7 @@ function appendLateThinking(
   const node: ExecutionNode = {
     id: lateId,
     type: 'thinking',
-    status: 'running',
+    status,
     label: 'thinking',
     children: [],
     text: delta,
@@ -1024,6 +1059,7 @@ function appendLateText(
   delta: string,
 ): ExecutionTree {
   const lateId = `${step.id}:late:text`;
+  const status = lateNodeStatusFor(step);
   const existing = findNode(state.rootNodes, lateId);
   const accumulated = (existing?.text ?? '') + delta;
   if (existing) {
@@ -1031,6 +1067,7 @@ function appendLateText(
       ...state,
       rootNodes: mapNode(state.rootNodes, lateId, (t) => ({
         ...t,
+        status,
         text: accumulated,
         label: previewLabel(accumulated),
       })),
@@ -1039,7 +1076,7 @@ function appendLateText(
   const node: ExecutionNode = {
     id: lateId,
     type: 'text',
-    status: 'running',
+    status,
     label: previewLabel(accumulated),
     children: [],
     text: accumulated,

--- a/aceclaw-dashboard/src/reducers/treeReducer.ts
+++ b/aceclaw-dashboard/src/reducers/treeReducer.ts
@@ -170,6 +170,48 @@ function findCurrentAgentScope(state: ExecutionTree): ExecutionNode | null {
 }
 
 /**
+ * Resolves the scope an inbound stream event should attach to and
+ * reports whether the daemon's explicit {@code parentStepId} disagrees
+ * with the activeNodeId-based heuristic. The override flag tells
+ * callers to bypass iteration-local anchors (currentThinkingId /
+ * currentTextId / activeNodeId) that may belong to a different step's
+ * iteration — same logic family as {@link addToolNode}'s explicitOverride.
+ *
+ * Override fires when:
+ *   - the explicit step's id differs from the heuristic scope, OR
+ *   - a candidate iteration anchor (currentTextId / currentThinkingId)
+ *     is NOT inside the explicit step's subtree (a leftover anchor
+ *     from a previous step that activateStep didn't clear).
+ *
+ * Skips the explicit step entirely when it resolves to a 'cancelled'
+ * replan tombstone — its composed id collides with the cancelled
+ * skeleton, but the actually-running step under the same plan carries
+ * a synthetic {@code :r{n}} id (issue #485).
+ */
+function resolveAgentScope(
+  state: ExecutionTree,
+  parentStepId: string | undefined,
+): { turn: ExecutionNode | null; override: boolean } {
+  const explicitNode = parentStepId
+    ? findNode(state.rootNodes, parentStepId)
+    : null;
+  const explicit = explicitNode?.status === 'cancelled' ? null : explicitNode;
+  const heuristic = findCurrentAgentScope(state);
+  const turn = explicit ?? heuristic;
+  if (!explicit) {
+    return { turn, override: false };
+  }
+  if (explicit.id !== (heuristic?.id ?? null)) {
+    return { turn, override: true };
+  }
+  const candidate = state.currentTextId ?? state.currentThinkingId;
+  const candidateInside = !candidate
+    ? true
+    : findNode(explicit.children, candidate) !== null;
+  return { turn, override: !candidateInside };
+}
+
+/**
  * Replaces a node anywhere in the forest by id. Returns a new forest with
  * structural sharing for branches that did not change.
  */
@@ -763,14 +805,16 @@ function appendTextToCurrentTurn(
   // skips its thinking block (model went straight from tool result to
   // final response) would silently merge into the previous iter's
   // text node, because both ids would key on the same currentThinkingId.
-  // findCurrentAgentScope returns running step if one is active,
-  // else running turn — so step-scoped agent loops anchor correctly.
-  const turn = findCurrentAgentScope(state);
+  // resolveAgentScope honours the daemon's explicit parentStepId
+  // (#485 follow-up) so a text delta routes to the right step even
+  // when activeNodeId / currentTextId / currentThinkingId belong to a
+  // previous step's iteration.
+  const { turn, override } = resolveAgentScope(state, params.parentStepId);
   if (!turn) return state;
 
   // If we're starting a new iteration's text without a fresh
   // stream.thinking event, mint a SYNTHETIC thinking node to anchor
-  // it. Two cases trigger this:
+  // it. Three cases trigger this:
   //   1. textIsOpen=false + thinkingSealed=true: previous iteration
   //      closed by a tool_use, next call started with text directly.
   //   2. textIsOpen=false + currentThinkingId=null: this is the very
@@ -779,6 +823,9 @@ function appendTextToCurrentTurn(
   //      thinking the text would land as a turn-direct child and
   //      addReActFlowEdges (which only iterates thinking siblings)
   //      would orphan it from the ReAct chain.
+  //   3. override=true: explicit parent step disagrees with the live
+  //      anchors. Force a fresh iteration thinking under the explicit
+  //      step so the new text doesn't extend a sibling-step's text.
   //
   // The synthetic thinking is created status=completed — the model
   // already finished thinking by the time we infer the boundary from
@@ -786,8 +833,9 @@ function appendTextToCurrentTurn(
   // so the layout chains identically.
   let workingState = state;
   if (
-    !state.textIsOpen &&
-    (state.thinkingSealed || state.currentThinkingId === null)
+    override ||
+    (!state.textIsOpen &&
+      (state.thinkingSealed || state.currentThinkingId === null))
   ) {
     workingState = mintIterationThinking(state, turn, '', 'completed').state;
   }
@@ -939,14 +987,19 @@ function appendThinkingToCurrentTurn(
   // current thinking node, so the next thinking delta starts a fresh one.
   // Parallel tool_use events from a single LLM response don't seal the
   // anchor between themselves (no thinking delta arrives between them), so
-  // they correctly attach to the same parent. findCurrentAgentScope
-  // returns the running step when one is active so each plan step's
-  // thinking lands under itself rather than on the enclosing turn.
-  const turn = findCurrentAgentScope(state);
+  // they correctly attach to the same parent.
+  //
+  // resolveAgentScope honours the daemon's explicit parentStepId
+  // (#485 follow-up) so a thinking delta routes to the right step even
+  // when activeNodeId is stale or the leftover currentThinkingId
+  // belongs to a previous step's iteration.
+  const { turn, override } = resolveAgentScope(state, params.parentStepId);
   if (!turn) return state;
 
   // Same iteration: append the delta to the existing thinking node.
-  if (state.currentThinkingId && !state.thinkingSealed) {
+  // Skip under override — the live thinking belongs to a different
+  // scope and must not absorb this iteration's delta.
+  if (!override && state.currentThinkingId && !state.thinkingSealed) {
     return {
       ...state,
       rootNodes: mapNode(state.rootNodes, state.currentThinkingId, (t) => ({

--- a/aceclaw-dashboard/src/types/events.ts
+++ b/aceclaw-dashboard/src/types/events.ts
@@ -111,11 +111,26 @@ export interface TurnCompletedParams {
 /** stream.thinking — extended thinking deltas. */
 export interface ThinkingDeltaParams {
   delta: string;
+  /**
+   * Plan step that owns this thinking iteration, when emitted from inside
+   * a SequentialPlanExecutor step. Same shape and intent as
+   * {@link ToolUseParams.parentStepId} (#485): lets the reducer route
+   * thinking under the right step without depending on activeNodeId
+   * being current. Optional for forward / backward compat.
+   */
+  parentStepId?: string;
 }
 
 /** stream.text — assistant text token deltas. */
 export interface TextDeltaParams {
   delta: string;
+  /**
+   * Plan step that owns this text iteration, mirroring
+   * {@link ThinkingDeltaParams.parentStepId} so narration text stays
+   * grouped under the step it belongs to even when arrival ordering
+   * disagrees with the heuristic anchor.
+   */
+  parentStepId?: string;
 }
 
 /** stream.tool_use — emitted at tool-use block start (input may still be partial). */

--- a/aceclaw-dashboard/tests/treeReducer.test.ts
+++ b/aceclaw-dashboard/tests/treeReducer.test.ts
@@ -3339,6 +3339,130 @@ describe('appendTextToCurrentTurn honours parentStepId (#485 follow-up)', () => 
   });
 });
 
+describe('scopeChanged late-delivery isolation (#485 follow-up)', () => {
+  // Build state where step 1 is COMPLETED, step 2 is RUNNING with a
+  // running tool under it. A late thinking/text for step 1 must NOT
+  // touch step 2's running tool, and multi-chunk late deltas for the
+  // same older step must accumulate into one node, not fragment.
+  function liveStep2WithRunningTool() {
+    return runAll(
+      freshTree(),
+      envelope('stream.session_started', {
+        sessionId: 'sess-1',
+        model: 'm',
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.turn_started', {
+        sessionId: 'sess-1',
+        requestId: 'req-1',
+        turnNumber: 1,
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.plan_created', {
+        planId: 'plan-1',
+        stepCount: 2,
+        goal: 'g',
+        steps: [
+          { index: 1, name: 's1', description: '' },
+          { index: 2, name: 's2', description: '' },
+        ],
+      }),
+      envelope('stream.plan_step_started', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        totalSteps: 2,
+        stepName: 's1',
+      }),
+      envelope('stream.plan_step_completed', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        stepName: 's1',
+        success: true,
+        durationMs: 50,
+        tokensUsed: 25,
+      }),
+      envelope('stream.plan_step_started', {
+        planId: 'plan-1',
+        stepId: 's2',
+        stepIndex: 2,
+        totalSteps: 2,
+        stepName: 's2',
+      }),
+      envelope('stream.thinking', {
+        delta: 'step 2 reasoning',
+        parentStepId: stepNodeId('plan-1', 2),
+      }),
+      envelope('stream.tool_use', {
+        id: 't-live',
+        name: 'read_file',
+        parentStepId: stepNodeId('plan-1', 2),
+      }),
+    );
+  }
+
+  it('late thinking for older step does NOT seal live step running tool (Codex P2 self-found)', () => {
+    let state = liveStep2WithRunningTool();
+    expect(findById(state, 't-live').status).toBe('running');
+    const liveAnchorsBefore = {
+      currentThinkingId: state.currentThinkingId,
+      currentTextId: state.currentTextId,
+      activeNodeId: state.activeNodeId,
+      thinkingSealed: state.thinkingSealed,
+      textIsOpen: state.textIsOpen,
+    };
+
+    state = runAll(
+      state,
+      envelope('stream.thinking', {
+        delta: 'late chunk for step 1',
+        parentStepId: stepNodeId('plan-1', 1),
+      }),
+    );
+
+    // Live tool unchanged.
+    expect(findById(state, 't-live').status).toBe('running');
+    // Live anchors unchanged.
+    expect(state.currentThinkingId).toBe(liveAnchorsBefore.currentThinkingId);
+    expect(state.currentTextId).toBe(liveAnchorsBefore.currentTextId);
+    expect(state.activeNodeId).toBe(liveAnchorsBefore.activeNodeId);
+    expect(state.thinkingSealed).toBe(liveAnchorsBefore.thinkingSealed);
+    expect(state.textIsOpen).toBe(liveAnchorsBefore.textIsOpen);
+    // Late content lands under step 1.
+    const step1 = findById(state, stepNodeId('plan-1', 1));
+    const late = step1.children.find((c) => c.type === 'thinking' && (c.text ?? '').includes('late chunk'));
+    expect(late).toBeDefined();
+  });
+
+  it('multi-chunk late text accumulates into one node rather than fragmenting (Codex P2 #490)', () => {
+    let state = liveStep2WithRunningTool();
+    // Three late text deltas for step 1 (a completed step).
+    state = runAll(
+      state,
+      envelope('stream.text', {
+        delta: 'first ',
+        parentStepId: stepNodeId('plan-1', 1),
+      }),
+      envelope('stream.text', {
+        delta: 'second ',
+        parentStepId: stepNodeId('plan-1', 1),
+      }),
+      envelope('stream.text', {
+        delta: 'third',
+        parentStepId: stepNodeId('plan-1', 1),
+      }),
+    );
+    const step1 = findById(state, stepNodeId('plan-1', 1));
+    const lateTexts = step1.children.filter((c) => c.type === 'text');
+    // One node accumulates all three chunks instead of three siblings.
+    expect(lateTexts).toHaveLength(1);
+    expect(lateTexts[0]?.text ?? '').toBe('first second third');
+    // Live tool still untouched.
+    expect(findById(state, 't-live').status).toBe('running');
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Step events arriving before plan_created — don't dangle activeNodeId
 // ---------------------------------------------------------------------------

--- a/aceclaw-dashboard/tests/treeReducer.test.ts
+++ b/aceclaw-dashboard/tests/treeReducer.test.ts
@@ -3435,6 +3435,145 @@ describe('scopeChanged late-delivery isolation (#485 follow-up)', () => {
     expect(late).toBeDefined();
   });
 
+  it('pending explicit step (race ahead of plan_step_started) is treated as live, not late (Codex #490)', () => {
+    // plan_created mints a 'pending' skeleton for step 2. In the race
+    // window before plan_step_started for step 2 is reduced, the
+    // daemon's first stream.thinking for step 2 arrives carrying
+    // parentStepId=step-2. Without the pending-is-live carve-out, this
+    // would be classified as scopeChanged → late path → first chunk
+    // lands in {step-2}:late:thinking. Once plan_step_started arrives
+    // and subsequent chunks no longer fire scopeChanged, those go to
+    // mintIterationThinking — splitting one streamed response across
+    // two nodes.
+    let state = runAll(
+      freshTree(),
+      envelope('stream.session_started', {
+        sessionId: 'sess-1',
+        model: 'm',
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.turn_started', {
+        sessionId: 'sess-1',
+        requestId: 'req-1',
+        turnNumber: 1,
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.plan_created', {
+        planId: 'plan-1',
+        stepCount: 2,
+        goal: 'g',
+        steps: [
+          { index: 1, name: 's1', description: '' },
+          { index: 2, name: 's2', description: '' },
+        ],
+      }),
+      envelope('stream.plan_step_started', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        totalSteps: 2,
+        stepName: 's1',
+      }),
+      envelope('stream.plan_step_completed', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        stepName: 's1',
+        success: true,
+        durationMs: 50,
+        tokensUsed: 25,
+      }),
+      // Race window: thinking for step 2 arrives BEFORE its plan_step_started.
+      envelope('stream.thinking', {
+        delta: 'race chunk one ',
+        parentStepId: stepNodeId('plan-1', 2),
+      }),
+      // Then plan_step_started arrives.
+      envelope('stream.plan_step_started', {
+        planId: 'plan-1',
+        stepId: 's2',
+        stepIndex: 2,
+        totalSteps: 2,
+        stepName: 's2',
+      }),
+      envelope('stream.thinking', {
+        delta: 'race chunk two',
+        parentStepId: stepNodeId('plan-1', 2),
+      }),
+    );
+
+    const step2 = findById(state, stepNodeId('plan-1', 2));
+    // No `:late:thinking` orphan should exist — both chunks live in
+    // the normal iteration thinking node.
+    const lateNode = step2.children.find((c) => c.id.endsWith(':late:thinking'));
+    expect(lateNode).toBeUndefined();
+    // Both chunks must accumulate into the same iteration thinking,
+    // not be split across two nodes.
+    const thinkingNodes = step2.children.filter((c) => c.type === 'thinking');
+    expect(thinkingNodes).toHaveLength(1);
+    expect(thinkingNodes[0]?.text ?? '').toBe('race chunk one race chunk two');
+  });
+
+  it('late nodes inherit terminal status from their owning step (CodeRabbit M1 #490)', () => {
+    let state = runAll(
+      freshTree(),
+      envelope('stream.session_started', {
+        sessionId: 'sess-1',
+        model: 'm',
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.turn_started', {
+        sessionId: 'sess-1',
+        requestId: 'req-1',
+        turnNumber: 1,
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.plan_created', {
+        planId: 'plan-1',
+        stepCount: 2,
+        goal: 'g',
+        steps: [
+          { index: 1, name: 's1', description: '' },
+          { index: 2, name: 's2', description: '' },
+        ],
+      }),
+      envelope('stream.plan_step_started', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        totalSteps: 2,
+        stepName: 's1',
+      }),
+      envelope('stream.plan_step_completed', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        stepName: 's1',
+        success: true,
+        durationMs: 50,
+        tokensUsed: 25,
+      }),
+      envelope('stream.plan_step_started', {
+        planId: 'plan-1',
+        stepId: 's2',
+        stepIndex: 2,
+        totalSteps: 2,
+        stepName: 's2',
+      }),
+      // Late delivery to step 1 (completed). Late node must be 'completed',
+      // not 'running' — otherwise it pulses indefinitely under a finished step.
+      envelope('stream.thinking', {
+        delta: 'late chunk for step 1',
+        parentStepId: stepNodeId('plan-1', 1),
+      }),
+    );
+
+    const step1 = findById(state, stepNodeId('plan-1', 1));
+    const lateThinking = step1.children.find((c) => c.id.endsWith(':late:thinking'));
+    expect(lateThinking).toBeDefined();
+    expect(lateThinking?.status).toBe('completed');
+  });
+
   it('non-cancelled replan tombstone falls back to live synthetic step (Codex #490)', () => {
     // Step 1 starts, COMPLETES, then a replan reuses stepIndex=1 →
     // dashboard's activateStep preserves the completed tombstone at
@@ -3502,7 +3641,11 @@ describe('scopeChanged late-delivery isolation (#485 follow-up)', () => {
     // finished step keeps its 'completed' status. (For a 'failed' /
     // 'paused' tombstone the same sibling-search rule applies — see
     // resolveExplicitStep.)
-    expect(['completed', 'cancelled']).toContain(tombstone.status);
+    // replacePlanSteps explicitly excludes 'completed' steps from the
+    // cancellation pass (countCancellableSteps), so the original step's
+    // history is preserved as 'completed'. Asserting strictly catches
+    // regressions where replan would downgrade a finished step's record.
+    expect(tombstone.status).toBe('completed');
     const plan = state.rootNodes[0]!.children[0]!.children[0]!;
     const liveSynthetic = plan.children.find(
       (c) => c.metadata?.['createdByReplan'] === true,

--- a/aceclaw-dashboard/tests/treeReducer.test.ts
+++ b/aceclaw-dashboard/tests/treeReducer.test.ts
@@ -3091,6 +3091,255 @@ describe('addToolNode honours parentStepId from daemon (#485)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// parentStepId on stream.thinking / stream.text (#485 follow-up): the
+// daemon tags thinking + text deltas with the same composed step id it
+// already attaches to tool_use, so iteration anchors stay routed to the
+// right step even when activeNodeId or currentTextId / currentThinkingId
+// belong to a previous step's iteration.
+// ---------------------------------------------------------------------------
+
+describe('appendThinkingToCurrentTurn honours parentStepId (#485 follow-up)', () => {
+  function planWithStep1Thinking() {
+    // Step 1 emits thinking, then completes. currentThinkingId is left
+    // pointing at step 1's thinking node (sealed once the iteration
+    // ends, but still inside step 1's subtree).
+    return runAll(
+      freshTree(),
+      envelope('stream.session_started', {
+        sessionId: 'sess-1',
+        model: 'm',
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.turn_started', {
+        sessionId: 'sess-1',
+        requestId: 'req-1',
+        turnNumber: 1,
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.plan_created', {
+        planId: 'plan-1',
+        stepCount: 2,
+        goal: 'g',
+        steps: [
+          { index: 1, name: 's1', description: '' },
+          { index: 2, name: 's2', description: '' },
+        ],
+      }),
+      envelope('stream.plan_step_started', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        totalSteps: 2,
+        stepName: 's1',
+      }),
+      envelope('stream.thinking', { delta: 'step 1 reasoning' }),
+      envelope('stream.plan_step_completed', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        stepName: 's1',
+        success: true,
+        durationMs: 50,
+        tokensUsed: 25,
+      }),
+      envelope('stream.plan_step_started', {
+        planId: 'plan-1',
+        stepId: 's2',
+        stepIndex: 2,
+        totalSteps: 2,
+        stepName: 's2',
+      }),
+    );
+  }
+
+  it('routes a thinking delta to the explicit step even when current anchor is from a prior step', () => {
+    let state = planWithStep1Thinking();
+    const step1Id = stepNodeId('plan-1', 1);
+    const step2Id = stepNodeId('plan-1', 2);
+    // Sanity: leftover thinking anchor lives under step 1.
+    function hasDescendant(node: ExecutionNode, id: string): boolean {
+      if (node.children.some((c) => c.id === id)) return true;
+      return node.children.some((c) => hasDescendant(c, id));
+    }
+    expect(state.currentThinkingId).not.toBeNull();
+    expect(hasDescendant(findById(state, step1Id), state.currentThinkingId!)).toBe(true);
+
+    state = runAll(
+      state,
+      envelope('stream.thinking', {
+        delta: 'step 2 reasoning',
+        parentStepId: step2Id,
+      }),
+    );
+
+    // Step 2's new thinking must land under step 2, not step 1.
+    const step2 = findById(state, step2Id);
+    const step2Thinking = step2.children.find((c) => c.type === 'thinking');
+    expect(step2Thinking).toBeDefined();
+    expect(step2Thinking?.text ?? '').toContain('step 2 reasoning');
+    // And step 1's content must not absorb the new delta.
+    const step1 = findById(state, step1Id);
+    const step1Thinking = step1.children.find((c) => c.type === 'thinking');
+    expect(step1Thinking?.text ?? '').not.toContain('step 2 reasoning');
+  });
+
+  it('continues the same-iteration delta when explicit and live anchors agree', () => {
+    let state = runAll(
+      freshTree(),
+      envelope('stream.session_started', {
+        sessionId: 'sess-1',
+        model: 'm',
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.turn_started', {
+        sessionId: 'sess-1',
+        requestId: 'req-1',
+        turnNumber: 1,
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.plan_created', {
+        planId: 'plan-1',
+        stepCount: 1,
+        goal: 'g',
+        steps: [{ index: 1, name: 's1', description: '' }],
+      }),
+      envelope('stream.plan_step_started', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        totalSteps: 1,
+        stepName: 's1',
+      }),
+      envelope('stream.thinking', {
+        delta: 'first chunk ',
+        parentStepId: stepNodeId('plan-1', 1),
+      }),
+      envelope('stream.thinking', {
+        delta: 'second chunk',
+        parentStepId: stepNodeId('plan-1', 1),
+      }),
+    );
+    const step = findById(state, stepNodeId('plan-1', 1));
+    const thinkingNodes = step.children.filter((c) => c.type === 'thinking');
+    // Both deltas land in the SAME thinking node (same iteration), not
+    // two separate nodes from spurious override-driven minting.
+    expect(thinkingNodes).toHaveLength(1);
+    expect(thinkingNodes[0]?.text ?? '').toBe('first chunk second chunk');
+  });
+});
+
+describe('appendTextToCurrentTurn honours parentStepId (#485 follow-up)', () => {
+  it('routes a text delta to the explicit step when activeNodeId / anchors are stale', () => {
+    let state = runAll(
+      freshTree(),
+      envelope('stream.session_started', {
+        sessionId: 'sess-1',
+        model: 'm',
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.turn_started', {
+        sessionId: 'sess-1',
+        requestId: 'req-1',
+        turnNumber: 1,
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.plan_created', {
+        planId: 'plan-1',
+        stepCount: 2,
+        goal: 'g',
+        steps: [
+          { index: 1, name: 's1', description: '' },
+          { index: 2, name: 's2', description: '' },
+        ],
+      }),
+      envelope('stream.plan_step_started', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        totalSteps: 2,
+        stepName: 's1',
+      }),
+      // Step 1 emits text → currentTextId points into step 1's subtree.
+      envelope('stream.text', { delta: 'step 1 result' }),
+      envelope('stream.plan_step_completed', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        stepName: 's1',
+        success: true,
+        durationMs: 50,
+        tokensUsed: 25,
+      }),
+      envelope('stream.plan_step_started', {
+        planId: 'plan-1',
+        stepId: 's2',
+        stepIndex: 2,
+        totalSteps: 2,
+        stepName: 's2',
+      }),
+    );
+
+    const step1Id = stepNodeId('plan-1', 1);
+    const step2Id = stepNodeId('plan-1', 2);
+
+    state = runAll(
+      state,
+      envelope('stream.text', {
+        delta: 'step 2 narration',
+        parentStepId: step2Id,
+      }),
+    );
+
+    function hasDescendantWithText(node: ExecutionNode, snippet: string): boolean {
+      if (node.children.some((c) => (c.text ?? '').includes(snippet))) return true;
+      return node.children.some((c) => hasDescendantWithText(c, snippet));
+    }
+    // Step 2's narration lands under step 2.
+    expect(hasDescendantWithText(findById(state, step2Id), 'step 2 narration')).toBe(true);
+    // Step 1's leftover text does NOT absorb step 2's delta.
+    expect(hasDescendantWithText(findById(state, step1Id), 'step 2 narration')).toBe(false);
+  });
+
+  it('falls back to the heuristic when parentStepId is missing (regression guard)', () => {
+    let state = runAll(
+      freshTree(),
+      envelope('stream.session_started', {
+        sessionId: 'sess-1',
+        model: 'm',
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.turn_started', {
+        sessionId: 'sess-1',
+        requestId: 'req-1',
+        turnNumber: 1,
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.plan_created', {
+        planId: 'plan-1',
+        stepCount: 1,
+        goal: 'g',
+        steps: [{ index: 1, name: 's1', description: '' }],
+      }),
+      envelope('stream.plan_step_started', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        totalSteps: 1,
+        stepName: 's1',
+      }),
+      envelope('stream.text', { delta: 'plain narration' }),
+    );
+
+    const step = findById(state, stepNodeId('plan-1', 1));
+    function hasDescendantWithText(node: ExecutionNode, snippet: string): boolean {
+      if (node.children.some((c) => (c.text ?? '').includes(snippet))) return true;
+      return node.children.some((c) => hasDescendantWithText(c, snippet));
+    }
+    expect(hasDescendantWithText(step, 'plain narration')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Step events arriving before plan_created — don't dangle activeNodeId
 // ---------------------------------------------------------------------------
 

--- a/aceclaw-dashboard/tests/treeReducer.test.ts
+++ b/aceclaw-dashboard/tests/treeReducer.test.ts
@@ -3670,6 +3670,96 @@ describe('scopeChanged late-delivery isolation (#485 follow-up)', () => {
     expect(hasDescendantWithText(findById(state, liveSynthetic!.id), 'replan reasoning')).toBe(true);
   });
 
+  it('redirects to latest synthetic replacement even after it has also completed (Codex #490)', () => {
+    // Step 1 completes → replan creates `plan-1:step:1:r1` → that
+    // synthetic also completes → late delta for the composed id
+    // arrives. Detection must NOT gate on the synthetic still being
+    // running; it should redirect to the synthetic regardless of
+    // status, so the late content accumulates under the most recent
+    // replacement (not the original historical tombstone).
+    let state = runAll(
+      freshTree(),
+      envelope('stream.session_started', {
+        sessionId: 'sess-1',
+        model: 'm',
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.turn_started', {
+        sessionId: 'sess-1',
+        requestId: 'req-1',
+        turnNumber: 1,
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.plan_created', {
+        planId: 'plan-1',
+        stepCount: 1,
+        goal: 'g',
+        steps: [{ index: 1, name: 's1', description: '' }],
+      }),
+      envelope('stream.plan_step_started', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        totalSteps: 1,
+        stepName: 's1',
+      }),
+      envelope('stream.plan_step_completed', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        stepName: 's1',
+        success: true,
+        durationMs: 50,
+        tokensUsed: 25,
+      }),
+      envelope('stream.plan_replanned', {
+        planId: 'plan-1',
+        replanAttempt: 1,
+        newStepCount: 1,
+        rationale: 'try again',
+      }),
+      envelope('stream.plan_step_started', {
+        planId: 'plan-1',
+        stepId: 's1-replan',
+        stepIndex: 1,
+        totalSteps: 1,
+        stepName: 's1-replan',
+      }),
+      // Synthetic replacement also completes.
+      envelope('stream.plan_step_completed', {
+        planId: 'plan-1',
+        stepId: 's1-replan',
+        stepIndex: 1,
+        stepName: 's1-replan',
+        success: true,
+        durationMs: 50,
+        tokensUsed: 25,
+      }),
+    );
+    const tombstoneId = stepNodeId('plan-1', 1);
+    const plan = state.rootNodes[0]!.children[0]!.children[0]!;
+    const synthetic = plan.children.find(
+      (c) => c.metadata?.['createdByReplan'] === true,
+    );
+    expect(synthetic?.status).toBe('completed');
+
+    state = runAll(
+      state,
+      envelope('stream.thinking', {
+        delta: 'late after both done',
+        parentStepId: tombstoneId,
+      }),
+    );
+
+    function hasDescendantWithText(node: ExecutionNode, snippet: string): boolean {
+      if (node.children.some((c) => (c.text ?? '').includes(snippet))) return true;
+      return node.children.some((c) => hasDescendantWithText(c, snippet));
+    }
+    // Original tombstone gets nothing; synthetic gets the late content.
+    expect(hasDescendantWithText(findById(state, tombstoneId), 'late after both done')).toBe(false);
+    expect(hasDescendantWithText(findById(state, synthetic!.id), 'late after both done')).toBe(true);
+  });
+
   it('multi-chunk late text accumulates into one node rather than fragmenting (Codex P2 #490)', () => {
     let state = liveStep2WithRunningTool();
     // Three late text deltas for step 1 (a completed step).

--- a/aceclaw-dashboard/tests/treeReducer.test.ts
+++ b/aceclaw-dashboard/tests/treeReducer.test.ts
@@ -3435,6 +3435,98 @@ describe('scopeChanged late-delivery isolation (#485 follow-up)', () => {
     expect(late).toBeDefined();
   });
 
+  it('non-cancelled replan tombstone falls back to live synthetic step (Codex #490)', () => {
+    // Step 1 starts, COMPLETES, then a replan reuses stepIndex=1 →
+    // dashboard's activateStep preserves the completed tombstone at
+    // the composed id and creates the live replacement at a synthetic
+    // `:r{n}` id. The daemon's currentStepId tracker still emits the
+    // composed form. Without the sibling-search fix, every post-replan
+    // delta would route to the COMPLETED tombstone instead of the
+    // running synthetic step.
+    let state = runAll(
+      freshTree(),
+      envelope('stream.session_started', {
+        sessionId: 'sess-1',
+        model: 'm',
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.turn_started', {
+        sessionId: 'sess-1',
+        requestId: 'req-1',
+        turnNumber: 1,
+        timestamp: new Date(2026, 0, 1).toISOString(),
+      }),
+      envelope('stream.plan_created', {
+        planId: 'plan-1',
+        stepCount: 1,
+        goal: 'g',
+        steps: [{ index: 1, name: 's1', description: '' }],
+      }),
+      envelope('stream.plan_step_started', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        totalSteps: 1,
+        stepName: 's1',
+      }),
+      // Step 1 completes (not cancelled — naturally finished).
+      envelope('stream.plan_step_completed', {
+        planId: 'plan-1',
+        stepId: 's1',
+        stepIndex: 1,
+        stepName: 's1',
+        success: true,
+        durationMs: 50,
+        tokensUsed: 25,
+      }),
+      // Replan reuses stepIndex=1 → activateStep mints synthetic.
+      envelope('stream.plan_replanned', {
+        planId: 'plan-1',
+        replanAttempt: 1,
+        newStepCount: 1,
+        rationale: 'try a different angle',
+      }),
+      envelope('stream.plan_step_started', {
+        planId: 'plan-1',
+        stepId: 's1-replan',
+        stepIndex: 1,
+        totalSteps: 1,
+        stepName: 's1-replan',
+      }),
+    );
+
+    const tombstoneId = stepNodeId('plan-1', 1);
+    const tombstone = findById(state, tombstoneId);
+    // The tombstone here is the COMPLETED original — replacePlanSteps
+    // only cancels non-completed/non-cancelled steps, so a normally-
+    // finished step keeps its 'completed' status. (For a 'failed' /
+    // 'paused' tombstone the same sibling-search rule applies — see
+    // resolveExplicitStep.)
+    expect(['completed', 'cancelled']).toContain(tombstone.status);
+    const plan = state.rootNodes[0]!.children[0]!.children[0]!;
+    const liveSynthetic = plan.children.find(
+      (c) => c.metadata?.['createdByReplan'] === true,
+    );
+    expect(liveSynthetic?.status).toBe('running');
+
+    // Daemon emits parentStepId=composed (= tombstone id).
+    state = runAll(
+      state,
+      envelope('stream.thinking', {
+        delta: 'replan reasoning',
+        parentStepId: tombstoneId,
+      }),
+    );
+
+    // Tombstone receives nothing; live synthetic step does.
+    function hasDescendantWithText(node: ExecutionNode, snippet: string): boolean {
+      if (node.children.some((c) => (c.text ?? '').includes(snippet))) return true;
+      return node.children.some((c) => hasDescendantWithText(c, snippet));
+    }
+    expect(hasDescendantWithText(findById(state, tombstoneId), 'replan reasoning')).toBe(false);
+    expect(hasDescendantWithText(findById(state, liveSynthetic!.id), 'replan reasoning')).toBe(true);
+  });
+
   it('multi-chunk late text accumulates into one node rather than fragmenting (Codex P2 #490)', () => {
     let state = liveStep2WithRunningTool();
     // Three late text deltas for step 1 (a completed step).


### PR DESCRIPTION
## Summary

Follow-up to #488 (PR 3/3 of #485). That PR added `parentStepId` only on `stream.tool_use`, leaving thinking and text deltas to fall back on the activeNodeId-based heuristic. Two real failure modes remained:

1. A thinking delta arriving before `plan_step_started` has updated activeNodeId (race during step transitions).
2. `currentThinkingId` / `currentTextId` leaking across step boundaries — `activateStep` moves activeNodeId but does not clear iteration anchors, so step 2's first text continues step 1's text node.

This PR closes both by tagging thinking + text deltas with the same composed step id the daemon already emits for tool_use.

### Daemon (`StreamingAgentHandler`)

- `onThinkingDelta` and `onTextDelta` read the same `currentStepId` `AtomicReference` set by the plan listener and emit `parentStepId` alongside the delta.

### Dashboard

- `ThinkingDeltaParams.parentStepId`, `TextDeltaParams.parentStepId` added as optional. Older daemons omit; reducer falls back to existing heuristic — backward compat preserved.
- New `resolveAgentScope` helper returns both the chosen scope AND an `override` flag. Fires when explicit step disagrees with the heuristic OR when a candidate iteration anchor (`currentTextId` / `currentThinkingId`) lives outside the explicit step's subtree. Skips override when the resolved step is a `'cancelled'` replan tombstone — same rule that `addToolNode` already uses (#488).
- `appendThinkingToCurrentTurn`: under override, does NOT append to the existing `currentThinkingId`; mints a fresh iteration thinking under the explicit step.
- `appendTextToCurrentTurn`: under override, forces the synthetic iteration-thinking mint so the text node lands fresh under the explicit step instead of extending a sibling step's text.

## Test plan

### Dashboard

- [x] `npm run typecheck` clean
- [x] `npm test` — 220/220 pass (4 new tests in `treeReducer.test.ts`)
  - thinking with `parentStepId` routes to the explicit step even when current anchor lives in a prior step
  - thinking with same explicit step continues the same-iteration delta (no spurious mint)
  - text with `parentStepId` routes to the explicit step when activeNodeId / anchors are stale
  - text without `parentStepId` falls back to the heuristic (regression guard)

### Daemon

- [x] `./gradlew :aceclaw-daemon:compileJava :aceclaw-daemon:compileTestJava` clean
- [x] `./gradlew :aceclaw-daemon:test --tests DaemonIntegrationTest.testCheckpointCreatedDuringPlanExecution` passes — augmented to assert `stream.text` during a plan step also carries `parentStepId == {planId}:step:{N}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming agent thinking and text updates now include step attribution so dashboard iterations are linked to their plan steps.

* **Bug Fixes**
  * Late or out-of-order thinking/text deltas no longer overwrite or misattach live step content; late chunks accumulate into stable per-step nodes.

* **Tests**
  * Added coverage validating step-attribution and late-arrival handling for streaming thinking/text updates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xinhuagu/AceClaw/pull/490)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->