### PR TITLE
fix(daemon+dashboard): raise per-step plan budget to 30 min + pin snapshot replay test

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
@@ -1344,7 +1344,7 @@ public final class AceClawConfig {
     /**
      * Returns the maximum wall-clock time in seconds per plan step.
      * The watchdog timer is reset before each step. 0 = disabled.
-     * Defaults to 300 (5 minutes).
+     * Defaults to 1800 (30 minutes).
      */
     public int maxPlanStepWallTimeSec() {
         return maxPlanStepWallTimeSec;

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
@@ -130,7 +130,7 @@ public final class AceClawConfig {
     // 0 means "derive from soft limit (3x)" in StreamingAgentHandler
     private static final int DEFAULT_MAX_AGENT_HARD_TURNS = 0;
     private static final int DEFAULT_MAX_AGENT_HARD_WALL_TIME_SEC = 0;
-    private static final int DEFAULT_MAX_PLAN_STEP_WALL_TIME_SEC = 300;
+    private static final int DEFAULT_MAX_PLAN_STEP_WALL_TIME_SEC = 1800;
     private static final int DEFAULT_MAX_PLAN_TOTAL_WALL_TIME_SEC = 3600;
     private static final boolean DEFAULT_DEFERRED_ACTION_ENABLED = true;
     private static final int DEFAULT_DEFERRED_ACTION_TICK_SECONDS = 5;

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -1787,7 +1787,7 @@ public final class StreamingAgentHandler {
     private int maxAgentWallTimeSec = 600;
     private int maxAgentHardTurns = 0;
     private int maxAgentHardWallTimeSec = 0;
-    private int maxPlanStepWallTimeSec = 300;
+    private int maxPlanStepWallTimeSec = 1800;
     private int maxPlanTotalWallTimeSec = 3600;
     private PlanCheckpointStore planCheckpointStore;
     private SkillMemoryFeedback skillMemoryFeedback;

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/AceClawConfigTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/AceClawConfigTest.java
@@ -208,4 +208,28 @@ class AceClawConfigTest {
         assertThat(config.apiKey()).isEqualTo("sk-ant-oat01-from-profile");
         assertThat(config.refreshToken()).isEqualTo("sk-ant-ort01-from-profile");
     }
+
+    // -- Plan watchdog budget defaults --
+
+    @Test
+    void planBudgetDefaultsAreThirtyMinutesPerStepAndOneHourTotal(@TempDir Path tempDir) throws Exception {
+        // Pins the per-step (1800s = 30 min) and plan-total (3600s = 1 h)
+        // watchdog defaults the SequentialPlanExecutor reads via
+        // setPlanBudgetConfig at daemon startup. The previous per-step
+        // default (300s) was cancelling multi-step research plans the
+        // moment step 1 finished, so a regression to a smaller value
+        // here would be a user-visible reliability hit.
+        var projectConfig = tempDir.resolve(".aceclaw").resolve("config.json");
+        Files.createDirectories(projectConfig.getParent());
+        Files.writeString(projectConfig, "{}");
+
+        var config = AceClawConfig.load(tempDir, null);
+
+        assertThat(config.maxPlanStepWallTimeSec())
+                .as("per-step plan budget default")
+                .isEqualTo(1800);
+        assertThat(config.maxPlanTotalWallTimeSec())
+                .as("total plan budget default")
+                .isEqualTo(3600);
+    }
 }

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/AceClawConfigTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/AceClawConfigTest.java
@@ -2,6 +2,7 @@ package dev.aceclaw.daemon;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.aceclaw.llm.anthropic.KeychainCredentialReader;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -219,6 +220,19 @@ class AceClawConfigTest {
         // default (300s) was cancelling multi-step research plans the
         // moment step 1 finished, so a regression to a smaller value
         // here would be a user-visible reliability hit.
+        //
+        // AceClawConfig.load() reads ACECLAW_MAX_PLAN_STEP_WALL_TIME_SEC and
+        // ACECLAW_MAX_PLAN_TOTAL_WALL_TIME_SEC from the process environment
+        // and lets them override file defaults. Java offers no portable way
+        // to clear an env var from inside a JVM, so skip when either is set
+        // — the test asserts a default and an override would make that
+        // assertion meaningless. CI runners ship without these vars set, so
+        // the test runs in CI.
+        Assumptions.assumeTrue(
+                System.getenv("ACECLAW_MAX_PLAN_STEP_WALL_TIME_SEC") == null
+                        && System.getenv("ACECLAW_MAX_PLAN_TOTAL_WALL_TIME_SEC") == null,
+                "skipping default-budget assertion because env override is set");
+
         var projectConfig = tempDir.resolve(".aceclaw").resolve("config.json");
         Files.createDirectories(projectConfig.getParent());
         Files.writeString(projectConfig, "{}");

--- a/aceclaw-dashboard/tests/snapshotReplay.test.ts
+++ b/aceclaw-dashboard/tests/snapshotReplay.test.ts
@@ -263,18 +263,25 @@ describe('snapshot replay (#432)', () => {
     // Each step has exactly one thinking child with exactly one tool nested
     // inside. The original symptom would manifest here as later steps having
     // a thinking child with no tool descendant (the tool got lost or
-    // attached to step 1 instead).
+    // attached to step 1 instead). Cardinality is asserted strictly so a
+    // future regression that duplicated nodes per step would also fail.
     for (let idx = 1; idx <= stepNames.length; idx++) {
       const step = plan.children.find((c) => c.id === stepIdOf(idx));
       expect(step, `step ${idx} should exist under plan`).toBeDefined();
-      const thinking = step!.children.find((c) => c.type === 'thinking');
-      expect(thinking, `step ${idx} should have a thinking child`).toBeDefined();
-      const tool = thinking!.children.find((c) => c.type === 'tool');
+      const thinkingChildren = step!.children.filter(
+        (c) => c.type === 'thinking',
+      );
       expect(
-        tool,
-        `step ${idx} thinking should have its tool_use nested inside`,
-      ).toBeDefined();
-      expect(tool!.id).toBe(`tu-${idx}`);
+        thinkingChildren,
+        `step ${idx} should have exactly one thinking child`,
+      ).toHaveLength(1);
+      const thinking = thinkingChildren[0]!;
+      const toolChildren = thinking.children.filter((c) => c.type === 'tool');
+      expect(
+        toolChildren,
+        `step ${idx} thinking should have exactly one tool_use nested inside`,
+      ).toHaveLength(1);
+      expect(toolChildren[0]!.id).toBe(`tu-${idx}`);
     }
 
     // Cross-check: step 1's subtree must NOT have absorbed steps 2-4's

--- a/aceclaw-dashboard/tests/snapshotReplay.test.ts
+++ b/aceclaw-dashboard/tests/snapshotReplay.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { parseEnvelopeFromObject } from '../src/hooks/useExecutionTree';
-import { executionTreeReducer } from '../src/reducers/treeReducer';
-import { emptyTree } from '../src/types/tree';
+import { executionTreeReducer, stepNodeId } from '../src/reducers/treeReducer';
+import { emptyTree, type ExecutionNode } from '../src/types/tree';
 
 /**
  * Pins the snapshot replay path (issue #432). The hook's WebSocket plumbing
@@ -162,6 +162,132 @@ describe('snapshot replay (#432)', () => {
         event: { method: 'stream.tool_use', params: { id: 't1' /* missing name */ } },
       }),
     ).toBeNull();
