### PR TITLE
fix(daemon): resolve pending permissions on agent.cancel

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -3794,21 +3794,31 @@ public final class StreamingAgentHandler {
          * back the future cancellation: the in-memory state must stay
          * consistent even if the wire send fails.
          *
-         * <p>Idempotent. The map snapshot + future cancellation runs
-         * under {@link #permissionLifecycleLock} so it's atomic against
-         * other writers (registerPermissionRequest / stopMonitor); the
-         * subsequent socket writes happen OUTSIDE the lock so a slow
-         * peer can't gate concurrent permission lifecycle operations.
+         * <p><b>Ordering:</b> the notification is sent <em>before</em>
+         * {@code future.cancel(false)}. Cancelling the future first
+         * would race the agent thread to the shared socket — once
+         * unblocked it returns a denied {@link ToolResult} and the
+         * turn's finally block emits the final JSON-RPC response. If
+         * that response wins the write, the CLI's
+         * {@code TaskStreamReader} stops reading further notifications
+         * and the trailing {@code permission.cancelled} is dropped on
+         * the floor, leaving the y/n modal stuck on stdin.
+         *
+         * <p>Idempotent. The snapshot + map drain runs under
+         * {@link #permissionLifecycleLock} so it's atomic against other
+         * writers (registerPermissionRequest / stopMonitor); the
+         * subsequent socket writes and future cancellations happen
+         * OUTSIDE the lock so a slow peer can't gate concurrent
+         * permission lifecycle operations.
          */
         private void cancelAllPendingPermissions(String via) {
-            // Snapshot + cancel + clear under the lock so we observe a
-            // consistent set and other writers see the cleared state
-            // before any new register attempts.
+            // Drain the maps under the lock — but DON'T cancel futures yet.
+            // The agent loop's future.get() stays blocked, so it can't race
+            // us to the socket while we're sending permission.cancelled below.
             var snapshot = new ArrayList<Map.Entry<String, CompletableFuture<JsonNode>>>();
             synchronized (permissionLifecycleLock) {
                 pendingPermissions.forEach((rid, future) -> {
                     snapshot.add(Map.entry(rid, future));
-                    future.cancel(false);
                     if (globalPermissionRegistry != null) {
                         // Match by future identity — same rationale as stopMonitor.
                         var pending = globalPermissionRegistry.get(rid);
@@ -3819,14 +3829,8 @@ public final class StreamingAgentHandler {
                 });
                 pendingPermissions.clear();
             }
-            // Socket writes outside the lock: sendNotification can block
-            // if the peer is slow/closed, and the existing routePermissionResponse
-            // path also sends permission.cancelled without holding any lock.
-            // The daemon-side future was already cancelled above so the
-            // agent loop is no longer blocked; this notification's job is
-            // purely to tell the CLI to dismiss its modal (it owns its
-            // own separate PermissionBridge future, which cancelExternal
-            // completes when the notification arrives).
+            // Outside lock: send dismissal first, THEN cancel the future.
+            // See class-level javadoc above for why this ordering is required.
             for (var entry : snapshot) {
                 try {
                     var cancelParams = objectMapper.createObjectNode();
@@ -3838,6 +3842,7 @@ public final class StreamingAgentHandler {
                     log.debug("Cancel monitor: failed to send permission.cancelled "
                             + "for requestId={}: {}", entry.getKey(), e.getMessage());
                 }
+                entry.getValue().cancel(false);
             }
         }
 

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -3774,12 +3774,85 @@ public final class StreamingAgentHandler {
         }
 
         /**
+         * Resolves every pending permission request as cancelled. Used by
+         * the {@code agent.cancel} branch of the monitor so the agent
+         * loop's {@code future.get()} on permission responses (line
+         * 4195) unblocks immediately with {@code CancellationException}
+         * instead of waiting up to {@link #PERMISSION_RESPONSE_TIMEOUT_MS}
+         * (120 s) — without this, Ctrl-C sets the cancellation token
+         * but the turn stays blocked on the permission future, so
+         * {@code stopMonitor()} never runs and the CLI's modal sits
+         * there until the daemon-side timeout fires.
+         *
+         * <p>Per request emits a best-effort {@code permission.cancelled}
+         * notification so the originating CLI's
+         * {@code TaskStreamReader.handlePermissionCancelled} can route
+         * it into {@link PermissionBridge#cancelExternal} — that path
+         * both completes the task-thread future and pokes the modal's
+         * polling loop so it dismisses without waiting on stdin.
+         * Send failures (socket closed, peer disconnected) don't roll
+         * back the future cancellation: the in-memory state must stay
+         * consistent even if the wire send fails.
+         *
+         * <p>Idempotent. The map snapshot + future cancellation runs
+         * under {@link #permissionLifecycleLock} so it's atomic against
+         * other writers (registerPermissionRequest / stopMonitor); the
+         * subsequent socket writes happen OUTSIDE the lock so a slow
+         * peer can't gate concurrent permission lifecycle operations.
+         */
+        private void cancelAllPendingPermissions(String via) {
+            // Snapshot + cancel + clear under the lock so we observe a
+            // consistent set and other writers see the cleared state
+            // before any new register attempts.
+            var snapshot = new ArrayList<Map.Entry<String, CompletableFuture<JsonNode>>>();
+            synchronized (permissionLifecycleLock) {
+                pendingPermissions.forEach((rid, future) -> {
+                    snapshot.add(Map.entry(rid, future));
+                    future.cancel(false);
+                    if (globalPermissionRegistry != null) {
+                        // Match by future identity — same rationale as stopMonitor.
+                        var pending = globalPermissionRegistry.get(rid);
+                        if (pending != null && pending.future() == future) {
+                            globalPermissionRegistry.remove(rid, pending);
+                        }
+                    }
+                });
+                pendingPermissions.clear();
+            }
+            // Socket writes outside the lock: sendNotification can block
+            // if the peer is slow/closed, and the existing routePermissionResponse
+            // path also sends permission.cancelled without holding any lock.
+            // The daemon-side future was already cancelled above so the
+            // agent loop is no longer blocked; this notification's job is
+            // purely to tell the CLI to dismiss its modal (it owns its
+            // own separate PermissionBridge future, which cancelExternal
+            // completes when the notification arrives).
+            for (var entry : snapshot) {
+                try {
+                    var cancelParams = objectMapper.createObjectNode();
+                    cancelParams.put("requestId", entry.getKey());
+                    cancelParams.put("approved", false);
+                    cancelParams.put("via", via);
+                    delegate.sendNotification("permission.cancelled", cancelParams);
+                } catch (IOException e) {
+                    log.debug("Cancel monitor: failed to send permission.cancelled "
+                            + "for requestId={}: {}", entry.getKey(), e.getMessage());
+                }
+            }
+        }
+
+        /**
          * Stops the monitor thread cleanly without interrupting.
          * Sets the stopped flag and wakes the selector so the thread exits promptly.
          */
         void stopMonitor() {
             stopped = true;
-            // Cancel all pending permission futures so waiting threads unblock
+            // Cancel all pending permission futures so waiting threads unblock.
+            // No permission.cancelled fan-out here: stopMonitor runs at the
+            // request's finally block, by which point the turn is wrapping up
+            // and the CLI will see stream.cancelled / final response anyway.
+            // The agent.cancel branch (cancelAllPendingPermissions) is what
+            // handles the in-flight dismissal case.
             synchronized (permissionLifecycleLock) {
                 pendingPermissions.forEach((rid, future) -> {
                     future.cancel(false);
@@ -3864,6 +3937,13 @@ public final class StreamingAgentHandler {
                                 if ("agent.cancel".equals(method)) {
                                     log.info("Cancel monitor: received agent.cancel");
                                     cancellationToken.cancel();
+                                    // Unblock the agent loop's permission future.get() (line 4195):
+                                    // setting the cancellation token alone doesn't propagate to
+                                    // CompletableFutures, so without this the turn sits blocked
+                                    // until PERMISSION_RESPONSE_TIMEOUT_MS (120 s) — and because
+                                    // the request never completes, stopMonitor() never runs and
+                                    // the CLI's y/n modal stays on screen waiting on stdin.
+                                    cancelAllPendingPermissions("agent-cancel");
                                     return;
                                 } else if ("permission.response".equals(method)) {
                                     log.debug("Cancel monitor: routing permission.response");

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -3776,8 +3776,8 @@ public final class StreamingAgentHandler {
         /**
          * Resolves every pending permission request as cancelled. Used by
          * the {@code agent.cancel} branch of the monitor so the agent
-         * loop's {@code future.get()} on permission responses (line
-         * 4195) unblocks immediately with {@code CancellationException}
+         * loop's {@code future.get()} in {@code PermissionAwareTool.execute}
+         * unblocks immediately with {@code CancellationException}
          * instead of waiting up to {@link #PERMISSION_RESPONSE_TIMEOUT_MS}
          * (120 s) — without this, Ctrl-C sets the cancellation token
          * but the turn stays blocked on the permission future, so
@@ -3937,7 +3937,7 @@ public final class StreamingAgentHandler {
                                 if ("agent.cancel".equals(method)) {
                                     log.info("Cancel monitor: received agent.cancel");
                                     cancellationToken.cancel();
-                                    // Unblock the agent loop's permission future.get() (line 4195):
+                                    // Unblock PermissionAwareTool.execute's future.get():
                                     // setting the cancellation token alone doesn't propagate to
                                     // CompletableFutures, so without this the turn sits blocked
                                     // until PERMISSION_RESPONSE_TIMEOUT_MS (120 s) — and because

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -3832,6 +3832,25 @@ public final class StreamingAgentHandler {
             // Outside lock: send dismissal first, THEN cancel the future.
             // See class-level javadoc above for why this ordering is required.
             for (var entry : snapshot) {
+                // Skip futures already resolved by a concurrent path —
+                // typically a WS permission.response that completed the
+                // future via routePermissionResponse without taking
+                // permissionLifecycleLock (per-context pendingPermissions
+                // is only drained by the monitor's UDS-side handler and
+                // by agent-loop unregister, so we can snapshot an entry
+                // whose future was already approved). Emitting an
+                // approved=false cancellation here would advertise a
+                // denial for a request that actually won via approval —
+                // Codex P2 on PR #493. Tiny isDone-then-completed race
+                // remains (microseconds) but is bounded and the CLI's
+                // PermissionBridge.cancelExternal uses putIfAbsent so a
+                // late-stale dismissal is dropped on the receiving side.
+                var future = entry.getValue();
+                if (future.isDone()) {
+                    log.debug("Cancel monitor: skipping permission.cancelled for "
+                            + "already-resolved requestId={}", entry.getKey());
+                    continue;
+                }
                 try {
                     var cancelParams = objectMapper.createObjectNode();
                     cancelParams.put("requestId", entry.getKey());
@@ -3842,7 +3861,7 @@ public final class StreamingAgentHandler {
                     log.debug("Cancel monitor: failed to send permission.cancelled "
                             + "for requestId={}: {}", entry.getKey(), e.getMessage());
                 }
-                entry.getValue().cancel(false);
+                future.cancel(false);
             }
         }
 

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/DaemonIntegrationTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/DaemonIntegrationTest.java
@@ -972,6 +972,14 @@ class DaemonIntegrationTest {
             // staying well under the CI per-test limit.
             long deadline = System.currentTimeMillis() + 15_000;
 
+            // Read sequentially and BREAK on finalResponse — this is what asserts
+            // the ordering invariant. If the daemon ever flipped the order
+            // (future.cancel before sendNotification, Codex P1 on PR #493), the
+            // agent thread could race to the socket and emit the final response
+            // first; we'd break before seeing permission.cancelled, leaving
+            // sawPermissionCancelled false and failing the assertion below.
+            // Mirrors the CLI's TaskStreamReader, which also stops reading
+            // notifications once the JSON-RPC response lands.
             while (System.currentTimeMillis() < deadline && finalResponse == null) {
                 var msg = readMessage(channel);
                 if (msg == null) {
@@ -1010,9 +1018,15 @@ class DaemonIntegrationTest {
                     .as("turn should complete after cancel — without the fix this hangs "
                             + "until the 120s permission timeout")
                     .isNotNull();
+            // Ordering invariant: permission.cancelled must have arrived BEFORE the
+            // final response (we observed it while reading earlier in the same loop).
+            // If the daemon ever flipped the order (future.cancel before
+            // sendNotification), the agent loop could race to the socket and emit
+            // the final response first; the CLI would stop reading and never see
+            // permission.cancelled, leaving the modal stuck on stdin.
             assertThat(sawPermissionCancelled)
-                    .as("daemon should emit permission.cancelled so the CLI can dismiss "
-                            + "its modal instead of waiting on stdin")
+                    .as("daemon must emit permission.cancelled BEFORE the final response "
+                            + "(modal dismissal would otherwise be dropped by CLI)")
                     .isTrue();
             assertThat(cancelledApproved)
                     .as("agent-cancel should resolve pending permission as denied")

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/DaemonIntegrationTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/DaemonIntegrationTest.java
@@ -930,116 +930,6 @@ class DaemonIntegrationTest {
     }
 
     @Test
-    @Order(16)
-    void testCancelWhilePermissionPendingUnblocksTurn() throws Exception {
-        // Reproduces the deadlock fixed in fix/cancel-resolves-pending-permissions:
-        // when agent.cancel arrives while the agent loop is blocked on a permission
-        // future, the daemon used to just flip cancellationToken (which only cancels
-        // the SSE stream) and the turn sat there until PERMISSION_RESPONSE_TIMEOUT_MS
-        // (120 s) fired. The fix is in CancelAwareStreamContext.monitorLoop:
-        // agent.cancel now also drains pendingPermissions, cancelling each future
-        // (so the agent loop unblocks with CancellationException → "denied" tool
-        // result) and emitting permission.cancelled so the CLI dismisses its modal.
-        try (var channel = connectToSocket()) {
-            String sessionId = createSession(channel, 1);
-
-            // write_file requires WRITE permission → daemon will send permission.request
-            mockLlm.enqueueResponse(MockLlmClient.toolUseResponse(
-                    "Writing file.",
-                    "toolu_cancel_perm_001", "write_file",
-                    "{\"file_path\":\"never-created.txt\",\"content\":\"unused\"}"
-            ));
-            // If the cancel path is broken, the loop will eventually consume this
-            // (after the permission denies on timeout). With the fix, the cancellation
-            // token short-circuits the loop before any follow-up call is made — but
-            // enqueue a placeholder so a regression doesn't NPE on missing response.
-            mockLlm.enqueueResponse(MockLlmClient.textResponse(
-                    "Would have continued, but turn was cancelled."));
-
-            var promptParams = objectMapper.createObjectNode();
-            promptParams.put("sessionId", sessionId);
-            promptParams.put("prompt", "Create never-created.txt");
-            sendRequest(channel, "agent.prompt", promptParams, 2);
-
-            String permRequestId = null;
-            boolean sawPermissionCancelled = false;
-            String cancelledVia = null;
-            boolean cancelledApproved = true;
-            JsonNode finalResponse = null;
-            // Generous wall-clock budget: the whole point is that with the fix this
-            // resolves in <1 s. Without the fix the test would hang for the daemon's
-            // 120 s permission timeout — capping at 15 s catches the regression while
-            // staying well under the CI per-test limit.
-            long deadline = System.currentTimeMillis() + 15_000;
-
-            // Read sequentially and BREAK on finalResponse — this is what asserts
-            // the ordering invariant. If the daemon ever flipped the order
-            // (future.cancel before sendNotification, Codex P1 on PR #493), the
-            // agent thread could race to the socket and emit the final response
-            // first; we'd break before seeing permission.cancelled, leaving
-            // sawPermissionCancelled false and failing the assertion below.
-            // Mirrors the CLI's TaskStreamReader, which also stops reading
-            // notifications once the JSON-RPC response lands.
-            while (System.currentTimeMillis() < deadline && finalResponse == null) {
-                var msg = readMessage(channel);
-                if (msg == null) {
-                    throw new IOException("Connection closed while waiting for response");
-                }
-
-                if (msg.has("id") && !msg.get("id").isNull()) {
-                    finalResponse = msg;
-                    break;
-                }
-
-                if (!msg.has("method")) continue;
-                String method = msg.get("method").asText();
-
-                if ("permission.request".equals(method) && permRequestId == null) {
-                    permRequestId = msg.path("params").path("requestId").asText();
-                    // Send agent.cancel WITHOUT ever sending permission.response.
-                    var cancelParams = objectMapper.createObjectNode();
-                    cancelParams.put("sessionId", sessionId);
-                    sendNotification(channel, "agent.cancel", cancelParams);
-                } else if ("permission.cancelled".equals(method)) {
-                    var params = msg.path("params");
-                    if (permRequestId != null
-                            && permRequestId.equals(params.path("requestId").asText())) {
-                        sawPermissionCancelled = true;
-                        cancelledVia = params.path("via").asText("");
-                        cancelledApproved = params.path("approved").asBoolean(true);
-                    }
-                }
-            }
-
-            assertThat(permRequestId)
-                    .as("daemon should send permission.request for write_file")
-                    .isNotNull();
-            assertThat(finalResponse)
-                    .as("turn should complete after cancel — without the fix this hangs "
-                            + "until the 120s permission timeout")
-                    .isNotNull();
-            // Ordering invariant: permission.cancelled must have arrived BEFORE the
-            // final response (we observed it while reading earlier in the same loop).
-            // If the daemon ever flipped the order (future.cancel before
-            // sendNotification), the agent loop could race to the socket and emit
-            // the final response first; the CLI would stop reading and never see
-            // permission.cancelled, leaving the modal stuck on stdin.
-            assertThat(sawPermissionCancelled)
-                    .as("daemon must emit permission.cancelled BEFORE the final response "
-                            + "(modal dismissal would otherwise be dropped by CLI)")
-                    .isTrue();
-            assertThat(cancelledApproved)
-                    .as("agent-cancel should resolve pending permission as denied")
-                    .isFalse();
-            assertThat(cancelledVia).isEqualTo("agent-cancel");
-            // Tool must not have run — permission was never approved.
-            assertThat(Files.exists(workDir.resolve("never-created.txt"))).isFalse();
-
-            destroySession(channel, sessionId, 3);
-        }
-    }
-
-    @Test
     @Order(14)
     void testPermissionStaleResponseIgnoredUntilMatchingRequestArrives() throws Exception {
         try (var channel = connectToSocket()) {
@@ -1194,6 +1084,116 @@ class DaemonIntegrationTest {
             assertThat(stats.falsePositiveCount()).isGreaterThanOrEqualTo(2);
 
             destroySession(channel, sessionId, 4);
+        }
+    }
+
+    @Test
+    @Order(16)
+    void testCancelWhilePermissionPendingUnblocksTurn() throws Exception {
+        // Reproduces the deadlock fixed in fix/cancel-resolves-pending-permissions:
+        // when agent.cancel arrives while the agent loop is blocked on a permission
+        // future, the daemon used to just flip cancellationToken (which only cancels
+        // the SSE stream) and the turn sat there until PERMISSION_RESPONSE_TIMEOUT_MS
+        // (120 s) fired. The fix is in CancelAwareStreamContext.monitorLoop:
+        // agent.cancel now also drains pendingPermissions, cancelling each future
+        // (so the agent loop unblocks with CancellationException → "denied" tool
+        // result) and emitting permission.cancelled so the CLI dismisses its modal.
+        try (var channel = connectToSocket()) {
+            String sessionId = createSession(channel, 1);
+
+            // write_file requires WRITE permission → daemon will send permission.request
+            mockLlm.enqueueResponse(MockLlmClient.toolUseResponse(
+                    "Writing file.",
+                    "toolu_cancel_perm_001", "write_file",
+                    "{\"file_path\":\"never-created.txt\",\"content\":\"unused\"}"
+            ));
+            // If the cancel path is broken, the loop will eventually consume this
+            // (after the permission denies on timeout). With the fix, the cancellation
+            // token short-circuits the loop before any follow-up call is made — but
+            // enqueue a placeholder so a regression doesn't NPE on missing response.
+            mockLlm.enqueueResponse(MockLlmClient.textResponse(
+                    "Would have continued, but turn was cancelled."));
+
+            var promptParams = objectMapper.createObjectNode();
+            promptParams.put("sessionId", sessionId);
+            promptParams.put("prompt", "Create never-created.txt");
+            sendRequest(channel, "agent.prompt", promptParams, 2);
+
+            String permRequestId = null;
+            boolean sawPermissionCancelled = false;
+            String cancelledVia = null;
+            boolean cancelledApproved = true;
+            JsonNode finalResponse = null;
+            // Generous wall-clock budget: the whole point is that with the fix this
+            // resolves in <1 s. Without the fix the test would hang for the daemon's
+            // 120 s permission timeout — capping at 15 s catches the regression while
+            // staying well under the CI per-test limit.
+            long deadline = System.currentTimeMillis() + 15_000;
+
+            // Read sequentially and BREAK on finalResponse — this is what asserts
+            // the ordering invariant. If the daemon ever flipped the order
+            // (future.cancel before sendNotification, Codex P1 on PR #493), the
+            // agent thread could race to the socket and emit the final response
+            // first; we'd break before seeing permission.cancelled, leaving
+            // sawPermissionCancelled false and failing the assertion below.
+            // Mirrors the CLI's TaskStreamReader, which also stops reading
+            // notifications once the JSON-RPC response lands.
+            while (System.currentTimeMillis() < deadline && finalResponse == null) {
+                var msg = readMessage(channel);
+                if (msg == null) {
+                    throw new IOException("Connection closed while waiting for response");
+                }
+
+                if (msg.has("id") && !msg.get("id").isNull()) {
+                    finalResponse = msg;
+                    break;
+                }
+
+                if (!msg.has("method")) continue;
+                String method = msg.get("method").asText();
+
+                if ("permission.request".equals(method) && permRequestId == null) {
+                    permRequestId = msg.path("params").path("requestId").asText();
+                    // Send agent.cancel WITHOUT ever sending permission.response.
+                    var cancelParams = objectMapper.createObjectNode();
+                    cancelParams.put("sessionId", sessionId);
+                    sendNotification(channel, "agent.cancel", cancelParams);
+                } else if ("permission.cancelled".equals(method)) {
+                    var params = msg.path("params");
+                    if (permRequestId != null
+                            && permRequestId.equals(params.path("requestId").asText())) {
+                        sawPermissionCancelled = true;
+                        cancelledVia = params.path("via").asText("");
+                        cancelledApproved = params.path("approved").asBoolean(true);
+                    }
+                }
+            }
+
+            assertThat(permRequestId)
+                    .as("daemon should send permission.request for write_file")
+                    .isNotNull();
+            assertThat(finalResponse)
+                    .as("turn should complete after cancel — without the fix this hangs "
+                            + "until the 120s permission timeout")
+                    .isNotNull();
+            // Ordering invariant: permission.cancelled must have arrived BEFORE the
+            // final response (we observed it while reading earlier in the same loop).
+            // If the daemon ever flipped the order (future.cancel before
+            // sendNotification), the agent loop could race to the socket and emit
+            // the final response first; the CLI would stop reading and never see
+            // permission.cancelled, leaving the modal stuck on stdin.
+            assertThat(sawPermissionCancelled)
+                    .as("daemon must emit permission.cancelled BEFORE the final response "
+                            + "(modal dismissal would otherwise be dropped by CLI)")
+                    .isTrue();
+            assertThat(cancelledApproved)
+                    .as("agent-cancel should resolve pending permission as denied")
+                    .isFalse();
+            assertThat(cancelledVia).isEqualTo("agent-cancel");
+            // Tool must not have run — permission was never approved.
+            assertThat(Files.exists(workDir.resolve("never-created.txt"))).isFalse();
+
+            destroySession(channel, sessionId, 3);
         }
     }
 

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/DaemonIntegrationTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/DaemonIntegrationTest.java
@@ -930,6 +930,102 @@ class DaemonIntegrationTest {
     }
 
     @Test
+    @Order(16)
+    void testCancelWhilePermissionPendingUnblocksTurn() throws Exception {
+        // Reproduces the deadlock fixed in fix/cancel-resolves-pending-permissions:
+        // when agent.cancel arrives while the agent loop is blocked on a permission
+        // future, the daemon used to just flip cancellationToken (which only cancels
+        // the SSE stream) and the turn sat there until PERMISSION_RESPONSE_TIMEOUT_MS
+        // (120 s) fired. The fix is in CancelAwareStreamContext.monitorLoop:
+        // agent.cancel now also drains pendingPermissions, cancelling each future
+        // (so the agent loop unblocks with CancellationException → "denied" tool
+        // result) and emitting permission.cancelled so the CLI dismisses its modal.
+        try (var channel = connectToSocket()) {
+            String sessionId = createSession(channel, 1);
+
+            // write_file requires WRITE permission → daemon will send permission.request
+            mockLlm.enqueueResponse(MockLlmClient.toolUseResponse(
+                    "Writing file.",
+                    "toolu_cancel_perm_001", "write_file",
+                    "{\"file_path\":\"never-created.txt\",\"content\":\"unused\"}"
+            ));
+            // If the cancel path is broken, the loop will eventually consume this
+            // (after the permission denies on timeout). With the fix, the cancellation
+            // token short-circuits the loop before any follow-up call is made — but
+            // enqueue a placeholder so a regression doesn't NPE on missing response.
+            mockLlm.enqueueResponse(MockLlmClient.textResponse(
+                    "Would have continued, but turn was cancelled."));
+
+            var promptParams = objectMapper.createObjectNode();
+            promptParams.put("sessionId", sessionId);
+            promptParams.put("prompt", "Create never-created.txt");
+            sendRequest(channel, "agent.prompt", promptParams, 2);
+
+            String permRequestId = null;
+            boolean sawPermissionCancelled = false;
+            String cancelledVia = null;
+            boolean cancelledApproved = true;
+            JsonNode finalResponse = null;
+            // Generous wall-clock budget: the whole point is that with the fix this
+            // resolves in <1 s. Without the fix the test would hang for the daemon's
+            // 120 s permission timeout — capping at 15 s catches the regression while
+            // staying well under the CI per-test limit.
+            long deadline = System.currentTimeMillis() + 15_000;
+
+            while (System.currentTimeMillis() < deadline && finalResponse == null) {
+                var msg = readMessage(channel);
+                if (msg == null) {
+                    throw new IOException("Connection closed while waiting for response");
+                }
+
+                if (msg.has("id") && !msg.get("id").isNull()) {
+                    finalResponse = msg;
+                    break;
+                }
+
+                if (!msg.has("method")) continue;
+                String method = msg.get("method").asText();
+
+                if ("permission.request".equals(method) && permRequestId == null) {
+                    permRequestId = msg.path("params").path("requestId").asText();
+                    // Send agent.cancel WITHOUT ever sending permission.response.
+                    var cancelParams = objectMapper.createObjectNode();
+                    cancelParams.put("sessionId", sessionId);
+                    sendNotification(channel, "agent.cancel", cancelParams);
+                } else if ("permission.cancelled".equals(method)) {
+                    var params = msg.path("params");
+                    if (permRequestId != null
+                            && permRequestId.equals(params.path("requestId").asText())) {
+                        sawPermissionCancelled = true;
+                        cancelledVia = params.path("via").asText("");
+                        cancelledApproved = params.path("approved").asBoolean(true);
+                    }
+                }
+            }
+
+            assertThat(permRequestId)
+                    .as("daemon should send permission.request for write_file")
+                    .isNotNull();
+            assertThat(finalResponse)
+                    .as("turn should complete after cancel — without the fix this hangs "
+                            + "until the 120s permission timeout")
+                    .isNotNull();
+            assertThat(sawPermissionCancelled)
+                    .as("daemon should emit permission.cancelled so the CLI can dismiss "
+                            + "its modal instead of waiting on stdin")
+                    .isTrue();
+            assertThat(cancelledApproved)
+                    .as("agent-cancel should resolve pending permission as denied")
+                    .isFalse();
+            assertThat(cancelledVia).isEqualTo("agent-cancel");
+            // Tool must not have run — permission was never approved.
+            assertThat(Files.exists(workDir.resolve("never-created.txt"))).isFalse();
+
+            destroySession(channel, sessionId, 3);
+        }
+    }
+
+    @Test
     @Order(14)
     void testPermissionStaleResponseIgnoredUntilMatchingRequestArrives() throws Exception {
         try (var channel = connectToSocket()) {


### PR DESCRIPTION
## Summary
- Ctrl-C while a permission y/n modal is up (with queued requests behind it) used to leave the CLI sitting for ~115 s waiting on each pending permission. Reason: `agent.cancel` only flipped `cancellationToken` (cancels the SSE stream, not `CompletableFuture`s), so the agent loop stayed blocked in `future.get()` until `PERMISSION_RESPONSE_TIMEOUT_MS` (120 s), and because the turn never completed, `stopMonitor()` never ran.
- Fix in `CancelAwareStreamContext.monitorLoop`: the `agent.cancel` branch now drains `pendingPermissions` — cancels each future (so the loop unblocks with `CancellationException` → "Permission denied: request cancelled" → turn tears down) and emits a `permission.cancelled` notification per request so the CLI's `TaskStreamReader` routes it into `PermissionBridge.cancelExternal` and the modal dismisses on the next polling tick.
- Snapshot + cancel runs under `permissionLifecycleLock`; socket writes happen outside the lock so a slow peer can't gate concurrent register/unregister.

## Test plan
- [x] New integration test `testCancelWhilePermissionPendingUnblocksTurn`: sends `agent.cancel` instead of `permission.response`, asserts turn completes in <15 s, `permission.cancelled` (`via=agent-cancel`, `approved=false`) is emitted, and the target file was never created. Passes in 0.21 s; would hang to the 120 s daemon-side timeout without the fix.
- [x] Existing cancel + permission tests: `testCancelDuringStreaming`, `testCancelDuringToolExecution`, `testPermissionStaleResponseIgnoredUntilMatchingRequestArrives`, `testSessionApprovalRemember`, full `PermissionRoutingTest` (8) and `PermissionResponseRoutingTest` (13) — all green.
- [ ] Manual smoke: trigger MCP wiki_search permission flow, Ctrl-C with the modal up, verify CLI returns to prompt immediately instead of hanging.

## Notes for reviewers
- One pre-existing edge case left unaddressed (out of scope): if a parallel-tool `registerPermissionRequest` lands between `agent.cancel` and `stopMonitor`, that new future still waits its full 120 s. Filing as a follow-up if reviewers want it covered here.
- `via=agent-cancel` value chosen to match the existing `via=websocket` convention used by `routePermissionResponse` so dashboards / log analyzers can distinguish dismissal sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Agent cancellation now dismisses pending permission prompts, clears pending state, emits permission.cancelled notifications (approved=false, via="agent-cancel"), and unblocks waiting operations so turns complete promptly.
  * Stopping the monitor still unblocks waiters but no longer emits dismissal notifications.

* **Tests**
  * Added an integration test verifying cancellation during a pending permission unblocks the flow, emits permission-cancelled, and prevents the denied action from running.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xinhuagu/AceClaw/pull/493)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->