### PR TITLE
feat(security): PolicyEngine with cross-cutting rules (#465 Scope #2)

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -36,7 +36,12 @@ import dev.aceclaw.memory.TrendDetector;
 import dev.aceclaw.memory.WorkspacePaths;
 import dev.aceclaw.security.DefaultPermissionPolicy;
 import dev.aceclaw.security.PermissionManager;
+import dev.aceclaw.security.PolicyEngine;
+import dev.aceclaw.security.RuleBasedPolicyEngine;
 import dev.aceclaw.security.audit.CapabilityAuditLog;
+import dev.aceclaw.security.rules.DenyDangerousForDeepSubAgentRule;
+import dev.aceclaw.security.rules.DenyEnvFileAccessRule;
+import dev.aceclaw.security.rules.DenyNetworkInPlanModeRule;
 import dev.aceclaw.mcp.McpClientManager;
 import dev.aceclaw.mcp.McpServerConfig;
 import dev.aceclaw.tools.*;
@@ -382,8 +387,26 @@ public final class AceClawDaemon {
         //    test isolations write audit artifacts under the same root as
         //    every other persisted thing (pid, sock, transcripts,
         //    checkpoints, ...).
+        //
+        //    PolicyEngine wiring (#465 Scope #2): cross-cutting rules
+        //    evaluated first, then fall back to the mode-based
+        //    DefaultPermissionPolicy. Rule order matters — env-file deny
+        //    is listed first so it short-circuits before plan-mode or
+        //    sub-agent rules even consider the request.
+        //
+        //    Sub-agent depth limit is 1 (top-level + one delegation
+        //    level may use DANGEROUS; deeper chains require an explicit
+        //    user turn — see DenyDangerousForDeepSubAgentRule javadoc).
+        var legacyFallback = PolicyEngine.fromLegacyPolicy(
+                new DefaultPermissionPolicy(config.permissionMode()));
+        var policyEngine = new RuleBasedPolicyEngine(
+                java.util.List.of(
+                        new DenyEnvFileAccessRule(),
+                        new DenyNetworkInPlanModeRule(config::permissionMode),
+                        new DenyDangerousForDeepSubAgentRule(1)),
+                legacyFallback);
         var permissionManager = new PermissionManager(
-                new DefaultPermissionPolicy(config.permissionMode()),
+                policyEngine,
                 buildCapabilityAuditLog(homeDir.resolve("audit")));
 
         // 4. Sub-agent infrastructure (task delegation) and skills

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/PermissionManager.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/PermissionManager.java
@@ -30,7 +30,7 @@ public final class PermissionManager {
 
     private static final Logger log = LoggerFactory.getLogger(PermissionManager.class);
 
-    private final PermissionPolicy policy;
+    private final PolicyEngine engine;
 
     /**
      * Per-session blanket approvals: {@code sessionId → toolName set}.
@@ -47,17 +47,40 @@ public final class PermissionManager {
      */
     private final CapabilityAuditLog auditLog;
 
+    /**
+     * Backward-compatible constructor: takes a legacy {@link PermissionPolicy}
+     * (request in, decision out) and adapts it to the new
+     * {@link PolicyEngine} contract via
+     * {@link PolicyEngine#fromLegacyPolicy(PermissionPolicy)}. Existing
+     * callers and tests that pass a {@code DefaultPermissionPolicy} or
+     * a lambda keep compiling and behaving identically — the structured
+     * {@link Capability} they were ignoring is still ignored, and the
+     * synthesised {@link PermissionRequest} carries exactly the same
+     * fields the manager used to build inline.
+     */
     public PermissionManager(PermissionPolicy policy) {
-        this(policy, null);
+        this(PolicyEngine.fromLegacyPolicy(policy), null);
     }
 
     /**
-     * Constructs a manager that signs and persists every decision to
-     * {@code auditLog}. Pass {@code null} to disable auditing (this is
-     * what the single-arg constructor does).
+     * Backward-compatible constructor with audit log. See
+     * {@link #PermissionManager(PermissionPolicy)}.
      */
     public PermissionManager(PermissionPolicy policy, CapabilityAuditLog auditLog) {
-        this.policy = policy;
+        this(PolicyEngine.fromLegacyPolicy(policy), auditLog);
+    }
+
+    /**
+     * Primary constructor (#465 Scope #2). Takes a {@link PolicyEngine}
+     * directly so daemon callers can wire a {@link RuleBasedPolicyEngine}
+     * with cross-cutting rules and a legacy-policy fallback.
+     *
+     * @param engine   the policy engine consulted for every structured check;
+     *                 must not be null
+     * @param auditLog optional signed audit log; {@code null} disables audit
+     */
+    public PermissionManager(PolicyEngine engine, CapabilityAuditLog auditLog) {
+        this.engine = Objects.requireNonNull(engine, "engine");
         this.auditLog = auditLog;
     }
 
@@ -151,12 +174,14 @@ public final class PermissionManager {
             }
         }
 
-        // PolicyEngine is still PermissionRequest-shaped today (#465 Scope
-        // #2 will change that). Build a request from the capability.
-        var request = new PermissionRequest(allowlistKey, description, capability.risk());
-        var decision = policy.evaluate(request);
-        log.debug("Permission check: key={}, level={}, sessionId={}, decision={}",
-                allowlistKey, capability.risk(), sessionIdOrNull,
+        // PolicyEngine takes the structured capability directly (#465
+        // Scope #2). The synthesised PermissionRequest used pre-Layer-2
+        // is rebuilt inside the legacy adapter fallback when needed —
+        // see PolicyEngine.fromLegacyPolicy.
+        var policyContext = new PolicyContext(allowlistKey, description);
+        var decision = engine.evaluate(capability, provenance, policyContext);
+        log.debug("Permission check: key={}, capability={}, sessionId={}, decision={}",
+                allowlistKey, capability.getClass().getSimpleName(), sessionIdOrNull,
                 decision.getClass().getSimpleName());
         audit(allowlistKey, capability, provenance, decision, null);
         return decision;

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/PolicyContext.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/PolicyContext.java
@@ -1,0 +1,35 @@
+package dev.aceclaw.security;
+
+import java.util.Objects;
+
+/**
+ * Per-check context carried alongside a {@link Capability} and
+ * {@link Provenance} into the {@link PolicyEngine} (#465 Scope #2).
+ *
+ * <p>What goes here vs. on the engine itself: anything the caller (today
+ * {@link PermissionManager}) knows on a per-check basis but the engine
+ * cannot derive from the capability — that's context. Anything the engine
+ * configures globally (e.g. mode supplier, the rule list) lives on the
+ * engine.
+ *
+ * <h3>Why {@code allowlistKey} and {@code description} live here</h3>
+ *
+ * The dispatcher's originating tool name and rich human-readable
+ * description need to reach the legacy-policy fallback so its
+ * {@link PermissionRequest} carries the same values it did pre-Layer 2.
+ * Without context they'd have to be reconstructed from the capability,
+ * losing per-tool information (two tools producing the same variant must
+ * stay distinct in the allowlist — see {@link Capability#allowlistKey()}).
+ *
+ * <p>Rules are free to ignore both fields; they exist for the legacy
+ * fallback adapter. A rule reasoning purely about the capability (e.g.
+ * "deny FileRead(.env)") should not branch on {@code allowlistKey} — that
+ * would re-introduce the per-adapter divergence that capability-style
+ * governance is meant to eliminate.
+ */
+public record PolicyContext(String allowlistKey, String description) {
+    public PolicyContext {
+        Objects.requireNonNull(allowlistKey, "allowlistKey");
+        Objects.requireNonNull(description, "description");
+    }
+}

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/PolicyEngine.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/PolicyEngine.java
@@ -1,0 +1,70 @@
+package dev.aceclaw.security;
+
+import java.util.Objects;
+
+/**
+ * One rule-evaluation surface for {@link Capability} checks (#465 Scope #2).
+ *
+ * <p>Pre-Layer 2 the {@link PermissionManager} built a synthetic
+ * {@link PermissionRequest} from the capability's flat {@link PermissionLevel}
+ * and handed it to a {@link PermissionPolicy}. Cross-cutting rules ("no
+ * {@code .env} reads from any adapter", "no network in plan mode", "no
+ * {@code DANGEROUS} for sub-agents past depth N") cannot be expressed
+ * against the flat shape — they need the structured variant and the
+ * {@link Provenance} chain. PolicyEngine consumes both.
+ *
+ * <h3>Relationship to {@link PermissionPolicy}</h3>
+ *
+ * {@link PermissionPolicy} stays as the legacy functional interface
+ * (request in, decision out) so existing callers compile unchanged. The
+ * adapter {@link #fromLegacyPolicy(PermissionPolicy)} wraps a legacy
+ * policy as a PolicyEngine that ignores the capability variant and routes
+ * a synthesised request through the legacy decision; this is what backs
+ * the {@code PermissionManager(PermissionPolicy)} constructor.
+ *
+ * <h3>Composition</h3>
+ *
+ * Engines compose. {@link RuleBasedPolicyEngine} takes an ordered list of
+ * {@link Rule}s and a fallback engine; the daemon wires built-in rules
+ * with a legacy-adapter fallback so default mode-driven behaviour is
+ * unchanged when no rule matches.
+ */
+@FunctionalInterface
+public interface PolicyEngine {
+
+    /**
+     * Evaluates a structured capability check.
+     *
+     * @param capability the structured capability the agent wants to use
+     * @param provenance how the agent arrived at this check (session, plan
+     *                   step, sub-agent depth, ...)
+     * @param context    per-check context the caller needs to pass through
+     *                   to the legacy fallback (allowlist key, description)
+     * @return the decision
+     */
+    PermissionDecision evaluate(Capability capability, Provenance provenance, PolicyContext context);
+
+    /**
+     * Adapts a legacy {@link PermissionPolicy} (request in, decision out)
+     * into a PolicyEngine. Used by {@link PermissionManager}'s legacy
+     * constructor and as the terminal fallback for {@link RuleBasedPolicyEngine}.
+     *
+     * <p>Reconstructs a {@link PermissionRequest} from the
+     * {@link PolicyContext}'s {@code allowlistKey} and {@code description}
+     * plus the capability's derived {@link Capability#risk()}. Crucially,
+     * the {@code allowlistKey} is preserved from the caller — two
+     * different tools producing the same {@link Capability} variant stay
+     * distinct in the legacy request (so existing "always allow X"
+     * approvals don't accidentally cross adapters).
+     */
+    static PolicyEngine fromLegacyPolicy(PermissionPolicy legacy) {
+        Objects.requireNonNull(legacy, "legacy");
+        return (capability, provenance, context) -> {
+            var request = new PermissionRequest(
+                    context.allowlistKey(),
+                    context.description(),
+                    capability.risk());
+            return legacy.evaluate(request);
+        };
+    }
+}

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/Rule.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/Rule.java
@@ -1,0 +1,61 @@
+package dev.aceclaw.security;
+
+import java.util.Optional;
+
+/**
+ * One cross-cutting policy rule for {@link PolicyEngine} (#465 Scope #2).
+ *
+ * <p>A rule examines a structured {@link Capability} and the
+ * {@link Provenance} that produced it; it returns
+ * {@link Optional#empty()} if it has no opinion (let the next rule or
+ * the fallback decide) or {@link Optional#of(Object)} with a concrete
+ * {@link PermissionDecision} to short-circuit the chain.
+ *
+ * <h3>Why {@code Optional} rather than a sentinel "PASS" decision</h3>
+ *
+ * The decision sealed type has three meaningful outcomes — Approved,
+ * Denied, NeedsUserApproval — every one of which is a real answer.
+ * Adding a fourth "no opinion" value would force every consumer to
+ * pattern-match on a case that doesn't represent a permission outcome,
+ * blurring the meaning of the type. {@code Optional<PermissionDecision>}
+ * keeps the decision type pure and makes "has the rule fired?" a
+ * presence check that's hard to misread.
+ *
+ * <h3>Ordering and conflict</h3>
+ *
+ * Rules are evaluated in declaration order; the first match wins. Two
+ * rules cannot both produce a decision for the same input — short-
+ * circuit avoids the conflict. Operators wanting "deny wins over approve"
+ * should put the deny rule first in the engine's rule list.
+ *
+ * <h3>Rules should be stateless or carry only configuration</h3>
+ *
+ * Per-check state lives on {@link PolicyContext}; engine-wide state
+ * (e.g. mode) is owned by the engine that wires the rule. A rule that
+ * mutates state on evaluate() will produce non-deterministic decisions
+ * and is essentially impossible to audit.
+ */
+@FunctionalInterface
+public interface Rule {
+
+    /**
+     * Evaluates this rule against a capability check.
+     *
+     * @param capability the structured capability under review
+     * @param provenance how the agent arrived at this check
+     * @param context    per-check caller context (allowlist key, description)
+     * @return {@link Optional#empty()} to defer to the next rule;
+     *         {@link Optional#of(Object)} to short-circuit with a decision
+     */
+    Optional<PermissionDecision> evaluate(
+            Capability capability, Provenance provenance, PolicyContext context);
+
+    /**
+     * Human-readable rule name for logs and audit. Defaults to the
+     * implementing class's simple name; lambdas should override (or use
+     * a named record).
+     */
+    default String name() {
+        return getClass().getSimpleName();
+    }
+}

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/RuleBasedPolicyEngine.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/RuleBasedPolicyEngine.java
@@ -1,0 +1,96 @@
+package dev.aceclaw.security;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * {@link PolicyEngine} that evaluates an ordered list of {@link Rule}s and
+ * falls back to a wrapped engine when no rule matches (#465 Scope #2).
+ *
+ * <h3>Decision flow</h3>
+ *
+ * <ol>
+ *   <li>Walk {@link #rules} in declaration order; the first rule whose
+ *       {@code evaluate(...)} returns a non-empty {@link PermissionDecision}
+ *       wins and short-circuits the chain.</li>
+ *   <li>If every rule defers (returns {@link java.util.Optional#empty()}),
+ *       delegate to {@link #fallback}. For the daemon this is
+ *       {@link PolicyEngine#fromLegacyPolicy(PermissionPolicy)} wrapping a
+ *       {@link DefaultPermissionPolicy}, so unmatched checks keep the
+ *       pre-Layer-2 mode-based behaviour exactly.</li>
+ * </ol>
+ *
+ * <p>The fallback is mandatory rather than defaulting to a permissive or
+ * restrictive built-in: silently approving / denying on "no rule
+ * matched" hides configuration bugs. Callers must make the policy
+ * explicit by passing one.
+ *
+ * <h3>Why "first match wins"</h3>
+ *
+ * The alternative is "deny wins over approve" (collect all decisions,
+ * pick the strictest). That makes rule order irrelevant but couples rule
+ * authors to each other — adding a permissive rule has to consider every
+ * other rule's denials. First-match keeps each rule's contract local
+ * ("if I fire, my answer stands") and makes ordering the explicit lever
+ * for "deny first, then narrow approve". Operators wanting a deny to
+ * trump a later approval put the deny earlier in the list.
+ *
+ * <h3>Logging</h3>
+ *
+ * Every fired rule logs at {@code DEBUG} so the dashboard timeline /
+ * operator can see which rule produced a decision without having to run
+ * the audit log through a query tool. Audit recording itself is in
+ * {@link PermissionManager#check}, not here — keeping engines pure of
+ * I/O lets them be tested without disk setup.
+ */
+public final class RuleBasedPolicyEngine implements PolicyEngine {
+
+    private static final Logger log = LoggerFactory.getLogger(RuleBasedPolicyEngine.class);
+
+    private final List<Rule> rules;
+    private final PolicyEngine fallback;
+
+    /**
+     * @param rules    ordered list of rules; first match wins. Defensively
+     *                 copied — later mutation of the source list cannot
+     *                 change the engine's behaviour out from under it.
+     * @param fallback engine consulted when every rule defers. Must not
+     *                 be null — see class-level note on explicitness.
+     */
+    public RuleBasedPolicyEngine(List<Rule> rules, PolicyEngine fallback) {
+        Objects.requireNonNull(rules, "rules");
+        this.rules = List.copyOf(rules);
+        this.fallback = Objects.requireNonNull(fallback, "fallback");
+    }
+
+    @Override
+    public PermissionDecision evaluate(
+            Capability capability, Provenance provenance, PolicyContext context) {
+        Objects.requireNonNull(capability, "capability");
+        Objects.requireNonNull(provenance, "provenance");
+        Objects.requireNonNull(context, "context");
+        for (Rule rule : rules) {
+            var maybeDecision = rule.evaluate(capability, provenance, context);
+            if (maybeDecision.isPresent()) {
+                var decision = maybeDecision.get();
+                log.debug("Rule '{}' fired for capability {} -> {}",
+                        rule.name(),
+                        capability.getClass().getSimpleName(),
+                        decision.getClass().getSimpleName());
+                return decision;
+            }
+        }
+        return fallback.evaluate(capability, provenance, context);
+    }
+
+    /**
+     * Exposed for tests / dashboard introspection — read-only view of the
+     * configured rule chain.
+     */
+    public List<Rule> rules() {
+        return rules;
+    }
+}

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/rules/DenyDangerousForDeepSubAgentRule.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/rules/DenyDangerousForDeepSubAgentRule.java
@@ -1,0 +1,85 @@
+package dev.aceclaw.security.rules;
+
+import dev.aceclaw.security.Capability;
+import dev.aceclaw.security.PermissionDecision;
+import dev.aceclaw.security.PermissionLevel;
+import dev.aceclaw.security.PolicyContext;
+import dev.aceclaw.security.Provenance;
+import dev.aceclaw.security.Rule;
+
+import java.util.Optional;
+
+/**
+ * Denies {@link PermissionLevel#DANGEROUS} capabilities when a
+ * sub-agent's nesting depth exceeds a configured maximum (#465 Scope #2 —
+ * canonical cross-cutting example from the epic: "no {@code DANGEROUS}
+ * for sub-agents below depth N").
+ *
+ * <h3>Depth semantics</h3>
+ *
+ * {@link Provenance#subAgentDepth()} is {@code 0} for the top-level
+ * agent's own checks, {@code 1} for a sub-agent spawned by the top-level,
+ * {@code 2} for a sub-sub-agent, and so on. This rule denies when
+ * {@code depth > maxDepth}, so:
+ *
+ * <ul>
+ *   <li>{@code maxDepth = 0} — only the top-level agent may do
+ *       {@code DANGEROUS} ops. All sub-agents are blocked.</li>
+ *   <li>{@code maxDepth = 1} — top-level and direct sub-agents may;
+ *       sub-sub-agents are blocked. This is the daemon default — the
+ *       common Task tool case (top-level delegates one sub-agent) keeps
+ *       working; the rarer chained delegation needs an explicit user
+ *       turn.</li>
+ *   <li>{@code maxDepth = Integer.MAX_VALUE} — effectively disabled.</li>
+ * </ul>
+ *
+ * <h3>Why depth-bound DANGEROUS</h3>
+ *
+ * The user prompt is the consent boundary. A top-level agent's
+ * {@code rm -rf} runs because the operator typed something that asked
+ * for cleanup. A sub-sub-agent invoking {@code rm -rf} is two
+ * delegation hops removed from that consent — the operator may not even
+ * see the prompt before the LLM auto-approves it via session blanket
+ * approval (sub-agents inherit the parent session, see {@code #457}).
+ * Bounding by depth makes the dangerous-action surface scale with
+ * operator visibility, not with the agent's planning ambition.
+ *
+ * <h3>What this rule does NOT do</h3>
+ *
+ * It does not deny {@code WRITE} or {@code EXECUTE} at depth. The
+ * justification only holds for irrecoverable operations; ordinary
+ * writes are still gated by the mode policy and per-tool approvals.
+ * Operators wanting tighter sub-agent confinement should add an
+ * additional rule rather than widening this one — keeping rules
+ * single-purpose makes "why was this denied?" answerable from the rule
+ * name.
+ */
+public final class DenyDangerousForDeepSubAgentRule implements Rule {
+
+    private final int maxDepth;
+
+    /**
+     * @param maxDepth the largest sub-agent depth that may use a
+     *                 {@link PermissionLevel#DANGEROUS} capability.
+     *                 Must be {@code >= 0}.
+     */
+    public DenyDangerousForDeepSubAgentRule(int maxDepth) {
+        if (maxDepth < 0) {
+            throw new IllegalArgumentException(
+                    "maxDepth must be non-negative; got " + maxDepth);
+        }
+        this.maxDepth = maxDepth;
+    }
+
+    @Override
+    public Optional<PermissionDecision> evaluate(
+            Capability capability, Provenance provenance, PolicyContext context) {
+        if (capability.risk() != PermissionLevel.DANGEROUS) return Optional.empty();
+        int depth = provenance.subAgentDepth();
+        if (depth <= maxDepth) return Optional.empty();
+        return Optional.of(new PermissionDecision.Denied(
+                "DANGEROUS capability blocked for sub-agent at depth " + depth
+                        + " (max=" + maxDepth + "): " + capability.displayLabel()
+                        + " (rule=" + name() + ")"));
+    }
+}

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/rules/DenyEnvFileAccessRule.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/rules/DenyEnvFileAccessRule.java
@@ -1,0 +1,145 @@
+package dev.aceclaw.security.rules;
+
+import dev.aceclaw.security.Capability;
+import dev.aceclaw.security.PermissionDecision;
+import dev.aceclaw.security.PolicyContext;
+import dev.aceclaw.security.Provenance;
+import dev.aceclaw.security.Rule;
+import dev.aceclaw.security.SearchKind;
+
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+/**
+ * Denies filesystem operations that target environment files, private
+ * keys, or other credentials regardless of which adapter requested them
+ * (#465 Scope #2 — canonical cross-cutting example from the epic:
+ * "no {@code .env} reads from any adapter").
+ *
+ * <h3>What "credential file" means here</h3>
+ *
+ * <p>Conservative deny-list, biased toward false positives that produce
+ * one extra prompt or a clear error rather than silent data leak:
+ *
+ * <ul>
+ *   <li><strong>{@code .env} family</strong> — filename is exactly
+ *       {@code .env} or starts with {@code .env.} ({@code .env.local},
+ *       {@code .env.production}, etc.). The historical leak vector for
+ *       Twelve-Factor apps.</li>
+ *   <li><strong>SSH / SSL private keys</strong> — {@code id_rsa},
+ *       {@code id_ed25519}, {@code id_dsa}, {@code id_ecdsa}, and any
+ *       file ending in {@code .pem} or {@code .key}.</li>
+ *   <li><strong>Cloud + tool credentials</strong> — any path whose final
+ *       segments contain {@code credentials} (matches
+ *       {@code ~/.aws/credentials}, {@code .git-credentials}, etc.).</li>
+ *   <li><strong>Token / config files</strong> — {@code .npmrc},
+ *       {@code .pypirc}, {@code .netrc}, {@code .docker/config.json}.
+ *       These commonly carry registry / auth tokens.</li>
+ * </ul>
+ *
+ * <h3>Why deny instead of prompt</h3>
+ *
+ * For built-in tools the user already has a prompt path
+ * ({@link PermissionDecision.NeedsUserApproval}); a rule that re-prompts
+ * doesn't add value over what {@link dev.aceclaw.security.DefaultPermissionPolicy}
+ * does for any {@link dev.aceclaw.security.PermissionLevel#WRITE} or
+ * {@link dev.aceclaw.security.PermissionLevel#EXECUTE} request. The
+ * cross-cutting rule's job is to enforce something the per-level mode
+ * cannot: deny the operation regardless of mode (including
+ * {@code auto-accept}, which would otherwise silently approve a
+ * credential read). Operators who genuinely need to access a credential
+ * file can rename, move it out of the workspace, or fork this rule's
+ * pattern set.
+ *
+ * <h3>Applies to which capability variants</h3>
+ *
+ * {@link Capability.FileRead}, {@link Capability.FileWrite},
+ * {@link Capability.FileDelete} on any path matching the deny-list.
+ * Read denies because credentials leak via INGRESS to the agent
+ * transcript; write/delete deny because they can corrupt operator
+ * credentials.
+ *
+ * <p>{@link Capability.FileSearch} matches conditionally:
+ * {@link SearchKind#GREP} rooted directly at a credential file is
+ * denied (it would disclose the file's contents to the agent), while
+ * {@link SearchKind#GLOB} / {@link SearchKind#LIST} are not — listing
+ * a directory that contains a {@code .env} doesn't disclose contents,
+ * and denying glob would break the normal "find my dotfiles" flow.
+ * The narrower form ("grep parent directory that happens to traverse
+ * an env file") is a real but harder vector, intentionally left for a
+ * follow-up rule that walks the search expansion.
+ *
+ * <p>{@link Capability.McpInvoke} cannot be matched here because the
+ * MCP variant doesn't carry path arguments (by design — args may be
+ * huge / contain secrets); MCP-side enforcement lives in the MCP
+ * normaliser layer.
+ */
+public final class DenyEnvFileAccessRule implements Rule {
+
+    /**
+     * Filename basename patterns that trigger denial. Match is performed
+     * against the {@link Path#getFileName()} portion only, so
+     * directory matches (e.g. anything inside {@code .ssh/}) require the
+     * {@link #DIRECTORY_SEGMENT_PATTERN} below.
+     */
+    private static final Pattern FILENAME_PATTERN = Pattern.compile(
+            "^(?:"
+                    + "\\.env"                   // .env (exact)
+                    + "|\\.env\\..+"             // .env.local, .env.production, ...
+                    + "|id_(?:rsa|dsa|ecdsa|ed25519)" // SSH private key conventional names
+                    + "|.+\\.(?:pem|key|kdbx|keystore|jks|p12|pfx)" // cert / keystore extensions
+                    + "|\\.netrc|\\.npmrc|\\.pypirc" // dot-config files with auth tokens
+                    + "|\\.git-credentials"
+                    + "|credentials(?:\\.json)?"  // ~/.aws/credentials, gcloud credentials.json
+                    + ")$");
+
+    /**
+     * Path-segment patterns that trigger denial regardless of basename —
+     * anything under {@code .ssh/}, {@code .aws/}, {@code .gnupg/},
+     * {@code .docker/} (config.json carries auth), or {@code .config/gcloud/}
+     * is treated as credential material.
+     */
+    private static final Pattern DIRECTORY_SEGMENT_PATTERN = Pattern.compile(
+            "^(?:\\.ssh|\\.aws|\\.gnupg|\\.docker|gcloud)$");
+
+    @Override
+    public Optional<PermissionDecision> evaluate(
+            Capability capability, Provenance provenance, PolicyContext context) {
+        Path path = switch (capability) {
+            case Capability.FileRead r -> r.path();
+            case Capability.FileWrite w -> w.path();
+            case Capability.FileDelete d -> d.path();
+            // GREP rooted at a credential file reads the file's bytes
+            // and ships matches into the agent transcript — same leak
+            // shape as FileRead. GLOB / LIST are defer (see class
+            // javadoc) — they don't disclose contents.
+            case Capability.FileSearch s when s.kind() == SearchKind.GREP -> s.root();
+            default -> null; // not a path-bearing filesystem op this rule covers
+        };
+        if (path == null) return Optional.empty();
+        if (!isCredentialPath(path)) return Optional.empty();
+
+        return Optional.of(new PermissionDecision.Denied(
+                "Capability blocked by policy: " + capability.displayLabel()
+                        + " (path matches credential-file deny-list — rule="
+                        + name() + ")"));
+    }
+
+    /**
+     * Visible for testing — true if {@code path} matches the basename or
+     * directory-segment pattern set.
+     */
+    static boolean isCredentialPath(Path path) {
+        Path fileName = path.getFileName();
+        if (fileName != null && FILENAME_PATTERN.matcher(fileName.toString()).matches()) {
+            return true;
+        }
+        for (Path segment : path) {
+            if (DIRECTORY_SEGMENT_PATTERN.matcher(segment.toString()).matches()) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/rules/DenyNetworkInPlanModeRule.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/rules/DenyNetworkInPlanModeRule.java
@@ -1,0 +1,70 @@
+package dev.aceclaw.security.rules;
+
+import dev.aceclaw.security.Capability;
+import dev.aceclaw.security.DefaultPermissionPolicy;
+import dev.aceclaw.security.PermissionDecision;
+import dev.aceclaw.security.PolicyContext;
+import dev.aceclaw.security.Provenance;
+import dev.aceclaw.security.Rule;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * Denies network-touching capabilities while the daemon is in
+ * {@link DefaultPermissionPolicy#MODE_PLAN plan mode} (#465 Scope #2 —
+ * canonical cross-cutting example from the epic: "no {@code NETWORK}
+ * during {@code plan} mode").
+ *
+ * <h3>Why this rule when DefaultPermissionPolicy already denies in plan mode</h3>
+ *
+ * {@link DefaultPermissionPolicy} denies any {@code WRITE} / {@code EXECUTE}
+ * / {@code DANGEROUS} request in plan mode with a generic message ("plan
+ * mode is read-only"). This rule fires <em>before</em> the fallback and
+ * produces a precise, actionable message naming the network capability,
+ * so operators reading the dashboard see "network use blocked in plan
+ * mode" instead of the generic mode message. That precision matters
+ * because plan mode legitimately allows local {@code EXECUTE} on some
+ * tools in user-extended configurations (e.g. dry-runs) — keeping the
+ * network deny called out separately makes the rationale auditable.
+ *
+ * <p>It also matters going forward: if {@link DefaultPermissionPolicy}'s
+ * plan-mode policy ever relaxes (e.g. allow read-only HTTP in plan mode),
+ * this rule continues to enforce the network ban explicitly — the
+ * cross-cutting concern doesn't depend on the mode rule's contents.
+ *
+ * <h3>Mode supplier</h3>
+ *
+ * Mode is read per-check via a {@link Supplier}, not captured at
+ * construction, so future mode-switching (e.g. an {@code agent.setMode}
+ * RPC mid-session) doesn't require rebuilding the engine. Today's daemon
+ * passes a constant supplier (mode is set once at startup); the
+ * indirection costs nothing and avoids a refactor when mode becomes
+ * dynamic.
+ */
+public final class DenyNetworkInPlanModeRule implements Rule {
+
+    private final Supplier<String> modeSupplier;
+
+    public DenyNetworkInPlanModeRule(Supplier<String> modeSupplier) {
+        this.modeSupplier = Objects.requireNonNull(modeSupplier, "modeSupplier");
+    }
+
+    @Override
+    public Optional<PermissionDecision> evaluate(
+            Capability capability, Provenance provenance, PolicyContext context) {
+        if (!DefaultPermissionPolicy.MODE_PLAN.equals(modeSupplier.get())) {
+            return Optional.empty();
+        }
+        return switch (capability) {
+            case Capability.HttpFetch h -> Optional.of(new PermissionDecision.Denied(
+                    "Network use blocked in plan mode: " + h.displayLabel()
+                            + " (rule=" + name() + ")"));
+            case Capability.BrowserAction b -> Optional.of(new PermissionDecision.Denied(
+                    "Network use blocked in plan mode: " + b.displayLabel()
+                            + " (rule=" + name() + ")"));
+            default -> Optional.empty();
+        };
+    }
+}

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/PolicyEngineCrossAdapterTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/PolicyEngineCrossAdapterTest.java
@@ -1,0 +1,85 @@
+package dev.aceclaw.security;
+
+import dev.aceclaw.security.rules.DenyEnvFileAccessRule;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Cross-adapter consistency check for {@link PolicyEngine} (#465 Scope #2,
+ * explicit success criterion from the epic):
+ *
+ * <blockquote>
+ *   Test matrix: same rule, different adapters → identical decision.
+ * </blockquote>
+ *
+ * <p>The whole point of capability-style governance is that two different
+ * adapters producing semantically the same {@link Capability} get the
+ * <em>same</em> policy answer. {@link Capability} intentionally omits an
+ * "adapter" field so policies cannot fork by who asked; the originating
+ * tool's name is recorded on {@link PolicyContext}'s {@code allowlistKey}
+ * (for legacy fallback + per-session approvals only) but the engine's
+ * rules must reach the same verdict regardless.
+ *
+ * <p>This test simulates two adapters by passing different allowlist
+ * keys ({@code "read_file"} vs. a hypothetical {@code "mcp_fs.read"})
+ * for the same {@link Capability.FileRead} and asserts identical
+ * decisions from the rule chain.
+ */
+final class PolicyEngineCrossAdapterTest {
+
+    private static final PolicyEngine FALLBACK_APPROVE =
+            (cap, prov, ctx) -> new PermissionDecision.Approved();
+
+    @Test
+    void sameCapabilityFromDifferentAdaptersGetsSameDecision() {
+        var engine = new RuleBasedPolicyEngine(
+                List.of(new DenyEnvFileAccessRule()),
+                FALLBACK_APPROVE);
+
+        var envFile = new Capability.FileRead(Path.of("/project/.env"));
+        var provenance = Provenance.daemonInternal();
+
+        var builtinAdapterDecision = engine.evaluate(
+                envFile, provenance, new PolicyContext("read_file", "read /project/.env"));
+        var mcpAdapterDecision = engine.evaluate(
+                envFile, provenance, new PolicyContext("mcp_fs.read", "read /project/.env via MCP"));
+        var skillAdapterDecision = engine.evaluate(
+                envFile, provenance, new PolicyContext("skill:dump-env", "skill reads .env"));
+
+        // All three adapters must hit the same rule and produce the
+        // SAME decision class. Any divergence would mean an adapter is
+        // smuggling state into the engine — exactly the failure mode
+        // capability-style governance prevents.
+        assertThat(builtinAdapterDecision)
+                .isInstanceOf(PermissionDecision.Denied.class);
+        assertThat(mcpAdapterDecision.getClass())
+                .as("MCP adapter must reach the same decision class as the built-in adapter")
+                .isEqualTo(builtinAdapterDecision.getClass());
+        assertThat(skillAdapterDecision.getClass())
+                .as("skill adapter must reach the same decision class as the built-in adapter")
+                .isEqualTo(builtinAdapterDecision.getClass());
+    }
+
+    @Test
+    void capabilityShapeDictatesDecisionNotAllowlistKey() {
+        // Negative angle: even a benign allowlist key ("safe_tool") still
+        // gets denied if the capability shape says so. The rule doesn't
+        // look at allowlistKey, by design.
+        var engine = new RuleBasedPolicyEngine(
+                List.of(new DenyEnvFileAccessRule()),
+                FALLBACK_APPROVE);
+
+        var decision = engine.evaluate(
+                new Capability.FileRead(Path.of("id_rsa")),
+                Provenance.daemonInternal(),
+                new PolicyContext("totally_safe_looking_tool", "boring description"));
+
+        assertThat(decision)
+                .as("rule's verdict comes from the capability variant + fields, not the caller's chosen key")
+                .isInstanceOf(PermissionDecision.Denied.class);
+    }
+}

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/RuleBasedPolicyEngineTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/RuleBasedPolicyEngineTest.java
@@ -1,0 +1,157 @@
+package dev.aceclaw.security;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Pins the {@link RuleBasedPolicyEngine}'s composition contract: ordered
+ * rules with first-match-wins short-circuit, mandatory non-null fallback,
+ * defensive copy of the rule list, and zero-rule behaviour identical to
+ * just running the fallback.
+ *
+ * <p>Built-in rule semantics are tested per-rule under {@code rules/};
+ * this file is strictly about the engine's plumbing.
+ */
+final class RuleBasedPolicyEngineTest {
+
+    private static final Capability FILE_READ =
+            new Capability.FileRead(Path.of("/tmp/x"));
+
+    private static final Provenance PROV = Provenance.daemonInternal();
+    private static final PolicyContext CTX =
+            new PolicyContext("read_file", "read /tmp/x");
+
+    private static final PolicyEngine ALWAYS_APPROVE_FALLBACK =
+            (cap, prov, ctx) -> new PermissionDecision.Approved();
+    private static final PolicyEngine ALWAYS_DENY_FALLBACK =
+            (cap, prov, ctx) -> new PermissionDecision.Denied("fallback denies");
+
+    @Test
+    void firstMatchingRuleWinsAndShortCircuits() {
+        AtomicInteger laterRuleCalls = new AtomicInteger();
+        Rule denyImmediately = (cap, prov, ctx) ->
+                Optional.of(new PermissionDecision.Denied("denied by first rule"));
+        Rule countCalls = (cap, prov, ctx) -> {
+            laterRuleCalls.incrementAndGet();
+            return Optional.of(new PermissionDecision.Approved());
+        };
+
+        var engine = new RuleBasedPolicyEngine(
+                List.of(denyImmediately, countCalls),
+                ALWAYS_APPROVE_FALLBACK);
+
+        var decision = engine.evaluate(FILE_READ, PROV, CTX);
+
+        assertThat(decision).isInstanceOf(PermissionDecision.Denied.class);
+        assertThat(laterRuleCalls.get())
+                .as("rules after the first match must not be evaluated")
+                .isEqualTo(0);
+    }
+
+    @Test
+    void deferringRuleFallsThroughToNextRule() {
+        Rule defer = (cap, prov, ctx) -> Optional.empty();
+        Rule denySecond = (cap, prov, ctx) ->
+                Optional.of(new PermissionDecision.Denied("denied by second rule"));
+
+        var engine = new RuleBasedPolicyEngine(
+                List.of(defer, denySecond),
+                ALWAYS_APPROVE_FALLBACK);
+
+        assertThat(engine.evaluate(FILE_READ, PROV, CTX))
+                .isInstanceOf(PermissionDecision.Denied.class);
+    }
+
+    @Test
+    void allRulesDeferingDelegatesToFallback() {
+        Rule defer = (cap, prov, ctx) -> Optional.empty();
+        var engine = new RuleBasedPolicyEngine(
+                List.of(defer, defer, defer),
+                ALWAYS_DENY_FALLBACK);
+
+        assertThat(engine.evaluate(FILE_READ, PROV, CTX))
+                .as("when no rule fires, fallback engine is consulted")
+                .isInstanceOf(PermissionDecision.Denied.class);
+    }
+
+    @Test
+    void emptyRuleListBehavesLikeJustTheFallback() {
+        var engine = new RuleBasedPolicyEngine(List.of(), ALWAYS_DENY_FALLBACK);
+        assertThat(engine.evaluate(FILE_READ, PROV, CTX))
+                .isInstanceOf(PermissionDecision.Denied.class);
+    }
+
+    @Test
+    void ruleListIsDefensivelyCopiedAtConstruction() {
+        // Mutating the caller-held list after construction must NOT change
+        // engine behaviour — otherwise a long-lived daemon could see its
+        // policy chain silently replaced by anyone holding the original
+        // reference.
+        var mutable = new java.util.ArrayList<Rule>();
+        mutable.add((cap, prov, ctx) -> Optional.empty());
+        var engine = new RuleBasedPolicyEngine(mutable, ALWAYS_APPROVE_FALLBACK);
+
+        mutable.add((cap, prov, ctx) ->
+                Optional.of(new PermissionDecision.Denied("late-added rule")));
+
+        assertThat(engine.evaluate(FILE_READ, PROV, CTX))
+                .as("post-construction mutation of source list must not affect engine")
+                .isInstanceOf(PermissionDecision.Approved.class);
+        assertThat(engine.rules())
+                .as("rules() exposes only the snapshot taken at construction")
+                .hasSize(1);
+    }
+
+    @Test
+    void rulesViewIsImmutable() {
+        var engine = new RuleBasedPolicyEngine(List.of(), ALWAYS_APPROVE_FALLBACK);
+        assertThatThrownBy(() -> engine.rules().add((c, p, ctx) -> Optional.empty()))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void nullFallbackIsRejected() {
+        assertThatThrownBy(() -> new RuleBasedPolicyEngine(List.of(), null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("fallback");
+    }
+
+    @Test
+    void nullRulesListIsRejected() {
+        assertThatThrownBy(() -> new RuleBasedPolicyEngine(null, ALWAYS_APPROVE_FALLBACK))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void fromLegacyPolicyAdapterPassesAllowlistKeyAndDescriptionToRequest() {
+        // The legacy adapter is what backs PermissionManager's
+        // (PermissionPolicy) constructor and RuleBasedPolicyEngine's
+        // typical fallback. Pin that PolicyContext fields reach the
+        // legacy PermissionRequest unchanged — losing them would mean
+        // legacy policies suddenly see a synthesised allowlistKey
+        // (variant class name) instead of the originating tool's name,
+        // breaking the per-tool "always allow" semantics.
+        var captured = new java.util.concurrent.atomic.AtomicReference<PermissionRequest>();
+        PermissionPolicy capturing = request -> {
+            captured.set(request);
+            return new PermissionDecision.Approved();
+        };
+
+        var engine = PolicyEngine.fromLegacyPolicy(capturing);
+        engine.evaluate(
+                new Capability.FileWrite(Path.of("/tmp/x"), WriteMode.OVERWRITE),
+                Provenance.daemonInternal(),
+                new PolicyContext("write_file", "Write /tmp/x (123 bytes)"));
+
+        assertThat(captured.get().toolName()).isEqualTo("write_file");
+        assertThat(captured.get().description()).isEqualTo("Write /tmp/x (123 bytes)");
+        assertThat(captured.get().level()).isEqualTo(PermissionLevel.WRITE);
+    }
+}

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/rules/DenyDangerousForDeepSubAgentRuleTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/rules/DenyDangerousForDeepSubAgentRuleTest.java
@@ -1,0 +1,86 @@
+package dev.aceclaw.security.rules;
+
+import dev.aceclaw.security.Capability;
+import dev.aceclaw.security.PermissionDecision;
+import dev.aceclaw.security.PolicyContext;
+import dev.aceclaw.security.Provenance;
+import dev.aceclaw.security.ids.SessionId;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+final class DenyDangerousForDeepSubAgentRuleTest {
+
+    private static final PolicyContext CTX = new PolicyContext("bash", "rm -rf /tmp/x");
+    /** Self-escalates to DANGEROUS via Capability.BashExec.isDestructive. */
+    private static final Capability DANGEROUS_BASH =
+            new Capability.BashExec("rm -rf /tmp/x", Path.of("/tmp"));
+    private static final Capability EXECUTE_BASH =
+            new Capability.BashExec("echo hi", Path.of("/tmp"));
+
+    private static Provenance provAtDepth(int depth) {
+        return new Provenance(
+                Optional.empty(),
+                Optional.of(new SessionId("s")),
+                Optional.empty(),
+                depth,
+                List.of());
+    }
+
+    @Test
+    void denyDangerousPastMaxDepth() {
+        var rule = new DenyDangerousForDeepSubAgentRule(1);
+        var decision = rule.evaluate(DANGEROUS_BASH, provAtDepth(2), CTX);
+        assertThat(decision).isPresent();
+        assertThat(((PermissionDecision.Denied) decision.get()).reason())
+                .as("denial reason must name the depth, the max, and the rule")
+                .contains("depth 2")
+                .contains("max=1")
+                .contains("DenyDangerousForDeepSubAgentRule");
+    }
+
+    @Test
+    void allowDangerousAtOrBelowMaxDepth() {
+        var rule = new DenyDangerousForDeepSubAgentRule(1);
+        assertThat(rule.evaluate(DANGEROUS_BASH, provAtDepth(0), CTX))
+                .as("depth 0 (top-level) is allowed")
+                .isEmpty();
+        assertThat(rule.evaluate(DANGEROUS_BASH, provAtDepth(1), CTX))
+                .as("depth 1 (direct sub-agent) is allowed at maxDepth=1")
+                .isEmpty();
+    }
+
+    @Test
+    void deferForNonDangerousAtAnyDepth() {
+        // EXECUTE-level capabilities are not depth-bounded by this rule.
+        var rule = new DenyDangerousForDeepSubAgentRule(0);
+        for (int depth = 0; depth <= 5; depth++) {
+            assertThat(rule.evaluate(EXECUTE_BASH, provAtDepth(depth), CTX))
+                    .as("EXECUTE bash at depth=%d must NOT be matched by depth rule", depth)
+                    .isEmpty();
+        }
+    }
+
+    @Test
+    void maxDepthZeroBlocksAllSubAgentsButPermitsTopLevel() {
+        var rule = new DenyDangerousForDeepSubAgentRule(0);
+        assertThat(rule.evaluate(DANGEROUS_BASH, provAtDepth(0), CTX))
+                .as("top-level always allowed regardless of maxDepth")
+                .isEmpty();
+        assertThat(rule.evaluate(DANGEROUS_BASH, provAtDepth(1), CTX))
+                .as("maxDepth=0 blocks any sub-agent from DANGEROUS")
+                .isPresent();
+    }
+
+    @Test
+    void negativeMaxDepthRejected() {
+        assertThatThrownBy(() -> new DenyDangerousForDeepSubAgentRule(-1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("non-negative");
+    }
+}

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/rules/DenyEnvFileAccessRuleTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/rules/DenyEnvFileAccessRuleTest.java
@@ -1,0 +1,155 @@
+package dev.aceclaw.security.rules;
+
+import dev.aceclaw.security.Capability;
+import dev.aceclaw.security.PermissionDecision;
+import dev.aceclaw.security.PolicyContext;
+import dev.aceclaw.security.Provenance;
+import dev.aceclaw.security.WriteMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class DenyEnvFileAccessRuleTest {
+
+    private static final PolicyContext CTX = new PolicyContext("any_tool", "any");
+    private static final Provenance PROV = Provenance.daemonInternal();
+    private static final DenyEnvFileAccessRule RULE = new DenyEnvFileAccessRule();
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            // .env family
+            ".env",
+            ".env.local",
+            ".env.production",
+            "/home/me/project/.env",
+            "/home/me/project/.env.test",
+            // SSH keys
+            "/home/me/.ssh/id_rsa",     // also matches via .ssh directory segment
+            "id_ed25519",
+            "id_dsa",
+            "id_ecdsa",
+            // Cert / keystore extensions
+            "/etc/ssl/server.pem",
+            "/var/secrets/api.key",
+            "wallet.kdbx",
+            "release.keystore",
+            "java.jks",
+            "client.p12",
+            "client.pfx",
+            // Auth-token configs
+            ".netrc",
+            ".npmrc",
+            ".pypirc",
+            ".git-credentials",
+            // AWS / cloud credentials
+            "/home/me/.aws/credentials",
+            "/home/me/.config/gcloud/credentials.json",
+            // Bare credentials
+            "credentials",
+            "credentials.json",
+    })
+    void denyForCredentialPaths(String pathStr) {
+        var read = new Capability.FileRead(Path.of(pathStr));
+        var decision = RULE.evaluate(read, PROV, CTX);
+        assertThat(decision)
+                .as("FileRead(%s) should be denied by env-file rule", pathStr)
+                .hasValueSatisfying(d -> assertThat(d).isInstanceOf(PermissionDecision.Denied.class));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/etc/hosts",
+            "/home/me/notes.md",
+            "envoy-config.yaml",        // contains "env" but isn't .env
+            "environment.txt",
+            "main.py",
+            "credentials_helper.go",    // not exactly "credentials"
+            "/home/me/code/.env.example.txt",  // .env.example.txt is .env.<segment> — match!
+            ".gitignore",
+            "id_rsa.pub",               // public key — fine to read
+    })
+    void deferForNonCredentialPaths(String pathStr) {
+        var read = new Capability.FileRead(Path.of(pathStr));
+        var decision = RULE.evaluate(read, PROV, CTX);
+        // NOTE: ".env.example.txt" actually MATCHES the .env.<...> pattern.
+        // That's the intended conservative bias — operators get a single
+        // false positive on the "example" template file rather than a real
+        // .env slipping through. Adjust the test if the rule pattern tightens.
+        if (pathStr.equals("/home/me/code/.env.example.txt")) {
+            assertThat(decision).isPresent();
+        } else {
+            assertThat(decision)
+                    .as("FileRead(%s) should NOT be matched by env-file rule", pathStr)
+                    .isEmpty();
+        }
+    }
+
+    @Test
+    void denyAppliesToWriteAndDelete() {
+        var path = Path.of("/home/me/.env");
+        assertThat(RULE.evaluate(new Capability.FileWrite(path, WriteMode.OVERWRITE), PROV, CTX))
+                .as("FileWrite to .env must be denied")
+                .isPresent();
+        assertThat(RULE.evaluate(new Capability.FileDelete(path), PROV, CTX))
+                .as("FileDelete on .env must be denied")
+                .isPresent();
+    }
+
+    @Test
+    void grepRootedAtCredentialFileIsDenied() {
+        // GREP rooted directly at a credential file reads the file's
+        // bytes and ships matches into the agent transcript — same leak
+        // shape as FileRead, so the rule denies it.
+        var grep = new Capability.FileSearch(
+                Path.of("/home/me/.env"), "PASSWORD", dev.aceclaw.security.SearchKind.GREP);
+        assertThat(RULE.evaluate(grep, PROV, CTX))
+                .as("GREP on a credential file must be denied (content-disclosing)")
+                .isPresent();
+    }
+
+    @Test
+    void globAndListAreDeferEvenOnCredentialPaths() {
+        // GLOB / LIST only see filenames, not contents. Denying them
+        // would break the normal "find my dotfiles" flow without
+        // adding meaningful protection (operators already know .env
+        // exists). Defer to the fallback policy (which decides
+        // read-vs-prompt based on PermissionLevel).
+        var glob = new Capability.FileSearch(
+                Path.of("/home/me/.env"), "*", dev.aceclaw.security.SearchKind.GLOB);
+        var list = new Capability.FileSearch(
+                Path.of("/home/me/.ssh"), "*", dev.aceclaw.security.SearchKind.LIST);
+        assertThat(RULE.evaluate(glob, PROV, CTX)).isEmpty();
+        assertThat(RULE.evaluate(list, PROV, CTX)).isEmpty();
+    }
+
+    @Test
+    void grepOnNonCredentialPathDefers() {
+        var grep = new Capability.FileSearch(
+                Path.of("/home/me/src"), "TODO", dev.aceclaw.security.SearchKind.GREP);
+        assertThat(RULE.evaluate(grep, PROV, CTX)).isEmpty();
+    }
+
+    @Test
+    void doesNotMatchUnrelatedCapabilityVariants() {
+        var bash = new Capability.BashExec("echo hi", Path.of("/tmp"));
+        var http = new Capability.HttpFetch(java.net.URI.create("https://example.com"), "GET");
+        assertThat(RULE.evaluate(bash, PROV, CTX)).isEmpty();
+        assertThat(RULE.evaluate(http, PROV, CTX)).isEmpty();
+    }
+
+    @Test
+    void denialReasonNamesTheRuleForAuditability() {
+        var decision = RULE.evaluate(
+                new Capability.FileRead(Path.of(".env")), PROV, CTX);
+        assertThat(decision).hasValueSatisfying(d -> {
+            var denied = (PermissionDecision.Denied) d;
+            assertThat(denied.reason())
+                    .as("denial reason must name the rule so audit readers know which rule fired")
+                    .contains("DenyEnvFileAccessRule");
+        });
+    }
+}

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/rules/DenyNetworkInPlanModeRuleTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/rules/DenyNetworkInPlanModeRuleTest.java
@@ -1,0 +1,91 @@
+package dev.aceclaw.security.rules;
+
+import dev.aceclaw.security.Capability;
+import dev.aceclaw.security.DefaultPermissionPolicy;
+import dev.aceclaw.security.PermissionDecision;
+import dev.aceclaw.security.PolicyContext;
+import dev.aceclaw.security.Provenance;
+import dev.aceclaw.security.WriteMode;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class DenyNetworkInPlanModeRuleTest {
+
+    private static final PolicyContext CTX = new PolicyContext("any", "any");
+    private static final Provenance PROV = Provenance.daemonInternal();
+
+    @Test
+    void denyHttpFetchInPlanMode() {
+        var rule = new DenyNetworkInPlanModeRule(() -> DefaultPermissionPolicy.MODE_PLAN);
+        var decision = rule.evaluate(
+                new Capability.HttpFetch(URI.create("https://example.com"), "GET"),
+                PROV, CTX);
+        assertThat(decision).isPresent();
+        assertThat(((PermissionDecision.Denied) decision.get()).reason())
+                .as("denial reason must call out plan mode + name the rule")
+                .contains("plan mode")
+                .contains("DenyNetworkInPlanModeRule");
+    }
+
+    @Test
+    void denyBrowserActionInPlanMode() {
+        var rule = new DenyNetworkInPlanModeRule(() -> DefaultPermissionPolicy.MODE_PLAN);
+        var decision = rule.evaluate(
+                new Capability.BrowserAction("navigate", Optional.of(URI.create("https://example.com"))),
+                PROV, CTX);
+        assertThat(decision).isPresent();
+    }
+
+    @Test
+    void deferInNonPlanModes() {
+        for (var mode : new String[]{
+                DefaultPermissionPolicy.MODE_NORMAL,
+                DefaultPermissionPolicy.MODE_ACCEPT_EDITS,
+                DefaultPermissionPolicy.MODE_AUTO_ACCEPT}) {
+            var rule = new DenyNetworkInPlanModeRule(() -> mode);
+            assertThat(rule.evaluate(
+                    new Capability.HttpFetch(URI.create("https://x"), "GET"), PROV, CTX))
+                    .as("rule must defer in mode '%s'", mode)
+                    .isEmpty();
+        }
+    }
+
+    @Test
+    void deferForNonNetworkCapabilitiesEvenInPlanMode() {
+        var rule = new DenyNetworkInPlanModeRule(() -> DefaultPermissionPolicy.MODE_PLAN);
+        // Filesystem writes ARE denied in plan mode, but by the fallback
+        // mode policy — not by this rule. Confirm the rule itself defers
+        // so the audit log credits the correct rule for the denial.
+        assertThat(rule.evaluate(
+                new Capability.FileWrite(Path.of("/tmp/x"), WriteMode.OVERWRITE), PROV, CTX))
+                .as("network rule defers on non-network capabilities; mode policy handles them")
+                .isEmpty();
+        assertThat(rule.evaluate(
+                new Capability.BashExec("ls", Path.of("/tmp")), PROV, CTX))
+                .isEmpty();
+    }
+
+    @Test
+    void modeIsReadPerCheckNotCaptured() {
+        // Supplier indirection enables future mode-switching mid-session
+        // without rebuilding the engine. Confirm the rule re-reads.
+        var mode = new AtomicReference<>(DefaultPermissionPolicy.MODE_NORMAL);
+        var rule = new DenyNetworkInPlanModeRule(mode::get);
+
+        var http = new Capability.HttpFetch(URI.create("https://x"), "GET");
+        assertThat(rule.evaluate(http, PROV, CTX))
+                .as("mode=normal — rule defers")
+                .isEmpty();
+
+        mode.set(DefaultPermissionPolicy.MODE_PLAN);
+        assertThat(rule.evaluate(http, PROV, CTX))
+                .as("mode flipped to plan — rule now denies same capability")
+                .isPresent();
+    }
+}


### PR DESCRIPTION
Part of #465 (epic Layer 2). PolicyEngine + Rule + RuleBasedPolicyEngine;
  built-in rules for env-file / plan-mode network / sub-agent depth. PermissionManager migrated, legacy PermissionPolicy constructors preserved via fromLegacyPolicy adapter. AceClawDaemon wires the chain.
  Cross-adapter consistency test pins same-Capability-different-adapter = same-decision. All :aceclaw-security/daemon/tools/core tests green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented rule-based policy engine for structured permission evaluation
  * Automatic denial of credential file access (`.env`, SSH keys, certificates, auth configs)
  * Blocked network operations when in plan mode
  * Sub-agent depth restrictions on dangerous capabilities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xinhuagu/AceClaw/pull/494?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->