+  });
+
+  it('replays a multi-step plan with parentStepId-tagged events and attributes each tool under its own step', () => {
+    // Regression pin for the user-visible symptom where late plan steps
+    // appeared to have only a thinking child (the 2026-05-11 GSCORD session).
+    // On snapshot reload, a multi-step plan where the daemon tags
+    // stream.thinking / stream.tool_use with the owning parentStepId must
+    // reconstruct one thinking + tool subtree per step, not collapse
+    // everything onto the first step.
+    //
+    // Exercises the full snapshot path: parseEnvelopeFromObject (envelope
+    // gate) -> executionTreeReducer (resolveExplicitStep + addToolNode
+    // override). A regression here would re-introduce the symptom because
+    // every late-arriving tool_use carrying parentStepId of an
+    // already-completed step would silently fall back to the heuristic and
+    // chain off step 1's anchor.
+    const planId = 'plan-gscord';
+    const stepIdOf = (idx: number) => stepNodeId(planId, idx);
+    const stepNames = [
+      'Locate & Retrieve',
+      'Analyse GSCORD',
+      'Create draw.io Diagram',
+      'Compose Documentation',
+    ];
+
+    const envelopes: Array<ReturnType<typeof buildEnvelope>> = [
+      buildEnvelope(1, 'sess-1', 'stream.session_started', {
+        sessionId: 'sess-1',
+        model: 'claude-opus-4-7',
+      }),
+      buildEnvelope(2, 'sess-1', 'stream.turn_started', {
+        requestId: 'r1',
+        turnNumber: 1,
+      }),
+      buildEnvelope(3, 'sess-1', 'stream.plan_created', {
+        planId,
+        goal: 'analyse GSCORD',
+        steps: stepNames.map((name, i) => ({ index: i + 1, name })),
+      }),
+    ];
+
+    // For each step: started -> thinking (with parentStepId) -> tool_use
+    // (with parentStepId) -> tool_completed -> step_completed.
+    let nextId = 4;
+    stepNames.forEach((name, i) => {
+      const idx = i + 1;
+      const stepId = stepIdOf(idx);
+      envelopes.push(
+        buildEnvelope(nextId++, 'sess-1', 'stream.plan_step_started', {
+          planId,
+          stepId,
+          stepIndex: idx,
+          totalSteps: stepNames.length,
+          stepName: name,
+        }),
+        buildEnvelope(nextId++, 'sess-1', 'stream.thinking', {
+          delta: `thinking for ${name}`,
+          parentStepId: stepId,
+        }),
+        buildEnvelope(nextId++, 'sess-1', 'stream.tool_use', {
+          id: `tu-${idx}`,
+          name: idx === 3 ? 'bash' : 'read_file',
+          parentStepId: stepId,
+        }),
+        buildEnvelope(nextId++, 'sess-1', 'stream.tool_completed', {
+          id: `tu-${idx}`,
+          name: idx === 3 ? 'bash' : 'read_file',
+          durationMs: 100,
+          isError: false,
+        }),
+        buildEnvelope(nextId++, 'sess-1', 'stream.plan_step_completed', {
+          planId,
+          stepId,
+          stepIndex: idx,
+          stepName: name,
+          success: true,
+          durationMs: 100,
+          tokensUsed: 100,
+        }),
+      );
+    });
+
+    let tree = emptyTree('sess-1');
+    for (const env of envelopes) {
+      const parsed = parseEnvelopeFromObject(env);
+      expect(parsed).not.toBeNull();
+      if (parsed?.kind === 'known') {
+        tree = executionTreeReducer(tree, parsed.envelope);
+      }
+    }
+
+    // Walk down to the plan node.
+    const session = tree.rootNodes.find((n) => n.type === 'session');
+    expect(session).toBeDefined();
+    const turn = session!.children[0]!;
+    const plan = turn.children.find((c) => c.type === 'plan')!;
+    expect(plan).toBeDefined();
+
+    // Each step has exactly one thinking child with exactly one tool nested
+    // inside. The original symptom would manifest here as later steps having
+    // a thinking child with no tool descendant (the tool got lost or
+    // attached to step 1 instead).
+    for (let idx = 1; idx <= stepNames.length; idx++) {
+      const step = plan.children.find((c) => c.id === stepIdOf(idx));
+      expect(step, `step ${idx} should exist under plan`).toBeDefined();
+      const thinking = step!.children.find((c) => c.type === 'thinking');
+      expect(thinking, `step ${idx} should have a thinking child`).toBeDefined();
+      const tool = thinking!.children.find((c) => c.type === 'tool');
+      expect(
+        tool,
+        `step ${idx} thinking should have its tool_use nested inside`,
+      ).toBeDefined();
+      expect(tool!.id).toBe(`tu-${idx}`);
+    }
+
+    // Cross-check: step 1's subtree must NOT have absorbed steps 2-4's
+    // tool calls. This is the explicit regression guard for the original
+    // "anchor walks up to step 1" bug.
+    const step1 = plan.children.find((c) => c.id === stepIdOf(1))!;
+    const allToolsUnderStep1: string[] = [];
+    function collect(node: ExecutionNode): void {
+      if (node.type === 'tool') allToolsUnderStep1.push(node.id);
+      for (const c of node.children) collect(c);
+    }
+    collect(step1);
+    expect(allToolsUnderStep1).toEqual(['tu-1']);
   });
 
   it('returns kind=unknown for forward-compat methods so callers can advance the watermark', () => {


### PR DESCRIPTION
## Summary
- Plan watchdog per-step wall-time default: **300s (5 min) → 1800s (30 min)**. A 5-minute cap was killing multi-step research plans the moment the first step finished (2026-05-11 GSCORD session: step 1 ran 300003ms and the watchdog cancelled step 2 before it could start).
- Plan total wall-time unchanged at 3600s (1 h). Users hitting that cap can override via `ACECLAW_MAX_PLAN_TOTAL_WALL_TIME_SEC` or `config.json`.
- New snapshot-replay regression test in \`aceclaw-dashboard/tests/snapshotReplay.test.ts\` mimics a 4-step plan where each \`stream.thinking\` / \`stream.tool_use\` carries \`parentStepId\`, and asserts each step gets its own thinking + tool subtree (not all collapsing onto step 1). Locks in the #485 / #488 / #490 contract on the full \`parseEnvelopeFromObject → reducer\` path.

## Files
- \`aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java\` — \`DEFAULT_MAX_PLAN_STEP_WALL_TIME_SEC\` 300 → 1800
- \`aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java\` — matching fallback field default 300 → 1800
- \`aceclaw-dashboard/tests/snapshotReplay.test.ts\` — new test \`replays a multi-step plan with parentStepId-tagged events and attributes each tool under its own step\`

## Test plan
- [x] \`./gradlew :aceclaw-daemon:compileJava\` — clean
- [x] \`./gradlew :aceclaw-daemon:test --tests "*Plan*" --tests "*Watchdog*" :aceclaw-core:test --tests "*Plan*" --tests "*Watchdog*" --rerun-tasks\` — green
- [x] \`npx vitest run\` (dashboard) — 227/227 pass, including the new replay test
- [ ] After merge: restart the daemon and confirm a multi-step plan can run >5 min per step without being cancelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Increased default maximum execution time per plan step from 5 minutes to 30 minutes; total plan budget default set to 1 hour to reduce premature timeouts.

* **Tests**
  * Added a unit test validating the new plan time defaults.
  * Added a snapshot-replay regression test ensuring multi-step plans reconstruct execution trees and preserve step-specific tool calls.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xinhuagu/AceClaw/pull/492)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->