### PR TITLE
feat(governance): unify policy engine on Capability + migrate MCP

### DIFF
--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/SubAgentPermissionChecker.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/SubAgentPermissionChecker.java
@@ -16,12 +16,11 @@ import java.util.function.BiPredicate;
  *
  * <h3>Per-session scope (#457)</h3>
  *
- * Pre-#457 this checker used a daemon-wide
- * {@code hasAnySessionApproval(toolName)} lookup that returned true if any
- * session had approved the tool — meaning a sub-agent in workspace B would
- * silently inherit a "remember" decision the user made in workspace A.
- * Now keyed on {@code (sessionId, toolName)} so each session's allow-list
- * stays in its own scope.
+ * Pre-#457 this checker used a daemon-wide allow-list lookup that returned
+ * true if any session had approved the tool — meaning a sub-agent in
+ * workspace B would silently inherit a "remember" decision the user made
+ * in workspace A. Now keyed on {@code (sessionId, toolName)} so each
+ * session's allow-list stays in its own scope.
  */
 public final class SubAgentPermissionChecker implements ToolPermissionChecker {
 
@@ -69,8 +68,10 @@ public final class SubAgentPermissionChecker implements ToolPermissionChecker {
         // session-blanket approval for the tool name (e.g. "always allow
         // write_file") MUST NOT let a sub-agent target .env / .ssh /
         // /etc/ etc. — the "overrides every approval" invariant of the
-        // hard-denial layer (Codex P1 on #495).
-        String structuralReason = structuralCheck.denyReason(toolName, inputJson);
+        // hard-denial layer (Codex P1 on #495). The sessionId is forwarded
+        // so the daemon-side probe can attribute the audit entry to the
+        // originating session, matching the main-dispatcher's audit shape.
+        String structuralReason = structuralCheck.denyReason(toolName, inputJson, sessionId);
         if (structuralReason != null) {
             return ToolPermissionResult.denied(structuralReason);
         }

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/SubAgentPermissionChecker.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/SubAgentPermissionChecker.java
@@ -27,6 +27,7 @@ public final class SubAgentPermissionChecker implements ToolPermissionChecker {
 
     private final Set<String> readOnlyTools;
     private final BiPredicate<String, String> isSessionApproved;
+    private final SubAgentStructuralCheck structuralCheck;
 
     /**
      * Creates a sub-agent permission checker.
@@ -37,9 +38,20 @@ public final class SubAgentPermissionChecker implements ToolPermissionChecker {
      *                          allow-list lookup. Wire to
      *                          {@code permissionManager::hasSessionApproval}
      *                          on the daemon side.
+     * @param structuralCheck   probe that runs <em>before</em> the read-only
+     *                          and session-approval shortcuts. Returns the
+     *                          denial reason when the tool's intended
+     *                          (toolName, inputJson) violates a cross-cutting
+     *                          rule like "never write to {@code .env}", so
+     *                          that a prior "always allow {@code write_file}"
+     *                          approval cannot route a sub-agent past the
+     *                          structural hard-denial layer (Codex P1 on
+     *                          #495). Pass {@link SubAgentStructuralCheck#NONE}
+     *                          in tests that don't exercise structural rules.
      */
     public SubAgentPermissionChecker(Set<String> readOnlyTools,
-                                     BiPredicate<String, String> isSessionApproved) {
+                                     BiPredicate<String, String> isSessionApproved,
+                                     SubAgentStructuralCheck structuralCheck) {
         // Fail fast on miswiring: a null predicate would only surface on
         // the first non-read-only tool execution, where the NPE would
         // bubble up as a permission-check error well after construction.
@@ -48,11 +60,23 @@ public final class SubAgentPermissionChecker implements ToolPermissionChecker {
         Objects.requireNonNull(readOnlyTools, "readOnlyTools");
         this.readOnlyTools = Set.copyOf(readOnlyTools);
         this.isSessionApproved = Objects.requireNonNull(isSessionApproved, "isSessionApproved");
+        this.structuralCheck = Objects.requireNonNull(structuralCheck, "structuralCheck");
     }
 
     @Override
     public ToolPermissionResult check(String toolName, String inputJson, String sessionId) {
-        // Read-only tools are always allowed
+        // Structural denials fire BEFORE any allow-list lookup. A prior
+        // session-blanket approval for the tool name (e.g. "always allow
+        // write_file") MUST NOT let a sub-agent target .env / .ssh /
+        // /etc/ etc. — the "overrides every approval" invariant of the
+        // hard-denial layer (Codex P1 on #495).
+        String structuralReason = structuralCheck.denyReason(toolName, inputJson);
+        if (structuralReason != null) {
+            return ToolPermissionResult.denied(structuralReason);
+        }
+
+        // Read-only tools are always allowed (structural rules don't cover
+        // FileRead, so reaching here means no rule applied).
         if (readOnlyTools.contains(toolName)) {
             return ToolPermissionResult.ALLOWED;
         }

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/SubAgentPermissionChecker.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/SubAgentPermissionChecker.java
@@ -64,6 +64,8 @@ public final class SubAgentPermissionChecker implements ToolPermissionChecker {
 
     @Override
     public ToolPermissionResult check(String toolName, String inputJson, String sessionId) {
+        Objects.requireNonNull(toolName, "toolName");
+
         // Structural denials fire BEFORE any allow-list lookup. A prior
         // session-blanket approval for the tool name (e.g. "always allow
         // write_file") MUST NOT let a sub-agent target .env / .ssh /

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/SubAgentStructuralCheck.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/SubAgentStructuralCheck.java
@@ -25,16 +25,23 @@ public interface SubAgentStructuralCheck {
 
     /**
      * Returns a non-null denial reason when {@code (toolName, inputJson)}
-     * matches a structural denial rule. Returns {@code null} when no
-     * structural rule applies — the caller then defers to the normal
-     * read-only / session-approval logic.
+     * matches a structural denial rule, given the calling sub-agent's
+     * {@code sessionId}. Returns {@code null} when no structural rule
+     * applies — the caller then defers to the normal read-only /
+     * session-approval logic.
+     *
+     * <p>{@code sessionId} is forwarded so the daemon-side implementation
+     * can build a {@code Provenance} and write an audit entry tagged with
+     * the originating session, matching the main-dispatcher's audit
+     * shape. {@code null} is allowed for daemon-internal callers that have
+     * no session in scope.
      *
      * <p>Implementations must not throw on malformed input — they should
      * return {@code null} for unparseable args so the standard fall-through
      * logic decides, rather than crash the dispatcher.
      */
-    String denyReason(String toolName, String inputJson);
+    String denyReason(String toolName, String inputJson, String sessionId);
 
     /** No-op probe — returns {@code null} for every input. */
-    SubAgentStructuralCheck NONE = (toolName, inputJson) -> null;
+    SubAgentStructuralCheck NONE = (toolName, inputJson, sessionId) -> null;
 }

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/SubAgentStructuralCheck.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/SubAgentStructuralCheck.java
@@ -1,0 +1,40 @@
+package dev.aceclaw.core.agent;
+
+/**
+ * Structural / system-invariant denial probe wired into
+ * {@link SubAgentPermissionChecker}. Returns the denial reason when the
+ * sub-agent's intended (toolName, inputJson) violates a cross-cutting rule
+ * (e.g. "never write to {@code .env}"), or {@code null} when no structural
+ * rule applies.
+ *
+ * <p>Lives in {@code aceclaw-core} as a string-shaped predicate so the core
+ * agent loop does not have to depend on {@code aceclaw-security}'s
+ * {@code Capability} / {@code PermissionDecision} types. The daemon wires
+ * the implementation: it resolves the tool, builds the structured
+ * {@code Capability}, calls {@code PermissionManager.checkStructural}, and
+ * returns the {@code Denied.reason()} when present.
+ *
+ * <p>Why structural denials must reach the sub-agent path: the sub-agent
+ * permission flow auto-approves any tool the parent session has blanket-
+ * approved. Without a structural probe, a prior "always allow {@code write_file}"
+ * would let a sub-agent call {@code write_file(".env")} without the same
+ * cross-cutting refusal the main dispatcher enforces — Codex P1 on #495.
+ */
+@FunctionalInterface
+public interface SubAgentStructuralCheck {
+
+    /**
+     * Returns a non-null denial reason when {@code (toolName, inputJson)}
+     * matches a structural denial rule. Returns {@code null} when no
+     * structural rule applies — the caller then defers to the normal
+     * read-only / session-approval logic.
+     *
+     * <p>Implementations must not throw on malformed input — they should
+     * return {@code null} for unparseable args so the standard fall-through
+     * logic decides, rather than crash the dispatcher.
+     */
+    String denyReason(String toolName, String inputJson);
+
+    /** No-op probe — returns {@code null} for every input. */
+    SubAgentStructuralCheck NONE = (toolName, inputJson) -> null;
+}

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/ToolPermissionChecker.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/ToolPermissionChecker.java
@@ -12,11 +12,11 @@ package dev.aceclaw.core.agent;
  *
  * The 3-arg {@link #check(String, String, String)} entry point carries the
  * owning session id so a per-session allow-list cannot leak across sessions.
- * Pre-#457 the sub-agent path used a daemon-wide {@code hasAnySessionApproval}
- * lookup that returned true if <em>any</em> session had approved the tool —
- * meaning a sub-agent in workspace B would inherit a "remember" approval
- * granted in workspace A. The 3-arg form lets the daemon wire a per-session
- * predicate so that leak is closed.
+ * Pre-#457 the sub-agent path used a daemon-wide allow-list lookup that
+ * returned true if <em>any</em> session had approved the tool — meaning a
+ * sub-agent in workspace B would inherit a "remember" approval granted in
+ * workspace A. The 3-arg form lets the daemon wire a per-session predicate
+ * so that leak is closed.
  *
  * <p>The legacy 2-arg form is preserved as a deprecated default that
  * delegates with a {@code null} sessionId — implementations should override

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/agent/SubAgentPermissionCheckerTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/agent/SubAgentPermissionCheckerTest.java
@@ -121,7 +121,7 @@ class SubAgentPermissionCheckerTest {
         // must fire BEFORE the allow-list shortcut so the hard-denial
         // invariant holds for sub-agent dispatch too.
         BiPredicate<String, String> approveEverything = (sid, tool) -> true;
-        SubAgentStructuralCheck refuseEnvWrites = (toolName, inputJson) -> {
+        SubAgentStructuralCheck refuseEnvWrites = (toolName, inputJson, sid) -> {
             if ("write_file".equals(toolName) && inputJson != null && inputJson.contains(".env")) {
                 return "Refusing to write sensitive .env";
             }
@@ -151,7 +151,7 @@ class SubAgentPermissionCheckerTest {
         // since structural rules only cover writes/deletes), they must
         // still take precedence.
         BiPredicate<String, String> denyAll = (sid, tool) -> false;
-        SubAgentStructuralCheck refuseReadOnly = (toolName, inputJson) -> "blocked";
+        SubAgentStructuralCheck refuseReadOnly = (toolName, inputJson, sid) -> "blocked";
         var checker = new SubAgentPermissionChecker(
                 READ_ONLY, denyAll, refuseReadOnly);
 

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/agent/SubAgentPermissionCheckerTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/agent/SubAgentPermissionCheckerTest.java
@@ -30,7 +30,7 @@ class SubAgentPermissionCheckerTest {
 
     /** Convenience: a checker with no session approvals at all. */
     private static SubAgentPermissionChecker denyAll() {
-        return new SubAgentPermissionChecker(READ_ONLY, (sid, tool) -> false);
+        return new SubAgentPermissionChecker(READ_ONLY, (sid, tool) -> false, SubAgentStructuralCheck.NONE);
     }
 
     @Test
@@ -50,7 +50,7 @@ class SubAgentPermissionCheckerTest {
         // Approval matrix: session "A" approved write_file; session "B" did not.
         BiPredicate<String, String> isApproved = (sid, tool) ->
                 "A".equals(sid) && "write_file".equals(tool);
-        var checker = new SubAgentPermissionChecker(READ_ONLY, isApproved);
+        var checker = new SubAgentPermissionChecker(READ_ONLY, isApproved, SubAgentStructuralCheck.NONE);
 
         assertThat(checker.check("write_file", "{}", "A").allowed())
                 .as("session A approved write_file → allowed under session A")
@@ -70,7 +70,7 @@ class SubAgentPermissionCheckerTest {
     void nullSessionIdFailsClosedForNonReadOnlyTools() {
         // A daemon-internal caller with no session in scope cannot match
         // any session-scoped approval — fail-closed by construction.
-        var alwaysApprove = new SubAgentPermissionChecker(READ_ONLY, (sid, tool) -> true);
+        var alwaysApprove = new SubAgentPermissionChecker(READ_ONLY, (sid, tool) -> true, SubAgentStructuralCheck.NONE);
 
         var result = alwaysApprove.check("write_file", "{}", null);
         assertThat(result.allowed())
@@ -106,10 +106,57 @@ class SubAgentPermissionCheckerTest {
         sessionApprovals.add("A:write_file");
         BiPredicate<String, String> isApproved =
                 (sid, tool) -> sessionApprovals.contains(sid + ":" + tool);
-        var checker = new SubAgentPermissionChecker(READ_ONLY, isApproved);
+        var checker = new SubAgentPermissionChecker(READ_ONLY, isApproved, SubAgentStructuralCheck.NONE);
 
         assertThat(checker.check("write_file", "{}", "A").allowed()).isTrue();
         assertThat(checker.check("write_file", "{}", "B").allowed()).isFalse();
         assertThat(checker.check("write_file", "{}", "C").allowed()).isFalse();
+    }
+
+    @Test
+    void structuralDenialOverridesSessionApproval() {
+        // Codex P1 on #495: a sub-agent could call write_file(".env") if
+        // the parent session blanket-approved write_file. The structural
+        // probe (wired to the policy's evaluateStructural in the daemon)
+        // must fire BEFORE the allow-list shortcut so the hard-denial
+        // invariant holds for sub-agent dispatch too.
+        BiPredicate<String, String> approveEverything = (sid, tool) -> true;
+        SubAgentStructuralCheck refuseEnvWrites = (toolName, inputJson) -> {
+            if ("write_file".equals(toolName) && inputJson != null && inputJson.contains(".env")) {
+                return "Refusing to write sensitive .env";
+            }
+            return null;
+        };
+        var checker = new SubAgentPermissionChecker(
+                READ_ONLY, approveEverything, refuseEnvWrites);
+
+        // A non-sensitive write still gets the blanket approval.
+        var safeResult = checker.check("write_file", "{\"path\":\"/tmp/safe\"}", "A");
+        assertThat(safeResult.allowed())
+                .as("safe write follows the blanket approval")
+                .isTrue();
+
+        // Sensitive write -- structural denial fires before the blanket check.
+        var sensitiveResult = checker.check("write_file", "{\"path\":\"/repo/.env\"}", "A");
+        assertThat(sensitiveResult.allowed())
+                .as("sensitive write must be denied even with blanket approval")
+                .isFalse();
+        assertThat(sensitiveResult.reason()).contains("sensitive");
+    }
+
+    @Test
+    void structuralDenialOverridesReadOnlyAllowlist() {
+        // Read-only allowlist normally short-circuits. If structural rules
+        // ever apply to a "read-only" tool (defensive -- they don't today
+        // since structural rules only cover writes/deletes), they must
+        // still take precedence.
+        BiPredicate<String, String> denyAll = (sid, tool) -> false;
+        SubAgentStructuralCheck refuseReadOnly = (toolName, inputJson) -> "blocked";
+        var checker = new SubAgentPermissionChecker(
+                READ_ONLY, denyAll, refuseReadOnly);
+
+        var result = checker.check("read_file", "{}", "A");
+        assertThat(result.allowed()).isFalse();
+        assertThat(result.reason()).isEqualTo("blocked");
     }
 }

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/agent/WatchdogTimerTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/agent/WatchdogTimerTest.java
@@ -95,8 +95,16 @@ class WatchdogTimerTest {
             watchdog.checkBudget(1000);
             assertFalse(watchdog.isExhausted());
 
-            Thread.sleep(200);
-            assertTrue(watchdog.isExhausted());
+            // Poll for the scheduled timer to fire. A fixed Thread.sleep(200)
+            // is flaky on CI under load — the SCHEDULER thread can take >100ms
+            // beyond the timer's deadline to actually run. Polling with a
+            // generous deadline avoids the race without changing test intent.
+            long deadlineMs = System.currentTimeMillis() + 2000;
+            while (!watchdog.isExhausted() && System.currentTimeMillis() < deadlineMs) {
+                Thread.sleep(20);
+            }
+            assertTrue(watchdog.isExhausted(),
+                    "time-budget timer should have fired within 2s of the 100ms deadline");
             assertEquals("time_budget", watchdog.exhaustionReason());
         }
     }

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
@@ -186,6 +186,16 @@ public final class AceClawConfig {
     private String logLevel;
     private String braveSearchApiKey;
     private String permissionMode;
+    /**
+     * Whether the policy's structural sensitive-path denials are active.
+     * Default {@code false} so an upgrade past #480 doesn't break workflows
+     * that legitimately write {@code .env} templates, {@code .git/config}
+     * entries, etc. Set to {@code true} via {@code security.denySensitivePaths}
+     * in {@code ~/.aceclaw/config.json} to enable the hard-denial layer
+     * (overrides every mode and prior approval — see
+     * {@link dev.aceclaw.security.DefaultPermissionPolicy} for the rule set).
+     */
+    private boolean denySensitivePaths;
     private boolean bootEnabled;
     private int bootTimeoutSeconds;
     private boolean schedulerEnabled;
@@ -294,6 +304,7 @@ public final class AceClawConfig {
         this.contextWindowTokens = DEFAULT_CONTEXT_WINDOW;
         this.logLevel = DEFAULT_LOG_LEVEL;
         this.permissionMode = "normal";
+        this.denySensitivePaths = false;
         this.bootEnabled = DEFAULT_BOOT_ENABLED;
         this.bootTimeoutSeconds = DEFAULT_BOOT_TIMEOUT_SECONDS;
         this.schedulerEnabled = DEFAULT_SCHEDULER_ENABLED;
@@ -972,6 +983,23 @@ public final class AceClawConfig {
     }
 
     /**
+     * Returns whether the policy's structural sensitive-path denials are
+     * enabled. Default {@code false} (opt-in).
+     *
+     * <p>Wired from {@code security.denySensitivePaths} in
+     * {@code ~/.aceclaw/config.json} or {@code {project}/.aceclaw/config.json}.
+     * When {@code true}, writes/deletes targeting {@code .env*}, {@code .ssh/*},
+     * {@code .git/config}, {@code credentials.json}, anything under
+     * {@code /etc/}, etc. are hard-denied regardless of permission mode or
+     * prior session approval. See
+     * {@link dev.aceclaw.security.DefaultPermissionPolicy} for the full rule
+     * set and rationale.
+     */
+    public boolean denySensitivePaths() {
+        return denySensitivePaths;
+    }
+
+    /**
      * Persists candidate injection settings to config.json.
      *
      * @param projectPath project root for project-scoped persistence (required when scope=project)
@@ -1639,6 +1667,9 @@ public final class AceClawConfig {
         if (fileConfig.braveSearchApiKey != null && !fileConfig.braveSearchApiKey.isBlank()) {
             this.braveSearchApiKey = fileConfig.braveSearchApiKey;
         }
+        if (fileConfig.security != null && fileConfig.security.denySensitivePaths != null) {
+            this.denySensitivePaths = fileConfig.security.denySensitivePaths;
+        }
         if (fileConfig.permissionMode != null && !fileConfig.permissionMode.isBlank()) {
             this.permissionMode = fileConfig.permissionMode.toLowerCase();
         }
@@ -1942,6 +1973,22 @@ public final class AceClawConfig {
         public Boolean context1m;
         public List<String> extraAnthropicBetas;
         public RetryConfigFormat retry;
+        public SecurityConfigFormat security;
+    }
+
+    /**
+     * JSON structure for the security section.
+     * <pre>{
+     *   "denySensitivePaths": true
+     * }</pre>
+     *
+     * <p>Nested for forward compatibility — future security knobs (custom
+     * sensitive-path patterns per follow-up, sandbox toggles, etc.) live
+     * under the same {@code security} object rather than littering the top
+     * level.
+     */
+    public static class SecurityConfigFormat {
+        public Boolean denySensitivePaths;
     }
 
     /**

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -38,6 +38,7 @@ import dev.aceclaw.security.Capability;
 import dev.aceclaw.security.CapabilityAware;
 import dev.aceclaw.security.DefaultPermissionPolicy;
 import dev.aceclaw.security.PermissionManager;
+import dev.aceclaw.security.Provenance;
 import dev.aceclaw.security.audit.CapabilityAuditLog;
 import dev.aceclaw.mcp.McpClientManager;
 import dev.aceclaw.mcp.McpServerConfig;
@@ -440,7 +441,7 @@ public final class AceClawDaemon {
                 return null;
             }
             if (cap == null) return null;
-            var provenance = dev.aceclaw.security.Provenance.fromNullableSessionId(sessionId);
+            var provenance = Provenance.fromNullableSessionId(sessionId);
             var denial = permissionManager.checkStructural(cap, provenance, toolName);
             return denial == null ? null : denial.reason();
         };

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -387,8 +387,12 @@ public final class AceClawDaemon {
         //    every other persisted thing (pid, sock, transcripts,
         //    checkpoints, ...).
         var permissionManager = new PermissionManager(
-                new DefaultPermissionPolicy(config.permissionMode()),
+                new DefaultPermissionPolicy(config.permissionMode(), config.denySensitivePaths()),
                 buildCapabilityAuditLog(homeDir.resolve("audit")));
+        if (config.denySensitivePaths()) {
+            log.info("Security: structural sensitive-path denials enabled "
+                    + "(.env*, .ssh/, .aws/, .git/config, /etc/*, etc. are hard-denied).");
+        }
 
         // 4. Sub-agent infrastructure (task delegation) and skills
         var agentTypeRegistry = AgentTypeRegistry.load(workingDir);

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -1,5 +1,6 @@
 package dev.aceclaw.daemon;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -427,23 +428,9 @@ public final class AceClawDaemon {
             var toolOpt = subAgentToolRegistry.get(toolName);
             if (toolOpt.isEmpty()) return null;
             if (!(toolOpt.get() instanceof CapabilityAware aware)) return null;
-            Capability cap;
-            try {
-                var argsNode = (inputJson == null || inputJson.isBlank())
-                        ? subAgentMapper.createObjectNode()
-                        : subAgentMapper.readTree(inputJson);
-                cap = aware.toCapability(argsNode);
-            } catch (Exception malformed) {
-                // Unparseable args — fall through to the normal allow-list
-                // logic rather than crash the dispatcher. The standard
-                // sub-agent gate will still deny non-read-only tools that
-                // lack session approval.
-                return null;
-            }
-            if (cap == null) return null;
-            var provenance = Provenance.fromNullableSessionId(sessionId);
-            var denial = permissionManager.checkStructural(cap, provenance, toolName);
-            return denial == null ? null : denial.reason();
+            return subAgentStructuralProbe(
+                    toolName, inputJson, sessionId,
+                    aware, subAgentMapper, permissionManager);
         };
 
         // Sub-agent allow-list lookup is now per-session (#457): the
@@ -1843,6 +1830,62 @@ public final class AceClawDaemon {
 
         log.info("Agent handler wired: provider={}, model={}, tools={}",
                 config.provider(), model, toolRegistry.size());
+    }
+
+    /**
+     * Sub-agent structural-denial probe — extracted from the lambda in
+     * {@link #wireAgentHandler} so the exception-handling contract can be
+     * exercised in isolation.
+     *
+     * <p>Returns the denial reason when the policy structurally rejects the
+     * call, or {@code null} when the request should fall through to the
+     * standard sub-agent allow-list logic. The choice between fallthrough
+     * and fail-closed depends on the failure mode (CodeRabbit major on
+     * #495):
+     *
+     * <ul>
+     *   <li>{@link JsonProcessingException} from {@code readTree} is
+     *       expected input — LLMs occasionally emit malformed JSON. Return
+     *       {@code null} so the downstream gate denies on the standard
+     *       "not in allow-list" path rather than on a parse error.</li>
+     *   <li>Any other {@link RuntimeException} from
+     *       {@link CapabilityAware#toCapability} is a bug in inference
+     *       code, not expected input. The PR's invariant — "hard-denial
+     *       overrides every approval" — would be broken if we silently
+     *       returned {@code null}: a prior session-blanket approval for
+     *       {@code write_file} would then route a sub-agent past the
+     *       structural layer the bug just disabled. Log + deny so the
+     *       failure is observable in forensics and the bypass cannot
+     *       occur.</li>
+     * </ul>
+     *
+     * <p>Package-private for testing.
+     */
+    static String subAgentStructuralProbe(
+            String toolName,
+            String inputJson,
+            String sessionId,
+            CapabilityAware aware,
+            ObjectMapper mapper,
+            PermissionManager permissionManager) {
+        Capability cap;
+        try {
+            var argsNode = (inputJson == null || inputJson.isBlank())
+                    ? mapper.createObjectNode()
+                    : mapper.readTree(inputJson);
+            cap = aware.toCapability(argsNode);
+        } catch (JsonProcessingException malformed) {
+            return null;
+        } catch (RuntimeException unexpected) {
+            log.warn("Structural capability probe failed for tool '{}': {}",
+                    toolName, unexpected.toString(), unexpected);
+            return "Blocked: structural policy evaluation failed for '"
+                    + toolName + "' (see daemon log).";
+        }
+        if (cap == null) return null;
+        var provenance = Provenance.fromNullableSessionId(sessionId);
+        var denial = permissionManager.checkStructural(cap, provenance, toolName);
+        return denial == null ? null : denial.reason();
     }
 
     /**

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -413,9 +413,16 @@ public final class AceClawDaemon {
         // shortcut, so a prior "always allow write_file" approval cannot
         // route a sub-agent past the .env / .ssh / /etc/ hard-denial layer
         // (Codex P1 on #495).
+        //
+        // Audit attribution: the denial is recorded via
+        // permissionManager.checkStructural which writes a v2 audit entry
+        // tagged with the originating session's Provenance and the tool
+        // name as the allowlistKey. Without that audit, a sub-agent's
+        // attempt to write .env would be invisible to forensics — the
+        // dispatcher main path's audit hook is bypassed here.
         var subAgentToolRegistry = toolRegistry;
         var subAgentMapper = objectMapper;
-        SubAgentStructuralCheck structuralCheck = (toolName, inputJson) -> {
+        SubAgentStructuralCheck structuralCheck = (toolName, inputJson, sessionId) -> {
             var toolOpt = subAgentToolRegistry.get(toolName);
             if (toolOpt.isEmpty()) return null;
             if (!(toolOpt.get() instanceof CapabilityAware aware)) return null;
@@ -433,7 +440,8 @@ public final class AceClawDaemon {
                 return null;
             }
             if (cap == null) return null;
-            var denial = permissionManager.checkStructural(cap);
+            var provenance = dev.aceclaw.security.Provenance.fromNullableSessionId(sessionId);
+            var denial = permissionManager.checkStructural(cap, provenance, toolName);
             return denial == null ? null : denial.reason();
         };
 

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -34,6 +34,8 @@ import dev.aceclaw.memory.MemoryConsolidator;
 import dev.aceclaw.memory.StrategyRefiner;
 import dev.aceclaw.memory.TrendDetector;
 import dev.aceclaw.memory.WorkspacePaths;
+import dev.aceclaw.security.Capability;
+import dev.aceclaw.security.CapabilityAware;
 import dev.aceclaw.security.DefaultPermissionPolicy;
 import dev.aceclaw.security.PermissionManager;
 import dev.aceclaw.security.audit.CapabilityAuditLog;
@@ -406,6 +408,35 @@ public final class AceClawDaemon {
             readOnlyTools = java.util.Set.copyOf(readOnlyTools);
             log.info("Sub-agent auto-approve tools extended with: {}", extraTools);
         }
+        // Structural-denial probe: routes the sub-agent's intended tool call
+        // through the policy's evaluateStructural before any allow-list
+        // shortcut, so a prior "always allow write_file" approval cannot
+        // route a sub-agent past the .env / .ssh / /etc/ hard-denial layer
+        // (Codex P1 on #495).
+        var subAgentToolRegistry = toolRegistry;
+        var subAgentMapper = objectMapper;
+        SubAgentStructuralCheck structuralCheck = (toolName, inputJson) -> {
+            var toolOpt = subAgentToolRegistry.get(toolName);
+            if (toolOpt.isEmpty()) return null;
+            if (!(toolOpt.get() instanceof CapabilityAware aware)) return null;
+            Capability cap;
+            try {
+                var argsNode = (inputJson == null || inputJson.isBlank())
+                        ? subAgentMapper.createObjectNode()
+                        : subAgentMapper.readTree(inputJson);
+                cap = aware.toCapability(argsNode);
+            } catch (Exception malformed) {
+                // Unparseable args — fall through to the normal allow-list
+                // logic rather than crash the dispatcher. The standard
+                // sub-agent gate will still deny non-read-only tools that
+                // lack session approval.
+                return null;
+            }
+            if (cap == null) return null;
+            var denial = permissionManager.checkStructural(cap);
+            return denial == null ? null : denial.reason();
+        };
+
         // Sub-agent allow-list lookup is now per-session (#457): the
         // checker receives the calling agent's sessionId on every check
         // and looks up the allow-list keyed on that session. This closes
@@ -413,7 +444,7 @@ public final class AceClawDaemon {
         // approval the user granted in session A — a regression of #456
         // confined to the sub-agent path until threading was done.
         var subAgentPermChecker = new SubAgentPermissionChecker(
-                readOnlyTools, permissionManager::hasSessionApproval);
+                readOnlyTools, permissionManager::hasSessionApproval, structuralCheck);
 
         // Project rules for sub-agent system prompts
         String projectRules = SystemPromptLoader.extractProjectRules(workingDir);

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/AceClawConfigTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/AceClawConfigTest.java
@@ -27,6 +27,54 @@ class AceClawConfigTest {
         assertThat(config.provider()).isEqualTo("openai-codex");
     }
 
+    // -- security.denySensitivePaths toggle --
+
+    @Test
+    void denySensitivePathsDefaultsOff(@TempDir Path tempDir) throws Exception {
+        // Empty config -- no security section -- the toggle must default to
+        // false so an upgrade past #480 doesn't break workflows that
+        // legitimately write .env templates, .git/config entries, etc.
+        var projectConfig = tempDir.resolve(".aceclaw").resolve("config.json");
+        Files.createDirectories(projectConfig.getParent());
+        Files.writeString(projectConfig, "{}");
+
+        var config = AceClawConfig.load(tempDir, null);
+
+        assertThat(config.denySensitivePaths())
+                .as("empty config must leave denySensitivePaths off (zero-config = no surprises on upgrade)")
+                .isFalse();
+    }
+
+    @Test
+    void denySensitivePathsEnabledViaProjectConfig(@TempDir Path tempDir) throws Exception {
+        // The opt-in path: a project config explicitly sets the toggle on.
+        // Verifies the JSON shape lives under `security.denySensitivePaths`
+        // (nested object so future security knobs cluster together rather
+        // than litter the top level).
+        var projectConfig = tempDir.resolve(".aceclaw").resolve("config.json");
+        Files.createDirectories(projectConfig.getParent());
+        Files.writeString(projectConfig,
+                "{\"security\":{\"denySensitivePaths\":true}}");
+
+        var config = AceClawConfig.load(tempDir, null);
+
+        assertThat(config.denySensitivePaths()).isTrue();
+    }
+
+    @Test
+    void denySensitivePathsExplicitFalseStaysOff(@TempDir Path tempDir) throws Exception {
+        // Defensive: explicit false in the file behaves like absent. Pins
+        // that there's no weird truthy-coercion in the JSON merge path.
+        var projectConfig = tempDir.resolve(".aceclaw").resolve("config.json");
+        Files.createDirectories(projectConfig.getParent());
+        Files.writeString(projectConfig,
+                "{\"security\":{\"denySensitivePaths\":false}}");
+
+        var config = AceClawConfig.load(tempDir, null);
+
+        assertThat(config.denySensitivePaths()).isFalse();
+    }
+
     // -- WebSocket loopback gating (#446) --
 
     @Test

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/BackgroundTaskIntegrationTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/BackgroundTaskIntegrationTest.java
@@ -80,7 +80,8 @@ class BackgroundTaskIntegrationTest {
         var agentTypeRegistry = AgentTypeRegistry.withBuiltins();
         var readOnlyTools = java.util.Set.of("read_file", "glob", "grep");
         var subAgentPermChecker = new SubAgentPermissionChecker(
-                readOnlyTools, permissionManager::hasSessionApproval);
+                readOnlyTools, permissionManager::hasSessionApproval,
+                dev.aceclaw.core.agent.SubAgentStructuralCheck.NONE);
         var subAgentRunner = new SubAgentRunner(
                 mockLlm, toolRegistry, "mock-model", workDir, 4096, 0,
                 subAgentPermChecker, null);

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/SubAgentIntegrationTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/SubAgentIntegrationTest.java
@@ -84,7 +84,8 @@ class SubAgentIntegrationTest {
         var agentTypeRegistry = AgentTypeRegistry.withBuiltins();
         var readOnlyTools = java.util.Set.of("read_file", "glob", "grep");
         var subAgentPermChecker = new SubAgentPermissionChecker(
-                readOnlyTools, permissionManager::hasSessionApproval);
+                readOnlyTools, permissionManager::hasSessionApproval,
+                dev.aceclaw.core.agent.SubAgentStructuralCheck.NONE);
         var subAgentRunner = new SubAgentRunner(
                 mockLlm, toolRegistry, "mock-model", workDir, 4096, 0,
                 subAgentPermChecker, null);

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/SubAgentStructuralProbeTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/SubAgentStructuralProbeTest.java
@@ -1,0 +1,190 @@
+package dev.aceclaw.daemon;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.aceclaw.security.Capability;
+import dev.aceclaw.security.CapabilityAware;
+import dev.aceclaw.security.DefaultPermissionPolicy;
+import dev.aceclaw.security.PermissionManager;
+import dev.aceclaw.security.WriteMode;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link AceClawDaemon#subAgentStructuralProbe} — the
+ * exception-handling contract for the sub-agent structural-denial probe
+ * (CodeRabbit major on #495).
+ *
+ * <p>The PR's invariant is "hard-denial overrides every approval". The probe
+ * lives between the sub-agent gate and the policy's
+ * {@code evaluateStructural}, and an over-broad {@code catch (Exception)}
+ * would silently let a prior session-blanket approval route a sub-agent past
+ * a structural rule the inference layer crashed on. These tests pin the
+ * three contractual paths:
+ *
+ * <ul>
+ *   <li>structural denial → returns the denial reason;</li>
+ *   <li>malformed JSON args → returns {@code null} so the standard
+ *       allow-list gate handles it (LLMs occasionally emit invalid JSON;
+ *       refusing here would be an unrelated DoS);</li>
+ *   <li>unexpected {@link RuntimeException} from a
+ *       {@link CapabilityAware#toCapability} impl → returns a non-null
+ *       denial reason (fail-closed). Inference-code bugs MUST NOT open the
+ *       structural-bypass hole.</li>
+ * </ul>
+ */
+final class SubAgentStructuralProbeTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void allowsCallWhenStructuralPolicyDoesNotApply() {
+        // Happy path: capability resolves cleanly, policy has nothing to
+        // say structurally → probe returns null and the sub-agent gate
+        // moves on to the allow-list check.
+        CapabilityAware safeWrite = args ->
+                new Capability.FileWrite(Path.of("/tmp/safe.txt"), WriteMode.OVERWRITE);
+        var pm = new PermissionManager(new DefaultPermissionPolicy("normal"));
+
+        String result = AceClawDaemon.subAgentStructuralProbe(
+                "write_file", "{\"path\":\"/tmp/safe.txt\"}", "sess-1",
+                safeWrite, MAPPER, pm);
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void deniesCallWhenStructuralPolicyRejects() {
+        // The structural layer matches → probe returns the policy's denial
+        // reason so the sub-agent gate can short-circuit before the
+        // allow-list check.
+        CapabilityAware writeToEnv = args ->
+                new Capability.FileWrite(Path.of("/repo/.env"), WriteMode.OVERWRITE);
+        var pm = new PermissionManager(new DefaultPermissionPolicy("normal"));
+
+        String result = AceClawDaemon.subAgentStructuralProbe(
+                "write_file", "{\"path\":\"/repo/.env\"}", "sess-1",
+                writeToEnv, MAPPER, pm);
+
+        assertThat(result)
+                .as("structural denial of .env write should propagate as the reason string")
+                .isNotNull();
+    }
+
+    @Test
+    void malformedJsonFallsThroughToAllowList() {
+        // JsonProcessingException is expected input (LLMs sometimes emit
+        // bad JSON). Returning a denial here would convert a parse error
+        // into a structural-policy DoS unrelated to the actual capability.
+        // The downstream gate will deny non-read-only tools that lack
+        // session approval anyway, so fallthrough is safe.
+        CapabilityAware neverReached = args -> {
+            throw new AssertionError("toCapability must not be reached when readTree throws");
+        };
+        var pm = new PermissionManager(new DefaultPermissionPolicy("normal"));
+
+        String result = AceClawDaemon.subAgentStructuralProbe(
+                "write_file", "{not valid json", "sess-1",
+                neverReached, MAPPER, pm);
+
+        assertThat(result)
+                .as("malformed JSON args must fall through (null) to the standard allow-list gate")
+                .isNull();
+    }
+
+    @Test
+    void runtimeExceptionFromToCapabilityFailsClosed() {
+        // The core invariant: if toCapability throws unexpectedly, the
+        // probe MUST NOT return null. Returning null here would let a
+        // session-blanket approval (e.g. "always allow write_file") route
+        // the sub-agent past the structural layer that just crashed —
+        // breaking the PR's "hard-denial overrides every approval" sales
+        // pitch. Fail-closed: return a non-null denial reason that names
+        // the tool, so the audit + the agent's user-visible error both
+        // point at the bug.
+        CapabilityAware boom = args -> {
+            throw new IllegalStateException("inference bug");
+        };
+        var pm = new PermissionManager(new DefaultPermissionPolicy("normal"));
+
+        String result = AceClawDaemon.subAgentStructuralProbe(
+                "write_file", "{\"path\":\"/repo/.env\"}", "sess-1",
+                boom, MAPPER, pm);
+
+        assertThat(result)
+                .as("unexpected toCapability exception must fail-closed with a denial reason")
+                .isNotNull();
+        assertThat(result).contains("write_file");
+    }
+
+    @Test
+    void emptyInputUsesEmptyObjectAndStillCallsToCapability() {
+        // null/blank inputJson is a real path — the dispatcher sometimes
+        // hands the probe an empty args payload. Verify it doesn't go
+        // through the JSON parser at all (no parse exception) and
+        // toCapability still runs against an empty object node.
+        Capability[] seen = new Capability[1];
+        CapabilityAware capturingAware = args -> {
+            assertThat(args).isNotNull();
+            assertThat(args.isObject()).isTrue();
+            assertThat(args.size()).isEqualTo(0);
+            var cap = new Capability.FileWrite(Path.of("/tmp/x"), WriteMode.OVERWRITE);
+            seen[0] = cap;
+            return cap;
+        };
+        var pm = new PermissionManager(new DefaultPermissionPolicy("normal"));
+
+        String result = AceClawDaemon.subAgentStructuralProbe(
+                "write_file", null, "sess-1",
+                capturingAware, MAPPER, pm);
+
+        assertThat(result).isNull();
+        assertThat(seen[0]).isNotNull();
+
+        // Blank string takes the same branch.
+        seen[0] = null;
+        AceClawDaemon.subAgentStructuralProbe(
+                "write_file", "   ", "sess-1",
+                capturingAware, MAPPER, pm);
+        assertThat(seen[0]).isNotNull();
+    }
+
+    @Test
+    void nullCapabilityFromToCapabilityFallsThrough() {
+        // Some CapabilityAware impls return null when they decline to
+        // classify (e.g. the MCP bridge falling back to McpInvoke). That
+        // is NOT an error path — the probe should just return null so
+        // the standard gate handles the tool with the default flow.
+        CapabilityAware declines = args -> null;
+        var pm = new PermissionManager(new DefaultPermissionPolicy("normal"));
+
+        String result = AceClawDaemon.subAgentStructuralProbe(
+                "write_file", "{}", "sess-1",
+                declines, MAPPER, pm);
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void nullJsonNodePathStillProbesPolicy() {
+        // Sanity: a non-null JsonNode (object) flows through to the
+        // policy. Pairs with malformedJsonFallsThroughToAllowList — the
+        // happy parse path must end up calling checkStructural, otherwise
+        // the policy is bypassed for every well-formed call.
+        boolean[] called = {false};
+        CapabilityAware tracking = (JsonNode args) -> {
+            called[0] = true;
+            return new Capability.FileWrite(Path.of("/tmp/x"), WriteMode.OVERWRITE);
+        };
+        var pm = new PermissionManager(new DefaultPermissionPolicy("normal"));
+
+        AceClawDaemon.subAgentStructuralProbe(
+                "write_file", "{\"path\":\"/tmp/x\"}", null,
+                tracking, MAPPER, pm);
+
+        assertThat(called[0]).isTrue();
+    }
+}

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/SubAgentStructuralProbeTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/SubAgentStructuralProbeTest.java
@@ -63,7 +63,10 @@ final class SubAgentStructuralProbeTest {
         // allow-list check.
         CapabilityAware writeToEnv = args ->
                 new Capability.FileWrite(Path.of("/repo/.env"), WriteMode.OVERWRITE);
-        var pm = new PermissionManager(new DefaultPermissionPolicy("normal"));
+        // Sensitive-path denials are opt-in on the policy — enable here so
+        // the structural rule actually fires and the probe sees a denial.
+        var pm = new PermissionManager(
+                new DefaultPermissionPolicy("normal", /* denySensitivePaths */ true));
 
         String result = AceClawDaemon.subAgentStructuralProbe(
                 "write_file", "{\"path\":\"/repo/.env\"}", "sess-1",

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/ToolPermissionRouterTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/ToolPermissionRouterTest.java
@@ -10,6 +10,7 @@ import dev.aceclaw.security.PermissionLevel;
 import dev.aceclaw.security.PermissionManager;
 import dev.aceclaw.security.PermissionPolicy;
 import dev.aceclaw.security.PermissionRequest;
+import dev.aceclaw.security.Provenance;
 import dev.aceclaw.security.WriteMode;
 import org.junit.jupiter.api.Test;
 
@@ -36,14 +37,18 @@ final class ToolPermissionRouterTest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
-    /** Capturing policy: records the {@link PermissionRequest} so the test can pin what was sent. */
+    /** Capturing policy: records the structured triple so the test can pin what was sent. */
     private static final class CapturingPolicy implements PermissionPolicy {
-        final AtomicReference<PermissionRequest> last = new AtomicReference<>();
+        final AtomicReference<Capability> lastCapability = new AtomicReference<>();
+        final AtomicReference<String> lastDescription = new AtomicReference<>();
+        final AtomicReference<Provenance> lastProvenance = new AtomicReference<>();
         final AtomicInteger calls = new AtomicInteger();
 
         @Override
-        public PermissionDecision evaluate(PermissionRequest request) {
-            last.set(request);
+        public PermissionDecision evaluate(Capability capability, Provenance provenance, String description) {
+            lastCapability.set(capability);
+            lastDescription.set(description);
+            lastProvenance.set(provenance);
             calls.incrementAndGet();
             return new PermissionDecision.Approved();
         }
@@ -84,8 +89,9 @@ final class ToolPermissionRouterTest {
     void capabilityAwareToolTakesStructuredPath() {
         // The whole point of CapabilityAware: when the tool can produce a
         // structured Capability, the router uses it instead of the flat
-        // legacy PermissionRequest. Pin both: toCapability was called, AND
-        // the policy received a request derived from the capability.
+        // legacy PermissionRequest. Pin: toCapability was called, the policy
+        // received the structured FileWrite variant (not a LegacyToolUse
+        // bridge), and the rich description was forwarded.
         var policy = new CapturingPolicy();
         var pm = new PermissionManager(policy);
         var tool = new SpyCapabilityAwareTool();
@@ -97,22 +103,22 @@ final class ToolPermissionRouterTest {
         assertThat(tool.toCapabilityCalls.get())
                 .as("structured path must call toCapability")
                 .isEqualTo(1);
-        assertThat(policy.last.get().toolName())
-                .as("router passes the originating tool name as allowlist key")
-                .isEqualTo("spy_tool");
-        assertThat(policy.last.get().description())
+        assertThat(policy.lastCapability.get())
+                .as("policy receives the structured variant, not a LegacyToolUse bridge")
+                .isInstanceOf(Capability.FileWrite.class);
+        assertThat(policy.lastDescription.get())
                 .as("router passes the rich caller-supplied description, not displayLabel")
                 .isEqualTo("Write /tmp/x");
-        assertThat(policy.last.get().level())
-                .as("level comes from the capability variant, not the fallback level")
+        assertThat(policy.lastCapability.get().risk())
+                .as("risk is derived from the variant, not the fallback level")
                 .isEqualTo(PermissionLevel.WRITE);
     }
 
     @Test
     void plainToolTakesLegacyPath() {
-        // A non-CapabilityAware tool must not reach toCapability (there's
-        // nothing to call) and must produce the same legacy
-        // PermissionRequest the dispatcher built before #480.
+        // A non-CapabilityAware tool must produce the LegacyToolUse bridge
+        // variant the dispatcher built before #480: tool name + declared
+        // fallback level, no path/URL/etc.
         var policy = new CapturingPolicy();
         var pm = new PermissionManager(policy);
         var tool = new LegacyOnlyTool();
@@ -120,9 +126,13 @@ final class ToolPermissionRouterTest {
         ToolPermissionRouter.check(
                 tool, "{}", "sess-1", "describe me", PermissionLevel.EXECUTE, pm, MAPPER);
 
-        assertThat(policy.last.get().toolName()).isEqualTo("legacy_tool");
-        assertThat(policy.last.get().description()).isEqualTo("describe me");
-        assertThat(policy.last.get().level()).isEqualTo(PermissionLevel.EXECUTE);
+        assertThat(policy.lastCapability.get())
+                .as("legacy path produces the LegacyToolUse bridge variant")
+                .isInstanceOf(Capability.LegacyToolUse.class);
+        var legacy = (Capability.LegacyToolUse) policy.lastCapability.get();
+        assertThat(legacy.toolName()).isEqualTo("legacy_tool");
+        assertThat(legacy.declaredLevel()).isEqualTo(PermissionLevel.EXECUTE);
+        assertThat(policy.lastDescription.get()).isEqualTo("describe me");
     }
 
     @Test
@@ -142,7 +152,10 @@ final class ToolPermissionRouterTest {
 
         assertThat(decision).isInstanceOf(PermissionDecision.Approved.class);
         assertThat(tool.toCapabilityCalls.get()).isEqualTo(1);
-        assertThat(policy.last.get().level())
+        assertThat(policy.lastCapability.get())
+                .as("fallback lands on the LegacyToolUse bridge")
+                .isInstanceOf(Capability.LegacyToolUse.class);
+        assertThat(policy.lastCapability.get().risk())
                 .as("fallback uses the caller-supplied level, not a derived risk")
                 .isEqualTo(PermissionLevel.WRITE);
     }
@@ -176,7 +189,7 @@ final class ToolPermissionRouterTest {
         // bugs. Re-running the legacy path on them would mask real
         // failures and could change the decision behind the user's back.
         // Pin: a policy that throws bubbles up through the structured path.
-        PermissionPolicy crashingPolicy = req -> {
+        PermissionPolicy crashingPolicy = (cap, prov, desc) -> {
             throw new IllegalStateException("policy bug");
         };
         var pm = new PermissionManager(crashingPolicy);
@@ -207,10 +220,12 @@ final class ToolPermissionRouterTest {
         assertThat(tool.toCapabilityCalls.get())
                 .as("null input never reaches toCapability — readTree fails first, caught, legacy fallback")
                 .isZero();
-        assertThat(policy.last.get().toolName())
-                .as("legacy fallback was used")
-                .isEqualTo("spy_tool");
-        assertThat(policy.last.get().level())
+        assertThat(policy.lastCapability.get())
+                .as("legacy fallback lands on LegacyToolUse")
+                .isInstanceOf(Capability.LegacyToolUse.class);
+        var legacy = (Capability.LegacyToolUse) policy.lastCapability.get();
+        assertThat(legacy.toolName()).isEqualTo("spy_tool");
+        assertThat(legacy.declaredLevel())
                 .as("legacy fallback uses caller-supplied level")
                 .isEqualTo(PermissionLevel.WRITE);
     }
@@ -231,11 +246,17 @@ final class ToolPermissionRouterTest {
         ToolPermissionRouter.check(
                 new SpyCapabilityAwareTool(), "{}", (String) null, "no session",
                 PermissionLevel.WRITE, pm, MAPPER);
-        assertThat(policy.last.get().toolName()).isEqualTo("spy_tool");
+        assertThat(policy.lastCapability.get())
+                .as("structured path called for CapabilityAware tool")
+                .isInstanceOf(Capability.FileWrite.class);
 
         ToolPermissionRouter.check(
                 new LegacyOnlyTool(), "{}", (String) null, "no session",
                 PermissionLevel.READ, pm, MAPPER);
-        assertThat(policy.last.get().toolName()).isEqualTo("legacy_tool");
+        assertThat(policy.lastCapability.get())
+                .as("legacy path called for plain Tool")
+                .isInstanceOf(Capability.LegacyToolUse.class);
+        assertThat(((Capability.LegacyToolUse) policy.lastCapability.get()).toolName())
+                .isEqualTo("legacy_tool");
     }
 }

--- a/aceclaw-mcp/build.gradle.kts
+++ b/aceclaw-mcp/build.gradle.kts
@@ -2,7 +2,12 @@
 
 dependencies {
     implementation(project(":aceclaw-core"))
-    implementation(project(":aceclaw-security"))
+    // api(): McpToolBridge implements CapabilityAware and exposes
+    // Capability in toCapability()'s return type, so the dependency is
+    // part of this module's public Java API. (aceclaw-tools has the same
+    // shape on every built-in tool but still uses implementation(); flip
+    // it in a follow-up consistency PR.)
+    api(project(":aceclaw-security"))
 
     implementation("io.modelcontextprotocol.sdk:mcp")
     implementation("com.fasterxml.jackson.core:jackson-databind")

--- a/aceclaw-mcp/build.gradle.kts
+++ b/aceclaw-mcp/build.gradle.kts
@@ -2,6 +2,7 @@
 
 dependencies {
     implementation(project(":aceclaw-core"))
+    implementation(project(":aceclaw-security"))
 
     implementation("io.modelcontextprotocol.sdk:mcp")
     implementation("com.fasterxml.jackson.core:jackson-databind")

--- a/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpCapabilityInference.java
+++ b/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpCapabilityInference.java
@@ -115,6 +115,16 @@ final class McpCapabilityInference {
     private static Capability inferMoveCopy(String normalizedName, JsonNode args) {
         Path dst = safePath(extractField(args, DESTINATION_FIELDS));
         Path src = safePath(extractField(args, SOURCE_FIELDS));
+        // Some MCP schemas use `path` for the existing file on a move/rename:
+        // e.g. rename({"path": "/repo/.env", "new_path": "/tmp/env.bak"}). The
+        // SOURCE_FIELDS lookup misses `path`, so without this fallback `src`
+        // is null, the call degrades to FileWrite(dst), and the sensitive
+        // source is never checked — structural denial bypassed. Only fall
+        // back when SOURCE_FIELDS produced nothing, so explicit source/src/
+        // from still wins if both are present.
+        if (src == null) {
+            src = safePath(extractField(args, PATH_FIELDS));
+        }
         boolean deletesSource = !COPY_VERB.matcher(normalizedName).matches();
 
         if (src != null && dst != null) {

--- a/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpCapabilityInference.java
+++ b/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpCapabilityInference.java
@@ -2,7 +2,6 @@ package dev.aceclaw.mcp;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import dev.aceclaw.security.Capability;
-import dev.aceclaw.security.DefaultPermissionPolicy;
 import dev.aceclaw.security.WriteMode;
 
 import java.nio.file.InvalidPathException;
@@ -54,14 +53,11 @@ import java.util.regex.Pattern;
  * variant — args can be huge and may carry secrets; policies decide on
  * {@code (server, method)} or the resolved path alone.
  *
- * <p><strong>Cross-module coupling note:</strong> this class calls
- * {@link DefaultPermissionPolicy#isSensitivePath(Path)} to disambiguate
- * move/copy operations where source vs destination sensitivity matters.
- * That bakes the default-policy's sensitive-path rules into MCP-side
- * classification; a deployment that swaps in a different policy with
- * different sensitivity rules would still see this class produce variants
- * based on the default rules. Tracked as a follow-up cleanup
- * ({@code SensitivePaths} utility to decouple).
+ * <p>Move/copy ops emit a {@link Capability.FileMove} carrying both source
+ * and destination — the policy's {@code evaluateStructural} checks both
+ * endpoints. No sensitivity probing at this layer (which previously coupled
+ * the inference to {@code DefaultPermissionPolicy}); the inference is now
+ * pure data classification.
  */
 final class McpCapabilityInference {
 
@@ -96,49 +92,36 @@ final class McpCapabilityInference {
     }
 
     /**
-     * Two-arg op (move/rename/copy) disambiguation. Returns:
+     * Two-arg op (move/rename/copy) classification. Emits a structured
+     * {@link Capability.FileMove} carrying both endpoints when both resolve,
+     * so the policy's {@code evaluateStructural} can check both sides for
+     * sensitivity in a single pass — and the audit log accurately records
+     * {@code @type=FileMove} for what is actually a move/copy.
      *
-     * <ol>
-     *   <li>{@link Capability.FileWrite}(dst) when {@code dst} is sensitive —
-     *       catches the destination-write attack ("move/copy to {@code .env}").</li>
-     *   <li>{@link Capability.FileDelete}(src) when {@code src} resolves and
-     *       either the op is a move (source really is removed) or {@code src}
-     *       is sensitive (copying credentials away is exfiltration). Two
-     *       distinct purposes folded together:
-     *     <ul>
-     *       <li>Moves get {@link Capability.FileDelete}'s DANGEROUS risk so
-     *           they prompt in {@code accept-edits} mode where
-     *           {@link Capability.FileWrite} would auto-approve. Preserves
-     *           pre-#495 MCP move behaviour (Codex P2 on #495).</li>
-     *       <li>Copies from sensitive source land on {@code FileDelete} so
-     *           the structural denial fires on the source path. Audit log
-     *           shows {@code @type=FileDelete} for a copy — slightly
-     *           misleading but safer than missing the denial; the
-     *           {@code toolName} field on the audit entry still carries
-     *           the original {@code mcp__<server>__copy_file} so operators
-     *           can correlate (Codex P1 on #495).</li>
-     *     </ul>
-     *   </li>
-     *   <li>{@link Capability.FileWrite}(dst) for the safe-both-sides copy
-     *       case. Genuine WRITE risk; auto-approval in {@code accept-edits}
-     *       is fine because the source is intact.</li>
-     * </ol>
-     *
-     * <p>{@code null} when neither side resolves (incomplete args) — caller
-     * falls back to {@link Capability.McpInvoke}.
+     * <p>When only one endpoint resolves (malformed args from the MCP
+     * server), degrades gracefully:
+     * <ul>
+     *   <li>dst-only → {@link Capability.FileWrite} (destination is being
+     *       written; nothing to say about source).</li>
+     *   <li>src-only on a move → {@link Capability.FileDelete} (source is
+     *       being removed; no destination to check). Copies with no
+     *       destination fall through to {@link Capability.McpInvoke} since
+     *       a copy with no target is meaningless and a {@code FileRead}
+     *       wouldn't trigger structural rules anyway.</li>
+     *   <li>Neither → {@code null}, caller falls back to
+     *       {@link Capability.McpInvoke}.</li>
+     * </ul>
      */
     private static Capability inferMoveCopy(String normalizedName, JsonNode args) {
         Path dst = safePath(extractField(args, DESTINATION_FIELDS));
         Path src = safePath(extractField(args, SOURCE_FIELDS));
-        boolean isMove = !COPY_VERB.matcher(normalizedName).matches();
+        boolean deletesSource = !COPY_VERB.matcher(normalizedName).matches();
 
-        if (dst != null && DefaultPermissionPolicy.isSensitivePath(dst)) {
-            return new Capability.FileWrite(dst, WriteMode.OVERWRITE);
-        }
-        if (src != null && (isMove || DefaultPermissionPolicy.isSensitivePath(src))) {
-            return new Capability.FileDelete(src);
+        if (src != null && dst != null) {
+            return new Capability.FileMove(src, dst, deletesSource);
         }
         if (dst != null) return new Capability.FileWrite(dst, WriteMode.OVERWRITE);
+        if (src != null && deletesSource) return new Capability.FileDelete(src);
         return null;
     }
 

--- a/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpCapabilityInference.java
+++ b/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpCapabilityInference.java
@@ -1,0 +1,293 @@
+package dev.aceclaw.mcp;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import dev.aceclaw.security.Capability;
+import dev.aceclaw.security.DefaultPermissionPolicy;
+import dev.aceclaw.security.WriteMode;
+
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * Best-effort mapping from an MCP {@code (methodName, args)} pair to a
+ * structured {@link Capability} variant.
+ *
+ * <p>Extracted from {@link McpToolBridge} so the bridge can stay a thin
+ * {@code Tool} adapter and the inference rules can be evolved + unit-tested
+ * independently. Pure utility class; no instance state.
+ *
+ * <h3>What gets inferred and why</h3>
+ *
+ * The structural denial layer in {@link DefaultPermissionPolicy} only matches
+ * on {@link Capability.FileWrite} / {@link Capability.FileDelete} variants —
+ * an MCP call that lands as opaque {@link Capability.McpInvoke} would skip
+ * the hard-denial rules even when its args target {@code .env} or {@code .ssh/}.
+ * This class promotes the common file-op patterns (write/delete/move/copy)
+ * to the structured variants so the same rules fire uniformly.
+ *
+ * <h3>What gets classified as what</h3>
+ *
+ * <ul>
+ *   <li>Method name matches {@code write|create|edit|append|put|save} (prefix
+ *       or suffix) with a {@code path}-style arg → {@link Capability.FileWrite}.</li>
+ *   <li>Method name matches {@code delete|remove|unlink|rm} with a similar
+ *       arg → {@link Capability.FileDelete}.</li>
+ *   <li>Method name matches {@code move|rename|copy|mv|cp} with a
+ *       destination-style arg → see disambiguation in
+ *       {@link #inferMoveCopy(String, JsonNode)}.</li>
+ *   <li>Anything else → {@code null} (caller falls back to
+ *       {@link Capability.McpInvoke}).</li>
+ * </ul>
+ *
+ * <p>Conservative on both sides. False positives — a non-filesystem method
+ * named {@code write_log(path=...)} would be classified as {@code FileWrite}
+ * — only result in a more aggressive prompt; the user can still approve.
+ * False negatives — an obscurely named file op that misses the patterns —
+ * fall back to the standard MCP prompt.
+ *
+ * <p>The args payload itself is intentionally not retained on the emitted
+ * variant — args can be huge and may carry secrets; policies decide on
+ * {@code (server, method)} or the resolved path alone.
+ *
+ * <p><strong>Cross-module coupling note:</strong> this class calls
+ * {@link DefaultPermissionPolicy#isSensitivePath(Path)} to disambiguate
+ * move/copy operations where source vs destination sensitivity matters.
+ * That bakes the default-policy's sensitive-path rules into MCP-side
+ * classification; a deployment that swaps in a different policy with
+ * different sensitivity rules would still see this class produce variants
+ * based on the default rules. Tracked as a follow-up cleanup
+ * ({@code SensitivePaths} utility to decouple).
+ */
+final class McpCapabilityInference {
+
+    private McpCapabilityInference() {}
+
+    /**
+     * Returns the inferred structured {@link Capability} for the given MCP
+     * method invocation, or {@code null} when no inference rule applies (the
+     * caller should fall back to {@link Capability.McpInvoke}).
+     */
+    static Capability infer(String mcpMethodName, JsonNode args) {
+        if (args == null || args.isNull() || !args.isObject()) return null;
+        String name = normalizeMethodName(mcpMethodName);
+
+        if (WRITE_VERB.matcher(name).matches()) {
+            // Most single-write methods use a `path`-style field. Some
+            // weirder names (`write_to_destination(...)`) use a destination-
+            // style field; cascade so they're caught too.
+            Path p = safePath(extractField(args, PATH_FIELDS));
+            if (p == null) p = safePath(extractField(args, DESTINATION_FIELDS));
+            return p == null ? null : new Capability.FileWrite(p, WriteMode.OVERWRITE);
+        }
+        if (DELETE_VERB.matcher(name).matches()) {
+            Path p = safePath(extractField(args, PATH_FIELDS));
+            if (p == null) p = safePath(extractField(args, SOURCE_FIELDS));
+            return p == null ? null : new Capability.FileDelete(p);
+        }
+        if (MOVE_DEST_VERB.matcher(name).matches()) {
+            return inferMoveCopy(name, args);
+        }
+        return null;
+    }
+
+    /**
+     * Two-arg op (move/rename/copy) disambiguation. Returns:
+     *
+     * <ol>
+     *   <li>{@link Capability.FileWrite}(dst) when {@code dst} is sensitive —
+     *       catches the destination-write attack ("move/copy to {@code .env}").</li>
+     *   <li>{@link Capability.FileDelete}(src) when {@code src} resolves and
+     *       either the op is a move (source really is removed) or {@code src}
+     *       is sensitive (copying credentials away is exfiltration). Two
+     *       distinct purposes folded together:
+     *     <ul>
+     *       <li>Moves get {@link Capability.FileDelete}'s DANGEROUS risk so
+     *           they prompt in {@code accept-edits} mode where
+     *           {@link Capability.FileWrite} would auto-approve. Preserves
+     *           pre-#495 MCP move behaviour (Codex P2 on #495).</li>
+     *       <li>Copies from sensitive source land on {@code FileDelete} so
+     *           the structural denial fires on the source path. Audit log
+     *           shows {@code @type=FileDelete} for a copy — slightly
+     *           misleading but safer than missing the denial; the
+     *           {@code toolName} field on the audit entry still carries
+     *           the original {@code mcp__<server>__copy_file} so operators
+     *           can correlate (Codex P1 on #495).</li>
+     *     </ul>
+     *   </li>
+     *   <li>{@link Capability.FileWrite}(dst) for the safe-both-sides copy
+     *       case. Genuine WRITE risk; auto-approval in {@code accept-edits}
+     *       is fine because the source is intact.</li>
+     * </ol>
+     *
+     * <p>{@code null} when neither side resolves (incomplete args) — caller
+     * falls back to {@link Capability.McpInvoke}.
+     */
+    private static Capability inferMoveCopy(String normalizedName, JsonNode args) {
+        Path dst = safePath(extractField(args, DESTINATION_FIELDS));
+        Path src = safePath(extractField(args, SOURCE_FIELDS));
+        boolean isMove = !COPY_VERB.matcher(normalizedName).matches();
+
+        if (dst != null && DefaultPermissionPolicy.isSensitivePath(dst)) {
+            return new Capability.FileWrite(dst, WriteMode.OVERWRITE);
+        }
+        if (src != null && (isMove || DefaultPermissionPolicy.isSensitivePath(src))) {
+            return new Capability.FileDelete(src);
+        }
+        if (dst != null) return new Capability.FileWrite(dst, WriteMode.OVERWRITE);
+        return null;
+    }
+
+    // ---------------------------------------------------------------------
+    // Verb patterns
+    // ---------------------------------------------------------------------
+
+    /**
+     * Method names with clear file-write intent (matched against the
+     * normalized snake_case form). Prefix and suffix alternations include
+     * the short {@code put} form on both sides so {@code foo_put} matches
+     * just like {@code put_foo} does.
+     */
+    private static final Pattern WRITE_VERB = Pattern.compile(
+            "^(write|create|edit|append|put|save)(_.*)?$|.*_(write|create|edit|append|save|put)$");
+
+    /**
+     * Method names with clear file-delete intent. Short {@code rm} included
+     * on both sides for the same reason as {@link #WRITE_VERB}.
+     */
+    private static final Pattern DELETE_VERB = Pattern.compile(
+            "^(delete|remove|unlink|rm)(_.*)?$|.*_(delete|remove|unlink|rm)$");
+
+    /**
+     * Method names for two-arg destination-receiving ops: move/rename/copy.
+     * Short {@code mv}/{@code cp} forms included on both sides.
+     */
+    private static final Pattern MOVE_DEST_VERB = Pattern.compile(
+            "^(move|mv|rename|copy|cp)(_.*)?$|.*_(move|rename|copy|mv|cp)$");
+
+    /**
+     * Subset of {@link #MOVE_DEST_VERB} that does NOT remove the source —
+     * copy/cp. Used to decide whether a sensitive source path should be
+     * treated as a delete: copy doesn't delete the source, move does.
+     */
+    private static final Pattern COPY_VERB = Pattern.compile(
+            "^(copy|cp)(_.*)?$|.*_(copy|cp)$");
+
+    // ---------------------------------------------------------------------
+    // Field-name lookups
+    // ---------------------------------------------------------------------
+
+    /**
+     * Common keys MCP filesystem-style servers use for the target path of
+     * a single-arg write/delete. Order matters only for readability — only
+     * the first match is extracted.
+     */
+    private static final List<String> PATH_FIELDS = List.of(
+            "path", "file_path", "filepath", "filename", "file");
+
+    /**
+     * Common keys for the destination of a two-arg op (move/rename/copy).
+     * The destination receives a new file, so it's effectively a write.
+     */
+    private static final List<String> DESTINATION_FIELDS = List.of(
+            "destination", "dest", "target", "to", "new_path", "output_path", "output");
+
+    /**
+     * Common keys for the source of a two-arg op. For moves (not copies)
+     * the source disappears, so it's effectively a delete.
+     */
+    private static final List<String> SOURCE_FIELDS = List.of(
+            "source", "src", "from", "old_path", "input_path", "input");
+
+    /**
+     * Looks up a field in {@code args} matching any of {@code keys}, tolerant
+     * of casing and underscore differences. So {@code path}, {@code Path},
+     * {@code file_path}, {@code filePath}, {@code FILEPATH} all match the
+     * canonical entry {@code path} or {@code file_path} in the keys list.
+     * Necessary because MCP servers in the wild use mixed conventions
+     * (snake_case in the official filesystem server, camelCase in many
+     * third-party servers).
+     */
+    private static String extractField(JsonNode args, List<String> keys) {
+        // Build a normalized → original lookup over args once. Cheap (args
+        // objects are small) and avoids O(keys × argFields) repeat scans.
+        Map<String, String> argKeysByNormalized = new HashMap<>();
+        var iter = args.fieldNames();
+        while (iter.hasNext()) {
+            String k = iter.next();
+            argKeysByNormalized.putIfAbsent(normalizeFieldName(k), k);
+        }
+        for (String key : keys) {
+            String original = argKeysByNormalized.get(normalizeFieldName(key));
+            if (original != null) {
+                var node = args.get(original);
+                if (node != null && node.isTextual()) {
+                    return node.asText();
+                }
+            }
+        }
+        return null;
+    }
+
+    // ---------------------------------------------------------------------
+    // Normalization
+    // ---------------------------------------------------------------------
+
+    /**
+     * Folds casing + strips underscores so {@code filePath}, {@code file_path},
+     * {@code FilePath}, {@code FILEPATH} all normalize to {@code filepath}.
+     * Locale.ROOT for stable case-folding regardless of host locale.
+     */
+    private static String normalizeFieldName(String s) {
+        return s.toLowerCase(Locale.ROOT).replace("_", "");
+    }
+
+    /**
+     * Normalizes a method name to snake_case so the verb regexes — which
+     * expect snake_case or bare verbs — can match across naming conventions.
+     * {@code writeFile} / {@code write-file} / {@code WriteFile} all
+     * normalize to {@code write_file}.
+     *
+     * <p>Algorithm (order matters):
+     * <ol>
+     *   <li>{@code -} and {@code .} → {@code _} (kebab and dotted forms).</li>
+     *   <li>Insert {@code _} before each uppercase that follows a lowercase
+     *       or digit (camelCase split).</li>
+     *   <li>Lowercase under {@link Locale#ROOT}.</li>
+     * </ol>
+     */
+    private static String normalizeMethodName(String s) {
+        String collapsed = s.replace('-', '_').replace('.', '_');
+        var sb = new StringBuilder(collapsed.length() + 4);
+        for (int i = 0; i < collapsed.length(); i++) {
+            char c = collapsed.charAt(i);
+            if (i > 0 && Character.isUpperCase(c)) {
+                char prev = collapsed.charAt(i - 1);
+                if (Character.isLowerCase(prev) || Character.isDigit(prev)) {
+                    sb.append('_');
+                }
+            }
+            sb.append(c);
+        }
+        return sb.toString().toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Parses {@code raw} into a {@link Path} or returns {@code null} when the
+     * input is blank or malformed. Malformed paths fall back so the caller
+     * can route through {@link Capability.McpInvoke} rather than crash the
+     * dispatcher.
+     */
+    private static Path safePath(String raw) {
+        if (raw == null || raw.isBlank()) return null;
+        try {
+            return Path.of(raw);
+        } catch (InvalidPathException malformed) {
+            return null;
+        }
+    }
+}

--- a/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpToolBridge.java
+++ b/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpToolBridge.java
@@ -3,6 +3,8 @@ package dev.aceclaw.mcp;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.aceclaw.core.agent.Tool;
+import dev.aceclaw.security.Capability;
+import dev.aceclaw.security.CapabilityAware;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.spec.McpSchema;
 import org.slf4j.Logger;
@@ -20,20 +22,22 @@ import java.util.Map;
  * <p>Tool execution delegates to the {@link McpSyncClient#callTool} method and converts the
  * {@link McpSchema.CallToolResult} back to a {@link Tool.ToolResult}.
  */
-public final class McpToolBridge implements Tool {
+public final class McpToolBridge implements Tool, CapabilityAware {
 
     private static final Logger log = LoggerFactory.getLogger(McpToolBridge.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private final String qualifiedName;
+    private final String serverName;
     private final String mcpToolName;
     private final String description;
     private final JsonNode inputSchema;
     private final McpSyncClient client;
 
-    private McpToolBridge(String qualifiedName, String mcpToolName, String description,
+    private McpToolBridge(String qualifiedName, String serverName, String mcpToolName, String description,
                           JsonNode inputSchema, McpSyncClient client) {
         this.qualifiedName = qualifiedName;
+        this.serverName = serverName;
         this.mcpToolName = mcpToolName;
         this.description = description;
         this.inputSchema = inputSchema;
@@ -62,7 +66,7 @@ public final class McpToolBridge implements Tool {
                     .put("type", "object");
         }
 
-        return new McpToolBridge(qualifiedName, mcpTool.name(),
+        return new McpToolBridge(qualifiedName, serverName, mcpTool.name(),
                 mcpTool.description(), inputSchema, client);
     }
 
@@ -107,6 +111,18 @@ public final class McpToolBridge implements Tool {
                 qualifiedName, isError, output.length());
 
         return new ToolResult(output, isError);
+    }
+
+    /**
+     * Produces the structured {@link Capability.McpInvoke} variant for the
+     * governance pipeline (#480 / runtime-governance). The args payload is
+     * intentionally not included on the variant — it can be huge and may
+     * carry secrets; policies decide on {@code (server, method)} alone, and
+     * the audit log retains the full args separately when configured.
+     */
+    @Override
+    public Capability toCapability(JsonNode args) {
+        return new Capability.McpInvoke(serverName, mcpToolName);
     }
 
     /**

--- a/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpToolBridge.java
+++ b/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpToolBridge.java
@@ -234,7 +234,7 @@ public final class McpToolBridge implements Tool, CapabilityAware {
 
     private Capability inferFileCapability(JsonNode args) {
         if (args == null || args.isNull() || !args.isObject()) return null;
-        String name = mcpToolName.toLowerCase(Locale.ROOT);
+        String name = normalizeMethodName(mcpToolName);
 
         if (WRITE_VERB.matcher(name).matches()) {
             // Most single-write methods use a `path`-style field. Some
@@ -330,6 +330,38 @@ public final class McpToolBridge implements Tool, CapabilityAware {
      */
     private static String normalizeFieldName(String s) {
         return s.toLowerCase(Locale.ROOT).replace("_", "");
+    }
+
+    /**
+     * Normalizes a method name to snake_case so the verb regexes — which
+     * expect snake_case or bare verbs — can match across naming conventions.
+     * {@code writeFile} / {@code write-file} / {@code WriteFile} all
+     * normalize to {@code write_file}. Without this an MCP server using
+     * camelCase/kebab-case method names would slip past the inference and
+     * structural denial (Codex P1 on #495).
+     *
+     * <p>Algorithm (order matters):
+     * <ol>
+     *   <li>{@code -} and {@code .} → {@code _} (kebab and dotted forms).</li>
+     *   <li>Insert {@code _} before each uppercase that follows a lowercase
+     *       or digit (camelCase split).</li>
+     *   <li>Lowercase under {@link Locale#ROOT}.</li>
+     * </ol>
+     */
+    private static String normalizeMethodName(String s) {
+        String collapsed = s.replace('-', '_').replace('.', '_');
+        var sb = new StringBuilder(collapsed.length() + 4);
+        for (int i = 0; i < collapsed.length(); i++) {
+            char c = collapsed.charAt(i);
+            if (i > 0 && Character.isUpperCase(c)) {
+                char prev = collapsed.charAt(i - 1);
+                if (Character.isLowerCase(prev) || Character.isDigit(prev)) {
+                    sb.append('_');
+                }
+            }
+            sb.append(c);
+        }
+        return sb.toString().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpToolBridge.java
+++ b/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpToolBridge.java
@@ -5,13 +5,18 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.aceclaw.core.agent.Tool;
 import dev.aceclaw.security.Capability;
 import dev.aceclaw.security.CapabilityAware;
+import dev.aceclaw.security.WriteMode;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.spec.McpSchema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * Adapts an MCP tool to the AceClaw {@link Tool} interface.
@@ -114,15 +119,81 @@ public final class McpToolBridge implements Tool, CapabilityAware {
     }
 
     /**
-     * Produces the structured {@link Capability.McpInvoke} variant for the
-     * governance pipeline (#480 / runtime-governance). The args payload is
-     * intentionally not included on the variant — it can be huge and may
-     * carry secrets; policies decide on {@code (server, method)} alone, and
-     * the audit log retains the full args separately when configured.
+     * Produces the structured {@link Capability} for the governance pipeline
+     * (#480 / runtime-governance).
+     *
+     * <p>Best-effort inference: when the MCP method name has clear file-write
+     * or file-delete intent <em>and</em> the args contain a path-shaped field,
+     * emit {@link Capability.FileWrite} / {@link Capability.FileDelete} so the
+     * structural hard-denial layer can refuse writes/deletes to {@code .env*},
+     * {@code .ssh/*}, {@code /etc/*}, etc. — exactly as it does for built-in
+     * file tools (Codex P1 follow-up on #495). Without this, an MCP filesystem
+     * server's {@code write_file(path=".env")} would land as opaque
+     * {@code McpInvoke} and the structural rules would never see the path.
+     *
+     * <p>Conservative on both sides: ambiguous method names (no obvious verb,
+     * no path arg) fall through to {@link Capability.McpInvoke} which still
+     * gets the standard policy + audit treatment. False positives just mean
+     * the user sees a slightly more aggressive prompt — they can still
+     * approve. False negatives mean the structural denial is missed, which is
+     * the pre-fix behaviour.
+     *
+     * <p>The args payload itself is intentionally not retained on either
+     * variant — args can be huge and may carry secrets; policies decide on
+     * (server, method) / path alone.
      */
     @Override
     public Capability toCapability(JsonNode args) {
-        return new Capability.McpInvoke(serverName, mcpToolName);
+        var inferred = inferFileCapability(args);
+        return inferred != null ? inferred : new Capability.McpInvoke(serverName, mcpToolName);
+    }
+
+    /**
+     * Common keys MCP filesystem-style servers use for the target path. Order
+     * matters only for readability — only the first non-null textual match is
+     * extracted.
+     */
+    private static final List<String> PATH_FIELDS = List.of(
+            "path", "file_path", "filepath", "filename", "file");
+
+    /** Method names with clear file-write intent (matched against lowercased mcpToolName). */
+    private static final Pattern WRITE_VERB = Pattern.compile(
+            "^(write|create|edit|append|put|save)(_.*)?$|.*_(write|create|edit|append|save)$");
+
+    /** Method names with clear file-delete intent (matched against lowercased mcpToolName). */
+    private static final Pattern DELETE_VERB = Pattern.compile(
+            "^(delete|remove|unlink|rm)(_.*)?$|.*_(delete|remove|unlink)$");
+
+    private Capability inferFileCapability(JsonNode args) {
+        if (args == null || args.isNull() || !args.isObject()) return null;
+        String path = extractPath(args);
+        if (path == null || path.isBlank()) return null;
+        Path parsed;
+        try {
+            parsed = Path.of(path);
+        } catch (InvalidPathException malformed) {
+            // Garbage path from a misconfigured MCP server — fall back to McpInvoke
+            // so the user still sees a prompt rather than a dispatcher crash.
+            return null;
+        }
+        String name = mcpToolName.toLowerCase();
+        if (WRITE_VERB.matcher(name).matches()) {
+            return new Capability.FileWrite(parsed, WriteMode.OVERWRITE);
+        }
+        if (DELETE_VERB.matcher(name).matches()) {
+            return new Capability.FileDelete(parsed);
+        }
+        return null;
+    }
+
+    private static String extractPath(JsonNode args) {
+        for (String key : PATH_FIELDS) {
+            var node = args.get(key);
+            if (node != null && node.isTextual()) {
+                return node.asText();
+            }
+        }
+        return null;
     }
 
     /**

--- a/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpToolBridge.java
+++ b/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpToolBridge.java
@@ -18,6 +18,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 /**
@@ -60,6 +61,9 @@ public final class McpToolBridge implements Tool, CapabilityAware {
      * @return a new tool bridge instance
      */
     public static McpToolBridge create(String serverName, McpSchema.Tool mcpTool, McpSyncClient client) {
+        Objects.requireNonNull(serverName, "serverName");
+        Objects.requireNonNull(mcpTool, "mcpTool");
+        Objects.requireNonNull(client, "client");
         var qualifiedName = "mcp__" + serverName + "__" + mcpTool.name();
 
         // Convert MCP input schema to Jackson JsonNode
@@ -196,22 +200,28 @@ public final class McpToolBridge implements Tool, CapabilityAware {
     private static final List<String> SOURCE_FIELDS = List.of(
             "source", "src", "from", "old_path", "input_path", "input");
 
-    /** Method names with clear file-write intent (matched against lowercased mcpToolName). */
+    /**
+     * Method names with clear file-write intent (matched against lowercased
+     * mcpToolName). Prefix and suffix alternations include the short
+     * {@code put} form on both sides so {@code foo_put} matches just like
+     * {@code put_foo} does.
+     */
     private static final Pattern WRITE_VERB = Pattern.compile(
-            "^(write|create|edit|append|put|save)(_.*)?$|.*_(write|create|edit|append|save)$");
+            "^(write|create|edit|append|put|save)(_.*)?$|.*_(write|create|edit|append|save|put)$");
 
-    /** Method names with clear file-delete intent (matched against lowercased mcpToolName). */
+    /**
+     * Method names with clear file-delete intent. Short {@code rm} included
+     * on both sides for the same reason as {@link #WRITE_VERB}.
+     */
     private static final Pattern DELETE_VERB = Pattern.compile(
-            "^(delete|remove|unlink|rm)(_.*)?$|.*_(delete|remove|unlink)$");
+            "^(delete|remove|unlink|rm)(_.*)?$|.*_(delete|remove|unlink|rm)$");
 
     /**
      * Method names for two-arg destination-receiving ops: move/rename/copy.
-     * Includes the short {@code mv} and {@code cp} forms as standalone names
-     * (so a method literally named {@code mv} matches, but a method named
-     * {@code recipe} does not — anchored full-word match).
+     * Short {@code mv}/{@code cp} forms included on both sides.
      */
     private static final Pattern MOVE_DEST_VERB = Pattern.compile(
-            "^(move|mv|rename|copy|cp)(_.*)?$|.*_(move|rename|copy)$");
+            "^(move|mv|rename|copy|cp)(_.*)?$|.*_(move|rename|copy|mv|cp)$");
 
     /**
      * Subset of {@link #MOVE_DEST_VERB} that does NOT remove the source —
@@ -219,7 +229,7 @@ public final class McpToolBridge implements Tool, CapabilityAware {
      * treated as a delete: copy doesn't delete the source, move does.
      */
     private static final Pattern COPY_VERB = Pattern.compile(
-            "^(copy|cp)(_.*)?$|.*_copy$");
+            "^(copy|cp)(_.*)?$|.*_(copy|cp)$");
 
     private Capability inferFileCapability(JsonNode args) {
         if (args == null || args.isNull() || !args.isObject()) return null;
@@ -241,17 +251,24 @@ public final class McpToolBridge implements Tool, CapabilityAware {
         if (MOVE_DEST_VERB.matcher(name).matches()) {
             // Two-arg op: destination is the "write" target; source is the
             // "delete" target (for moves only — copies leave the source).
-            // The structural denial layer only sees one Capability, so we
-            // disambiguate up front with DefaultPermissionPolicy.isSensitivePath:
-            //   1. If destination resolves AND is sensitive → FileWrite(dst).
-            //      Catches "move/copy to .env" — destination-write attack.
-            //   2. Else if the op is a move (not copy), source resolves, AND
-            //      is sensitive → FileDelete(src). Catches "move .env away"
-            //      — source-delete attack that the destination-first model
-            //      missed (Codex P1 second follow-up on #495).
-            //   3. Else fall back to destination if present, otherwise
-            //      source-as-delete for moves. Benign cases get the standard
-            //      MCP prompt via the tool-name allowlist key.
+            // Disambiguation order:
+            //   1. dst is sensitive → FileWrite(dst). Catches "move/copy to
+            //      .env" — destination-write attack.
+            //   2. Op is a move (not copy) and src resolves → FileDelete(src).
+            //      Two purposes:
+            //        a. Catches "move .env away" — source-delete attack the
+            //           destination-first model missed (Codex P1 follow-up #2
+            //           on #495).
+            //        b. Preserves DANGEROUS risk on the move semantics so even
+            //           benign moves don't auto-approve in accept-edits mode.
+            //           Pre-#495 MCP moves prompted via EXECUTE risk; FileWrite
+            //           is WRITE which IS auto-approved in accept-edits — that
+            //           would silently delete the source. FileDelete is
+            //           DANGEROUS, which is the closest match (Codex P2
+            //           on #495).
+            //   3. Pure copies (no source side-effect) → FileWrite(dst). Risk
+            //      is the genuine WRITE risk; auto-approval in accept-edits
+            //      is fine because the source is intact.
             Path dst = safePath(extractField(args, DESTINATION_FIELDS));
             Path src = safePath(extractField(args, SOURCE_FIELDS));
             boolean isMove = !COPY_VERB.matcher(name).matches();
@@ -259,11 +276,10 @@ public final class McpToolBridge implements Tool, CapabilityAware {
             if (dst != null && DefaultPermissionPolicy.isSensitivePath(dst)) {
                 return new Capability.FileWrite(dst, WriteMode.OVERWRITE);
             }
-            if (isMove && src != null && DefaultPermissionPolicy.isSensitivePath(src)) {
+            if (isMove && src != null) {
                 return new Capability.FileDelete(src);
             }
             if (dst != null) return new Capability.FileWrite(dst, WriteMode.OVERWRITE);
-            if (isMove && src != null) return new Capability.FileDelete(src);
         }
         return null;
     }

--- a/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpToolBridge.java
+++ b/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpToolBridge.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.aceclaw.core.agent.Tool;
 import dev.aceclaw.security.Capability;
 import dev.aceclaw.security.CapabilityAware;
+import dev.aceclaw.security.DefaultPermissionPolicy;
 import dev.aceclaw.security.WriteMode;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.spec.McpSchema;
@@ -123,21 +124,45 @@ public final class McpToolBridge implements Tool, CapabilityAware {
      * Produces the structured {@link Capability} for the governance pipeline
      * (#480 / runtime-governance).
      *
-     * <p>Best-effort inference: when the MCP method name has clear file-write
-     * or file-delete intent <em>and</em> the args contain a path-shaped field,
-     * emit {@link Capability.FileWrite} / {@link Capability.FileDelete} so the
-     * structural hard-denial layer can refuse writes/deletes to {@code .env*},
+     * <p>Best-effort inference at this boundary so the policy's structural
+     * hard-denial layer can refuse writes/deletes to {@code .env*},
      * {@code .ssh/*}, {@code /etc/*}, etc. — exactly as it does for built-in
-     * file tools (Codex P1 follow-up on #495). Without this, an MCP filesystem
-     * server's {@code write_file(path=".env")} would land as opaque
-     * {@code McpInvoke} and the structural rules would never see the path.
+     * file tools. Without this, an MCP filesystem server's
+     * {@code write_file(path=".env")} would land as opaque {@code McpInvoke}
+     * and the structural rules would never see the path.
      *
-     * <p>Conservative on both sides: ambiguous method names (no obvious verb,
-     * no path arg) fall through to {@link Capability.McpInvoke} which still
-     * gets the standard policy + audit treatment. False positives just mean
-     * the user sees a slightly more aggressive prompt — they can still
-     * approve. False negatives mean the structural denial is missed, which is
+     * <h3>What gets classified as what</h3>
+     *
+     * <ul>
+     *   <li>Method name matches {@code write|create|edit|append|put|save}
+     *       (as prefix or suffix) with a {@code path}/{@code file_path}/etc.
+     *       arg → {@link Capability.FileWrite}.</li>
+     *   <li>Method name matches {@code delete|remove|unlink|rm} with a
+     *       similar arg → {@link Capability.FileDelete}.</li>
+     *   <li>Method name matches {@code move|rename|copy|mv|cp} with a
+     *       destination-style arg ({@code destination}, {@code dest},
+     *       {@code target}, {@code to}, {@code new_path}, …) →
+     *       {@link Capability.FileWrite} of the destination. For moves
+     *       (not copies) with only a source-style arg ({@code source},
+     *       {@code src}, {@code from}, {@code old_path}, …) →
+     *       {@link Capability.FileDelete} of the source.</li>
+     *   <li>Everything else → {@link Capability.McpInvoke} (server, method)
+     *       and gets the standard policy + audit treatment via the MCP
+     *       method's allowlist key.</li>
+     * </ul>
+     *
+     * <p>Conservative on both sides. False positives — a non-filesystem
+     * method named {@code write_log(path=...)} would be classified as
+     * {@code FileWrite} — only result in a more aggressive prompt; the user
+     * can still approve. False negatives — an obscurely named file op that
+     * misses the patterns — fall back to the standard MCP prompt, which is
      * the pre-fix behaviour.
+     *
+     * <p>Note that the audit log will record {@code @type=FileWrite} for
+     * benign moves, which can surprise operators searching by capability
+     * type. The {@code toolName} field on the audit entry still carries
+     * {@code mcp__<server>__<method>}, so the original MCP method remains
+     * traceable.
      *
      * <p>The args payload itself is intentionally not retained on either
      * variant — args can be huge and may carry secrets; policies decide on
@@ -201,29 +226,44 @@ public final class McpToolBridge implements Tool, CapabilityAware {
         String name = mcpToolName.toLowerCase(Locale.ROOT);
 
         if (WRITE_VERB.matcher(name).matches()) {
+            // Most single-write methods use a `path`-style field. Some
+            // weirder names (`write_to_destination(...)`) use a destination-
+            // style field; cascade so they're caught too.
             Path p = safePath(extractField(args, PATH_FIELDS));
+            if (p == null) p = safePath(extractField(args, DESTINATION_FIELDS));
             return p == null ? null : new Capability.FileWrite(p, WriteMode.OVERWRITE);
         }
         if (DELETE_VERB.matcher(name).matches()) {
             Path p = safePath(extractField(args, PATH_FIELDS));
+            if (p == null) p = safePath(extractField(args, SOURCE_FIELDS));
             return p == null ? null : new Capability.FileDelete(p);
         }
         if (MOVE_DEST_VERB.matcher(name).matches()) {
             // Two-arg op: destination is the "write" target; source is the
             // "delete" target (for moves only — copies leave the source).
-            // The structural denial layer only sees one Capability, so:
-            //   - If destination resolves, emit FileWrite(dest). This covers
-            //     "move/copy to .env" — the most common attack vector
-            //     (Codex P1 follow-up on #495).
-            //   - Else if the op is a move (not a copy) and source resolves,
-            //     emit FileDelete(source). Catches "move .env elsewhere"
-            //     which effectively deletes .env.
+            // The structural denial layer only sees one Capability, so we
+            // disambiguate up front with DefaultPermissionPolicy.isSensitivePath:
+            //   1. If destination resolves AND is sensitive → FileWrite(dst).
+            //      Catches "move/copy to .env" — destination-write attack.
+            //   2. Else if the op is a move (not copy), source resolves, AND
+            //      is sensitive → FileDelete(src). Catches "move .env away"
+            //      — source-delete attack that the destination-first model
+            //      missed (Codex P1 second follow-up on #495).
+            //   3. Else fall back to destination if present, otherwise
+            //      source-as-delete for moves. Benign cases get the standard
+            //      MCP prompt via the tool-name allowlist key.
             Path dst = safePath(extractField(args, DESTINATION_FIELDS));
-            if (dst != null) return new Capability.FileWrite(dst, WriteMode.OVERWRITE);
-            if (!COPY_VERB.matcher(name).matches()) {
-                Path src = safePath(extractField(args, SOURCE_FIELDS));
-                if (src != null) return new Capability.FileDelete(src);
+            Path src = safePath(extractField(args, SOURCE_FIELDS));
+            boolean isMove = !COPY_VERB.matcher(name).matches();
+
+            if (dst != null && DefaultPermissionPolicy.isSensitivePath(dst)) {
+                return new Capability.FileWrite(dst, WriteMode.OVERWRITE);
             }
+            if (isMove && src != null && DefaultPermissionPolicy.isSensitivePath(src)) {
+                return new Capability.FileDelete(src);
+            }
+            if (dst != null) return new Capability.FileWrite(dst, WriteMode.OVERWRITE);
+            if (isMove && src != null) return new Capability.FileDelete(src);
         }
         return null;
     }

--- a/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpToolBridge.java
+++ b/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpToolBridge.java
@@ -5,22 +5,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.aceclaw.core.agent.Tool;
 import dev.aceclaw.security.Capability;
 import dev.aceclaw.security.CapabilityAware;
-import dev.aceclaw.security.DefaultPermissionPolicy;
-import dev.aceclaw.security.WriteMode;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.spec.McpSchema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.nio.file.InvalidPathException;
-import java.nio.file.Path;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.regex.Pattern;
 
 /**
  * Adapts an MCP tool to the AceClaw {@link Tool} interface.
@@ -126,257 +118,19 @@ public final class McpToolBridge implements Tool, CapabilityAware {
     }
 
     /**
-     * Produces the structured {@link Capability} for the governance pipeline
-     * (#480 / runtime-governance).
+     * Produces the structured {@link Capability} for the governance pipeline.
+     * Delegates to {@link McpCapabilityInference} for the best-effort
+     * inference; returns the opaque {@link Capability.McpInvoke} when no
+     * pattern matches.
      *
-     * <p>Best-effort inference at this boundary so the policy's structural
-     * hard-denial layer can refuse writes/deletes to {@code .env*},
-     * {@code .ssh/*}, {@code /etc/*}, etc. — exactly as it does for built-in
-     * file tools. Without this, an MCP filesystem server's
-     * {@code write_file(path=".env")} would land as opaque {@code McpInvoke}
-     * and the structural rules would never see the path.
-     *
-     * <h3>What gets classified as what</h3>
-     *
-     * <ul>
-     *   <li>Method name matches {@code write|create|edit|append|put|save}
-     *       (as prefix or suffix) with a {@code path}/{@code file_path}/etc.
-     *       arg → {@link Capability.FileWrite}.</li>
-     *   <li>Method name matches {@code delete|remove|unlink|rm} with a
-     *       similar arg → {@link Capability.FileDelete}.</li>
-     *   <li>Method name matches {@code move|rename|copy|mv|cp} with a
-     *       destination-style arg ({@code destination}, {@code dest},
-     *       {@code target}, {@code to}, {@code new_path}, …) →
-     *       {@link Capability.FileWrite} of the destination. For moves
-     *       (not copies) with only a source-style arg ({@code source},
-     *       {@code src}, {@code from}, {@code old_path}, …) →
-     *       {@link Capability.FileDelete} of the source.</li>
-     *   <li>Everything else → {@link Capability.McpInvoke} (server, method)
-     *       and gets the standard policy + audit treatment via the MCP
-     *       method's allowlist key.</li>
-     * </ul>
-     *
-     * <p>Conservative on both sides. False positives — a non-filesystem
-     * method named {@code write_log(path=...)} would be classified as
-     * {@code FileWrite} — only result in a more aggressive prompt; the user
-     * can still approve. False negatives — an obscurely named file op that
-     * misses the patterns — fall back to the standard MCP prompt, which is
-     * the pre-fix behaviour.
-     *
-     * <p>Note that the audit log will record {@code @type=FileWrite} for
-     * benign moves, which can surprise operators searching by capability
-     * type. The {@code toolName} field on the audit entry still carries
-     * {@code mcp__<server>__<method>}, so the original MCP method remains
-     * traceable.
-     *
-     * <p>The args payload itself is intentionally not retained on either
+     * <p>The args payload is intentionally not retained on the emitted
      * variant — args can be huge and may carry secrets; policies decide on
-     * (server, method) / path alone.
+     * (server, method) or the resolved path alone.
      */
     @Override
     public Capability toCapability(JsonNode args) {
-        var inferred = inferFileCapability(args);
+        var inferred = McpCapabilityInference.infer(mcpToolName, args);
         return inferred != null ? inferred : new Capability.McpInvoke(serverName, mcpToolName);
-    }
-
-    /**
-     * Common keys MCP filesystem-style servers use for the target path of
-     * a single-arg write/delete. Order matters only for readability — only
-     * the first non-null textual match is extracted.
-     */
-    private static final List<String> PATH_FIELDS = List.of(
-            "path", "file_path", "filepath", "filename", "file");
-
-    /**
-     * Common keys for the destination of a two-arg op (move/rename/copy).
-     * The destination receives a new file, so it's effectively a write.
-     */
-    private static final List<String> DESTINATION_FIELDS = List.of(
-            "destination", "dest", "target", "to", "new_path", "output_path", "output");
-
-    /**
-     * Common keys for the source of a two-arg op. For moves (not copies)
-     * the source disappears, so it's effectively a delete.
-     */
-    private static final List<String> SOURCE_FIELDS = List.of(
-            "source", "src", "from", "old_path", "input_path", "input");
-
-    /**
-     * Method names with clear file-write intent (matched against lowercased
-     * mcpToolName). Prefix and suffix alternations include the short
-     * {@code put} form on both sides so {@code foo_put} matches just like
-     * {@code put_foo} does.
-     */
-    private static final Pattern WRITE_VERB = Pattern.compile(
-            "^(write|create|edit|append|put|save)(_.*)?$|.*_(write|create|edit|append|save|put)$");
-
-    /**
-     * Method names with clear file-delete intent. Short {@code rm} included
-     * on both sides for the same reason as {@link #WRITE_VERB}.
-     */
-    private static final Pattern DELETE_VERB = Pattern.compile(
-            "^(delete|remove|unlink|rm)(_.*)?$|.*_(delete|remove|unlink|rm)$");
-
-    /**
-     * Method names for two-arg destination-receiving ops: move/rename/copy.
-     * Short {@code mv}/{@code cp} forms included on both sides.
-     */
-    private static final Pattern MOVE_DEST_VERB = Pattern.compile(
-            "^(move|mv|rename|copy|cp)(_.*)?$|.*_(move|rename|copy|mv|cp)$");
-
-    /**
-     * Subset of {@link #MOVE_DEST_VERB} that does NOT remove the source —
-     * copy/cp. Used to decide whether a sensitive source path should be
-     * treated as a delete: copy doesn't delete the source, move does.
-     */
-    private static final Pattern COPY_VERB = Pattern.compile(
-            "^(copy|cp)(_.*)?$|.*_(copy|cp)$");
-
-    private Capability inferFileCapability(JsonNode args) {
-        if (args == null || args.isNull() || !args.isObject()) return null;
-        String name = normalizeMethodName(mcpToolName);
-
-        if (WRITE_VERB.matcher(name).matches()) {
-            // Most single-write methods use a `path`-style field. Some
-            // weirder names (`write_to_destination(...)`) use a destination-
-            // style field; cascade so they're caught too.
-            Path p = safePath(extractField(args, PATH_FIELDS));
-            if (p == null) p = safePath(extractField(args, DESTINATION_FIELDS));
-            return p == null ? null : new Capability.FileWrite(p, WriteMode.OVERWRITE);
-        }
-        if (DELETE_VERB.matcher(name).matches()) {
-            Path p = safePath(extractField(args, PATH_FIELDS));
-            if (p == null) p = safePath(extractField(args, SOURCE_FIELDS));
-            return p == null ? null : new Capability.FileDelete(p);
-        }
-        if (MOVE_DEST_VERB.matcher(name).matches()) {
-            // Two-arg op: destination is the "write" target; source is the
-            // "delete" target (for moves only — copies leave the source).
-            // Disambiguation order:
-            //   1. dst is sensitive → FileWrite(dst). Catches "move/copy to
-            //      .env" — the destination-write attack.
-            //   2. src resolves AND (op is a move OR src is sensitive) →
-            //      FileDelete(src). Two distinct purposes folded together:
-            //        a. For MOVES (regardless of src sensitivity): the
-            //           source really is removed, and FileDelete's DANGEROUS
-            //           risk prompts in accept-edits where FileWrite would
-            //           auto-approve. Pre-#495 MCP moves prompted via
-            //           EXECUTE risk; this preserves that floor (Codex P2
-            //           on #495).
-            //        b. For COPIES from a sensitive source: copies don't
-            //           actually delete the source, but duplicating a
-            //           credentials file to a non-sensitive location IS
-            //           exfiltration. Pre-#495 the same call prompted via
-            //           the EXECUTE fallback; emitting FileDelete here
-            //           triggers the structural denial via the sensitive
-            //           source path (Codex P1 on #495 — "preserve prompts
-            //           for copies from sensitive sources"). Audit log
-            //           shows @type=FileDelete for a copy — slightly
-            //           misleading but safer than missing the denial; the
-            //           toolName field still carries
-            //           mcp__<server>__copy_file so operators can correlate.
-            //   3. Pure copy with non-sensitive src (dst is safe per step 1)
-            //      → FileWrite(dst). Genuine WRITE risk; auto-approval in
-            //      accept-edits is fine.
-            Path dst = safePath(extractField(args, DESTINATION_FIELDS));
-            Path src = safePath(extractField(args, SOURCE_FIELDS));
-            boolean isMove = !COPY_VERB.matcher(name).matches();
-
-            if (dst != null && DefaultPermissionPolicy.isSensitivePath(dst)) {
-                return new Capability.FileWrite(dst, WriteMode.OVERWRITE);
-            }
-            if (src != null && (isMove || DefaultPermissionPolicy.isSensitivePath(src))) {
-                return new Capability.FileDelete(src);
-            }
-            if (dst != null) return new Capability.FileWrite(dst, WriteMode.OVERWRITE);
-        }
-        return null;
-    }
-
-    /**
-     * Looks up a field in {@code args} matching any of {@code keys}, tolerant
-     * of casing and underscore differences. So {@code path}, {@code Path},
-     * {@code file_path}, {@code filePath}, {@code FILEPATH} all match the
-     * canonical entry {@code path} or {@code file_path} in the keys list.
-     * Necessary because MCP servers in the wild use mixed conventions
-     * (snake_case in the official filesystem server, camelCase in many
-     * third-party servers — Codex P2 on #495).
-     */
-    private static String extractField(JsonNode args, List<String> keys) {
-        // Build a normalized → original lookup over args once. Cheap (args
-        // objects are small) and avoids O(keys × argFields) repeat scans.
-        Map<String, String> argKeysByNormalized = new HashMap<>();
-        var iter = args.fieldNames();
-        while (iter.hasNext()) {
-            String k = iter.next();
-            argKeysByNormalized.putIfAbsent(normalizeFieldName(k), k);
-        }
-        for (String key : keys) {
-            String original = argKeysByNormalized.get(normalizeFieldName(key));
-            if (original != null) {
-                var node = args.get(original);
-                if (node != null && node.isTextual()) {
-                    return node.asText();
-                }
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Folds casing + strips underscores so {@code filePath}, {@code file_path},
-     * {@code FilePath}, {@code FILEPATH} all normalize to {@code filepath}.
-     * Locale.ROOT for stable case-folding regardless of host locale.
-     */
-    private static String normalizeFieldName(String s) {
-        return s.toLowerCase(Locale.ROOT).replace("_", "");
-    }
-
-    /**
-     * Normalizes a method name to snake_case so the verb regexes — which
-     * expect snake_case or bare verbs — can match across naming conventions.
-     * {@code writeFile} / {@code write-file} / {@code WriteFile} all
-     * normalize to {@code write_file}. Without this an MCP server using
-     * camelCase/kebab-case method names would slip past the inference and
-     * structural denial (Codex P1 on #495).
-     *
-     * <p>Algorithm (order matters):
-     * <ol>
-     *   <li>{@code -} and {@code .} → {@code _} (kebab and dotted forms).</li>
-     *   <li>Insert {@code _} before each uppercase that follows a lowercase
-     *       or digit (camelCase split).</li>
-     *   <li>Lowercase under {@link Locale#ROOT}.</li>
-     * </ol>
-     */
-    private static String normalizeMethodName(String s) {
-        String collapsed = s.replace('-', '_').replace('.', '_');
-        var sb = new StringBuilder(collapsed.length() + 4);
-        for (int i = 0; i < collapsed.length(); i++) {
-            char c = collapsed.charAt(i);
-            if (i > 0 && Character.isUpperCase(c)) {
-                char prev = collapsed.charAt(i - 1);
-                if (Character.isLowerCase(prev) || Character.isDigit(prev)) {
-                    sb.append('_');
-                }
-            }
-            sb.append(c);
-        }
-        return sb.toString().toLowerCase(Locale.ROOT);
-    }
-
-    /**
-     * Parses {@code raw} into a {@link Path} or returns {@code null} when the
-     * input is blank or malformed. Malformed paths (e.g. invalid characters
-     * for the host filesystem) fall back to {@code McpInvoke} rather than
-     * crash the dispatcher.
-     */
-    private static Path safePath(String raw) {
-        if (raw == null || raw.isBlank()) return null;
-        try {
-            return Path.of(raw);
-        } catch (InvalidPathException malformed) {
-            return null;
-        }
     }
 
     /**

--- a/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpToolBridge.java
+++ b/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpToolBridge.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -284,14 +285,43 @@ public final class McpToolBridge implements Tool, CapabilityAware {
         return null;
     }
 
+    /**
+     * Looks up a field in {@code args} matching any of {@code keys}, tolerant
+     * of casing and underscore differences. So {@code path}, {@code Path},
+     * {@code file_path}, {@code filePath}, {@code FILEPATH} all match the
+     * canonical entry {@code path} or {@code file_path} in the keys list.
+     * Necessary because MCP servers in the wild use mixed conventions
+     * (snake_case in the official filesystem server, camelCase in many
+     * third-party servers — Codex P2 on #495).
+     */
     private static String extractField(JsonNode args, List<String> keys) {
+        // Build a normalized → original lookup over args once. Cheap (args
+        // objects are small) and avoids O(keys × argFields) repeat scans.
+        Map<String, String> argKeysByNormalized = new HashMap<>();
+        var iter = args.fieldNames();
+        while (iter.hasNext()) {
+            String k = iter.next();
+            argKeysByNormalized.putIfAbsent(normalizeFieldName(k), k);
+        }
         for (String key : keys) {
-            var node = args.get(key);
-            if (node != null && node.isTextual()) {
-                return node.asText();
+            String original = argKeysByNormalized.get(normalizeFieldName(key));
+            if (original != null) {
+                var node = args.get(original);
+                if (node != null && node.isTextual()) {
+                    return node.asText();
+                }
             }
         }
         return null;
+    }
+
+    /**
+     * Folds casing + strips underscores so {@code filePath}, {@code file_path},
+     * {@code FilePath}, {@code FILEPATH} all normalize to {@code filepath}.
+     * Locale.ROOT for stable case-folding regardless of host locale.
+     */
+    private static String normalizeFieldName(String s) {
+        return s.toLowerCase(Locale.ROOT).replace("_", "");
     }
 
     /**

--- a/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpToolBridge.java
+++ b/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpToolBridge.java
@@ -15,6 +15,7 @@ import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -149,12 +150,26 @@ public final class McpToolBridge implements Tool, CapabilityAware {
     }
 
     /**
-     * Common keys MCP filesystem-style servers use for the target path. Order
-     * matters only for readability — only the first non-null textual match is
-     * extracted.
+     * Common keys MCP filesystem-style servers use for the target path of
+     * a single-arg write/delete. Order matters only for readability — only
+     * the first non-null textual match is extracted.
      */
     private static final List<String> PATH_FIELDS = List.of(
             "path", "file_path", "filepath", "filename", "file");
+
+    /**
+     * Common keys for the destination of a two-arg op (move/rename/copy).
+     * The destination receives a new file, so it's effectively a write.
+     */
+    private static final List<String> DESTINATION_FIELDS = List.of(
+            "destination", "dest", "target", "to", "new_path", "output_path", "output");
+
+    /**
+     * Common keys for the source of a two-arg op. For moves (not copies)
+     * the source disappears, so it's effectively a delete.
+     */
+    private static final List<String> SOURCE_FIELDS = List.of(
+            "source", "src", "from", "old_path", "input_path", "input");
 
     /** Method names with clear file-write intent (matched against lowercased mcpToolName). */
     private static final Pattern WRITE_VERB = Pattern.compile(
@@ -164,36 +179,78 @@ public final class McpToolBridge implements Tool, CapabilityAware {
     private static final Pattern DELETE_VERB = Pattern.compile(
             "^(delete|remove|unlink|rm)(_.*)?$|.*_(delete|remove|unlink)$");
 
+    /**
+     * Method names for two-arg destination-receiving ops: move/rename/copy.
+     * Includes the short {@code mv} and {@code cp} forms as standalone names
+     * (so a method literally named {@code mv} matches, but a method named
+     * {@code recipe} does not — anchored full-word match).
+     */
+    private static final Pattern MOVE_DEST_VERB = Pattern.compile(
+            "^(move|mv|rename|copy|cp)(_.*)?$|.*_(move|rename|copy)$");
+
+    /**
+     * Subset of {@link #MOVE_DEST_VERB} that does NOT remove the source —
+     * copy/cp. Used to decide whether a sensitive source path should be
+     * treated as a delete: copy doesn't delete the source, move does.
+     */
+    private static final Pattern COPY_VERB = Pattern.compile(
+            "^(copy|cp)(_.*)?$|.*_copy$");
+
     private Capability inferFileCapability(JsonNode args) {
         if (args == null || args.isNull() || !args.isObject()) return null;
-        String path = extractPath(args);
-        if (path == null || path.isBlank()) return null;
-        Path parsed;
-        try {
-            parsed = Path.of(path);
-        } catch (InvalidPathException malformed) {
-            // Garbage path from a misconfigured MCP server — fall back to McpInvoke
-            // so the user still sees a prompt rather than a dispatcher crash.
-            return null;
-        }
-        String name = mcpToolName.toLowerCase();
+        String name = mcpToolName.toLowerCase(Locale.ROOT);
+
         if (WRITE_VERB.matcher(name).matches()) {
-            return new Capability.FileWrite(parsed, WriteMode.OVERWRITE);
+            Path p = safePath(extractField(args, PATH_FIELDS));
+            return p == null ? null : new Capability.FileWrite(p, WriteMode.OVERWRITE);
         }
         if (DELETE_VERB.matcher(name).matches()) {
-            return new Capability.FileDelete(parsed);
+            Path p = safePath(extractField(args, PATH_FIELDS));
+            return p == null ? null : new Capability.FileDelete(p);
+        }
+        if (MOVE_DEST_VERB.matcher(name).matches()) {
+            // Two-arg op: destination is the "write" target; source is the
+            // "delete" target (for moves only — copies leave the source).
+            // The structural denial layer only sees one Capability, so:
+            //   - If destination resolves, emit FileWrite(dest). This covers
+            //     "move/copy to .env" — the most common attack vector
+            //     (Codex P1 follow-up on #495).
+            //   - Else if the op is a move (not a copy) and source resolves,
+            //     emit FileDelete(source). Catches "move .env elsewhere"
+            //     which effectively deletes .env.
+            Path dst = safePath(extractField(args, DESTINATION_FIELDS));
+            if (dst != null) return new Capability.FileWrite(dst, WriteMode.OVERWRITE);
+            if (!COPY_VERB.matcher(name).matches()) {
+                Path src = safePath(extractField(args, SOURCE_FIELDS));
+                if (src != null) return new Capability.FileDelete(src);
+            }
         }
         return null;
     }
 
-    private static String extractPath(JsonNode args) {
-        for (String key : PATH_FIELDS) {
+    private static String extractField(JsonNode args, List<String> keys) {
+        for (String key : keys) {
             var node = args.get(key);
             if (node != null && node.isTextual()) {
                 return node.asText();
             }
         }
         return null;
+    }
+
+    /**
+     * Parses {@code raw} into a {@link Path} or returns {@code null} when the
+     * input is blank or malformed. Malformed paths (e.g. invalid characters
+     * for the host filesystem) fall back to {@code McpInvoke} rather than
+     * crash the dispatcher.
+     */
+    private static Path safePath(String raw) {
+        if (raw == null || raw.isBlank()) return null;
+        try {
+            return Path.of(raw);
+        } catch (InvalidPathException malformed) {
+            return null;
+        }
     }
 
     /**

--- a/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpToolBridge.java
+++ b/aceclaw-mcp/src/main/java/dev/aceclaw/mcp/McpToolBridge.java
@@ -254,22 +254,30 @@ public final class McpToolBridge implements Tool, CapabilityAware {
             // "delete" target (for moves only — copies leave the source).
             // Disambiguation order:
             //   1. dst is sensitive → FileWrite(dst). Catches "move/copy to
-            //      .env" — destination-write attack.
-            //   2. Op is a move (not copy) and src resolves → FileDelete(src).
-            //      Two purposes:
-            //        a. Catches "move .env away" — source-delete attack the
-            //           destination-first model missed (Codex P1 follow-up #2
+            //      .env" — the destination-write attack.
+            //   2. src resolves AND (op is a move OR src is sensitive) →
+            //      FileDelete(src). Two distinct purposes folded together:
+            //        a. For MOVES (regardless of src sensitivity): the
+            //           source really is removed, and FileDelete's DANGEROUS
+            //           risk prompts in accept-edits where FileWrite would
+            //           auto-approve. Pre-#495 MCP moves prompted via
+            //           EXECUTE risk; this preserves that floor (Codex P2
             //           on #495).
-            //        b. Preserves DANGEROUS risk on the move semantics so even
-            //           benign moves don't auto-approve in accept-edits mode.
-            //           Pre-#495 MCP moves prompted via EXECUTE risk; FileWrite
-            //           is WRITE which IS auto-approved in accept-edits — that
-            //           would silently delete the source. FileDelete is
-            //           DANGEROUS, which is the closest match (Codex P2
-            //           on #495).
-            //   3. Pure copies (no source side-effect) → FileWrite(dst). Risk
-            //      is the genuine WRITE risk; auto-approval in accept-edits
-            //      is fine because the source is intact.
+            //        b. For COPIES from a sensitive source: copies don't
+            //           actually delete the source, but duplicating a
+            //           credentials file to a non-sensitive location IS
+            //           exfiltration. Pre-#495 the same call prompted via
+            //           the EXECUTE fallback; emitting FileDelete here
+            //           triggers the structural denial via the sensitive
+            //           source path (Codex P1 on #495 — "preserve prompts
+            //           for copies from sensitive sources"). Audit log
+            //           shows @type=FileDelete for a copy — slightly
+            //           misleading but safer than missing the denial; the
+            //           toolName field still carries
+            //           mcp__<server>__copy_file so operators can correlate.
+            //   3. Pure copy with non-sensitive src (dst is safe per step 1)
+            //      → FileWrite(dst). Genuine WRITE risk; auto-approval in
+            //      accept-edits is fine.
             Path dst = safePath(extractField(args, DESTINATION_FIELDS));
             Path src = safePath(extractField(args, SOURCE_FIELDS));
             boolean isMove = !COPY_VERB.matcher(name).matches();
@@ -277,7 +285,7 @@ public final class McpToolBridge implements Tool, CapabilityAware {
             if (dst != null && DefaultPermissionPolicy.isSensitivePath(dst)) {
                 return new Capability.FileWrite(dst, WriteMode.OVERWRITE);
             }
-            if (isMove && src != null) {
+            if (src != null && (isMove || DefaultPermissionPolicy.isSensitivePath(src))) {
                 return new Capability.FileDelete(src);
             }
             if (dst != null) return new Capability.FileWrite(dst, WriteMode.OVERWRITE);

--- a/aceclaw-mcp/src/test/java/dev/aceclaw/mcp/McpToolBridgeTest.java
+++ b/aceclaw-mcp/src/test/java/dev/aceclaw/mcp/McpToolBridgeTest.java
@@ -440,6 +440,48 @@ class McpToolBridgeTest {
     }
 
     @Test
+    void camelCasePathFieldMatches() {
+        // Codex P2 on #495: many MCP servers use camelCase JSON keys
+        // (filePath rather than file_path). Field-name normalization
+        // (lowercase + strip underscores) makes both match the same
+        // canonical entry.
+        var tool = McpToolBridge.create("fs", mcpTool("write_file", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode().put("filePath", "/repo/.env");
+        var cap = tool.toCapability(args);
+
+        assertThat(cap).isInstanceOf(Capability.FileWrite.class);
+        assertThat(((Capability.FileWrite) cap).path()).isEqualTo(Path.of("/repo/.env"));
+    }
+
+    @Test
+    void camelCaseDestinationFieldMatches() {
+        var tool = McpToolBridge.create("fs", mcpTool("move_file", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode()
+                .put("sourcePath", "/tmp/a")
+                .put("newPath", "/repo/.env");
+        var cap = tool.toCapability(args);
+
+        assertThat(cap)
+                .as("camelCase newPath should still trigger destination-sensitive denial")
+                .isInstanceOf(Capability.FileWrite.class);
+        assertThat(((Capability.FileWrite) cap).path()).isEqualTo(Path.of("/repo/.env"));
+    }
+
+    @Test
+    void uppercaseFieldNameMatches() {
+        // Defensive: a server using PASCALCASE or SCREAMING_SNAKE shouldn't
+        // bypass the inference either.
+        var tool = McpToolBridge.create("fs", mcpTool("write_file", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode().put("FILEPATH", "/repo/.env");
+        var cap = tool.toCapability(args);
+
+        assertThat(cap).isInstanceOf(Capability.FileWrite.class);
+    }
+
+    @Test
     void writeToDestinationFieldStillInfersFileWrite() {
         // Self-review preemptive fix: a write-verb method that uses a
         // destination-style field (`write_to_destination(destination=...)`)

--- a/aceclaw-mcp/src/test/java/dev/aceclaw/mcp/McpToolBridgeTest.java
+++ b/aceclaw-mcp/src/test/java/dev/aceclaw/mcp/McpToolBridgeTest.java
@@ -291,6 +291,74 @@ class McpToolBridgeTest {
     }
 
     @Test
+    void moveFromSensitiveSourceWithSafeDestinationInfersFileDelete() {
+        // Codex P1 second follow-up on #495: when destination is safe but
+        // source is sensitive, the "destination wins" rule used to emit
+        // FileWrite(safe-dest) and the structural layer would never see the
+        // sensitive source being deleted. Source-sensitivity is now probed
+        // explicitly so the structural denial fires on the delete side.
+        var tool = McpToolBridge.create("fs", mcpTool("move_file", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode()
+                .put("source", "/repo/.env")
+                .put("destination", "/tmp/env-backup.txt");
+        var cap = tool.toCapability(args);
+
+        assertThat(cap)
+                .as("safe-dst + sensitive-src move must produce FileDelete to trigger denial")
+                .isInstanceOf(Capability.FileDelete.class);
+        assertThat(((Capability.FileDelete) cap).path()).isEqualTo(Path.of("/repo/.env"));
+    }
+
+    @Test
+    void copyFromSensitiveSourceWithSafeDestinationStaysAsFileWrite() {
+        // Copies don't delete the source - the source-sensitivity probe only
+        // kicks in for moves. A copy from .env to safe-dest still emits
+        // FileWrite(safe-dest) (the destination side), gets the standard
+        // prompt - no source-side denial because the source is left intact.
+        var tool = McpToolBridge.create("fs", mcpTool("copy_file", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode()
+                .put("source", "/repo/.env")
+                .put("destination", "/tmp/env-copy.txt");
+        var cap = tool.toCapability(args);
+
+        assertThat(cap).isInstanceOf(Capability.FileWrite.class);
+        assertThat(((Capability.FileWrite) cap).path()).isEqualTo(Path.of("/tmp/env-copy.txt"));
+    }
+
+    @Test
+    void benignMoveWithSafeBothSidesEmitsFileWrite() {
+        // No sensitivity on either side - falls through to "destination wins"
+        // FileWrite. Session-blanket approval for the MCP method (allowlist
+        // key) still auto-approves because the blanket is keyed by tool name.
+        var tool = McpToolBridge.create("fs", mcpTool("move_file", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode()
+                .put("source", "/tmp/a.txt")
+                .put("destination", "/tmp/b.txt");
+        var cap = tool.toCapability(args);
+
+        assertThat(cap).isInstanceOf(Capability.FileWrite.class);
+        assertThat(((Capability.FileWrite) cap).path()).isEqualTo(Path.of("/tmp/b.txt"));
+    }
+
+    @Test
+    void writeToDestinationFieldStillInfersFileWrite() {
+        // Self-review preemptive fix: a write-verb method that uses a
+        // destination-style field (`write_to_destination(destination=...)`)
+        // instead of `path` should still emit FileWrite. The WRITE_VERB
+        // branch cascades to DESTINATION_FIELDS when PATH_FIELDS is empty.
+        var tool = McpToolBridge.create("fs", mcpTool("write_to", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode().put("destination", "/repo/.env");
+        var cap = tool.toCapability(args);
+
+        assertThat(cap).isInstanceOf(Capability.FileWrite.class);
+        assertThat(((Capability.FileWrite) cap).path()).isEqualTo(Path.of("/repo/.env"));
+    }
+
+    @Test
     void mcpMoveToSensitiveDestinationIsStructurallyDenied() {
         // End-to-end: move to .env composes through to a structural denial.
         var tool = McpToolBridge.create("fs", mcpTool("move_file", "desc"), client);

--- a/aceclaw-mcp/src/test/java/dev/aceclaw/mcp/McpToolBridgeTest.java
+++ b/aceclaw-mcp/src/test/java/dev/aceclaw/mcp/McpToolBridgeTest.java
@@ -1,5 +1,7 @@
 package dev.aceclaw.mcp;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.aceclaw.security.Capability;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.spec.McpSchema;
 import org.junit.jupiter.api.Test;
@@ -99,5 +101,35 @@ class McpToolBridgeTest {
 
         assertThat(tool.inputSchema()).isNotNull();
         assertThat(tool.inputSchema().get("type").asText()).isEqualTo("object");
+    }
+
+    @Test
+    void toCapabilityProducesMcpInvokeWithServerAndMethod() {
+        // McpToolBridge is now CapabilityAware (#480 PR 4 / runtime-governance):
+        // it produces a structured Capability.McpInvoke so the policy and audit
+        // log see (server, method) directly instead of falling back to the
+        // LegacyToolUse bridge.
+        var tool = McpToolBridge.create("my-server", mcpTool("do_thing", "desc"), client);
+
+        var capability = tool.toCapability(new ObjectMapper().createObjectNode());
+
+        assertThat(capability).isInstanceOf(Capability.McpInvoke.class);
+        var invoke = (Capability.McpInvoke) capability;
+        assertThat(invoke.server()).isEqualTo("my-server");
+        assertThat(invoke.method()).isEqualTo("do_thing");
+    }
+
+    @Test
+    void toCapabilityIgnoresArgs() {
+        // Args payload is intentionally NOT carried on McpInvoke (size + secret
+        // risk). Different args produce the same capability variant — policies
+        // decide on (server, method) alone.
+        var tool = McpToolBridge.create("s", mcpTool("t", "desc"), client);
+
+        var mapper = new ObjectMapper();
+        var cap1 = tool.toCapability(mapper.createObjectNode().put("k", "v1"));
+        var cap2 = tool.toCapability(mapper.createObjectNode().put("k", "v2"));
+
+        assertThat(cap1).isEqualTo(cap2);
     }
 }

--- a/aceclaw-mcp/src/test/java/dev/aceclaw/mcp/McpToolBridgeTest.java
+++ b/aceclaw-mcp/src/test/java/dev/aceclaw/mcp/McpToolBridgeTest.java
@@ -302,6 +302,47 @@ class McpToolBridgeTest {
     }
 
     @Test
+    void renameWithPathAsSourceInfersFileMove() {
+        // Codex P1 follow-up to #495: some MCP filesystem schemas use the
+        // single `path` field for the existing file on a rename/move (with
+        // the new name in `new_path`/`destination`). Without falling back to
+        // PATH_FIELDS as a source alias on moves, `src` resolves to null and
+        // the call degrades to FileWrite(dst) — bypassing the sensitive-
+        // source structural check.
+        var tool = McpToolBridge.create("fs", mcpTool("rename", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode()
+                .put("path", "/repo/.env")
+                .put("new_path", "/tmp/env.bak");
+        var cap = tool.toCapability(args);
+
+        assertThat(cap).isInstanceOf(Capability.FileMove.class);
+        var fm = (Capability.FileMove) cap;
+        assertThat(fm.source()).isEqualTo(Path.of("/repo/.env"));
+        assertThat(fm.destination()).isEqualTo(Path.of("/tmp/env.bak"));
+        assertThat(fm.deletesSource()).isTrue();
+    }
+
+    @Test
+    void explicitSourceWinsOverPathOnMove() {
+        // PATH_FIELDS is only a fallback. If both `source` and `path` are
+        // present (unusual but possible with a permissive MCP schema), the
+        // explicit `source` should be honored — otherwise a server could
+        // hide the real source under `path` and mask it from the audit log.
+        var tool = McpToolBridge.create("fs", mcpTool("move_file", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode()
+                .put("source", "/tmp/explicit-src")
+                .put("path", "/repo/.env")
+                .put("destination", "/tmp/dst");
+        var cap = tool.toCapability(args);
+
+        assertThat(cap).isInstanceOf(Capability.FileMove.class);
+        assertThat(((Capability.FileMove) cap).source())
+                .isEqualTo(Path.of("/tmp/explicit-src"));
+    }
+
+    @Test
     void moveSourceOnlyDegradesToFileDelete() {
         // When destination is missing (malformed args), a move still tells
         // us the source is being removed. Emit FileDelete so the structural

--- a/aceclaw-mcp/src/test/java/dev/aceclaw/mcp/McpToolBridgeTest.java
+++ b/aceclaw-mcp/src/test/java/dev/aceclaw/mcp/McpToolBridgeTest.java
@@ -453,6 +453,63 @@ class McpToolBridgeTest {
     }
 
     @Test
+    void camelCaseMethodNameMatchesWriteVerb() {
+        // Codex P1 on #495 (round-11): MCP servers using camelCase tool
+        // names (writeFile) or kebab-case (write-file) bypassed the
+        // snake_case-only verb regex. Method-name normalization now folds
+        // both forms to snake_case before matching.
+        var tool = McpToolBridge.create("fs", mcpTool("writeFile", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode().put("path", "/repo/.env");
+        var cap = tool.toCapability(args);
+
+        assertThat(cap).isInstanceOf(Capability.FileWrite.class);
+    }
+
+    @Test
+    void kebabCaseMethodNameMatchesWriteVerb() {
+        var tool = McpToolBridge.create("fs", mcpTool("write-file", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode().put("path", "/repo/.env");
+        var cap = tool.toCapability(args);
+
+        assertThat(cap).isInstanceOf(Capability.FileWrite.class);
+    }
+
+    @Test
+    void camelCaseDeleteMethodMatches() {
+        var tool = McpToolBridge.create("fs", mcpTool("deleteFile", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode().put("path", "/repo/.env");
+        var cap = tool.toCapability(args);
+
+        assertThat(cap).isInstanceOf(Capability.FileDelete.class);
+    }
+
+    @Test
+    void camelCaseMoveMethodMatches() {
+        var tool = McpToolBridge.create("fs", mcpTool("moveFile", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode()
+                .put("source", "/tmp/a")
+                .put("destination", "/repo/.env");
+        var cap = tool.toCapability(args);
+
+        assertThat(cap).isInstanceOf(Capability.FileWrite.class);
+    }
+
+    @Test
+    void pascalCaseMethodMatches() {
+        // PascalCase like "WriteFile" — also covered by the camelCase split.
+        var tool = McpToolBridge.create("fs", mcpTool("WriteFile", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode().put("path", "/repo/.env");
+        var cap = tool.toCapability(args);
+
+        assertThat(cap).isInstanceOf(Capability.FileWrite.class);
+    }
+
+    @Test
     void camelCasePathFieldMatches() {
         // Codex P2 on #495: many MCP servers use camelCase JSON keys
         // (filePath rather than file_path). Field-name normalization

--- a/aceclaw-mcp/src/test/java/dev/aceclaw/mcp/McpToolBridgeTest.java
+++ b/aceclaw-mcp/src/test/java/dev/aceclaw/mcp/McpToolBridgeTest.java
@@ -305,17 +305,22 @@ class McpToolBridgeTest {
     }
 
     @Test
-    void copyFromSensitiveSourceDoesNotInferDelete() {
-        // Copies leave the source intact — no FileDelete inferred.
+    void copyFromSensitiveSourceWithoutDestinationInfersFileDelete() {
+        // Codex P1 follow-up on #495 (round-9): copies from sensitive sources
+        // re-classify as FileDelete(src) so the structural denial fires --
+        // duplicating credentials anywhere is exfiltration regardless of
+        // destination. The op doesn't actually delete the source; the
+        // classification is intentionally over-conservative (audit log shows
+        // FileDelete but toolName=mcp__<server>__copy_file keeps it
+        // traceable).
         var tool = McpToolBridge.create("fs", mcpTool("copy_file", "desc"), client);
 
         var args = new ObjectMapper().createObjectNode()
                 .put("source", "/repo/.env");
         var cap = tool.toCapability(args);
 
-        // No destination resolved; not a delete (copy doesn't delete source).
-        // Falls through to McpInvoke.
-        assertThat(cap).isInstanceOf(Capability.McpInvoke.class);
+        assertThat(cap).isInstanceOf(Capability.FileDelete.class);
+        assertThat(((Capability.FileDelete) cap).path()).isEqualTo(Path.of("/repo/.env"));
     }
 
     @Test
@@ -339,11 +344,14 @@ class McpToolBridgeTest {
     }
 
     @Test
-    void copyFromSensitiveSourceWithSafeDestinationStaysAsFileWrite() {
-        // Copies don't delete the source - the source-sensitivity probe only
-        // kicks in for moves. A copy from .env to safe-dest still emits
-        // FileWrite(safe-dest) (the destination side), gets the standard
-        // prompt - no source-side denial because the source is left intact.
+    void copyFromSensitiveSourceToSafeDestinationIsStructurallyDeniedAsExfil() {
+        // Codex P1 on #495 (round-9): copy_file(.env, /tmp/env-copy) reads
+        // sensitive content and duplicates it to a non-sensitive location --
+        // a credential-exfiltration vector. Pre-fix this auto-approved in
+        // accept-edits because FileWrite(safe-dst) has WRITE risk. Re-classify
+        // copies-from-sensitive-src as FileDelete(src) so the structural
+        // denial layer refuses them regardless of destination, matching the
+        // pre-#495 EXECUTE-prompt behaviour for MCP tools.
         var tool = McpToolBridge.create("fs", mcpTool("copy_file", "desc"), client);
 
         var args = new ObjectMapper().createObjectNode()
@@ -351,8 +359,13 @@ class McpToolBridgeTest {
                 .put("destination", "/tmp/env-copy.txt");
         var cap = tool.toCapability(args);
 
-        assertThat(cap).isInstanceOf(Capability.FileWrite.class);
-        assertThat(((Capability.FileWrite) cap).path()).isEqualTo(Path.of("/tmp/env-copy.txt"));
+        assertThat(cap)
+                .as("copy from sensitive src must be classified as FileDelete to trigger denial")
+                .isInstanceOf(Capability.FileDelete.class);
+        var decision = new DefaultPermissionPolicy("auto-accept").evaluateStructural(cap);
+        assertThat(decision)
+                .as("structural denial fires even in auto-accept mode")
+                .isNotNull();
     }
 
     @Test

--- a/aceclaw-mcp/src/test/java/dev/aceclaw/mcp/McpToolBridgeTest.java
+++ b/aceclaw-mcp/src/test/java/dev/aceclaw/mcp/McpToolBridgeTest.java
@@ -2,6 +2,8 @@ package dev.aceclaw.mcp;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.aceclaw.security.Capability;
+import dev.aceclaw.security.DefaultPermissionPolicy;
+import dev.aceclaw.security.PermissionDecision;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.spec.McpSchema;
 import org.junit.jupiter.api.Test;
@@ -9,6 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
@@ -121,15 +124,117 @@ class McpToolBridgeTest {
 
     @Test
     void toCapabilityIgnoresArgs() {
-        // Args payload is intentionally NOT carried on McpInvoke (size + secret
-        // risk). Different args produce the same capability variant — policies
-        // decide on (server, method) alone.
-        var tool = McpToolBridge.create("s", mcpTool("t", "desc"), client);
+        // For methods that don't pattern-match as file ops, args are NOT
+        // carried on McpInvoke (size + secret risk). Different args produce
+        // the same capability variant.
+        var tool = McpToolBridge.create("s", mcpTool("opaque_method", "desc"), client);
 
         var mapper = new ObjectMapper();
         var cap1 = tool.toCapability(mapper.createObjectNode().put("k", "v1"));
         var cap2 = tool.toCapability(mapper.createObjectNode().put("k", "v2"));
 
         assertThat(cap1).isEqualTo(cap2);
+        assertThat(cap1).isInstanceOf(Capability.McpInvoke.class);
+    }
+
+    // -- Best-effort file-capability inference (Codex P1 follow-up on #495) --
+
+    @Test
+    void writeFileMethodWithPathInfersFileWrite() {
+        var tool = McpToolBridge.create("fs", mcpTool("write_file", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode().put("path", "/repo/.env");
+        var cap = tool.toCapability(args);
+
+        assertThat(cap).isInstanceOf(Capability.FileWrite.class);
+        assertThat(((Capability.FileWrite) cap).path()).isEqualTo(Path.of("/repo/.env"));
+    }
+
+    @Test
+    void createFileMethodWithFilePathInfersFileWrite() {
+        var tool = McpToolBridge.create("fs", mcpTool("create_file", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode().put("file_path", "/tmp/x.txt");
+        var cap = tool.toCapability(args);
+
+        assertThat(cap).isInstanceOf(Capability.FileWrite.class);
+    }
+
+    @Test
+    void deleteFileMethodInfersFileDelete() {
+        var tool = McpToolBridge.create("fs", mcpTool("delete_file", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode().put("path", "/repo/.env");
+        var cap = tool.toCapability(args);
+
+        assertThat(cap).isInstanceOf(Capability.FileDelete.class);
+    }
+
+    @Test
+    void removeMethodInfersFileDelete() {
+        var tool = McpToolBridge.create("fs", mcpTool("remove", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode().put("path", "/tmp/x");
+        var cap = tool.toCapability(args);
+
+        assertThat(cap).isInstanceOf(Capability.FileDelete.class);
+    }
+
+    @Test
+    void writeMethodWithoutPathArgFallsBackToMcpInvoke() {
+        // A method with a write-shaped name but no recognized path field is
+        // genuinely opaque; produce McpInvoke and let the standard prompt
+        // handle it.
+        var tool = McpToolBridge.create("fs", mcpTool("write_file", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode().put("destination_uri", "x");
+        var cap = tool.toCapability(args);
+
+        assertThat(cap).isInstanceOf(Capability.McpInvoke.class);
+    }
+
+    @Test
+    void opaqueMethodNameWithPathArgFallsBackToMcpInvoke() {
+        // Conservative on the false-positive side: if the method name has no
+        // obvious write/delete verb, do NOT promote to FileWrite even when a
+        // path arg is present.
+        var tool = McpToolBridge.create("fs", mcpTool("get_metadata", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode().put("path", "/etc/hosts");
+        var cap = tool.toCapability(args);
+
+        assertThat(cap).isInstanceOf(Capability.McpInvoke.class);
+    }
+
+    @Test
+    void readFileMethodFallsBackToMcpInvoke() {
+        // Reads aren't promoted to FileRead - the structural rules don't cover
+        // reads, and McpInvoke keeps the prompt flow identical to a generic
+        // MCP call.
+        var tool = McpToolBridge.create("fs", mcpTool("read_file", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode().put("path", "/etc/hosts");
+        var cap = tool.toCapability(args);
+
+        assertThat(cap).isInstanceOf(Capability.McpInvoke.class);
+    }
+
+    @Test
+    void mcpFileWriteToSensitivePathIsStructurallyDenied() {
+        // End-to-end: an MCP server's write_file(path=".env") composes through
+        // McpToolBridge.toCapability() into a Capability.FileWrite that the
+        // structural-denial layer refuses. Pins that the wiring between the
+        // MCP boundary and DefaultPermissionPolicy works for the bypass Codex
+        // P1 flagged (#495).
+        var tool = McpToolBridge.create("fs", mcpTool("write_file", "desc"), client);
+        var args = new ObjectMapper().createObjectNode().put("path", "/repo/.env");
+
+        var cap = tool.toCapability(args);
+        var decision = new DefaultPermissionPolicy("auto-accept").evaluateStructural(cap);
+
+        assertThat(decision)
+                .as("MCP-driven write to .env must be structurally denied even in auto-accept")
+                .isNotNull();
+        assertThat(decision.reason()).contains("sensitive path");
     }
 }

--- a/aceclaw-mcp/src/test/java/dev/aceclaw/mcp/McpToolBridgeTest.java
+++ b/aceclaw-mcp/src/test/java/dev/aceclaw/mcp/McpToolBridgeTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -29,6 +30,33 @@ class McpToolBridgeTest {
     private McpSchema.Tool mcpTool(String name, String description) {
         var schema = new McpSchema.JsonSchema("object", Map.of(), List.of(), null, null, null);
         return new McpSchema.Tool(name, null, description, schema, null, null, null);
+    }
+
+    @Test
+    void createNullServerNameThrows() {
+        // CodeRabbit on #495: null params used in string concatenation /
+        // method calls must fail fast at the factory boundary, not produce
+        // garbage like "mcp__null__do_thing".
+        assertThatThrownBy(() ->
+                McpToolBridge.create(null, mcpTool("do_thing", "desc"), client))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("serverName");
+    }
+
+    @Test
+    void createNullMcpToolThrows() {
+        assertThatThrownBy(() ->
+                McpToolBridge.create("server", null, client))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("mcpTool");
+    }
+
+    @Test
+    void createNullClientThrows() {
+        assertThatThrownBy(() ->
+                McpToolBridge.create("server", mcpTool("t", "desc"), null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("client");
     }
 
     @Test
@@ -328,11 +356,31 @@ class McpToolBridgeTest {
     }
 
     @Test
-    void benignMoveWithSafeBothSidesEmitsFileWrite() {
-        // No sensitivity on either side - falls through to "destination wins"
-        // FileWrite. Session-blanket approval for the MCP method (allowlist
-        // key) still auto-approves because the blanket is keyed by tool name.
+    void benignMoveWithSafeBothSidesEmitsFileDeleteToPreserveDangerousRisk() {
+        // Codex P2 on #495: a benign move emitted FileWrite(dst) (WRITE risk)
+        // which auto-approves in accept-edits mode, silently removing the
+        // source. Pre-#495 MCP moves prompted via EXECUTE risk. To match
+        // that floor — and since the move semantics ARE a delete of the
+        // source — emit FileDelete(src) instead. FileDelete is DANGEROUS,
+        // so it prompts in every mode except auto-accept.
         var tool = McpToolBridge.create("fs", mcpTool("move_file", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode()
+                .put("source", "/tmp/a.txt")
+                .put("destination", "/tmp/b.txt");
+        var cap = tool.toCapability(args);
+
+        assertThat(cap).isInstanceOf(Capability.FileDelete.class);
+        assertThat(((Capability.FileDelete) cap).path()).isEqualTo(Path.of("/tmp/a.txt"));
+        // Sanity: FileDelete is DANGEROUS, so accept-edits won't auto-approve.
+        assertThat(cap.risk()).isEqualTo(dev.aceclaw.security.PermissionLevel.DANGEROUS);
+    }
+
+    @Test
+    void benignCopyWithSafeBothSidesEmitsFileWrite() {
+        // Copies don't delete the source, so the WRITE risk on the
+        // destination is honest — accept-edits auto-approval is fine.
+        var tool = McpToolBridge.create("fs", mcpTool("copy_file", "desc"), client);
 
         var args = new ObjectMapper().createObjectNode()
                 .put("source", "/tmp/a.txt")
@@ -341,6 +389,54 @@ class McpToolBridgeTest {
 
         assertThat(cap).isInstanceOf(Capability.FileWrite.class);
         assertThat(((Capability.FileWrite) cap).path()).isEqualTo(Path.of("/tmp/b.txt"));
+    }
+
+    @Test
+    void writeVerbSuffixShortFormMatches() {
+        // CodeRabbit on #495: short-form suffixes (foo_put, foo_rm) were
+        // missing from the suffix alternation; foo_put is a clear write,
+        // it should be classified.
+        var tool = McpToolBridge.create("fs", mcpTool("blob_put", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode().put("path", "/tmp/x");
+        var cap = tool.toCapability(args);
+
+        assertThat(cap).isInstanceOf(Capability.FileWrite.class);
+    }
+
+    @Test
+    void deleteVerbSuffixShortFormMatches() {
+        var tool = McpToolBridge.create("fs", mcpTool("blob_rm", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode().put("path", "/tmp/x");
+        var cap = tool.toCapability(args);
+
+        assertThat(cap).isInstanceOf(Capability.FileDelete.class);
+    }
+
+    @Test
+    void moveVerbSuffixShortFormMatches() {
+        var tool = McpToolBridge.create("fs", mcpTool("blob_mv", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode()
+                .put("source", "/tmp/a")
+                .put("destination", "/tmp/b");
+        var cap = tool.toCapability(args);
+
+        // Move semantics → FileDelete(source) for the dangerous risk.
+        assertThat(cap).isInstanceOf(Capability.FileDelete.class);
+    }
+
+    @Test
+    void copyVerbSuffixShortFormMatches() {
+        var tool = McpToolBridge.create("fs", mcpTool("blob_cp", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode()
+                .put("source", "/tmp/a")
+                .put("destination", "/tmp/b");
+        var cap = tool.toCapability(args);
+
+        assertThat(cap).isInstanceOf(Capability.FileWrite.class);
     }
 
     @Test

--- a/aceclaw-mcp/src/test/java/dev/aceclaw/mcp/McpToolBridgeTest.java
+++ b/aceclaw-mcp/src/test/java/dev/aceclaw/mcp/McpToolBridgeTest.java
@@ -220,6 +220,92 @@ class McpToolBridgeTest {
     }
 
     @Test
+    void moveFileToSensitiveDestinationInfersFileWrite() {
+        // Codex P1 follow-up #2 on #495: move/rename/copy with a destination
+        // field must be classified as FileWrite of the destination so the
+        // structural denial sees "writing to .env".
+        var tool = McpToolBridge.create("fs", mcpTool("move_file", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode()
+                .put("source", "/tmp/safe.txt")
+                .put("destination", "/repo/.env");
+        var cap = tool.toCapability(args);
+
+        assertThat(cap).isInstanceOf(Capability.FileWrite.class);
+        assertThat(((Capability.FileWrite) cap).path()).isEqualTo(Path.of("/repo/.env"));
+    }
+
+    @Test
+    void renameWithNewPathInfersFileWrite() {
+        var tool = McpToolBridge.create("fs", mcpTool("rename", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode()
+                .put("old_path", "/tmp/safe.txt")
+                .put("new_path", "/repo/.env");
+        var cap = tool.toCapability(args);
+
+        assertThat(cap).isInstanceOf(Capability.FileWrite.class);
+    }
+
+    @Test
+    void copyWithTargetInfersFileWrite() {
+        var tool = McpToolBridge.create("fs", mcpTool("copy_file", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode()
+                .put("source", "/tmp/x")
+                .put("target", "/etc/hosts");
+        var cap = tool.toCapability(args);
+
+        assertThat(cap).isInstanceOf(Capability.FileWrite.class);
+    }
+
+    @Test
+    void moveFromSensitiveSourceInfersFileDelete() {
+        // When destination is missing/non-resolvable but source resolves and
+        // the op is a move (not copy), the source is effectively being
+        // deleted — emit FileDelete so the structural layer can catch
+        // attempts to move .env away.
+        var tool = McpToolBridge.create("fs", mcpTool("move_file", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode()
+                .put("source", "/repo/.env");
+        // No destination field.
+        var cap = tool.toCapability(args);
+
+        assertThat(cap).isInstanceOf(Capability.FileDelete.class);
+        assertThat(((Capability.FileDelete) cap).path()).isEqualTo(Path.of("/repo/.env"));
+    }
+
+    @Test
+    void copyFromSensitiveSourceDoesNotInferDelete() {
+        // Copies leave the source intact — no FileDelete inferred.
+        var tool = McpToolBridge.create("fs", mcpTool("copy_file", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode()
+                .put("source", "/repo/.env");
+        var cap = tool.toCapability(args);
+
+        // No destination resolved; not a delete (copy doesn't delete source).
+        // Falls through to McpInvoke.
+        assertThat(cap).isInstanceOf(Capability.McpInvoke.class);
+    }
+
+    @Test
+    void mcpMoveToSensitiveDestinationIsStructurallyDenied() {
+        // End-to-end: move to .env composes through to a structural denial.
+        var tool = McpToolBridge.create("fs", mcpTool("move_file", "desc"), client);
+        var args = new ObjectMapper().createObjectNode()
+                .put("source", "/tmp/safe.txt")
+                .put("destination", "/repo/.env");
+
+        var cap = tool.toCapability(args);
+        var decision = new DefaultPermissionPolicy("auto-accept").evaluateStructural(cap);
+
+        assertThat(decision).isNotNull();
+        assertThat(decision.reason()).contains("sensitive path");
+    }
+
+    @Test
     void mcpFileWriteToSensitivePathIsStructurallyDenied() {
         // End-to-end: an MCP server's write_file(path=".env") composes through
         // McpToolBridge.toCapability() into a Capability.FileWrite that the

--- a/aceclaw-mcp/src/test/java/dev/aceclaw/mcp/McpToolBridgeTest.java
+++ b/aceclaw-mcp/src/test/java/dev/aceclaw/mcp/McpToolBridgeTest.java
@@ -247,15 +247,96 @@ class McpToolBridgeTest {
         assertThat(cap).isInstanceOf(Capability.McpInvoke.class);
     }
 
+    // -- Move/rename/copy: now emit Capability.FileMove ---------------------
+    // Round-16 follow-up to #495: previously these emitted FileWrite or
+    // FileDelete to coerce the structural-denial layer into checking the
+    // right side. Now the structured FileMove(src, dst, deletesSource)
+    // carries both endpoints, the policy checks both, and the audit log
+    // accurately reflects "this was a move/copy" instead of pretending
+    // it was a delete.
+
     @Test
-    void moveFileToSensitiveDestinationInfersFileWrite() {
-        // Codex P1 follow-up #2 on #495: move/rename/copy with a destination
-        // field must be classified as FileWrite of the destination so the
-        // structural denial sees "writing to .env".
+    void moveFileBothEndpointsInferFileMove() {
         var tool = McpToolBridge.create("fs", mcpTool("move_file", "desc"), client);
 
         var args = new ObjectMapper().createObjectNode()
                 .put("source", "/tmp/safe.txt")
+                .put("destination", "/repo/.env");
+        var cap = tool.toCapability(args);
+
+        assertThat(cap).isInstanceOf(Capability.FileMove.class);
+        var fm = (Capability.FileMove) cap;
+        assertThat(fm.source()).isEqualTo(Path.of("/tmp/safe.txt"));
+        assertThat(fm.destination()).isEqualTo(Path.of("/repo/.env"));
+        assertThat(fm.deletesSource())
+                .as("move ops delete the source")
+                .isTrue();
+    }
+
+    @Test
+    void renameInfersFileMoveWithDeletesSource() {
+        var tool = McpToolBridge.create("fs", mcpTool("rename", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode()
+                .put("old_path", "/tmp/safe.txt")
+                .put("new_path", "/repo/.env");
+        var cap = tool.toCapability(args);
+
+        assertThat(cap).isInstanceOf(Capability.FileMove.class);
+        assertThat(((Capability.FileMove) cap).deletesSource()).isTrue();
+    }
+
+    @Test
+    void copyInfersFileMoveWithoutDeletesSource() {
+        var tool = McpToolBridge.create("fs", mcpTool("copy_file", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode()
+                .put("source", "/tmp/x")
+                .put("target", "/etc/hosts");
+        var cap = tool.toCapability(args);
+
+        assertThat(cap).isInstanceOf(Capability.FileMove.class);
+        assertThat(((Capability.FileMove) cap).deletesSource())
+                .as("copies do not delete the source")
+                .isFalse();
+    }
+
+    @Test
+    void moveSourceOnlyDegradesToFileDelete() {
+        // When destination is missing (malformed args), a move still tells
+        // us the source is being removed. Emit FileDelete so the structural
+        // layer can catch attempts to move .env away.
+        var tool = McpToolBridge.create("fs", mcpTool("move_file", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode()
+                .put("source", "/repo/.env");
+        var cap = tool.toCapability(args);
+
+        assertThat(cap).isInstanceOf(Capability.FileDelete.class);
+        assertThat(((Capability.FileDelete) cap).path()).isEqualTo(Path.of("/repo/.env"));
+    }
+
+    @Test
+    void copySourceOnlyFallsBackToMcpInvoke() {
+        // A copy with no destination is a malformed call (nothing is being
+        // created). FileRead wouldn't trigger structural rules anyway, so
+        // fall back to McpInvoke for the standard prompt.
+        var tool = McpToolBridge.create("fs", mcpTool("copy_file", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode()
+                .put("source", "/repo/.env");
+        var cap = tool.toCapability(args);
+
+        assertThat(cap).isInstanceOf(Capability.McpInvoke.class);
+    }
+
+    @Test
+    void moveDestinationOnlyDegradesToFileWrite() {
+        // Destination resolves but source doesn't — emit FileWrite of the
+        // destination since that's the visible side of the operation.
+        var tool = McpToolBridge.create("fs", mcpTool("move_file", "desc"), client);
+
+        var args = new ObjectMapper().createObjectNode()
                 .put("destination", "/repo/.env");
         var cap = tool.toCapability(args);
 
@@ -264,144 +345,98 @@ class McpToolBridgeTest {
     }
 
     @Test
-    void renameWithNewPathInfersFileWrite() {
-        var tool = McpToolBridge.create("fs", mcpTool("rename", "desc"), client);
-
-        var args = new ObjectMapper().createObjectNode()
-                .put("old_path", "/tmp/safe.txt")
-                .put("new_path", "/repo/.env");
-        var cap = tool.toCapability(args);
-
-        assertThat(cap).isInstanceOf(Capability.FileWrite.class);
-    }
-
-    @Test
-    void copyWithTargetInfersFileWrite() {
-        var tool = McpToolBridge.create("fs", mcpTool("copy_file", "desc"), client);
-
-        var args = new ObjectMapper().createObjectNode()
-                .put("source", "/tmp/x")
-                .put("target", "/etc/hosts");
-        var cap = tool.toCapability(args);
-
-        assertThat(cap).isInstanceOf(Capability.FileWrite.class);
-    }
-
-    @Test
-    void moveFromSensitiveSourceInfersFileDelete() {
-        // When destination is missing/non-resolvable but source resolves and
-        // the op is a move (not copy), the source is effectively being
-        // deleted — emit FileDelete so the structural layer can catch
-        // attempts to move .env away.
+    void fileMoveRiskReflectsDeletesSource() {
+        // Sanity: FileMove(deletesSource=true) is DANGEROUS so accept-edits
+        // mode prompts. FileMove(deletesSource=false) is WRITE — copies don't
+        // remove the source so the lower risk is honest.
         var tool = McpToolBridge.create("fs", mcpTool("move_file", "desc"), client);
+        var moveArgs = new ObjectMapper().createObjectNode()
+                .put("source", "/tmp/a")
+                .put("destination", "/tmp/b");
+        assertThat(tool.toCapability(moveArgs).risk())
+                .isEqualTo(dev.aceclaw.security.PermissionLevel.DANGEROUS);
 
-        var args = new ObjectMapper().createObjectNode()
-                .put("source", "/repo/.env");
-        // No destination field.
-        var cap = tool.toCapability(args);
-
-        assertThat(cap).isInstanceOf(Capability.FileDelete.class);
-        assertThat(((Capability.FileDelete) cap).path()).isEqualTo(Path.of("/repo/.env"));
+        var copyTool = McpToolBridge.create("fs", mcpTool("copy_file", "desc"), client);
+        var copyArgs = new ObjectMapper().createObjectNode()
+                .put("source", "/tmp/a")
+                .put("destination", "/tmp/b");
+        assertThat(copyTool.toCapability(copyArgs).risk())
+                .isEqualTo(dev.aceclaw.security.PermissionLevel.WRITE);
     }
 
     @Test
-    void copyFromSensitiveSourceWithoutDestinationInfersFileDelete() {
-        // Codex P1 follow-up on #495 (round-9): copies from sensitive sources
-        // re-classify as FileDelete(src) so the structural denial fires --
-        // duplicating credentials anywhere is exfiltration regardless of
-        // destination. The op doesn't actually delete the source; the
-        // classification is intentionally over-conservative (audit log shows
-        // FileDelete but toolName=mcp__<server>__copy_file keeps it
-        // traceable).
-        var tool = McpToolBridge.create("fs", mcpTool("copy_file", "desc"), client);
-
-        var args = new ObjectMapper().createObjectNode()
-                .put("source", "/repo/.env");
-        var cap = tool.toCapability(args);
-
-        assertThat(cap).isInstanceOf(Capability.FileDelete.class);
-        assertThat(((Capability.FileDelete) cap).path()).isEqualTo(Path.of("/repo/.env"));
-    }
-
-    @Test
-    void moveFromSensitiveSourceWithSafeDestinationInfersFileDelete() {
-        // Codex P1 second follow-up on #495: when destination is safe but
-        // source is sensitive, the "destination wins" rule used to emit
-        // FileWrite(safe-dest) and the structural layer would never see the
-        // sensitive source being deleted. Source-sensitivity is now probed
-        // explicitly so the structural denial fires on the delete side.
+    void moveToSensitiveDestinationIsStructurallyDenied() {
+        // End-to-end: FileMove with sensitive dst → structural denial fires
+        // on the destination side.
         var tool = McpToolBridge.create("fs", mcpTool("move_file", "desc"), client);
+        var args = new ObjectMapper().createObjectNode()
+                .put("source", "/tmp/safe.txt")
+                .put("destination", "/repo/.env");
 
+        var cap = tool.toCapability(args);
+        var decision = new DefaultPermissionPolicy("auto-accept").evaluateStructural(cap);
+
+        assertThat(decision).isNotNull();
+    }
+
+    @Test
+    void moveFromSensitiveSourceIsStructurallyDenied() {
+        // End-to-end: FileMove with sensitive src + safe dst → structural
+        // denial fires on the source side because the move removes the
+        // sensitive file.
+        var tool = McpToolBridge.create("fs", mcpTool("move_file", "desc"), client);
         var args = new ObjectMapper().createObjectNode()
                 .put("source", "/repo/.env")
                 .put("destination", "/tmp/env-backup.txt");
+
         var cap = tool.toCapability(args);
-
-        assertThat(cap)
-                .as("safe-dst + sensitive-src move must produce FileDelete to trigger denial")
-                .isInstanceOf(Capability.FileDelete.class);
-        assertThat(((Capability.FileDelete) cap).path()).isEqualTo(Path.of("/repo/.env"));
-    }
-
-    @Test
-    void copyFromSensitiveSourceToSafeDestinationIsStructurallyDeniedAsExfil() {
-        // Codex P1 on #495 (round-9): copy_file(.env, /tmp/env-copy) reads
-        // sensitive content and duplicates it to a non-sensitive location --
-        // a credential-exfiltration vector. Pre-fix this auto-approved in
-        // accept-edits because FileWrite(safe-dst) has WRITE risk. Re-classify
-        // copies-from-sensitive-src as FileDelete(src) so the structural
-        // denial layer refuses them regardless of destination, matching the
-        // pre-#495 EXECUTE-prompt behaviour for MCP tools.
-        var tool = McpToolBridge.create("fs", mcpTool("copy_file", "desc"), client);
-
-        var args = new ObjectMapper().createObjectNode()
-                .put("source", "/repo/.env")
-                .put("destination", "/tmp/env-copy.txt");
-        var cap = tool.toCapability(args);
-
-        assertThat(cap)
-                .as("copy from sensitive src must be classified as FileDelete to trigger denial")
-                .isInstanceOf(Capability.FileDelete.class);
         var decision = new DefaultPermissionPolicy("auto-accept").evaluateStructural(cap);
+
         assertThat(decision)
-                .as("structural denial fires even in auto-accept mode")
+                .as("removing sensitive source via move must be denied")
                 .isNotNull();
     }
 
     @Test
-    void benignMoveWithSafeBothSidesEmitsFileDeleteToPreserveDangerousRisk() {
-        // Codex P2 on #495: a benign move emitted FileWrite(dst) (WRITE risk)
-        // which auto-approves in accept-edits mode, silently removing the
-        // source. Pre-#495 MCP moves prompted via EXECUTE risk. To match
-        // that floor — and since the move semantics ARE a delete of the
-        // source — emit FileDelete(src) instead. FileDelete is DANGEROUS,
-        // so it prompts in every mode except auto-accept.
-        var tool = McpToolBridge.create("fs", mcpTool("move_file", "desc"), client);
-
+    void copyFromSensitiveSourceToSafeDestinationIsStructurallyDeniedAsExfil() {
+        // Credential exfiltration: copy_file(.env, /tmp/x) duplicates a
+        // sensitive file into a non-sensitive location. FileMove carries
+        // both endpoints so the policy can refuse the read side.
+        var tool = McpToolBridge.create("fs", mcpTool("copy_file", "desc"), client);
         var args = new ObjectMapper().createObjectNode()
-                .put("source", "/tmp/a.txt")
-                .put("destination", "/tmp/b.txt");
-        var cap = tool.toCapability(args);
+                .put("source", "/repo/.env")
+                .put("destination", "/tmp/env-copy.txt");
 
-        assertThat(cap).isInstanceOf(Capability.FileDelete.class);
-        assertThat(((Capability.FileDelete) cap).path()).isEqualTo(Path.of("/tmp/a.txt"));
-        // Sanity: FileDelete is DANGEROUS, so accept-edits won't auto-approve.
-        assertThat(cap.risk()).isEqualTo(dev.aceclaw.security.PermissionLevel.DANGEROUS);
+        var cap = tool.toCapability(args);
+        assertThat(cap).isInstanceOf(Capability.FileMove.class);
+        assertThat(((Capability.FileMove) cap).deletesSource())
+                .as("copy semantics preserved -- this is FileMove(deletesSource=false)")
+                .isFalse();
+
+        var decision = new DefaultPermissionPolicy("auto-accept").evaluateStructural(cap);
+        assertThat(decision)
+                .as("copy from sensitive source must be denied even in auto-accept")
+                .isNotNull();
     }
 
     @Test
-    void benignCopyWithSafeBothSidesEmitsFileWrite() {
-        // Copies don't delete the source, so the WRITE risk on the
-        // destination is honest — accept-edits auto-approval is fine.
-        var tool = McpToolBridge.create("fs", mcpTool("copy_file", "desc"), client);
-
+    void benignMoveBothSidesEmitsFileMoveNotDenied() {
+        // No sensitive paths on either side — structural denial returns null,
+        // FileMove(deletesSource=true) bubbles up to the mode-based check.
+        // Audit log accurately records @type=FileMove rather than the old
+        // FileDelete coercion.
+        var tool = McpToolBridge.create("fs", mcpTool("move_file", "desc"), client);
         var args = new ObjectMapper().createObjectNode()
                 .put("source", "/tmp/a.txt")
                 .put("destination", "/tmp/b.txt");
+
         var cap = tool.toCapability(args);
 
-        assertThat(cap).isInstanceOf(Capability.FileWrite.class);
-        assertThat(((Capability.FileWrite) cap).path()).isEqualTo(Path.of("/tmp/b.txt"));
+        assertThat(cap).isInstanceOf(Capability.FileMove.class);
+        var decision = new DefaultPermissionPolicy("normal").evaluateStructural(cap);
+        assertThat(decision)
+                .as("no sensitive paths -> structural denial returns null")
+                .isNull();
     }
 
     @Test
@@ -436,8 +471,8 @@ class McpToolBridgeTest {
                 .put("destination", "/tmp/b");
         var cap = tool.toCapability(args);
 
-        // Move semantics → FileDelete(source) for the dangerous risk.
-        assertThat(cap).isInstanceOf(Capability.FileDelete.class);
+        assertThat(cap).isInstanceOf(Capability.FileMove.class);
+        assertThat(((Capability.FileMove) cap).deletesSource()).isTrue();
     }
 
     @Test
@@ -449,7 +484,8 @@ class McpToolBridgeTest {
                 .put("destination", "/tmp/b");
         var cap = tool.toCapability(args);
 
-        assertThat(cap).isInstanceOf(Capability.FileWrite.class);
+        assertThat(cap).isInstanceOf(Capability.FileMove.class);
+        assertThat(((Capability.FileMove) cap).deletesSource()).isFalse();
     }
 
     @Test
@@ -495,7 +531,8 @@ class McpToolBridgeTest {
                 .put("destination", "/repo/.env");
         var cap = tool.toCapability(args);
 
-        assertThat(cap).isInstanceOf(Capability.FileWrite.class);
+        assertThat(cap).isInstanceOf(Capability.FileMove.class);
+        assertThat(((Capability.FileMove) cap).destination()).isEqualTo(Path.of("/repo/.env"));
     }
 
     @Test
@@ -564,21 +601,6 @@ class McpToolBridgeTest {
 
         assertThat(cap).isInstanceOf(Capability.FileWrite.class);
         assertThat(((Capability.FileWrite) cap).path()).isEqualTo(Path.of("/repo/.env"));
-    }
-
-    @Test
-    void mcpMoveToSensitiveDestinationIsStructurallyDenied() {
-        // End-to-end: move to .env composes through to a structural denial.
-        var tool = McpToolBridge.create("fs", mcpTool("move_file", "desc"), client);
-        var args = new ObjectMapper().createObjectNode()
-                .put("source", "/tmp/safe.txt")
-                .put("destination", "/repo/.env");
-
-        var cap = tool.toCapability(args);
-        var decision = new DefaultPermissionPolicy("auto-accept").evaluateStructural(cap);
-
-        assertThat(decision).isNotNull();
-        assertThat(decision.reason()).contains("sensitive path");
     }
 
     @Test

--- a/aceclaw-mcp/src/test/java/dev/aceclaw/mcp/McpToolBridgeTest.java
+++ b/aceclaw-mcp/src/test/java/dev/aceclaw/mcp/McpToolBridgeTest.java
@@ -415,7 +415,7 @@ class McpToolBridgeTest {
                 .put("destination", "/repo/.env");
 
         var cap = tool.toCapability(args);
-        var decision = new DefaultPermissionPolicy("auto-accept").evaluateStructural(cap);
+        var decision = new DefaultPermissionPolicy("auto-accept", /* denySensitivePaths */ true).evaluateStructural(cap);
 
         assertThat(decision).isNotNull();
     }
@@ -431,7 +431,7 @@ class McpToolBridgeTest {
                 .put("destination", "/tmp/env-backup.txt");
 
         var cap = tool.toCapability(args);
-        var decision = new DefaultPermissionPolicy("auto-accept").evaluateStructural(cap);
+        var decision = new DefaultPermissionPolicy("auto-accept", /* denySensitivePaths */ true).evaluateStructural(cap);
 
         assertThat(decision)
                 .as("removing sensitive source via move must be denied")
@@ -454,7 +454,7 @@ class McpToolBridgeTest {
                 .as("copy semantics preserved -- this is FileMove(deletesSource=false)")
                 .isFalse();
 
-        var decision = new DefaultPermissionPolicy("auto-accept").evaluateStructural(cap);
+        var decision = new DefaultPermissionPolicy("auto-accept", /* denySensitivePaths */ true).evaluateStructural(cap);
         assertThat(decision)
                 .as("copy from sensitive source must be denied even in auto-accept")
                 .isNotNull();
@@ -474,7 +474,10 @@ class McpToolBridgeTest {
         var cap = tool.toCapability(args);
 
         assertThat(cap).isInstanceOf(Capability.FileMove.class);
-        var decision = new DefaultPermissionPolicy("normal").evaluateStructural(cap);
+        // Layer enabled here so the "returns null on benign paths" assertion
+        // actually tests the rule, not the toggle's off-state.
+        var decision = new DefaultPermissionPolicy("normal", /* denySensitivePaths */ true)
+                .evaluateStructural(cap);
         assertThat(decision)
                 .as("no sensitive paths -> structural denial returns null")
                 .isNull();
@@ -655,7 +658,7 @@ class McpToolBridgeTest {
         var args = new ObjectMapper().createObjectNode().put("path", "/repo/.env");
 
         var cap = tool.toCapability(args);
-        var decision = new DefaultPermissionPolicy("auto-accept").evaluateStructural(cap);
+        var decision = new DefaultPermissionPolicy("auto-accept", /* denySensitivePaths */ true).evaluateStructural(cap);
 
         assertThat(decision)
                 .as("MCP-driven write to .env must be structurally denied even in auto-accept")

--- a/aceclaw-memory/src/test/java/dev/aceclaw/memory/CandidateStoreTest.java
+++ b/aceclaw-memory/src/test/java/dev/aceclaw/memory/CandidateStoreTest.java
@@ -351,8 +351,15 @@ class CandidateStoreTest {
         var evidenceCount = 2;
         var successCount = 1;
         var failureCount = 0;
-        var firstSeenAt = Instant.parse("2026-02-20T00:00:00Z");
-        var lastSeenAt = Instant.parse("2026-02-22T00:00:00Z");
+        // Use clock-relative timestamps so this test doesn't time-bomb against
+        // CandidateStore.DEFAULT_RETENTION (90 days). Fixed dates from the
+        // original test (2026-02-20..22) silently expired on 2026-05-22 when
+        // the load-time maintenance pass started purging the legacy entry
+        // before the assertion ran — making this look like a migration
+        // regression even though it was just a calendar bomb.
+        var now = Instant.now();
+        var firstSeenAt = now.minus(Duration.ofDays(3));
+        var lastSeenAt = now.minus(Duration.ofDays(1));
         var sourceRefs = List.of("legacy:session");
 
         String legacyPayload = id + "|" + category + "|" + kind + "|" + state + "|" + content + "|" + toolTag + "|"

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/Capability.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/Capability.java
@@ -72,6 +72,7 @@ import java.util.regex.Pattern;
         @JsonSubTypes.Type(value = Capability.FileRead.class, name = "FileRead"),
         @JsonSubTypes.Type(value = Capability.FileWrite.class, name = "FileWrite"),
         @JsonSubTypes.Type(value = Capability.FileDelete.class, name = "FileDelete"),
+        @JsonSubTypes.Type(value = Capability.FileMove.class, name = "FileMove"),
         @JsonSubTypes.Type(value = Capability.FileSearch.class, name = "FileSearch"),
         @JsonSubTypes.Type(value = Capability.BashExec.class, name = "BashExec"),
         @JsonSubTypes.Type(value = Capability.OsScript.class, name = "OsScript"),
@@ -181,6 +182,40 @@ public sealed interface Capability {
         @Override public PermissionLevel risk() { return PermissionLevel.DANGEROUS; }
         @Override public DataFlow dataFlow() { return DataFlow.EGRESS; }
         @Override public String displayLabel() { return "delete " + renderPath(path); }
+    }
+
+    /**
+     * Two-arg file operation: {@code move}, {@code rename}, {@code copy}.
+     * Carries both endpoints so {@link DefaultPermissionPolicy#evaluateStructural}
+     * can check source AND destination sensitivity in one pass — without this
+     * variant, the MCP-side inference had to choose ONE of {@link FileWrite}
+     * or {@link FileDelete} and lost the other side's information, which
+     * showed up in the audit log as {@code @type=FileDelete} entries for
+     * what were actually copy operations.
+     *
+     * <p>{@code deletesSource} distinguishes moves (true — source is removed)
+     * from copies (false — source persists). The risk classification flows
+     * from this flag: moves are {@code DANGEROUS} (a delete happens), copies
+     * are {@code WRITE} (only the destination is created).
+     */
+    record FileMove(Path source, Path destination, boolean deletesSource) implements Capability {
+        public FileMove {
+            Objects.requireNonNull(source, "source");
+            Objects.requireNonNull(destination, "destination");
+        }
+
+        @Override public PermissionLevel risk() {
+            // Moves remove the source; the operation's risk class matches
+            // FileDelete (DANGEROUS) so accept-edits mode doesn't auto-
+            // approve them. Copies leave the source intact, so the destination
+            // write is the only effect — WRITE is honest.
+            return deletesSource ? PermissionLevel.DANGEROUS : PermissionLevel.WRITE;
+        }
+        @Override public DataFlow dataFlow() { return DataFlow.BOTH; }
+        @Override public String displayLabel() {
+            return (deletesSource ? "move " : "copy ")
+                    + renderPath(source) + " -> " + renderPath(destination);
+        }
     }
 
     // -- Filesystem search ----------------------------------------------

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/DefaultPermissionPolicy.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/DefaultPermissionPolicy.java
@@ -1,5 +1,8 @@
 package dev.aceclaw.security;
 
+import java.nio.file.Path;
+import java.util.Set;
+
 /**
  * The default permission policy for the AceClaw agent.
  *
@@ -12,6 +15,17 @@ package dev.aceclaw.security;
  * </ul>
  *
  * <p>READ-level operations are always auto-approved in all modes.
+ *
+ * <h3>Structural hard-denial layer</h3>
+ *
+ * <p>Some capabilities are denied <em>regardless of mode</em> — including
+ * {@code auto-accept}. Today that means writes and deletes targeting paths
+ * that hold credentials or other operator-critical material:
+ * {@code .env*}, {@code .ssh/*}, {@code .git/config}, {@code credentials.json},
+ * anything under {@code /etc/}. This is the "cross-cutting rule" surface the
+ * runtime-governance doc names: a single check the agent cannot route around
+ * by being in the wrong mode. Detection matches on path segments (not
+ * substrings) so {@code /repo/notes-on-dotenv.md} is unaffected.
  */
 public final class DefaultPermissionPolicy implements PermissionPolicy {
 
@@ -20,6 +34,29 @@ public final class DefaultPermissionPolicy implements PermissionPolicy {
     public static final String MODE_ACCEPT_EDITS = "accept-edits";
     public static final String MODE_PLAN = "plan";
     public static final String MODE_AUTO_ACCEPT = "auto-accept";
+
+    /**
+     * File names whose <em>basename</em> is sensitive in every project layout.
+     * Matched against {@link Path#getFileName()} so siblings like
+     * {@code dotenv-notes.md} don't trigger.
+     */
+    private static final Set<String> SENSITIVE_FILENAMES = Set.of(
+            ".env",
+            "credentials.json",
+            ".netrc",
+            "id_rsa",
+            "id_ed25519");
+
+    /**
+     * Path segments that, when present anywhere in the path, mark the file
+     * as sensitive. {@code .ssh} catches both {@code ~/.ssh/id_rsa} and a
+     * cloned {@code ./.ssh/config}; {@code .git/config} catches per-repo
+     * git config writes (a common credential-store smuggling vector).
+     */
+    private static final Set<String> SENSITIVE_PATH_SEGMENTS = Set.of(
+            ".ssh",
+            ".aws",
+            ".gnupg");
 
     private final String mode;
 
@@ -64,38 +101,123 @@ public final class DefaultPermissionPolicy implements PermissionPolicy {
     }
 
     @Override
-    public PermissionDecision evaluate(PermissionRequest request) {
-        // READ is always auto-approved in all modes
-        if (request.level() == PermissionLevel.READ) {
+    public PermissionDecision evaluate(Capability capability, Provenance provenance, String description) {
+        // 1. Structural hard denial — overrides every mode, including auto-accept.
+        var denial = checkHardDenial(capability);
+        if (denial != null) return denial;
+
+        // 2. READ is always auto-approved in all modes.
+        if (capability.risk() == PermissionLevel.READ) {
             return new PermissionDecision.Approved();
         }
 
+        // 3. Mode-based decision. `description` is the dispatcher's rich
+        //    human-readable phrasing — surface it in the prompt so the user
+        //    sees what the tool actually intends to do.
         return switch (mode) {
             case MODE_AUTO_ACCEPT -> new PermissionDecision.Approved();
 
             case MODE_PLAN -> new PermissionDecision.Denied(
                     "Operation denied: plan mode is read-only. " +
-                    "Requested: " + request.description());
+                    "Requested: " + description);
 
-            case MODE_ACCEPT_EDITS -> switch (request.level()) {
+            case MODE_ACCEPT_EDITS -> switch (capability.risk()) {
                 case READ, WRITE -> new PermissionDecision.Approved();
                 case EXECUTE, DANGEROUS -> new PermissionDecision.NeedsUserApproval(
-                        formatPrompt(request));
+                        formatPrompt(capability, description));
             };
 
             // MODE_NORMAL (default)
-            default -> new PermissionDecision.NeedsUserApproval(
-                    formatPrompt(request));
+            default -> new PermissionDecision.NeedsUserApproval(formatPrompt(capability, description));
         };
     }
 
-    private static String formatPrompt(PermissionRequest request) {
-        String action = switch (request.level()) {
+    /**
+     * Returns a {@link PermissionDecision.Denied} when the capability targets
+     * a structurally sensitive resource, or {@code null} when no hard rule
+     * applies. Today only file writes and deletes have hard rules; other
+     * variants fall through to the mode-driven path. Adding a rule here is
+     * the way to encode "this resource is sensitive no matter the mode."
+     */
+    private static PermissionDecision checkHardDenial(Capability capability) {
+        return switch (capability) {
+            case Capability.FileWrite fw -> denyIfSensitivePath(fw.path(), "write to");
+            case Capability.FileDelete fd -> denyIfSensitivePath(fd.path(), "delete");
+            default -> null;
+        };
+    }
+
+    /**
+     * Walks {@code path}'s segments looking for sensitive markers. Uses
+     * segment-level matching (not {@code String.contains}) so legitimate
+     * siblings like {@code repo/notes-on-env.md} don't false-trip.
+     *
+     * <p>The path is {@link Path#normalize() normalized} first — purely
+     * lexical {@code ..} collapsing, no filesystem I/O — so attempts like
+     * {@code /tmp/../etc/hosts} cannot route around the {@code /etc/} rule.
+     */
+    private static PermissionDecision denyIfSensitivePath(Path rawPath, String verb) {
+        var path = rawPath.normalize();
+        // Match the basename (e.g. ".env", "credentials.json")
+        var fileName = path.getFileName();
+        if (fileName != null) {
+            String name = fileName.toString();
+            if (SENSITIVE_FILENAMES.contains(name)) {
+                return deniedSensitive(verb, path);
+            }
+            // .env, .env.local, .env.production all match — but NOT
+            // dotenv-notes.md or env-template (basename must START with .env).
+            if (name.startsWith(".env")) {
+                return deniedSensitive(verb, path);
+            }
+        }
+
+        // Match any path segment for things like .ssh/, .aws/credentials.
+        for (Path segment : path) {
+            if (SENSITIVE_PATH_SEGMENTS.contains(segment.toString())) {
+                return deniedSensitive(verb, path);
+            }
+        }
+
+        // .git/config is sensitive (credential-helper config sits here); the
+        // rest of .git/ is fine to write so we cannot deny on segment ".git"
+        // alone — gradle/git plugins legitimately rewrite .git/HEAD,
+        // packed-refs, etc. during normal operation.
+        var nameOnly = fileName == null ? "" : fileName.toString();
+        if ("config".equals(nameOnly)) {
+            for (Path segment : path) {
+                if (".git".equals(segment.toString())) {
+                    return deniedSensitive(verb, path);
+                }
+            }
+        }
+
+        // Absolute /etc/* — system-wide config. Tools that legitimately
+        // need to touch /etc must be invoked outside the agent.
+        if (path.isAbsolute()) {
+            var root = path.getRoot();
+            if (root != null && path.getNameCount() > 0
+                    && "etc".equals(path.getName(0).toString())) {
+                return deniedSensitive(verb, path);
+            }
+        }
+
+        return null;
+    }
+
+    private static PermissionDecision deniedSensitive(String verb, Path path) {
+        return new PermissionDecision.Denied(
+                "Refusing to " + verb + " a sensitive path: " + path
+                        + " (this rule overrides all permission modes)");
+    }
+
+    private static String formatPrompt(Capability capability, String description) {
+        String action = switch (capability.risk()) {
             case WRITE -> "write to";
             case EXECUTE -> "execute";
             case DANGEROUS -> "perform a potentially destructive action:";
             default -> "access";
         };
-        return String.format("The agent wants to %s: %s", action, request.description());
+        return String.format("The agent wants to %s: %s", action, description);
     }
 }

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/DefaultPermissionPolicy.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/DefaultPermissionPolicy.java
@@ -1,6 +1,7 @@
 package dev.aceclaw.security;
 
 import java.nio.file.Path;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 
@@ -38,8 +39,11 @@ public final class DefaultPermissionPolicy implements PermissionPolicy {
 
     /**
      * File names whose <em>basename</em> is sensitive in every project layout.
-     * Matched against {@link Path#getFileName()} so siblings like
-     * {@code dotenv-notes.md} don't trigger.
+     * Matched against {@link Path#getFileName()} case-insensitively (under
+     * {@link Locale#ROOT}) so case-insensitive filesystems like the default
+     * macOS APFS or Windows NTFS can't be bypassed with {@code .ENV} or
+     * {@code Credentials.json} pointing at the same underlying file.
+     * Store these entries lowercased; the comparison lowercases the input.
      */
     private static final Set<String> SENSITIVE_FILENAMES = Set.of(
             ".env",
@@ -53,6 +57,8 @@ public final class DefaultPermissionPolicy implements PermissionPolicy {
      * as sensitive. {@code .ssh} catches both {@code ~/.ssh/id_rsa} and a
      * cloned {@code ./.ssh/config}; {@code .git/config} catches per-repo
      * git config writes (a common credential-store smuggling vector).
+     * Compared case-insensitively for the same reason as
+     * {@link #SENSITIVE_FILENAMES}.
      */
     private static final Set<String> SENSITIVE_PATH_SEGMENTS = Set.of(
             ".ssh",
@@ -164,23 +170,26 @@ public final class DefaultPermissionPolicy implements PermissionPolicy {
      */
     private static PermissionDecision.Denied denyIfSensitivePath(Path rawPath, String verb) {
         var path = rawPath.normalize();
-        // Match the basename (e.g. ".env", "credentials.json")
+        // Match the basename (e.g. ".env", "credentials.json"). Lowercase
+        // under Locale.ROOT for stable case-insensitive comparison — a
+        // case-insensitive filesystem treats `.ENV` and `.env` as the same
+        // file, so the structural rule has to too. (Codex P2 on #495.)
         var fileName = path.getFileName();
+        String nameLower = fileName == null ? "" : fileName.toString().toLowerCase(Locale.ROOT);
         if (fileName != null) {
-            String name = fileName.toString();
-            if (SENSITIVE_FILENAMES.contains(name)) {
+            if (SENSITIVE_FILENAMES.contains(nameLower)) {
                 return deniedSensitive(verb, path);
             }
             // .env, .env.local, .env.production all match — but NOT
             // dotenv-notes.md or env-template (basename must START with .env).
-            if (name.startsWith(".env")) {
+            if (nameLower.startsWith(".env")) {
                 return deniedSensitive(verb, path);
             }
         }
 
         // Match any path segment for things like .ssh/, .aws/credentials.
         for (Path segment : path) {
-            if (SENSITIVE_PATH_SEGMENTS.contains(segment.toString())) {
+            if (SENSITIVE_PATH_SEGMENTS.contains(segment.toString().toLowerCase(Locale.ROOT))) {
                 return deniedSensitive(verb, path);
             }
         }
@@ -189,10 +198,9 @@ public final class DefaultPermissionPolicy implements PermissionPolicy {
         // rest of .git/ is fine to write so we cannot deny on segment ".git"
         // alone — gradle/git plugins legitimately rewrite .git/HEAD,
         // packed-refs, etc. during normal operation.
-        var nameOnly = fileName == null ? "" : fileName.toString();
-        if ("config".equals(nameOnly)) {
+        if ("config".equals(nameLower)) {
             for (Path segment : path) {
-                if (".git".equals(segment.toString())) {
+                if (".git".equals(segment.toString().toLowerCase(Locale.ROOT))) {
                     return deniedSensitive(verb, path);
                 }
             }
@@ -203,7 +211,7 @@ public final class DefaultPermissionPolicy implements PermissionPolicy {
         if (path.isAbsolute()) {
             var root = path.getRoot();
             if (root != null && path.getNameCount() > 0
-                    && "etc".equals(path.getName(0).toString())) {
+                    && "etc".equals(path.getName(0).toString().toLowerCase(Locale.ROOT))) {
                 return deniedSensitive(verb, path);
             }
         }

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/DefaultPermissionPolicy.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/DefaultPermissionPolicy.java
@@ -1,6 +1,7 @@
 package dev.aceclaw.security;
 
 import java.nio.file.Path;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -102,18 +103,20 @@ public final class DefaultPermissionPolicy implements PermissionPolicy {
 
     @Override
     public PermissionDecision evaluate(Capability capability, Provenance provenance, String description) {
-        // 1. Structural hard denial — overrides every mode, including auto-accept.
-        var denial = checkHardDenial(capability);
-        if (denial != null) return denial;
+        Objects.requireNonNull(capability, "capability");
+        Objects.requireNonNull(provenance, "provenance");
+        Objects.requireNonNull(description, "description");
 
-        // 2. READ is always auto-approved in all modes.
+        // READ is always auto-approved in all modes. (Structural hard-denials
+        // are run earlier by PermissionManager via evaluateStructural — they
+        // do not reach this method.)
         if (capability.risk() == PermissionLevel.READ) {
             return new PermissionDecision.Approved();
         }
 
-        // 3. Mode-based decision. `description` is the dispatcher's rich
-        //    human-readable phrasing — surface it in the prompt so the user
-        //    sees what the tool actually intends to do.
+        // Mode-based decision. `description` is the dispatcher's rich
+        // human-readable phrasing — surface it in the prompt so the user
+        // sees what the tool actually intends to do.
         return switch (mode) {
             case MODE_AUTO_ACCEPT -> new PermissionDecision.Approved();
 
@@ -133,13 +136,16 @@ public final class DefaultPermissionPolicy implements PermissionPolicy {
     }
 
     /**
-     * Returns a {@link PermissionDecision.Denied} when the capability targets
-     * a structurally sensitive resource, or {@code null} when no hard rule
-     * applies. Today only file writes and deletes have hard rules; other
-     * variants fall through to the mode-driven path. Adding a rule here is
-     * the way to encode "this resource is sensitive no matter the mode."
+     * Structural rules that fire before the session-blanket lookup so an
+     * "always allow X" approval cannot let the agent route a write to
+     * {@code .env} or {@code .ssh/id_rsa} past the policy. Returns
+     * {@code null} when no rule applies — see
+     * {@link PermissionPolicy#evaluateStructural(Capability)} for the
+     * contract.
      */
-    private static PermissionDecision checkHardDenial(Capability capability) {
+    @Override
+    public PermissionDecision.Denied evaluateStructural(Capability capability) {
+        Objects.requireNonNull(capability, "capability");
         return switch (capability) {
             case Capability.FileWrite fw -> denyIfSensitivePath(fw.path(), "write to");
             case Capability.FileDelete fd -> denyIfSensitivePath(fd.path(), "delete");
@@ -156,7 +162,7 @@ public final class DefaultPermissionPolicy implements PermissionPolicy {
      * lexical {@code ..} collapsing, no filesystem I/O — so attempts like
      * {@code /tmp/../etc/hosts} cannot route around the {@code /etc/} rule.
      */
-    private static PermissionDecision denyIfSensitivePath(Path rawPath, String verb) {
+    private static PermissionDecision.Denied denyIfSensitivePath(Path rawPath, String verb) {
         var path = rawPath.normalize();
         // Match the basename (e.g. ".env", "credentials.json")
         var fileName = path.getFileName();
@@ -205,7 +211,7 @@ public final class DefaultPermissionPolicy implements PermissionPolicy {
         return null;
     }
 
-    private static PermissionDecision deniedSensitive(String verb, Path path) {
+    private static PermissionDecision.Denied deniedSensitive(String verb, Path path) {
         return new PermissionDecision.Denied(
                 "Refusing to " + verb + " a sensitive path: " + path
                         + " (this rule overrides all permission modes)");
@@ -215,7 +221,10 @@ public final class DefaultPermissionPolicy implements PermissionPolicy {
         String action = switch (capability.risk()) {
             case WRITE -> "write to";
             case EXECUTE -> "execute";
-            case DANGEROUS -> "perform a potentially destructive action:";
+            // Pre-#480 this branch ended with a colon and the format string
+            // below contributed another, producing "...action:: description".
+            // Keep the descriptor and let the format string add the single colon.
+            case DANGEROUS -> "perform a potentially destructive action";
             default -> "access";
         };
         return String.format("The agent wants to %s: %s", action, description);

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/DefaultPermissionPolicy.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/DefaultPermissionPolicy.java
@@ -18,14 +18,22 @@ import java.util.Objects;
  *
  * <h3>Structural hard-denial layer</h3>
  *
- * <p>Some capabilities are denied <em>regardless of mode</em> — including
- * {@code auto-accept}. Today that means writes and deletes targeting paths
+ * <p>Some capabilities can be denied <em>regardless of mode</em> — including
+ * {@code auto-accept}. Today that targets writes and deletes against paths
  * that hold credentials or other operator-critical material:
  * {@code .env*}, {@code .ssh/*}, {@code .git/config}, {@code credentials.json},
- * anything under {@code /etc/}. This is the "cross-cutting rule" surface the
- * runtime-governance doc names: a single check the agent cannot route around
- * by being in the wrong mode. Detection matches on path segments (not
+ * anything under {@code /etc/}. Detection matches on path segments (not
  * substrings) so {@code /repo/notes-on-dotenv.md} is unaffected.
+ *
+ * <p>The layer is <b>opt-in</b> via the {@code denySensitivePaths}
+ * constructor flag (default: {@code false}). With the flag off,
+ * {@link #evaluateStructural} returns {@code null} for every input and the
+ * policy behaves exactly like the pre-#480 mode-only policy — so an upgrade
+ * doesn't break workflows that legitimately write {@code .env} templates,
+ * {@code .git/config} entries, etc. Security-conscious operators enable it
+ * by setting {@code security.denySensitivePaths = true} in
+ * {@code ~/.aceclaw/config.json}; once on, the rule overrides every mode and
+ * every prior approval (session blanket, sub-agent dispatch).
  */
 public final class DefaultPermissionPolicy implements PermissionPolicy {
 
@@ -36,38 +44,61 @@ public final class DefaultPermissionPolicy implements PermissionPolicy {
     public static final String MODE_AUTO_ACCEPT = "auto-accept";
 
     private final String mode;
+    private final boolean denySensitivePaths;
 
     /**
-     * Creates a policy with the standard "normal" permission rules.
+     * Creates a policy with the standard "normal" permission rules and
+     * structural sensitive-path denials <b>off</b> (opt-in).
      */
     public DefaultPermissionPolicy() {
-        this(MODE_NORMAL);
+        this(MODE_NORMAL, false);
     }
 
     /**
-     * Creates a policy with the specified permission mode.
+     * Creates a policy with the specified permission mode and structural
+     * sensitive-path denials <b>off</b> (opt-in). Backwards-compatible with
+     * pre-flag callers — pass {@code denySensitivePaths=true} to enable the
+     * hard-denial layer.
      *
      * @param mode one of "normal", "accept-edits", "plan", "auto-accept"
      * @throws IllegalArgumentException if mode is not recognized
      */
     public DefaultPermissionPolicy(String mode) {
+        this(mode, false);
+    }
+
+    /**
+     * Creates a policy with the specified permission mode and an explicit
+     * choice on whether structural sensitive-path denials are active.
+     *
+     * @param mode               one of "normal", "accept-edits", "plan", "auto-accept"
+     * @param denySensitivePaths when {@code true}, writes/deletes targeting
+     *                           credential paths ({@code .env*}, {@code .ssh/*},
+     *                           {@code /etc/*}, etc.) are hard-denied via
+     *                           {@link #evaluateStructural}; when {@code false},
+     *                           {@code evaluateStructural} returns {@code null}
+     *                           and the policy behaves as mode-only.
+     * @throws IllegalArgumentException if mode is not recognized
+     */
+    public DefaultPermissionPolicy(String mode, boolean denySensitivePaths) {
         this.mode = switch (mode) {
             case MODE_NORMAL, MODE_ACCEPT_EDITS, MODE_PLAN, MODE_AUTO_ACCEPT -> mode;
             default -> throw new IllegalArgumentException(
                     "Unknown permission mode: '" + mode + "'. " +
                     "Valid modes: normal, accept-edits, plan, auto-accept");
         };
+        this.denySensitivePaths = denySensitivePaths;
     }
 
     /**
      * Creates a policy with the legacy auto-approve flag.
      *
      * @param autoApproveAll if true, equivalent to "auto-accept" mode
-     * @deprecated Use {@link #DefaultPermissionPolicy(String)} instead
+     * @deprecated Use {@link #DefaultPermissionPolicy(String, boolean)} instead
      */
     @Deprecated
     public DefaultPermissionPolicy(boolean autoApproveAll) {
-        this(autoApproveAll ? MODE_AUTO_ACCEPT : MODE_NORMAL);
+        this(autoApproveAll ? MODE_AUTO_ACCEPT : MODE_NORMAL, false);
     }
 
     /**
@@ -112,16 +143,33 @@ public final class DefaultPermissionPolicy implements PermissionPolicy {
     }
 
     /**
+     * Returns whether the structural sensitive-path layer is enabled on this
+     * policy instance — i.e. whether {@link #evaluateStructural} will ever
+     * return a non-{@code null} denial.
+     */
+    public boolean denySensitivePaths() {
+        return denySensitivePaths;
+    }
+
+    /**
      * Structural rules that fire before the session-blanket lookup so an
      * "always allow X" approval cannot let the agent route a write to
      * {@code .env} or {@code .ssh/id_rsa} past the policy. Returns
      * {@code null} when no rule applies — see
      * {@link PermissionPolicy#evaluateStructural(Capability)} for the
      * contract.
+     *
+     * <p>When {@code denySensitivePaths} was set to {@code false} on this
+     * instance (the default), this method short-circuits to {@code null} for
+     * every input — the policy is pure mode-based and never structurally
+     * denies. Operators opt in to the hard-denial layer via the constructor
+     * flag (typically wired from {@code security.denySensitivePaths} in
+     * {@code ~/.aceclaw/config.json}).
      */
     @Override
     public PermissionDecision.Denied evaluateStructural(Capability capability) {
         Objects.requireNonNull(capability, "capability");
+        if (!denySensitivePaths) return null;
         return switch (capability) {
             case Capability.FileWrite fw -> denyIfSensitivePath(fw.path(), "write to");
             case Capability.FileDelete fd -> denyIfSensitivePath(fd.path(), "delete");

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/DefaultPermissionPolicy.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/DefaultPermissionPolicy.java
@@ -50,7 +50,11 @@ public final class DefaultPermissionPolicy implements PermissionPolicy {
             "credentials.json",
             ".netrc",
             "id_rsa",
-            "id_ed25519");
+            "id_ed25519",
+            "id_ecdsa",
+            ".npmrc",
+            ".pypirc",
+            "service-account.json");
 
     /**
      * Path segments that, when present anywhere in the path, mark the file
@@ -63,7 +67,9 @@ public final class DefaultPermissionPolicy implements PermissionPolicy {
     private static final Set<String> SENSITIVE_PATH_SEGMENTS = Set.of(
             ".ssh",
             ".aws",
-            ".gnupg");
+            ".gnupg",
+            ".kube",
+            ".docker");
 
     private final String mode;
 

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/DefaultPermissionPolicy.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/DefaultPermissionPolicy.java
@@ -169,28 +169,40 @@ public final class DefaultPermissionPolicy implements PermissionPolicy {
      * {@code /tmp/../etc/hosts} cannot route around the {@code /etc/} rule.
      */
     private static PermissionDecision.Denied denyIfSensitivePath(Path rawPath, String verb) {
+        return isSensitivePath(rawPath) ? deniedSensitive(verb, rawPath.normalize()) : null;
+    }
+
+    /**
+     * Returns {@code true} when {@code rawPath} resolves to a path the
+     * structural-denial layer refuses to write or delete. Exposed so
+     * adapter-side code (notably {@code McpToolBridge}) can disambiguate
+     * two-arg ops like {@code move(source, destination)} where either side
+     * could be sensitive but only one capability variant can be emitted
+     * (Codex P1 follow-up on #495 — "deny moves that remove sensitive
+     * sources").
+     *
+     * <p>The path is {@link Path#normalize() normalized} before matching so
+     * {@code /tmp/../etc/hosts} resolves to {@code /etc/hosts}. Basename and
+     * segment comparisons are case-insensitive under {@link Locale#ROOT} so
+     * case-insensitive filesystems (default macOS APFS, Windows NTFS) can't
+     * be bypassed with {@code .ENV}.
+     */
+    public static boolean isSensitivePath(Path rawPath) {
+        if (rawPath == null) return false;
         var path = rawPath.normalize();
-        // Match the basename (e.g. ".env", "credentials.json"). Lowercase
-        // under Locale.ROOT for stable case-insensitive comparison — a
-        // case-insensitive filesystem treats `.ENV` and `.env` as the same
-        // file, so the structural rule has to too. (Codex P2 on #495.)
         var fileName = path.getFileName();
         String nameLower = fileName == null ? "" : fileName.toString().toLowerCase(Locale.ROOT);
         if (fileName != null) {
-            if (SENSITIVE_FILENAMES.contains(nameLower)) {
-                return deniedSensitive(verb, path);
-            }
+            if (SENSITIVE_FILENAMES.contains(nameLower)) return true;
             // .env, .env.local, .env.production all match — but NOT
             // dotenv-notes.md or env-template (basename must START with .env).
-            if (nameLower.startsWith(".env")) {
-                return deniedSensitive(verb, path);
-            }
+            if (nameLower.startsWith(".env")) return true;
         }
 
         // Match any path segment for things like .ssh/, .aws/credentials.
         for (Path segment : path) {
             if (SENSITIVE_PATH_SEGMENTS.contains(segment.toString().toLowerCase(Locale.ROOT))) {
-                return deniedSensitive(verb, path);
+                return true;
             }
         }
 
@@ -201,7 +213,7 @@ public final class DefaultPermissionPolicy implements PermissionPolicy {
         if ("config".equals(nameLower)) {
             for (Path segment : path) {
                 if (".git".equals(segment.toString().toLowerCase(Locale.ROOT))) {
-                    return deniedSensitive(verb, path);
+                    return true;
                 }
             }
         }
@@ -212,11 +224,11 @@ public final class DefaultPermissionPolicy implements PermissionPolicy {
             var root = path.getRoot();
             if (root != null && path.getNameCount() > 0
                     && "etc".equals(path.getName(0).toString().toLowerCase(Locale.ROOT))) {
-                return deniedSensitive(verb, path);
+                return true;
             }
         }
 
-        return null;
+        return false;
     }
 
     private static PermissionDecision.Denied deniedSensitive(String verb, Path path) {

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/DefaultPermissionPolicy.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/DefaultPermissionPolicy.java
@@ -1,9 +1,7 @@
 package dev.aceclaw.security;
 
 import java.nio.file.Path;
-import java.util.Locale;
 import java.util.Objects;
-import java.util.Set;
 
 /**
  * The default permission policy for the AceClaw agent.
@@ -36,40 +34,6 @@ public final class DefaultPermissionPolicy implements PermissionPolicy {
     public static final String MODE_ACCEPT_EDITS = "accept-edits";
     public static final String MODE_PLAN = "plan";
     public static final String MODE_AUTO_ACCEPT = "auto-accept";
-
-    /**
-     * File names whose <em>basename</em> is sensitive in every project layout.
-     * Matched against {@link Path#getFileName()} case-insensitively (under
-     * {@link Locale#ROOT}) so case-insensitive filesystems like the default
-     * macOS APFS or Windows NTFS can't be bypassed with {@code .ENV} or
-     * {@code Credentials.json} pointing at the same underlying file.
-     * Store these entries lowercased; the comparison lowercases the input.
-     */
-    private static final Set<String> SENSITIVE_FILENAMES = Set.of(
-            ".env",
-            "credentials.json",
-            ".netrc",
-            "id_rsa",
-            "id_ed25519",
-            "id_ecdsa",
-            ".npmrc",
-            ".pypirc",
-            "service-account.json");
-
-    /**
-     * Path segments that, when present anywhere in the path, mark the file
-     * as sensitive. {@code .ssh} catches both {@code ~/.ssh/id_rsa} and a
-     * cloned {@code ./.ssh/config}; {@code .git/config} catches per-repo
-     * git config writes (a common credential-store smuggling vector).
-     * Compared case-insensitively for the same reason as
-     * {@link #SENSITIVE_FILENAMES}.
-     */
-    private static final Set<String> SENSITIVE_PATH_SEGMENTS = Set.of(
-            ".ssh",
-            ".aws",
-            ".gnupg",
-            ".kube",
-            ".docker");
 
     private final String mode;
 
@@ -161,80 +125,32 @@ public final class DefaultPermissionPolicy implements PermissionPolicy {
         return switch (capability) {
             case Capability.FileWrite fw -> denyIfSensitivePath(fw.path(), "write to");
             case Capability.FileDelete fd -> denyIfSensitivePath(fd.path(), "delete");
+            case Capability.FileMove fm -> {
+                // Both endpoints matter. Destination is the file being written
+                // ("move/copy TO .env"); source is the file being read or
+                // removed ("copy FROM .env" is exfiltration; "move FROM .env"
+                // is also a delete of the source). Check destination first
+                // because that's the more direct "write to sensitive" attack;
+                // fall back to the source side if destination is safe but
+                // source is sensitive.
+                var dstDenial = denyIfSensitivePath(fm.destination(), "write to");
+                if (dstDenial != null) yield dstDenial;
+                yield denyIfSensitivePath(fm.source(), fm.deletesSource() ? "remove" : "read from");
+            }
             default -> null;
         };
     }
 
     /**
-     * Walks {@code path}'s segments looking for sensitive markers. Uses
-     * segment-level matching (not {@code String.contains}) so legitimate
-     * siblings like {@code repo/notes-on-env.md} don't false-trip.
-     *
-     * <p>The path is {@link Path#normalize() normalized} first — purely
-     * lexical {@code ..} collapsing, no filesystem I/O — so attempts like
-     * {@code /tmp/../etc/hosts} cannot route around the {@code /etc/} rule.
+     * Delegates to {@link SensitivePaths#matches(Path)} for the sensitivity
+     * rule set, returning a {@link PermissionDecision.Denied} with a human
+     * reason when the path matches. Sensitivity rules live in
+     * {@code SensitivePaths} so adapter-side code (notably
+     * {@code McpCapabilityInference}) can call the same rules without
+     * depending on this policy class.
      */
     private static PermissionDecision.Denied denyIfSensitivePath(Path rawPath, String verb) {
-        return isSensitivePath(rawPath) ? deniedSensitive(verb, rawPath.normalize()) : null;
-    }
-
-    /**
-     * Returns {@code true} when {@code rawPath} resolves to a path the
-     * structural-denial layer refuses to write or delete. Exposed so
-     * adapter-side code (notably {@code McpToolBridge}) can disambiguate
-     * two-arg ops like {@code move(source, destination)} where either side
-     * could be sensitive but only one capability variant can be emitted
-     * (Codex P1 follow-up on #495 — "deny moves that remove sensitive
-     * sources").
-     *
-     * <p>The path is {@link Path#normalize() normalized} before matching so
-     * {@code /tmp/../etc/hosts} resolves to {@code /etc/hosts}. Basename and
-     * segment comparisons are case-insensitive under {@link Locale#ROOT} so
-     * case-insensitive filesystems (default macOS APFS, Windows NTFS) can't
-     * be bypassed with {@code .ENV}.
-     */
-    public static boolean isSensitivePath(Path rawPath) {
-        if (rawPath == null) return false;
-        var path = rawPath.normalize();
-        var fileName = path.getFileName();
-        String nameLower = fileName == null ? "" : fileName.toString().toLowerCase(Locale.ROOT);
-        if (fileName != null) {
-            if (SENSITIVE_FILENAMES.contains(nameLower)) return true;
-            // .env, .env.local, .env.production all match — but NOT
-            // dotenv-notes.md or env-template (basename must START with .env).
-            if (nameLower.startsWith(".env")) return true;
-        }
-
-        // Match any path segment for things like .ssh/, .aws/credentials.
-        for (Path segment : path) {
-            if (SENSITIVE_PATH_SEGMENTS.contains(segment.toString().toLowerCase(Locale.ROOT))) {
-                return true;
-            }
-        }
-
-        // .git/config is sensitive (credential-helper config sits here); the
-        // rest of .git/ is fine to write so we cannot deny on segment ".git"
-        // alone — gradle/git plugins legitimately rewrite .git/HEAD,
-        // packed-refs, etc. during normal operation.
-        if ("config".equals(nameLower)) {
-            for (Path segment : path) {
-                if (".git".equals(segment.toString().toLowerCase(Locale.ROOT))) {
-                    return true;
-                }
-            }
-        }
-
-        // Absolute /etc/* — system-wide config. Tools that legitimately
-        // need to touch /etc must be invoked outside the agent.
-        if (path.isAbsolute()) {
-            var root = path.getRoot();
-            if (root != null && path.getNameCount() > 0
-                    && "etc".equals(path.getName(0).toString().toLowerCase(Locale.ROOT))) {
-                return true;
-            }
-        }
-
-        return false;
+        return SensitivePaths.matches(rawPath) ? deniedSensitive(verb, rawPath.normalize()) : null;
     }
 
     private static PermissionDecision.Denied deniedSensitive(String verb, Path path) {

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/PermissionManager.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/PermissionManager.java
@@ -247,6 +247,25 @@ public final class PermissionManager {
     }
 
     /**
+     * Runs only the structural / system-invariant denial layer of the policy
+     * — no session-blanket lookup, no mode-based decision. Used by the
+     * sub-agent permission path (which previously consulted only the
+     * session-approval boolean, bypassing the structural rules entirely —
+     * Codex P1 on #495). Returns {@code null} when no structural rule
+     * applies; the caller then routes through whatever approval logic is
+     * appropriate for its context.
+     *
+     * <p>No audit record is written here — the caller is expected to either
+     * approve (and audit elsewhere) or deny (and audit the denial in its
+     * own surface). Audit duplication between this method and a follow-up
+     * {@link #check} call would inflate the on-disk log.
+     */
+    public PermissionDecision.Denied checkStructural(Capability capability) {
+        Objects.requireNonNull(capability, "capability");
+        return policy.evaluateStructural(capability);
+    }
+
+    /**
      * Records a blanket session-level approval for a tool. After this
      * call, future requests for this tool from THIS session are
      * auto-approved (other sessions are unaffected — see #456).

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/PermissionManager.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/PermissionManager.java
@@ -124,10 +124,21 @@ public final class PermissionManager {
      *       tools — no UX regression during migration.</li>
      * </ul>
      *
-     * <p>Pipeline is unchanged: session allowlist first, then policy.
-     * PolicyEngine (#465 Scope #2) will eventually consume the structured
-     * {@link Capability} directly; until then this method bridges by
-     * constructing a {@link PermissionRequest} on the fly.
+     * <h4>Pipeline (#480 PR 4 / #495)</h4>
+     *
+     * <ol>
+     *   <li><b>Structural denial</b> ({@link PermissionPolicy#evaluateStructural}):
+     *       cross-cutting refusals like "never write to {@code .env}" run
+     *       FIRST so they cannot be bypassed by a prior "always allow X"
+     *       approval. Audited and returned immediately when matched.</li>
+     *   <li><b>Session blanket approval</b>: if the originating tool has been
+     *       blanket-approved in this session (per-session, #456), auto-approve
+     *       and audit with the {@code session-blanket-approval} marker.</li>
+     *   <li><b>Policy evaluation</b> ({@link PermissionPolicy#evaluate}):
+     *       the structured {@link Capability} + {@link Provenance} +
+     *       description go to the policy directly — no flat-record bridge.
+     *       Result audited.</li>
+     * </ol>
      */
     public PermissionDecision check(
             Capability capability,
@@ -255,14 +266,42 @@ public final class PermissionManager {
      * applies; the caller then routes through whatever approval logic is
      * appropriate for its context.
      *
-     * <p>No audit record is written here — the caller is expected to either
-     * approve (and audit elsewhere) or deny (and audit the denial in its
-     * own surface). Audit duplication between this method and a follow-up
-     * {@link #check} call would inflate the on-disk log.
+     * <p>When the structural layer denies, an audit entry is written so
+     * sub-agent attempts to write {@code .env} / {@code .ssh/} / etc. are
+     * observable in the same on-disk record as main-dispatcher denials.
+     * Without this entry, a successful structural denial on the sub-agent
+     * path would be invisible to forensics — the caller (the sub-agent
+     * permission checker) can't audit because it doesn't depend on
+     * {@code aceclaw-security}'s audit types.
+     *
+     * <p>No double-audit risk on the main dispatcher path: that path runs
+     * {@code policy.evaluateStructural} directly inside
+     * {@link #check(Capability, Provenance, String, String)} (which has its
+     * own audit hook) and does NOT route through this method.
+     *
+     * @param capability  the structured capability to test
+     * @param provenance  audit context recorded when a denial is written.
+     *                    {@code null} is allowed for callers that have no
+     *                    session in scope; uses
+     *                    {@link Provenance#daemonInternal()} as a stand-in.
+     * @param allowlistKey audit context — the originating tool name, so
+     *                     {@code grep toolName=...} on the on-disk log
+     *                     keeps working uniformly across denial sources.
      */
-    public PermissionDecision.Denied checkStructural(Capability capability) {
+    public PermissionDecision.Denied checkStructural(
+            Capability capability,
+            Provenance provenance,
+            String allowlistKey) {
         Objects.requireNonNull(capability, "capability");
-        return policy.evaluateStructural(capability);
+        var denial = policy.evaluateStructural(capability);
+        if (denial != null) {
+            var prov = provenance != null ? provenance : Provenance.daemonInternal();
+            String key = allowlistKey != null ? allowlistKey : capability.allowlistKey();
+            log.debug("Permission denied (structural, out-of-band): key={}, reason={}",
+                    key, denial.reason());
+            audit(key, capability, prov, denial, null);
+        }
+        return denial;
     }
 
     /**
@@ -313,27 +352,4 @@ public final class PermissionManager {
         return allow != null && allow.contains(toolName);
     }
 
-    /**
-     * Returns whether ANY session has blanket-approved the given tool.
-     *
-     * <p>Compatibility shim for the sub-agent permission checker: that
-     * checker is constructed once at daemon startup and doesn't have a
-     * session in scope at check time, so it can't ask the per-session
-     * variant. Until the sub-agent path threads sessionId through
-     * {@code ToolPermissionChecker} (separate refactor), this preserves
-     * the pre-#456 behaviour where a session-approved tool was reachable
-     * by sub-agents anywhere in the daemon.
-     *
-     * <p>This is permissive on purpose: a sub-agent in session B inherits
-     * approvals granted in session A. The right scoping is per-session,
-     * but losing the approval-flow entirely (always-deny) would regress
-     * usability. Tracked as a follow-up.
-     */
-    public boolean hasAnySessionApproval(String toolName) {
-        Objects.requireNonNull(toolName, "toolName");
-        for (var allow : sessionApprovals.values()) {
-            if (allow.contains(toolName)) return true;
-        }
-        return false;
-    }
 }

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/PermissionManager.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/PermissionManager.java
@@ -139,6 +139,19 @@ public final class PermissionManager {
         Objects.requireNonNull(allowlistKey, "allowlistKey");
         Objects.requireNonNull(description, "description");
 
+        // Structural denials (sensitive paths like .env, .ssh/, /etc/*) MUST
+        // fire BEFORE the session-blanket lookup. Otherwise a user who clicked
+        // "always allow write_file" earlier could route a FileWrite(.env) past
+        // the rule — defeating the "overrides all modes" invariant of the
+        // hard-denial layer (Codex P1 on #495).
+        var structural = policy.evaluateStructural(capability);
+        if (structural != null) {
+            log.debug("Permission denied (structural): key={}, reason={}",
+                    allowlistKey, structural.reason());
+            audit(allowlistKey, capability, provenance, structural, null);
+            return structural;
+        }
+
         String sessionIdOrNull = provenance.sessionId().map(s -> s.value()).orElse(null);
         if (sessionIdOrNull != null) {
             var allow = sessionApprovals.get(sessionIdOrNull);

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/PermissionManager.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/PermissionManager.java
@@ -151,10 +151,15 @@ public final class PermissionManager {
             }
         }
 
-        // PolicyEngine is still PermissionRequest-shaped today (#465 Scope
-        // #2 will change that). Build a request from the capability.
-        var request = new PermissionRequest(allowlistKey, description, capability.risk());
-        var decision = policy.evaluate(request);
+        // PolicyEngine now consumes the structured capability + provenance
+        // directly (#465 Scope #2 / #480 PR 4). The flat PermissionRequest
+        // bridge is gone — policies pattern-match on the sealed variant and
+        // can reach fields like FileWrite.path, HttpFetch.url, etc.
+        // `description` is the dispatcher's rich human-readable phrasing,
+        // forwarded so the policy can produce a user-facing prompt that
+        // matches the tool side rather than the variant's synthetic
+        // displayLabel.
+        var decision = policy.evaluate(capability, provenance, description);
         log.debug("Permission check: key={}, level={}, sessionId={}, decision={}",
                 allowlistKey, capability.risk(), sessionIdOrNull,
                 decision.getClass().getSimpleName());

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/PermissionPolicy.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/PermissionPolicy.java
@@ -3,18 +3,38 @@ package dev.aceclaw.security;
 /**
  * Strategy interface for permission evaluation.
  *
- * <p>Different policies can be composed to create layered permission logic
- * (e.g. session-level approvals, allowlists, blocklists).
+ * <p>Receives the structured {@link Capability} the agent wants to exercise
+ * together with the {@link Provenance} that records how the agent arrived
+ * here, plus a {@code description} the dispatcher computed for human display
+ * (used by the policy when it builds the
+ * {@link PermissionDecision.NeedsUserApproval} prompt text so the user sees
+ * the rich tool-side phrasing rather than the variant's synthetic label).
+ *
+ * <p>Policies pattern-match on the sealed {@code Capability} variant to
+ * encode rules like "deny writes to {@code .env}", "block HTTP egress to
+ * non-allowlisted hosts", or "tighten constraints when
+ * {@code provenance.subAgentDepth() > 0}". The {@code description} is
+ * presentation-only — policies should make decisions from {@code capability}
+ * and {@code provenance}, never from the human string, since it can vary
+ * per dispatcher.
+ *
+ * <p>This signature replaces the pre-#480-PR-4 {@code evaluate(PermissionRequest)}
+ * shape, which only carried a flat tool name + 4-tier risk level and forced
+ * policies to be capability-blind.
  */
 @FunctionalInterface
 public interface PermissionPolicy {
 
     /**
-     * Evaluates whether the given permission request should be approved,
-     * denied, or needs user confirmation.
+     * Evaluates whether the given capability use should be approved, denied,
+     * or needs interactive user confirmation.
      *
-     * @param request the permission request to evaluate
+     * @param capability  the structured capability the agent will exercise
+     * @param provenance  how the agent arrived at this check — session,
+     *                    sub-agent depth, plan step, retry chain
+     * @param description rich human-readable phrasing for the prompt; not
+     *                    used for policy decisions
      * @return the decision
      */
-    PermissionDecision evaluate(PermissionRequest request);
+    PermissionDecision evaluate(Capability capability, Provenance provenance, String description);
 }

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/PermissionPolicy.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/PermissionPolicy.java
@@ -37,4 +37,22 @@ public interface PermissionPolicy {
      * @return the decision
      */
     PermissionDecision evaluate(Capability capability, Provenance provenance, String description);
+
+    /**
+     * Structural / system-invariant denials that fire <em>before</em> any
+     * session-level allow-list lookup or mode-based decision in
+     * {@link PermissionManager}. Use this for cross-cutting rules that must
+     * not be bypassable by "always allow X" approvals — e.g. "never write
+     * to {@code .env}", "never delete {@code .ssh/id_rsa}".
+     *
+     * <p>Returning {@code null} (the default) means "no structural rule
+     * applies; defer to the rest of the pipeline." Returning a
+     * {@link PermissionDecision.Denied} ends the check immediately with
+     * that denial; other decision variants are not accepted here (returning
+     * an Approved would meaningfully short-circuit the user-approval prompt,
+     * which is what {@link #evaluate} is for).
+     */
+    default PermissionDecision.Denied evaluateStructural(Capability capability) {
+        return null;
+    }
 }

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/SensitivePaths.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/SensitivePaths.java
@@ -108,14 +108,15 @@ public final class SensitivePaths {
         }
         if (sawDotGit && "config".equals(nameLower)) return true;
 
-        // Absolute /etc/* — system-wide config. Tools that legitimately
-        // need to touch /etc must be invoked outside the agent.
-        if (path.isAbsolute()) {
-            var root = path.getRoot();
-            if (root != null && path.getNameCount() > 0
-                    && "etc".equals(path.getName(0).toString().toLowerCase(Locale.ROOT))) {
-                return true;
-            }
+        // Absolute /etc/* — system-wide config. The agent's intent is what
+        // matters here ("write /etc/hosts" is a system-config write regardless
+        // of host OS), so use an OS-independent string check rather than
+        // Path.isAbsolute() which returns false on Windows for Unix-style
+        // paths (no drive letter). Render with forward slashes, lowercase,
+        // then prefix-check.
+        String normalized = path.toString().replace('\\', '/').toLowerCase(Locale.ROOT);
+        if (normalized.equals("/etc") || normalized.startsWith("/etc/")) {
+            return true;
         }
 
         return false;

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/SensitivePaths.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/SensitivePaths.java
@@ -1,5 +1,6 @@
 package dev.aceclaw.security;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Locale;
 import java.util.Set;
@@ -43,6 +44,26 @@ import java.util.Set;
  * {@code .ENV} or {@code Credentials.json}. The path is
  * {@link Path#normalize() normalized} before matching so {@code /tmp/../etc/hosts}
  * resolves to {@code /etc/hosts}.
+ *
+ * <h3>Symlink resolution</h3>
+ *
+ * The matcher is run on the lexical path first; if that says "not sensitive",
+ * the path is canonicalized via {@link Path#toRealPath} and the rules run
+ * again on the resolved form. So writing through {@code /tmp/safe-link}
+ * (a symlink to {@code ~/.ssh/config}) is denied just like writing
+ * {@code ~/.ssh/config} directly. For paths that don't yet exist (the common
+ * case for new file writes), the deepest existing prefix is resolved and the
+ * missing tail re-appended — that's enough to catch the "symlinked
+ * directory" trick (e.g. {@code /tmp/safe-dir/id_rsa} where
+ * {@code safe-dir → ~/.ssh}).
+ *
+ * <p>This is still best-effort, not airtight: a TOCTOU window between the
+ * permission check and the actual write can swap the symlink underneath.
+ * True enforcement needs the OS-level sandbox (Seatbelt / bubblewrap) that
+ * {@code runtime-governance.md} still marks as 🚧. Symlink resolution here
+ * closes the easy bypasses — a malicious or buggy MCP server putting a
+ * safe-looking name in front of a sensitive target — while keeping the rule
+ * set agnostic to which adversary model is in play.
  */
 public final class SensitivePaths {
 
@@ -82,8 +103,33 @@ public final class SensitivePaths {
      * should not be written or deleted by the agent. Case-insensitive,
      * normalize-before-match, segment-level (not substring) comparisons —
      * see class-level javadoc for the full rule set.
+     *
+     * <p>Runs the lexical rules on the input path first; if they don't fire,
+     * canonicalizes through symlinks and re-runs. Both checks must pass for
+     * a path to be considered safe. Lexical-first means a lexically-sensitive
+     * path (e.g. {@code /etc/hosts}) is still denied even if filesystem
+     * resolution would move it away from the rule (e.g. macOS resolves
+     * {@code /etc} to {@code /private/etc}).
      */
     public static boolean matches(Path rawPath) {
+        if (rawPath == null) return false;
+        if (matchesLexical(rawPath)) return true;
+        // Lexical rules cleared — but a symlink-fronted alias could still
+        // route through to a sensitive target. Resolve and try again.
+        Path resolved = resolveSymlinksBestEffort(rawPath);
+        if (resolved != null && !resolved.equals(rawPath.normalize())) {
+            return matchesLexical(resolved);
+        }
+        return false;
+    }
+
+    /**
+     * Lexical-only sensitivity check. Pure function over the normalized path
+     * string — no filesystem IO, no symlink resolution. Public for callers
+     * that need the rule set without the side effects (audit dry-runs,
+     * symbolic analysis, etc.).
+     */
+    public static boolean matchesLexical(Path rawPath) {
         if (rawPath == null) return false;
         var path = rawPath.normalize();
         var fileName = path.getFileName();
@@ -120,5 +166,48 @@ public final class SensitivePaths {
         }
 
         return false;
+    }
+
+    /**
+     * Canonicalizes {@code raw} through symlinks, tolerating non-existent
+     * tail segments. Used by {@link #matches} to catch writes routed through
+     * a safe-looking name that aliases to a sensitive target.
+     *
+     * <p>Algorithm: try {@link Path#toRealPath} on the full path first. If
+     * that throws (commonly because the file doesn't exist yet — a new-file
+     * write), walk parents up until one resolves, then re-append the
+     * skipped trailing segments. Returns {@code null} when nothing along the
+     * path resolves or any unrecoverable IO error occurs — the caller treats
+     * that as "no further information" and the lexical check alone is taken
+     * as authoritative.
+     *
+     * <p>Package-private for testing the corner cases (symlink to sensitive
+     * target, symlink in the middle of the path, fully non-existent path).
+     */
+    static Path resolveSymlinksBestEffort(Path raw) {
+        if (raw == null) return null;
+        Path probe = raw;
+        Path appended = null;
+        // Walk up until a parent resolves on disk. The accumulated `appended`
+        // captures the segments we popped off, in original order, to be
+        // re-attached to the real path of the deepest existing ancestor.
+        while (probe != null) {
+            try {
+                Path real = probe.toRealPath();
+                return appended == null ? real : real.resolve(appended);
+            } catch (IOException missingOrUnreadable) {
+                Path name = probe.getFileName();
+                if (name != null) {
+                    appended = appended == null ? name : name.resolve(appended);
+                }
+                probe = probe.getParent();
+            } catch (SecurityException sandboxRefusedRead) {
+                // A SecurityManager (or platform sandbox) blocked our probe.
+                // Don't crash the permission check — fall back to lexical
+                // and let the caller's other defenses kick in.
+                return null;
+            }
+        }
+        return null;
     }
 }

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/SensitivePaths.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/SensitivePaths.java
@@ -1,6 +1,5 @@
 package dev.aceclaw.security;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Locale;
 import java.util.Set;
@@ -44,26 +43,6 @@ import java.util.Set;
  * {@code .ENV} or {@code Credentials.json}. The path is
  * {@link Path#normalize() normalized} before matching so {@code /tmp/../etc/hosts}
  * resolves to {@code /etc/hosts}.
- *
- * <h3>Symlink resolution</h3>
- *
- * The matcher is run on the lexical path first; if that says "not sensitive",
- * the path is canonicalized via {@link Path#toRealPath} and the rules run
- * again on the resolved form. So writing through {@code /tmp/safe-link}
- * (a symlink to {@code ~/.ssh/config}) is denied just like writing
- * {@code ~/.ssh/config} directly. For paths that don't yet exist (the common
- * case for new file writes), the deepest existing prefix is resolved and the
- * missing tail re-appended — that's enough to catch the "symlinked
- * directory" trick (e.g. {@code /tmp/safe-dir/id_rsa} where
- * {@code safe-dir → ~/.ssh}).
- *
- * <p>This is still best-effort, not airtight: a TOCTOU window between the
- * permission check and the actual write can swap the symlink underneath.
- * True enforcement needs the OS-level sandbox (Seatbelt / bubblewrap) that
- * {@code runtime-governance.md} still marks as 🚧. Symlink resolution here
- * closes the easy bypasses — a malicious or buggy MCP server putting a
- * safe-looking name in front of a sensitive target — while keeping the rule
- * set agnostic to which adversary model is in play.
  */
 public final class SensitivePaths {
 
@@ -103,33 +82,8 @@ public final class SensitivePaths {
      * should not be written or deleted by the agent. Case-insensitive,
      * normalize-before-match, segment-level (not substring) comparisons —
      * see class-level javadoc for the full rule set.
-     *
-     * <p>Runs the lexical rules on the input path first; if they don't fire,
-     * canonicalizes through symlinks and re-runs. Both checks must pass for
-     * a path to be considered safe. Lexical-first means a lexically-sensitive
-     * path (e.g. {@code /etc/hosts}) is still denied even if filesystem
-     * resolution would move it away from the rule (e.g. macOS resolves
-     * {@code /etc} to {@code /private/etc}).
      */
     public static boolean matches(Path rawPath) {
-        if (rawPath == null) return false;
-        if (matchesLexical(rawPath)) return true;
-        // Lexical rules cleared — but a symlink-fronted alias could still
-        // route through to a sensitive target. Resolve and try again.
-        Path resolved = resolveSymlinksBestEffort(rawPath);
-        if (resolved != null && !resolved.equals(rawPath.normalize())) {
-            return matchesLexical(resolved);
-        }
-        return false;
-    }
-
-    /**
-     * Lexical-only sensitivity check. Pure function over the normalized path
-     * string — no filesystem IO, no symlink resolution. Public for callers
-     * that need the rule set without the side effects (audit dry-runs,
-     * symbolic analysis, etc.).
-     */
-    public static boolean matchesLexical(Path rawPath) {
         if (rawPath == null) return false;
         var path = rawPath.normalize();
         var fileName = path.getFileName();
@@ -166,48 +120,5 @@ public final class SensitivePaths {
         }
 
         return false;
-    }
-
-    /**
-     * Canonicalizes {@code raw} through symlinks, tolerating non-existent
-     * tail segments. Used by {@link #matches} to catch writes routed through
-     * a safe-looking name that aliases to a sensitive target.
-     *
-     * <p>Algorithm: try {@link Path#toRealPath} on the full path first. If
-     * that throws (commonly because the file doesn't exist yet — a new-file
-     * write), walk parents up until one resolves, then re-append the
-     * skipped trailing segments. Returns {@code null} when nothing along the
-     * path resolves or any unrecoverable IO error occurs — the caller treats
-     * that as "no further information" and the lexical check alone is taken
-     * as authoritative.
-     *
-     * <p>Package-private for testing the corner cases (symlink to sensitive
-     * target, symlink in the middle of the path, fully non-existent path).
-     */
-    static Path resolveSymlinksBestEffort(Path raw) {
-        if (raw == null) return null;
-        Path probe = raw;
-        Path appended = null;
-        // Walk up until a parent resolves on disk. The accumulated `appended`
-        // captures the segments we popped off, in original order, to be
-        // re-attached to the real path of the deepest existing ancestor.
-        while (probe != null) {
-            try {
-                Path real = probe.toRealPath();
-                return appended == null ? real : real.resolve(appended);
-            } catch (IOException missingOrUnreadable) {
-                Path name = probe.getFileName();
-                if (name != null) {
-                    appended = appended == null ? name : name.resolve(appended);
-                }
-                probe = probe.getParent();
-            } catch (SecurityException sandboxRefusedRead) {
-                // A SecurityManager (or platform sandbox) blocked our probe.
-                // Don't crash the permission check — fall back to lexical
-                // and let the caller's other defenses kick in.
-                return null;
-            }
-        }
-        return null;
     }
 }

--- a/aceclaw-security/src/main/java/dev/aceclaw/security/SensitivePaths.java
+++ b/aceclaw-security/src/main/java/dev/aceclaw/security/SensitivePaths.java
@@ -1,0 +1,123 @@
+package dev.aceclaw.security;
+
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Canonical "do not write or delete this file" rule set.
+ *
+ * <p>Decoupled from any {@link PermissionPolicy} implementation so callers
+ * that need the same sensitivity classification — notably MCP-side capability
+ * inference at the adapter boundary — don't have to depend on a specific
+ * policy class. {@link DefaultPermissionPolicy} delegates here for its
+ * structural-denial layer; {@code McpCapabilityInference} (in
+ * {@code aceclaw-mcp}) calls {@link #matches(Path)} directly to disambiguate
+ * move/copy source vs destination sensitivity.
+ *
+ * <h3>What is "sensitive"</h3>
+ *
+ * Files that hold credentials, signing keys, or operator-critical
+ * configuration. The rule set is intentionally narrow — a write/delete
+ * blocked here is "the agent shouldn't be doing this regardless of mode or
+ * approval state" rather than "this is unusual."
+ *
+ * <h3>Matching rules</h3>
+ *
+ * <ul>
+ *   <li><b>Basename</b> match against a fixed lowercased set
+ *       ({@code .env}, {@code credentials.json}, {@code id_rsa}, …).</li>
+ *   <li><b>{@code .env*} prefix</b> on the basename so {@code .env},
+ *       {@code .env.local}, {@code .env.production} all match while
+ *       {@code dotenv-notes.md} does not.</li>
+ *   <li><b>Path segment</b> match anywhere in the path for credential-
+ *       bearing directories ({@code .ssh}, {@code .aws}, {@code .gnupg},
+ *       {@code .kube}, {@code .docker}).</li>
+ *   <li><b>{@code .git/config}</b> specifically — the rest of {@code .git/}
+ *       is fine to write (gradle/git plugins legitimately do).</li>
+ *   <li><b>{@code /etc/}</b> as an absolute prefix.</li>
+ * </ul>
+ *
+ * <p>All string comparisons use {@link Locale#ROOT} so a case-insensitive
+ * filesystem (default macOS APFS, Windows NTFS) can't be bypassed with
+ * {@code .ENV} or {@code Credentials.json}. The path is
+ * {@link Path#normalize() normalized} before matching so {@code /tmp/../etc/hosts}
+ * resolves to {@code /etc/hosts}.
+ */
+public final class SensitivePaths {
+
+    private SensitivePaths() {}
+
+    /**
+     * File names whose <em>basename</em> is sensitive in every project layout.
+     * Matched against {@link Path#getFileName()} case-insensitively.
+     * Store these entries lowercased; the comparison lowercases the input.
+     */
+    private static final Set<String> SENSITIVE_FILENAMES = Set.of(
+            ".env",
+            "credentials.json",
+            ".netrc",
+            "id_rsa",
+            "id_ed25519",
+            "id_ecdsa",
+            ".npmrc",
+            ".pypirc",
+            "service-account.json");
+
+    /**
+     * Path segments that, when present anywhere in the path, mark the file
+     * as sensitive. {@code .ssh} catches both {@code ~/.ssh/id_rsa} and a
+     * cloned {@code ./.ssh/config}; {@code .git/config} catches per-repo
+     * git config writes (a common credential-store smuggling vector).
+     */
+    private static final Set<String> SENSITIVE_PATH_SEGMENTS = Set.of(
+            ".ssh",
+            ".aws",
+            ".gnupg",
+            ".kube",
+            ".docker");
+
+    /**
+     * Returns {@code true} when {@code rawPath} resolves to a path that
+     * should not be written or deleted by the agent. Case-insensitive,
+     * normalize-before-match, segment-level (not substring) comparisons —
+     * see class-level javadoc for the full rule set.
+     */
+    public static boolean matches(Path rawPath) {
+        if (rawPath == null) return false;
+        var path = rawPath.normalize();
+        var fileName = path.getFileName();
+        String nameLower = fileName == null ? "" : fileName.toString().toLowerCase(Locale.ROOT);
+        if (fileName != null) {
+            if (SENSITIVE_FILENAMES.contains(nameLower)) return true;
+            // .env, .env.local, .env.production all match — but NOT
+            // dotenv-notes.md or env-template (basename must START with .env).
+            if (nameLower.startsWith(".env")) return true;
+        }
+
+        // Single pass over segments: detect (a) any sensitive segment like
+        // .ssh/.aws/.gnupg/.kube/.docker (b) the presence of .git/ so the
+        // basename=="config" rule below can fire without re-iterating.
+        // .git/config alone is sensitive — the rest of .git/ (HEAD,
+        // packed-refs, etc.) is touched by legitimate git plugins.
+        boolean sawDotGit = false;
+        for (Path segment : path) {
+            String seg = segment.toString().toLowerCase(Locale.ROOT);
+            if (SENSITIVE_PATH_SEGMENTS.contains(seg)) return true;
+            if (".git".equals(seg)) sawDotGit = true;
+        }
+        if (sawDotGit && "config".equals(nameLower)) return true;
+
+        // Absolute /etc/* — system-wide config. Tools that legitimately
+        // need to touch /etc must be invoked outside the agent.
+        if (path.isAbsolute()) {
+            var root = path.getRoot();
+            if (root != null && path.getNameCount() > 0
+                    && "etc".equals(path.getName(0).toString().toLowerCase(Locale.ROOT))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/CapabilityTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/CapabilityTest.java
@@ -399,6 +399,7 @@ final class CapabilityTest {
             case Capability.FileRead r -> r.displayLabel();
             case Capability.FileWrite w -> w.displayLabel();
             case Capability.FileDelete d -> d.displayLabel();
+            case Capability.FileMove fm -> fm.displayLabel();
             case Capability.FileSearch fs -> fs.displayLabel();
             case Capability.BashExec b -> b.displayLabel();
             case Capability.OsScript o -> o.displayLabel();

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/DefaultPermissionPolicyTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/DefaultPermissionPolicyTest.java
@@ -256,6 +256,41 @@ class DefaultPermissionPolicyTest {
         assertNull(STRUCTURAL.evaluateStructural(bash("rm -rf /tmp/junk")));
     }
 
+    // -- Case-insensitive matching (Codex P2 on #495) -----------------------
+    // On case-insensitive filesystems (default macOS APFS, Windows NTFS),
+    // `.ENV` and `.env` resolve to the same underlying file, so the
+    // structural rule has to match case-insensitively.
+
+    @Test
+    void uppercaseDotEnvIsStructurallyDenied() {
+        assertNotNull(STRUCTURAL.evaluateStructural(write("/repo/.ENV")));
+    }
+
+    @Test
+    void mixedCaseDotEnvLocalIsStructurallyDenied() {
+        assertNotNull(STRUCTURAL.evaluateStructural(write("/repo/.Env.local")));
+    }
+
+    @Test
+    void capitalizedCredentialsJsonIsStructurallyDenied() {
+        assertNotNull(STRUCTURAL.evaluateStructural(write("/tmp/Credentials.json")));
+    }
+
+    @Test
+    void uppercaseSshSegmentIsStructurallyDenied() {
+        assertNotNull(STRUCTURAL.evaluateStructural(write("/home/u/.SSH/config")));
+    }
+
+    @Test
+    void uppercaseGitConfigIsStructurallyDenied() {
+        assertNotNull(STRUCTURAL.evaluateStructural(write("/repo/.GIT/config")));
+    }
+
+    @Test
+    void uppercaseEtcPrefixIsStructurallyDenied() {
+        assertNotNull(STRUCTURAL.evaluateStructural(write("/ETC/hosts")));
+    }
+
     // -- Legacy boolean constructor ------------------------------------------
 
     @SuppressWarnings("deprecation")

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/DefaultPermissionPolicyTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/DefaultPermissionPolicyTest.java
@@ -160,9 +160,12 @@ class DefaultPermissionPolicyTest {
     // -- Structural hard-denial: sensitive paths -----------------------------
     // These rules live on evaluateStructural(), which PermissionManager runs
     // BEFORE the session-blanket lookup so an "always allow X" approval can't
-    // route past them.
+    // route past them. Layer is opt-in (denySensitivePaths constructor flag);
+    // explicitly enable it here since the entire test block is about pinning
+    // that opt-in's behaviour.
 
-    private static final DefaultPermissionPolicy STRUCTURAL = new DefaultPermissionPolicy("normal");
+    private static final DefaultPermissionPolicy STRUCTURAL =
+            new DefaultPermissionPolicy("normal", /* denySensitivePaths */ true);
 
     @Test
     void writingDotEnvIsStructurallyDenied() {
@@ -342,6 +345,54 @@ class DefaultPermissionPolicyTest {
     void legacyFalse_isNormal() {
         var policy = new DefaultPermissionPolicy(false);
         assertEquals("normal", policy.mode());
+    }
+
+    // -- denySensitivePaths opt-in flag -------------------------------------
+    // The structural layer is opt-in (default off) so an upgrade doesn't
+    // suddenly break workflows that legitimately write .env templates or
+    // .git/config entries. These tests pin both sides of the toggle.
+
+    @Test
+    void defaultConstructorLeavesStructuralLayerOff() {
+        // The zero-arg constructor preserves the pre-flag contract: no
+        // structural denials at all. PermissionManager.checkStructural will
+        // see null and the request flows to the standard mode-based path.
+        var policy = new DefaultPermissionPolicy();
+        assertFalse(policy.denySensitivePaths(),
+                "default constructor must leave structural layer off");
+        assertNull(policy.evaluateStructural(write("/repo/.env")),
+                ".env write must NOT be structurally denied when flag is off");
+        assertNull(policy.evaluateStructural(write("/home/u/.ssh/config")));
+        assertNull(policy.evaluateStructural(write("/etc/hosts")));
+    }
+
+    @Test
+    void singleArgModeConstructorLeavesStructuralLayerOff() {
+        // Backwards compat: pre-flag callers passing only a mode keep the
+        // layer off. Opt-in must be explicit.
+        var policy = new DefaultPermissionPolicy("auto-accept");
+        assertFalse(policy.denySensitivePaths());
+        assertNull(policy.evaluateStructural(write("/repo/.env")),
+                "auto-accept + flag off must NOT structurally deny .env");
+    }
+
+    @Test
+    void explicitFalseFlagBehavesLikeDefault() {
+        var policy = new DefaultPermissionPolicy("normal", false);
+        assertFalse(policy.denySensitivePaths());
+        assertNull(policy.evaluateStructural(write("/repo/.env")));
+        assertNull(policy.evaluateStructural(write("/etc/hosts")));
+    }
+
+    @Test
+    void explicitTrueFlagEnablesStructuralLayer() {
+        // Counterpart to the off tests above — pin that flipping the flag
+        // does turn the rules on. (The full rule coverage lives in STRUCTURAL
+        // above; this is just the toggle wiring.)
+        var policy = new DefaultPermissionPolicy("normal", true);
+        assertTrue(policy.denySensitivePaths());
+        assertNotNull(policy.evaluateStructural(write("/repo/.env")));
+        assertNotNull(policy.evaluateStructural(write("/etc/hosts")));
     }
 
     // -- Invalid mode --------------------------------------------------------

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/DefaultPermissionPolicyTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/DefaultPermissionPolicyTest.java
@@ -1,30 +1,52 @@
 package dev.aceclaw.security;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
+
+import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Tests for {@link DefaultPermissionPolicy} covering all four permission modes.
+ * Tests for {@link DefaultPermissionPolicy} covering all four permission
+ * modes and the structural hard-denial layer that overrides every mode.
  */
 class DefaultPermissionPolicyTest {
+
+    private static final Provenance PROV = Provenance.daemonInternal();
+
+    private static Capability.FileRead read(String p) {
+        return new Capability.FileRead(Path.of(p));
+    }
+
+    private static Capability.FileWrite write(String p) {
+        return new Capability.FileWrite(Path.of(p), WriteMode.OVERWRITE);
+    }
+
+    private static Capability.FileDelete delete(String p) {
+        return new Capability.FileDelete(Path.of(p));
+    }
+
+    private static Capability.BashExec bash(String command) {
+        return new Capability.BashExec(command, Path.of("/tmp"));
+    }
+
+    private static PermissionDecision evaluate(DefaultPermissionPolicy policy, Capability cap, String desc) {
+        return policy.evaluate(cap, PROV, desc);
+    }
 
     // -- Mode: normal --------------------------------------------------------
 
     @Test
     void normalMode_readIsAutoApproved() {
         var policy = new DefaultPermissionPolicy("normal");
-        var request = new PermissionRequest("read_file", "Read test.txt", PermissionLevel.READ);
-        assertInstanceOf(PermissionDecision.Approved.class, policy.evaluate(request));
+        assertInstanceOf(PermissionDecision.Approved.class,
+                evaluate(policy, read("test.txt"), "Read test.txt"));
     }
 
     @Test
     void normalMode_writeNeedsApproval() {
         var policy = new DefaultPermissionPolicy("normal");
-        var request = new PermissionRequest("write_file", "Write test.txt", PermissionLevel.WRITE);
-        var decision = policy.evaluate(request);
+        var decision = evaluate(policy, write("/tmp/foo.txt"), "Write /tmp/foo.txt");
         assertInstanceOf(PermissionDecision.NeedsUserApproval.class, decision);
         assertTrue(((PermissionDecision.NeedsUserApproval) decision).prompt().contains("write to"));
     }
@@ -32,15 +54,15 @@ class DefaultPermissionPolicyTest {
     @Test
     void normalMode_executeNeedsApproval() {
         var policy = new DefaultPermissionPolicy("normal");
-        var request = new PermissionRequest("bash", "Run ls -la", PermissionLevel.EXECUTE);
-        assertInstanceOf(PermissionDecision.NeedsUserApproval.class, policy.evaluate(request));
+        assertInstanceOf(PermissionDecision.NeedsUserApproval.class,
+                evaluate(policy, bash("ls -la"), "Run ls -la"));
     }
 
     @Test
     void normalMode_dangerousNeedsApproval() {
+        // BashExec self-escalates "rm -rf" to DANGEROUS via Capability.risk().
         var policy = new DefaultPermissionPolicy("normal");
-        var request = new PermissionRequest("bash", "rm -rf /", PermissionLevel.DANGEROUS);
-        var decision = policy.evaluate(request);
+        var decision = evaluate(policy, bash("rm -rf /tmp/junk"), "Run rm -rf /tmp/junk");
         assertInstanceOf(PermissionDecision.NeedsUserApproval.class, decision);
         assertTrue(((PermissionDecision.NeedsUserApproval) decision).prompt().contains("destructive"));
     }
@@ -56,22 +78,22 @@ class DefaultPermissionPolicyTest {
     @Test
     void acceptEditsMode_writeIsAutoApproved() {
         var policy = new DefaultPermissionPolicy("accept-edits");
-        var request = new PermissionRequest("write_file", "Write test.txt", PermissionLevel.WRITE);
-        assertInstanceOf(PermissionDecision.Approved.class, policy.evaluate(request));
+        assertInstanceOf(PermissionDecision.Approved.class,
+                evaluate(policy, write("/tmp/foo.txt"), "Write /tmp/foo.txt"));
     }
 
     @Test
     void acceptEditsMode_executeStillNeedsApproval() {
         var policy = new DefaultPermissionPolicy("accept-edits");
-        var request = new PermissionRequest("bash", "Run ls", PermissionLevel.EXECUTE);
-        assertInstanceOf(PermissionDecision.NeedsUserApproval.class, policy.evaluate(request));
+        assertInstanceOf(PermissionDecision.NeedsUserApproval.class,
+                evaluate(policy, bash("ls"), "Run ls"));
     }
 
     @Test
     void acceptEditsMode_readIsAutoApproved() {
         var policy = new DefaultPermissionPolicy("accept-edits");
-        var request = new PermissionRequest("read_file", "Read file", PermissionLevel.READ);
-        assertInstanceOf(PermissionDecision.Approved.class, policy.evaluate(request));
+        assertInstanceOf(PermissionDecision.Approved.class,
+                evaluate(policy, read("file"), "Read file"));
     }
 
     // -- Mode: plan ----------------------------------------------------------
@@ -79,15 +101,14 @@ class DefaultPermissionPolicyTest {
     @Test
     void planMode_readIsAutoApproved() {
         var policy = new DefaultPermissionPolicy("plan");
-        var request = new PermissionRequest("read_file", "Read file", PermissionLevel.READ);
-        assertInstanceOf(PermissionDecision.Approved.class, policy.evaluate(request));
+        assertInstanceOf(PermissionDecision.Approved.class,
+                evaluate(policy, read("file"), "Read file"));
     }
 
     @Test
     void planMode_writeIsDenied() {
         var policy = new DefaultPermissionPolicy("plan");
-        var request = new PermissionRequest("write_file", "Write file", PermissionLevel.WRITE);
-        var decision = policy.evaluate(request);
+        var decision = evaluate(policy, write("/tmp/foo.txt"), "Write file");
         assertInstanceOf(PermissionDecision.Denied.class, decision);
         assertTrue(((PermissionDecision.Denied) decision).reason().contains("plan mode is read-only"));
     }
@@ -95,25 +116,159 @@ class DefaultPermissionPolicyTest {
     @Test
     void planMode_executeIsDenied() {
         var policy = new DefaultPermissionPolicy("plan");
-        var request = new PermissionRequest("bash", "Run command", PermissionLevel.EXECUTE);
-        assertInstanceOf(PermissionDecision.Denied.class, policy.evaluate(request));
+        assertInstanceOf(PermissionDecision.Denied.class,
+                evaluate(policy, bash("ls"), "Run command"));
     }
 
     @Test
     void planMode_dangerousIsDenied() {
         var policy = new DefaultPermissionPolicy("plan");
-        var request = new PermissionRequest("bash", "Dangerous op", PermissionLevel.DANGEROUS);
-        assertInstanceOf(PermissionDecision.Denied.class, policy.evaluate(request));
+        assertInstanceOf(PermissionDecision.Denied.class,
+                evaluate(policy, bash("rm -rf /"), "Dangerous op"));
     }
 
     // -- Mode: auto-accept ---------------------------------------------------
 
-    @ParameterizedTest
-    @EnumSource(PermissionLevel.class)
-    void autoAcceptMode_allLevelsApproved(PermissionLevel level) {
+    @Test
+    void autoAcceptMode_readApproved() {
         var policy = new DefaultPermissionPolicy("auto-accept");
-        var request = new PermissionRequest("any_tool", "Any operation", level);
-        assertInstanceOf(PermissionDecision.Approved.class, policy.evaluate(request));
+        assertInstanceOf(PermissionDecision.Approved.class,
+                evaluate(policy, read("any.txt"), "any"));
+    }
+
+    @Test
+    void autoAcceptMode_writeApproved() {
+        var policy = new DefaultPermissionPolicy("auto-accept");
+        assertInstanceOf(PermissionDecision.Approved.class,
+                evaluate(policy, write("/tmp/any.txt"), "any"));
+    }
+
+    @Test
+    void autoAcceptMode_executeApproved() {
+        var policy = new DefaultPermissionPolicy("auto-accept");
+        assertInstanceOf(PermissionDecision.Approved.class,
+                evaluate(policy, bash("any command"), "any"));
+    }
+
+    @Test
+    void autoAcceptMode_dangerousApproved() {
+        var policy = new DefaultPermissionPolicy("auto-accept");
+        assertInstanceOf(PermissionDecision.Approved.class,
+                evaluate(policy, bash("rm -rf /tmp/junk"), "destructive bash"));
+    }
+
+    // -- Structural hard-denial: sensitive paths -----------------------------
+
+    @Test
+    void writingDotEnvIsDeniedEvenInAutoAccept() {
+        var policy = new DefaultPermissionPolicy("auto-accept");
+        var decision = evaluate(policy, write("/repo/.env"), "write .env");
+        assertInstanceOf(PermissionDecision.Denied.class, decision);
+        assertTrue(((PermissionDecision.Denied) decision).reason().contains("sensitive path"));
+    }
+
+    @Test
+    void writingDotEnvLocalIsDenied() {
+        var policy = new DefaultPermissionPolicy("auto-accept");
+        assertInstanceOf(PermissionDecision.Denied.class,
+                evaluate(policy, write("/repo/.env.local"), "write .env.local"));
+    }
+
+    @Test
+    void writingDotEnvProductionIsDenied() {
+        var policy = new DefaultPermissionPolicy("normal");
+        assertInstanceOf(PermissionDecision.Denied.class,
+                evaluate(policy, write("/repo/.env.production"), "write .env.production"));
+    }
+
+    @Test
+    void writingDotenvNotesIsAllowed() {
+        // Defense against substring-style false positives — segment matching
+        // should NOT trip on files whose name merely contains "env".
+        var policy = new DefaultPermissionPolicy("normal");
+        var decision = evaluate(policy, write("/repo/dotenv-notes.md"), "write notes");
+        assertInstanceOf(PermissionDecision.NeedsUserApproval.class, decision);
+    }
+
+    @Test
+    void writingNotesAboutEnvIsAllowed() {
+        var policy = new DefaultPermissionPolicy("normal");
+        // Filename: "notes-on-env.md". Should NOT match (.env-prefix rule
+        // only catches basenames that literally start with .env).
+        var decision = evaluate(policy, write("/repo/notes-on-env.md"), "write notes");
+        assertInstanceOf(PermissionDecision.NeedsUserApproval.class, decision);
+    }
+
+    @Test
+    void writingInsideSshIsDenied() {
+        var policy = new DefaultPermissionPolicy("auto-accept");
+        assertInstanceOf(PermissionDecision.Denied.class,
+                evaluate(policy, write("/home/u/.ssh/config"), "write ssh config"));
+    }
+
+    @Test
+    void writingInsideAwsIsDenied() {
+        var policy = new DefaultPermissionPolicy("auto-accept");
+        assertInstanceOf(PermissionDecision.Denied.class,
+                evaluate(policy, write("/home/u/.aws/credentials"), "write aws creds"));
+    }
+
+    @Test
+    void writingCredentialsJsonIsDenied() {
+        var policy = new DefaultPermissionPolicy("auto-accept");
+        assertInstanceOf(PermissionDecision.Denied.class,
+                evaluate(policy, write("/tmp/credentials.json"), "write creds"));
+    }
+
+    @Test
+    void writingGitConfigIsDenied() {
+        var policy = new DefaultPermissionPolicy("auto-accept");
+        assertInstanceOf(PermissionDecision.Denied.class,
+                evaluate(policy, write("/repo/.git/config"), "write git config"));
+    }
+
+    @Test
+    void writingOtherGitInternalsIsAllowed() {
+        // Only .git/config is sensitive. .git/HEAD, .git/packed-refs, etc.
+        // are touched by legitimate git plugins during normal operation.
+        var policy = new DefaultPermissionPolicy("normal");
+        var decision = evaluate(policy, write("/repo/.git/HEAD"), "write HEAD");
+        assertInstanceOf(PermissionDecision.NeedsUserApproval.class, decision);
+    }
+
+    @Test
+    void writingUnderEtcIsDenied() {
+        var policy = new DefaultPermissionPolicy("auto-accept");
+        assertInstanceOf(PermissionDecision.Denied.class,
+                evaluate(policy, write("/etc/hosts"), "write /etc/hosts"));
+    }
+
+    @Test
+    void writingRelativeEtcLikePathIsAllowed() {
+        // Defense against root-level /etc rule false-tripping on relative
+        // paths that happen to contain "etc" as a segment but aren't system
+        // config (e.g. "docs/etc/notes.md").
+        var policy = new DefaultPermissionPolicy("normal");
+        var decision = evaluate(policy, write("docs/etc/notes.md"), "write notes");
+        assertInstanceOf(PermissionDecision.NeedsUserApproval.class, decision);
+    }
+
+    @Test
+    void pathTraversalBypassIsBlocked() {
+        // The /etc/ rule must not be bypassable by lexical traversal —
+        // /tmp/../etc/hosts effectively writes /etc/hosts. Path.normalize()
+        // collapses .. lexically (no filesystem I/O) so the prefix check
+        // still fires.
+        var policy = new DefaultPermissionPolicy("auto-accept");
+        assertInstanceOf(PermissionDecision.Denied.class,
+                evaluate(policy, write("/tmp/../etc/hosts"), "write via traversal"));
+    }
+
+    @Test
+    void deletingDotEnvIsDenied() {
+        var policy = new DefaultPermissionPolicy("auto-accept");
+        assertInstanceOf(PermissionDecision.Denied.class,
+                evaluate(policy, delete("/repo/.env"), "delete .env"));
     }
 
     // -- Legacy boolean constructor ------------------------------------------
@@ -155,5 +310,19 @@ class DefaultPermissionPolicyTest {
     @Test
     void isApproved_falseForNeedsUserApproval() {
         assertFalse(new PermissionDecision.NeedsUserApproval("prompt").isApproved());
+    }
+
+    // -- Description propagation to prompt -----------------------------------
+
+    @Test
+    void richDescriptionIsSurfacedInPrompt() {
+        // Pin that the dispatcher's rich description (not the variant's
+        // synthetic displayLabel) makes it into the user-facing prompt.
+        var policy = new DefaultPermissionPolicy("normal");
+        var decision = evaluate(policy, write("/tmp/foo.txt"),
+                "Write /tmp/foo.txt (123 chars of new content)");
+        var prompt = ((PermissionDecision.NeedsUserApproval) decision).prompt();
+        assertTrue(prompt.contains("123 chars of new content"),
+                "rich description should be surfaced verbatim in the prompt; got: " + prompt);
     }
 }

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/DefaultPermissionPolicyTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/DefaultPermissionPolicyTest.java
@@ -250,6 +250,43 @@ class DefaultPermissionPolicyTest {
     }
 
     @Test
+    void writingKubeConfigIsStructurallyDenied() {
+        // .kube/config — Kubernetes auth tokens.
+        assertNotNull(STRUCTURAL.evaluateStructural(write("/home/u/.kube/config")));
+    }
+
+    @Test
+    void writingDockerConfigIsStructurallyDenied() {
+        // .docker/config.json — registry credentials.
+        assertNotNull(STRUCTURAL.evaluateStructural(write("/home/u/.docker/config.json")));
+    }
+
+    @Test
+    void writingNpmrcIsStructurallyDenied() {
+        // .npmrc — npm registry auth tokens.
+        assertNotNull(STRUCTURAL.evaluateStructural(write("/repo/.npmrc")));
+    }
+
+    @Test
+    void writingPypircIsStructurallyDenied() {
+        // .pypirc — PyPI upload credentials.
+        assertNotNull(STRUCTURAL.evaluateStructural(write("/home/u/.pypirc")));
+    }
+
+    @Test
+    void writingIdEcdsaIsStructurallyDenied() {
+        // SSH ECDSA private key (separate from RSA / ED25519).
+        assertNotNull(STRUCTURAL.evaluateStructural(write("/home/u/id_ecdsa")));
+    }
+
+    @Test
+    void writingServiceAccountJsonIsStructurallyDenied() {
+        // GCP service account keys are commonly named this; named here so
+        // the rule fires even outside the .ssh/.aws/.gnupg segments.
+        assertNotNull(STRUCTURAL.evaluateStructural(write("/tmp/service-account.json")));
+    }
+
+    @Test
     void nonFileCapabilityIsNotStructurallyDenied() {
         // BashExec, HttpFetch, etc. fall through structural checks today —
         // the layer only covers FileWrite/FileDelete.

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/DefaultPermissionPolicyTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/DefaultPermissionPolicyTest.java
@@ -158,99 +158,81 @@ class DefaultPermissionPolicyTest {
     }
 
     // -- Structural hard-denial: sensitive paths -----------------------------
+    // These rules live on evaluateStructural(), which PermissionManager runs
+    // BEFORE the session-blanket lookup so an "always allow X" approval can't
+    // route past them.
+
+    private static final DefaultPermissionPolicy STRUCTURAL = new DefaultPermissionPolicy("normal");
 
     @Test
-    void writingDotEnvIsDeniedEvenInAutoAccept() {
-        var policy = new DefaultPermissionPolicy("auto-accept");
-        var decision = evaluate(policy, write("/repo/.env"), "write .env");
-        assertInstanceOf(PermissionDecision.Denied.class, decision);
-        assertTrue(((PermissionDecision.Denied) decision).reason().contains("sensitive path"));
+    void writingDotEnvIsStructurallyDenied() {
+        var decision = STRUCTURAL.evaluateStructural(write("/repo/.env"));
+        assertNotNull(decision);
+        assertTrue(decision.reason().contains("sensitive path"));
     }
 
     @Test
-    void writingDotEnvLocalIsDenied() {
-        var policy = new DefaultPermissionPolicy("auto-accept");
-        assertInstanceOf(PermissionDecision.Denied.class,
-                evaluate(policy, write("/repo/.env.local"), "write .env.local"));
+    void writingDotEnvLocalIsStructurallyDenied() {
+        assertNotNull(STRUCTURAL.evaluateStructural(write("/repo/.env.local")));
     }
 
     @Test
-    void writingDotEnvProductionIsDenied() {
-        var policy = new DefaultPermissionPolicy("normal");
-        assertInstanceOf(PermissionDecision.Denied.class,
-                evaluate(policy, write("/repo/.env.production"), "write .env.production"));
+    void writingDotEnvProductionIsStructurallyDenied() {
+        assertNotNull(STRUCTURAL.evaluateStructural(write("/repo/.env.production")));
     }
 
     @Test
-    void writingDotenvNotesIsAllowed() {
+    void writingDotenvNotesIsNotDenied() {
         // Defense against substring-style false positives — segment matching
         // should NOT trip on files whose name merely contains "env".
-        var policy = new DefaultPermissionPolicy("normal");
-        var decision = evaluate(policy, write("/repo/dotenv-notes.md"), "write notes");
-        assertInstanceOf(PermissionDecision.NeedsUserApproval.class, decision);
+        assertNull(STRUCTURAL.evaluateStructural(write("/repo/dotenv-notes.md")));
     }
 
     @Test
-    void writingNotesAboutEnvIsAllowed() {
-        var policy = new DefaultPermissionPolicy("normal");
+    void writingNotesAboutEnvIsNotDenied() {
         // Filename: "notes-on-env.md". Should NOT match (.env-prefix rule
         // only catches basenames that literally start with .env).
-        var decision = evaluate(policy, write("/repo/notes-on-env.md"), "write notes");
-        assertInstanceOf(PermissionDecision.NeedsUserApproval.class, decision);
+        assertNull(STRUCTURAL.evaluateStructural(write("/repo/notes-on-env.md")));
     }
 
     @Test
-    void writingInsideSshIsDenied() {
-        var policy = new DefaultPermissionPolicy("auto-accept");
-        assertInstanceOf(PermissionDecision.Denied.class,
-                evaluate(policy, write("/home/u/.ssh/config"), "write ssh config"));
+    void writingInsideSshIsStructurallyDenied() {
+        assertNotNull(STRUCTURAL.evaluateStructural(write("/home/u/.ssh/config")));
     }
 
     @Test
-    void writingInsideAwsIsDenied() {
-        var policy = new DefaultPermissionPolicy("auto-accept");
-        assertInstanceOf(PermissionDecision.Denied.class,
-                evaluate(policy, write("/home/u/.aws/credentials"), "write aws creds"));
+    void writingInsideAwsIsStructurallyDenied() {
+        assertNotNull(STRUCTURAL.evaluateStructural(write("/home/u/.aws/credentials")));
     }
 
     @Test
-    void writingCredentialsJsonIsDenied() {
-        var policy = new DefaultPermissionPolicy("auto-accept");
-        assertInstanceOf(PermissionDecision.Denied.class,
-                evaluate(policy, write("/tmp/credentials.json"), "write creds"));
+    void writingCredentialsJsonIsStructurallyDenied() {
+        assertNotNull(STRUCTURAL.evaluateStructural(write("/tmp/credentials.json")));
     }
 
     @Test
-    void writingGitConfigIsDenied() {
-        var policy = new DefaultPermissionPolicy("auto-accept");
-        assertInstanceOf(PermissionDecision.Denied.class,
-                evaluate(policy, write("/repo/.git/config"), "write git config"));
+    void writingGitConfigIsStructurallyDenied() {
+        assertNotNull(STRUCTURAL.evaluateStructural(write("/repo/.git/config")));
     }
 
     @Test
-    void writingOtherGitInternalsIsAllowed() {
+    void writingOtherGitInternalsIsNotDenied() {
         // Only .git/config is sensitive. .git/HEAD, .git/packed-refs, etc.
         // are touched by legitimate git plugins during normal operation.
-        var policy = new DefaultPermissionPolicy("normal");
-        var decision = evaluate(policy, write("/repo/.git/HEAD"), "write HEAD");
-        assertInstanceOf(PermissionDecision.NeedsUserApproval.class, decision);
+        assertNull(STRUCTURAL.evaluateStructural(write("/repo/.git/HEAD")));
     }
 
     @Test
-    void writingUnderEtcIsDenied() {
-        var policy = new DefaultPermissionPolicy("auto-accept");
-        assertInstanceOf(PermissionDecision.Denied.class,
-                evaluate(policy, write("/etc/hosts"), "write /etc/hosts"));
+    void writingUnderEtcIsStructurallyDenied() {
+        assertNotNull(STRUCTURAL.evaluateStructural(write("/etc/hosts")));
     }
 
     @Test
-    void writingRelativeEtcLikePathIsAllowed() {
+    void writingRelativeEtcLikePathIsNotDenied() {
         // Defense against root-level /etc rule false-tripping on relative
         // paths that happen to contain "etc" as a segment but aren't system
         // config (e.g. "docs/etc/notes.md").
-        var policy = new DefaultPermissionPolicy("normal");
-        var decision = evaluate(policy, write("docs/etc/notes.md"), "write notes");
-        assertInstanceOf(PermissionDecision.NeedsUserApproval.class, decision);
+        assertNull(STRUCTURAL.evaluateStructural(write("docs/etc/notes.md")));
     }
 
     @Test
@@ -259,16 +241,19 @@ class DefaultPermissionPolicyTest {
         // /tmp/../etc/hosts effectively writes /etc/hosts. Path.normalize()
         // collapses .. lexically (no filesystem I/O) so the prefix check
         // still fires.
-        var policy = new DefaultPermissionPolicy("auto-accept");
-        assertInstanceOf(PermissionDecision.Denied.class,
-                evaluate(policy, write("/tmp/../etc/hosts"), "write via traversal"));
+        assertNotNull(STRUCTURAL.evaluateStructural(write("/tmp/../etc/hosts")));
     }
 
     @Test
-    void deletingDotEnvIsDenied() {
-        var policy = new DefaultPermissionPolicy("auto-accept");
-        assertInstanceOf(PermissionDecision.Denied.class,
-                evaluate(policy, delete("/repo/.env"), "delete .env"));
+    void deletingDotEnvIsStructurallyDenied() {
+        assertNotNull(STRUCTURAL.evaluateStructural(delete("/repo/.env")));
+    }
+
+    @Test
+    void nonFileCapabilityIsNotStructurallyDenied() {
+        // BashExec, HttpFetch, etc. fall through structural checks today —
+        // the layer only covers FileWrite/FileDelete.
+        assertNull(STRUCTURAL.evaluateStructural(bash("rm -rf /tmp/junk")));
     }
 
     // -- Legacy boolean constructor ------------------------------------------

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/PermissionManagerAuditTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/PermissionManagerAuditTest.java
@@ -163,6 +163,42 @@ final class PermissionManagerAuditTest {
     }
 
     @Test
+    void checkStructuralNullProvenanceFallsBackToDaemonInternal(@TempDir Path tmp) throws IOException {
+        // Defensive contract: null Provenance is documented as "allowed,
+        // falls back to daemonInternal()". Cover the null+denial branch so
+        // a future caller that drops Provenance still gets an attributable
+        // audit entry (sessionId=null) instead of an NPE.
+        dev.aceclaw.security.PermissionPolicy structuralDeny = new dev.aceclaw.security.PermissionPolicy() {
+            @Override public PermissionDecision evaluate(
+                    dev.aceclaw.security.Capability cap,
+                    dev.aceclaw.security.Provenance prov,
+                    String desc) {
+                return new PermissionDecision.Approved();
+            }
+            @Override public PermissionDecision.Denied evaluateStructural(
+                    dev.aceclaw.security.Capability cap) {
+                return new PermissionDecision.Denied("sensitive");
+            }
+        };
+        var auditLog = CapabilityAuditLog.create(tmp);
+        var pm = new PermissionManager(structuralDeny, auditLog);
+
+        var cap = new dev.aceclaw.security.Capability.FileWrite(
+                java.nio.file.Path.of("/repo/.env"),
+                dev.aceclaw.security.WriteMode.OVERWRITE);
+
+        var result = pm.checkStructural(cap, null, null);
+
+        assertThat(result).isNotNull();
+        var entry = auditLog.readVerified().getFirst();
+        assertThat(entry.decisionKind()).isEqualTo("DENIED");
+        // sessionId is null because daemonInternal() carries no session.
+        assertThat(entry.sessionId()).isNull();
+        // Fallback allowlist key is the capability variant's class name.
+        assertThat(entry.toolName()).isEqualTo("FileWrite");
+    }
+
+    @Test
     void checkStructuralWritesNoAuditWhenNoRuleApplies(@TempDir Path tmp) throws IOException {
         // No double-cost: when no structural rule matches the capability,
         // checkStructural returns null and writes no audit entry.

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/PermissionManagerAuditTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/PermissionManagerAuditTest.java
@@ -124,6 +124,68 @@ final class PermissionManagerAuditTest {
     }
 
     @Test
+    void checkStructuralWritesAuditOnDenial(@TempDir Path tmp) throws IOException {
+        // Round-12 follow-up review on #495: structural denials reached via
+        // the sub-agent path (PermissionManager.checkStructural) used to be
+        // invisible to the audit log — only the main dispatcher's check(...)
+        // path audited. Forensics on "what did sub-agents try and get
+        // refused?" was blind. Now checkStructural writes its own entry.
+        dev.aceclaw.security.PermissionPolicy structuralDeny = new dev.aceclaw.security.PermissionPolicy() {
+            @Override public PermissionDecision evaluate(
+                    dev.aceclaw.security.Capability cap,
+                    dev.aceclaw.security.Provenance prov,
+                    String desc) {
+                return new PermissionDecision.Approved();
+            }
+            @Override public PermissionDecision.Denied evaluateStructural(
+                    dev.aceclaw.security.Capability cap) {
+                return new PermissionDecision.Denied("sensitive path");
+            }
+        };
+        var auditLog = CapabilityAuditLog.create(tmp);
+        var pm = new PermissionManager(structuralDeny, auditLog);
+
+        var cap = new dev.aceclaw.security.Capability.FileWrite(
+                java.nio.file.Path.of("/repo/.env"),
+                dev.aceclaw.security.WriteMode.OVERWRITE);
+        var prov = dev.aceclaw.security.Provenance.fromNullableSessionId("sess-X");
+
+        var result = pm.checkStructural(cap, prov, "write_file");
+
+        assertThat(result).isNotNull();
+        var entries = auditLog.readVerified();
+        assertThat(entries).hasSize(1);
+        var entry = entries.getFirst();
+        assertThat(entry.decisionKind()).isEqualTo("DENIED");
+        assertThat(entry.toolName()).isEqualTo("write_file");
+        assertThat(entry.sessionId()).isEqualTo("sess-X");
+        assertThat(entry.reason()).isEqualTo("sensitive path");
+    }
+
+    @Test
+    void checkStructuralWritesNoAuditWhenNoRuleApplies(@TempDir Path tmp) throws IOException {
+        // No double-cost: when no structural rule matches the capability,
+        // checkStructural returns null and writes no audit entry.
+        dev.aceclaw.security.PermissionPolicy noStructural = new dev.aceclaw.security.PermissionPolicy() {
+            @Override public PermissionDecision evaluate(
+                    dev.aceclaw.security.Capability cap,
+                    dev.aceclaw.security.Provenance prov,
+                    String desc) {
+                return new PermissionDecision.Approved();
+            }
+        };
+        var auditLog = CapabilityAuditLog.create(tmp);
+        var pm = new PermissionManager(noStructural, auditLog);
+
+        var cap = new dev.aceclaw.security.Capability.FileWrite(
+                java.nio.file.Path.of("/tmp/safe.txt"),
+                dev.aceclaw.security.WriteMode.OVERWRITE);
+
+        assertThat(pm.checkStructural(cap, null, "write_file")).isNull();
+        assertThat(auditLog.readVerified()).isEmpty();
+    }
+
+    @Test
     void everyCheckCallProducesExactlyOneEntry(@TempDir Path tmp) throws IOException {
         var auditLog = CapabilityAuditLog.create(tmp);
         var pm = new PermissionManager(APPROVE_POLICY, auditLog);

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/PermissionManagerAuditTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/PermissionManagerAuditTest.java
@@ -33,11 +33,11 @@ final class PermissionManagerAuditTest {
     private static final PermissionRequest EXEC_REQ =
             PermissionRequest.execute("bash", "rm /tmp/foo");
 
-    private static final PermissionPolicy APPROVE_POLICY = req ->
+    private static final PermissionPolicy APPROVE_POLICY = (cap, prov, desc) ->
             new PermissionDecision.Approved();
-    private static final PermissionPolicy DENY_POLICY = req ->
+    private static final PermissionPolicy DENY_POLICY = (cap, prov, desc) ->
             new PermissionDecision.Denied("policy denies");
-    private static final PermissionPolicy NEEDS_APPROVAL_POLICY = req ->
+    private static final PermissionPolicy NEEDS_APPROVAL_POLICY = (cap, prov, desc) ->
             new PermissionDecision.NeedsUserApproval("approve write to /tmp/foo?");
 
     @Test

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/PermissionManagerCapabilityTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/PermissionManagerCapabilityTest.java
@@ -130,6 +130,41 @@ final class PermissionManagerCapabilityTest {
     }
 
     @Test
+    void structuralDenialFiresEvenWithSessionBlanketApproval() {
+        // Codex P1 regression on #495: a user-granted "always allow write_file"
+        // must NOT let the agent route a FileWrite(.env) past the structural
+        // hard-denial layer. The structural check runs in PermissionManager
+        // BEFORE the session-blanket lookup so the invariant
+        // "hard-denials override every mode and every prior approval" holds.
+        var pm = new PermissionManager(new DefaultPermissionPolicy(DefaultPermissionPolicy.MODE_NORMAL));
+        pm.approveForSession("sess-A", "write_file");
+
+        // Sanity: a non-sensitive write still gets the blanket approval.
+        var safeDecision = pm.check(
+                new Capability.FileWrite(Path.of("/tmp/safe.txt"), WriteMode.OVERWRITE),
+                Provenance.forSession(new SessionId("sess-A")),
+                "write_file",
+                "write /tmp/safe.txt");
+        assertThat(safeDecision)
+                .as("non-sensitive write follows the blanket approval")
+                .isInstanceOf(PermissionDecision.Approved.class);
+
+        // The bug: same allowlist key, but the path is sensitive. Pre-fix this
+        // would have returned Approved via the blanket; post-fix the
+        // structural denial fires first and the write is refused.
+        var sensitiveDecision = pm.check(
+                new Capability.FileWrite(Path.of("/repo/.env"), WriteMode.OVERWRITE),
+                Provenance.forSession(new SessionId("sess-A")),
+                "write_file",
+                "write .env");
+        assertThat(sensitiveDecision)
+                .as("session blanket must not bypass structural denial")
+                .isInstanceOf(PermissionDecision.Denied.class);
+        assertThat(((PermissionDecision.Denied) sensitiveDecision).reason())
+                .contains("sensitive path");
+    }
+
+    @Test
     void legacyShimDelegatesToStructuredPath() {
         // The old check(PermissionRequest, sessionId) is now a thin shim
         // — confirmed by the absence of a separate decision-and-audit

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/PermissionManagerCapabilityTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/PermissionManagerCapabilityTest.java
@@ -136,7 +136,12 @@ final class PermissionManagerCapabilityTest {
         // hard-denial layer. The structural check runs in PermissionManager
         // BEFORE the session-blanket lookup so the invariant
         // "hard-denials override every mode and every prior approval" holds.
-        var pm = new PermissionManager(new DefaultPermissionPolicy(DefaultPermissionPolicy.MODE_NORMAL));
+        // Sensitive-path denials are opt-in on the policy (default off so an
+        // upgrade doesn't break workflows that legitimately write .env
+        // templates). Enable explicitly here -- the entire test is about
+        // pinning that opt-in's override semantics.
+        var pm = new PermissionManager(new DefaultPermissionPolicy(
+                DefaultPermissionPolicy.MODE_NORMAL, /* denySensitivePaths */ true));
         pm.approveForSession("sess-A", "write_file");
 
         // Sanity: a non-sensitive write still gets the blanket approval.

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/PermissionManagerCapabilityTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/PermissionManagerCapabilityTest.java
@@ -18,19 +18,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 final class PermissionManagerCapabilityTest {
 
     /** Always-deny policy so any Approved result must come from the session blanket. */
-    private static final PermissionPolicy DENY = req ->
+    private static final PermissionPolicy DENY = (cap, prov, desc) ->
             new PermissionDecision.Denied("test policy denies");
 
     @Test
-    void structuredCheckUsesCapabilityRiskInPolicyRequest() {
-        // PolicyEngine doesn't yet consume Capability directly (#465 Scope
-        // #2 lands later); for now the manager builds a PermissionRequest
-        // from the capability so DefaultPermissionPolicy etc. keep working
-        // unchanged. Confirm the level passed in is the variant's derived
-        // risk, not something a caller could lie about.
-        var captured = new java.util.concurrent.atomic.AtomicReference<PermissionRequest>();
-        PermissionPolicy capturing = req -> {
-            captured.set(req);
+    void policyReceivesStructuredCapabilityNotFlatRequest() {
+        // PolicyEngine now consumes the structured capability directly
+        // (#465 Scope #2 / #480 PR 4). Confirm the policy sees the full
+        // variant — fields like path, write mode are reachable — not just
+        // a 4-tier risk level.
+        var captured = new java.util.concurrent.atomic.AtomicReference<Capability>();
+        PermissionPolicy capturing = (cap, prov, desc) -> {
+            captured.set(cap);
             return new PermissionDecision.Approved();
         };
         var pm = new PermissionManager(capturing);
@@ -38,10 +37,10 @@ final class PermissionManagerCapabilityTest {
 
         pm.check(fileWrite, Provenance.forSession(new SessionId("s")));
 
-        assertThat(captured.get().level()).isEqualTo(PermissionLevel.WRITE);
-        assertThat(captured.get().toolName())
-                .as("toolName uses the capability's allowlistKey, not a stringly-typed name")
-                .isEqualTo("FileWrite");
+        assertThat(captured.get()).isInstanceOf(Capability.FileWrite.class);
+        assertThat(((Capability.FileWrite) captured.get()).path()).isEqualTo(Path.of("/tmp/x"));
+        assertThat(((Capability.FileWrite) captured.get()).mode()).isEqualTo(WriteMode.OVERWRITE);
+        assertThat(captured.get().risk()).isEqualTo(PermissionLevel.WRITE);
     }
 
     @Test
@@ -92,10 +91,10 @@ final class PermissionManagerCapabilityTest {
         // buildToolDescription(...) and passes it through. Pin that the
         // policy sees that string rather than the synthetic displayLabel
         // — losing it would regress the user's permission prompt UX.
-        var captured = new java.util.concurrent.atomic.AtomicReference<PermissionRequest>();
-        PermissionPolicy capturing = req -> {
-            captured.set(req);
-            return new PermissionDecision.NeedsUserApproval(req.description());
+        var capturedDesc = new java.util.concurrent.atomic.AtomicReference<String>();
+        PermissionPolicy capturing = (cap, prov, desc) -> {
+            capturedDesc.set(desc);
+            return new PermissionDecision.NeedsUserApproval(desc);
         };
         var pm = new PermissionManager(capturing);
 
@@ -105,11 +104,8 @@ final class PermissionManagerCapabilityTest {
                 "write_file",
                 "Write /tmp/x (123 chars of new content)");
 
-        assertThat(captured.get().description())
+        assertThat(capturedDesc.get())
                 .isEqualTo("Write /tmp/x (123 chars of new content)");
-        assertThat(captured.get().toolName())
-                .as("4-arg form uses the caller's allowlist key, not the variant class name")
-                .isEqualTo("write_file");
     }
 
     @Test

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/PermissionManagerTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/PermissionManagerTest.java
@@ -29,7 +29,7 @@ class PermissionManagerTest {
             "write_file", "Write to /tmp/foo");
 
     /** Always-deny policy so the only Approved path is via session-blanket. */
-    private static final PermissionPolicy DENY_POLICY = req ->
+    private static final PermissionPolicy DENY_POLICY = (cap, prov, desc) ->
             new PermissionDecision.Denied("test policy denies");
 
     @Test

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/SensitivePathsTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/SensitivePathsTest.java
@@ -1,15 +1,11 @@
 package dev.aceclaw.security;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Unit tests for the {@link SensitivePaths} utility. The same rules are
@@ -78,135 +74,4 @@ class SensitivePathsTest {
     // -- defensive ----------------------------------------------------------
 
     @Test void nullPathDoesNotMatch() { assertFalse(SensitivePaths.matches(null)); }
-
-    // -- symlink resolution (#18 / #21) -------------------------------------
-    // Real symlinks under @TempDir. Skipped on filesystems that refuse to
-    // create symlinks (Windows without dev-mode, locked-down sandboxes) —
-    // assumeTrue() turns the failure into a skip instead of a flake.
-
-    /**
-     * The original bypass: a directory symlink named innocuously points at a
-     * credentials dir, and a write through the alias hits the real target.
-     * Lexical match on the alias path doesn't fire; symlink resolution must
-     * promote it to a sensitive write.
-     */
-    @Test
-    void symlinkedDirectoryToDotSshIsSensitive(@TempDir Path tmp) throws IOException {
-        Path realSshDir = Files.createDirectory(tmp.resolve(".ssh"));
-        Path alias;
-        try {
-            alias = Files.createSymbolicLink(tmp.resolve("safe-dir"), realSshDir);
-        } catch (UnsupportedOperationException | IOException e) {
-            assumeTrue(false, "Filesystem refuses symlink creation: " + e.getMessage());
-            return;
-        }
-
-        // Writing through the alias targets the real sensitive dir.
-        assertTrue(SensitivePaths.matches(alias.resolve("id_rsa")),
-                "symlink-fronted path should resolve to sensitive target");
-        // Sanity: the real path is still recognised.
-        assertTrue(SensitivePaths.matches(realSshDir.resolve("id_rsa")));
-    }
-
-    /**
-     * Sensitive-source symlink: the file itself is a symlink to a credentials
-     * file. The alias name is innocuous; only resolution shows the real target.
-     */
-    @Test
-    void symlinkedFileToCredentialsIsSensitive(@TempDir Path tmp) throws IOException {
-        Path real = Files.writeString(tmp.resolve("credentials.json"), "{}");
-        Path alias;
-        try {
-            alias = Files.createSymbolicLink(tmp.resolve("config.txt"), real);
-        } catch (UnsupportedOperationException | IOException e) {
-            assumeTrue(false, "Filesystem refuses symlink creation: " + e.getMessage());
-            return;
-        }
-        assertTrue(SensitivePaths.matches(alias),
-                "alias whose target basename is sensitive must be denied");
-    }
-
-    /**
-     * New-file-write case: target file doesn't exist yet, but its parent is
-     * a symlink to a sensitive dir. The resolver should walk up to the parent
-     * (which exists), resolve, then re-append the missing tail.
-     */
-    @Test
-    void nonExistentFileUnderSymlinkedParentIsSensitive(@TempDir Path tmp) throws IOException {
-        Path realSshDir = Files.createDirectory(tmp.resolve(".ssh"));
-        Path alias;
-        try {
-            alias = Files.createSymbolicLink(tmp.resolve("safe-dir"), realSshDir);
-        } catch (UnsupportedOperationException | IOException e) {
-            assumeTrue(false, "Filesystem refuses symlink creation: " + e.getMessage());
-            return;
-        }
-        // The file doesn't exist — this is the typical "write a new key" flow.
-        Path newFileThroughAlias = alias.resolve("new_key");
-        assertFalse(Files.exists(newFileThroughAlias));
-        assertTrue(SensitivePaths.matches(newFileThroughAlias),
-                "non-existent file under symlinked sensitive parent must still match");
-    }
-
-    /**
-     * Lexical sensitivity wins even when resolution would move the path away
-     * from the rule set. {@code /etc/hosts} on macOS canonicalises to
-     * {@code /private/etc/hosts}, which doesn't lexically match the
-     * {@code /etc/} prefix rule — but the original path does. Lexical-first
-     * makes sure we don't lose denials to OS-specific filesystem layout.
-     */
-    @Test
-    void lexicalMatchTakesPrecedenceOverResolution() {
-        // /etc/hosts exists on macOS/Linux. Even though toRealPath may turn
-        // it into /private/etc/hosts (macOS), the lexical check on the
-        // ORIGINAL path catches it. This is a behaviour pin, not a setup
-        // requiring filesystem manipulation.
-        assertTrue(SensitivePaths.matches(Path.of("/etc/hosts")));
-    }
-
-    /**
-     * Non-existent path that doesn't resolve and isn't lexically sensitive.
-     * The resolver returns null; the matcher returns false. Should not throw.
-     */
-    @Test
-    void nonExistentSafePathReturnsFalse(@TempDir Path tmp) {
-        Path bogus = tmp.resolve("does-not-exist").resolve("definitely-not-here.txt");
-        assertFalse(Files.exists(bogus));
-        assertFalse(SensitivePaths.matches(bogus));
-    }
-
-    /**
-     * Symlink to a safe target stays safe. Catches the easy false-positive
-     * where any symlink would be treated as suspicious — only the resolved
-     * target's sensitivity matters.
-     */
-    @Test
-    void symlinkToSafeTargetStaysSafe(@TempDir Path tmp) throws IOException {
-        Path realSafeFile = Files.writeString(tmp.resolve("notes.md"), "hi");
-        Path alias;
-        try {
-            alias = Files.createSymbolicLink(tmp.resolve("aliased.txt"), realSafeFile);
-        } catch (UnsupportedOperationException | IOException e) {
-            assumeTrue(false, "Filesystem refuses symlink creation: " + e.getMessage());
-            return;
-        }
-        assertFalse(SensitivePaths.matches(alias));
-    }
-
-    // -- lexical-only API (matchesLexical) ---------------------------------
-
-    /**
-     * {@link SensitivePaths#matchesLexical} is the IO-free version exposed
-     * for callers that need the rule set without filesystem side effects
-     * (audit dry-runs, symbolic analysis). Verify it returns the same
-     * decision as {@code matches} for paths where symlinks don't change the
-     * answer.
-     */
-    @Test
-    void matchesLexicalAgreesOnPlainPaths() {
-        assertTrue(SensitivePaths.matchesLexical(Path.of("/repo/.env")));
-        assertTrue(SensitivePaths.matchesLexical(Path.of("/etc/hosts")));
-        assertFalse(SensitivePaths.matchesLexical(Path.of("/tmp/safe.txt")));
-        assertFalse(SensitivePaths.matchesLexical(null));
-    }
 }

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/SensitivePathsTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/SensitivePathsTest.java
@@ -1,11 +1,15 @@
 package dev.aceclaw.security;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Unit tests for the {@link SensitivePaths} utility. The same rules are
@@ -74,4 +78,135 @@ class SensitivePathsTest {
     // -- defensive ----------------------------------------------------------
 
     @Test void nullPathDoesNotMatch() { assertFalse(SensitivePaths.matches(null)); }
+
+    // -- symlink resolution (#18 / #21) -------------------------------------
+    // Real symlinks under @TempDir. Skipped on filesystems that refuse to
+    // create symlinks (Windows without dev-mode, locked-down sandboxes) —
+    // assumeTrue() turns the failure into a skip instead of a flake.
+
+    /**
+     * The original bypass: a directory symlink named innocuously points at a
+     * credentials dir, and a write through the alias hits the real target.
+     * Lexical match on the alias path doesn't fire; symlink resolution must
+     * promote it to a sensitive write.
+     */
+    @Test
+    void symlinkedDirectoryToDotSshIsSensitive(@TempDir Path tmp) throws IOException {
+        Path realSshDir = Files.createDirectory(tmp.resolve(".ssh"));
+        Path alias;
+        try {
+            alias = Files.createSymbolicLink(tmp.resolve("safe-dir"), realSshDir);
+        } catch (UnsupportedOperationException | IOException e) {
+            assumeTrue(false, "Filesystem refuses symlink creation: " + e.getMessage());
+            return;
+        }
+
+        // Writing through the alias targets the real sensitive dir.
+        assertTrue(SensitivePaths.matches(alias.resolve("id_rsa")),
+                "symlink-fronted path should resolve to sensitive target");
+        // Sanity: the real path is still recognised.
+        assertTrue(SensitivePaths.matches(realSshDir.resolve("id_rsa")));
+    }
+
+    /**
+     * Sensitive-source symlink: the file itself is a symlink to a credentials
+     * file. The alias name is innocuous; only resolution shows the real target.
+     */
+    @Test
+    void symlinkedFileToCredentialsIsSensitive(@TempDir Path tmp) throws IOException {
+        Path real = Files.writeString(tmp.resolve("credentials.json"), "{}");
+        Path alias;
+        try {
+            alias = Files.createSymbolicLink(tmp.resolve("config.txt"), real);
+        } catch (UnsupportedOperationException | IOException e) {
+            assumeTrue(false, "Filesystem refuses symlink creation: " + e.getMessage());
+            return;
+        }
+        assertTrue(SensitivePaths.matches(alias),
+                "alias whose target basename is sensitive must be denied");
+    }
+
+    /**
+     * New-file-write case: target file doesn't exist yet, but its parent is
+     * a symlink to a sensitive dir. The resolver should walk up to the parent
+     * (which exists), resolve, then re-append the missing tail.
+     */
+    @Test
+    void nonExistentFileUnderSymlinkedParentIsSensitive(@TempDir Path tmp) throws IOException {
+        Path realSshDir = Files.createDirectory(tmp.resolve(".ssh"));
+        Path alias;
+        try {
+            alias = Files.createSymbolicLink(tmp.resolve("safe-dir"), realSshDir);
+        } catch (UnsupportedOperationException | IOException e) {
+            assumeTrue(false, "Filesystem refuses symlink creation: " + e.getMessage());
+            return;
+        }
+        // The file doesn't exist — this is the typical "write a new key" flow.
+        Path newFileThroughAlias = alias.resolve("new_key");
+        assertFalse(Files.exists(newFileThroughAlias));
+        assertTrue(SensitivePaths.matches(newFileThroughAlias),
+                "non-existent file under symlinked sensitive parent must still match");
+    }
+
+    /**
+     * Lexical sensitivity wins even when resolution would move the path away
+     * from the rule set. {@code /etc/hosts} on macOS canonicalises to
+     * {@code /private/etc/hosts}, which doesn't lexically match the
+     * {@code /etc/} prefix rule — but the original path does. Lexical-first
+     * makes sure we don't lose denials to OS-specific filesystem layout.
+     */
+    @Test
+    void lexicalMatchTakesPrecedenceOverResolution() {
+        // /etc/hosts exists on macOS/Linux. Even though toRealPath may turn
+        // it into /private/etc/hosts (macOS), the lexical check on the
+        // ORIGINAL path catches it. This is a behaviour pin, not a setup
+        // requiring filesystem manipulation.
+        assertTrue(SensitivePaths.matches(Path.of("/etc/hosts")));
+    }
+
+    /**
+     * Non-existent path that doesn't resolve and isn't lexically sensitive.
+     * The resolver returns null; the matcher returns false. Should not throw.
+     */
+    @Test
+    void nonExistentSafePathReturnsFalse(@TempDir Path tmp) {
+        Path bogus = tmp.resolve("does-not-exist").resolve("definitely-not-here.txt");
+        assertFalse(Files.exists(bogus));
+        assertFalse(SensitivePaths.matches(bogus));
+    }
+
+    /**
+     * Symlink to a safe target stays safe. Catches the easy false-positive
+     * where any symlink would be treated as suspicious — only the resolved
+     * target's sensitivity matters.
+     */
+    @Test
+    void symlinkToSafeTargetStaysSafe(@TempDir Path tmp) throws IOException {
+        Path realSafeFile = Files.writeString(tmp.resolve("notes.md"), "hi");
+        Path alias;
+        try {
+            alias = Files.createSymbolicLink(tmp.resolve("aliased.txt"), realSafeFile);
+        } catch (UnsupportedOperationException | IOException e) {
+            assumeTrue(false, "Filesystem refuses symlink creation: " + e.getMessage());
+            return;
+        }
+        assertFalse(SensitivePaths.matches(alias));
+    }
+
+    // -- lexical-only API (matchesLexical) ---------------------------------
+
+    /**
+     * {@link SensitivePaths#matchesLexical} is the IO-free version exposed
+     * for callers that need the rule set without filesystem side effects
+     * (audit dry-runs, symbolic analysis). Verify it returns the same
+     * decision as {@code matches} for paths where symlinks don't change the
+     * answer.
+     */
+    @Test
+    void matchesLexicalAgreesOnPlainPaths() {
+        assertTrue(SensitivePaths.matchesLexical(Path.of("/repo/.env")));
+        assertTrue(SensitivePaths.matchesLexical(Path.of("/etc/hosts")));
+        assertFalse(SensitivePaths.matchesLexical(Path.of("/tmp/safe.txt")));
+        assertFalse(SensitivePaths.matchesLexical(null));
+    }
 }

--- a/aceclaw-security/src/test/java/dev/aceclaw/security/SensitivePathsTest.java
+++ b/aceclaw-security/src/test/java/dev/aceclaw/security/SensitivePathsTest.java
@@ -1,0 +1,77 @@
+package dev.aceclaw.security;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for the {@link SensitivePaths} utility. The same rules are
+ * exercised transitively by {@link DefaultPermissionPolicyTest}; this file
+ * keeps coverage local to the utility so a future change to the rule set
+ * gets pinned at its source rather than only through policy integration.
+ */
+class SensitivePathsTest {
+
+    private static boolean matches(String p) {
+        return SensitivePaths.matches(Path.of(p));
+    }
+
+    // -- basename rules ------------------------------------------------------
+
+    @Test void dotEnvMatches() { assertTrue(matches("/repo/.env")); }
+    @Test void dotEnvLocalMatches() { assertTrue(matches("/repo/.env.local")); }
+    @Test void dotEnvProductionMatches() { assertTrue(matches("/repo/.env.production")); }
+    @Test void credentialsJsonMatches() { assertTrue(matches("/tmp/credentials.json")); }
+    @Test void netrcMatches() { assertTrue(matches("/home/u/.netrc")); }
+    @Test void idRsaMatches() { assertTrue(matches("/home/u/id_rsa")); }
+    @Test void idEd25519Matches() { assertTrue(matches("/home/u/id_ed25519")); }
+    @Test void idEcdsaMatches() { assertTrue(matches("/home/u/id_ecdsa")); }
+    @Test void npmrcMatches() { assertTrue(matches("/repo/.npmrc")); }
+    @Test void pypircMatches() { assertTrue(matches("/home/u/.pypirc")); }
+    @Test void serviceAccountJsonMatches() { assertTrue(matches("/tmp/service-account.json")); }
+
+    // -- case-insensitivity (macOS APFS, Windows NTFS) ----------------------
+
+    @Test void uppercaseDotEnvMatches() { assertTrue(matches("/repo/.ENV")); }
+    @Test void mixedCaseCredentialsJsonMatches() { assertTrue(matches("/tmp/Credentials.json")); }
+    @Test void uppercaseSshSegmentMatches() { assertTrue(matches("/home/u/.SSH/config")); }
+
+    // -- segment rules ------------------------------------------------------
+
+    @Test void sshSegmentMatches() { assertTrue(matches("/home/u/.ssh/config")); }
+    @Test void awsCredentialsMatches() { assertTrue(matches("/home/u/.aws/credentials")); }
+    @Test void gnupgMatches() { assertTrue(matches("/home/u/.gnupg/secring.gpg")); }
+    @Test void kubeConfigMatches() { assertTrue(matches("/home/u/.kube/config")); }
+    @Test void dockerConfigMatches() { assertTrue(matches("/home/u/.docker/config.json")); }
+
+    // -- .git/config special case -------------------------------------------
+
+    @Test void gitConfigMatches() { assertTrue(matches("/repo/.git/config")); }
+    @Test void gitHeadDoesNotMatch() { assertFalse(matches("/repo/.git/HEAD")); }
+    @Test void gitPackedRefsDoesNotMatch() { assertFalse(matches("/repo/.git/packed-refs")); }
+
+    // -- /etc/ absolute prefix ----------------------------------------------
+
+    @Test void etcHostsMatches() { assertTrue(matches("/etc/hosts")); }
+    @Test void relativeEtcLikePathDoesNotMatch() { assertFalse(matches("docs/etc/notes.md")); }
+
+    // -- traversal safety ---------------------------------------------------
+
+    @Test void pathTraversalToEtcIsNormalized() {
+        // /tmp/../etc/hosts normalizes to /etc/hosts -> matches.
+        assertTrue(matches("/tmp/../etc/hosts"));
+    }
+
+    // -- false-positive guards ----------------------------------------------
+
+    @Test void dotenvNotesDoesNotMatch() { assertFalse(matches("/repo/dotenv-notes.md")); }
+    @Test void notesAboutEnvDoesNotMatch() { assertFalse(matches("/repo/notes-on-env.md")); }
+    @Test void plainSafeFileDoesNotMatch() { assertFalse(matches("/tmp/foo.txt")); }
+
+    // -- defensive ----------------------------------------------------------
+
+    @Test void nullPathDoesNotMatch() { assertFalse(SensitivePaths.matches(null)); }
+}

--- a/aceclaw-tools/build.gradle.kts
+++ b/aceclaw-tools/build.gradle.kts
@@ -3,7 +3,11 @@
 dependencies {
     implementation(project(":aceclaw-core"))
     implementation(project(":aceclaw-memory"))
-    implementation(project(":aceclaw-security"))
+    // api(): every built-in tool here implements CapabilityAware and exposes
+    // dev.aceclaw.security.Capability as the return type of toCapability(),
+    // so the dependency is part of this module's public Java API. Matches
+    // the scope already used in :aceclaw-mcp. (Tracked as #497.)
+    api(project(":aceclaw-security"))
 
     implementation("com.fasterxml.jackson.core:jackson-databind")
     implementation("org.slf4j:slf4j-api")

--- a/docs/runtime-governance.md
+++ b/docs/runtime-governance.md
@@ -36,13 +36,13 @@ The runtime governance scaffolding is real and shipping. The capability-abstract
 | Live execution tree — every decision traceable end-to-end | ✅ shipped | `aceclaw-dashboard` (#430 epic, #459) |
 | Cron runs governed by the same path as user sessions | ✅ shipped | #459 cron-as-session |
 | HMAC-signed memory entries (signed audit chain on the memory tier) | ✅ shipped | `MemorySigner` |
-| Cross-adapter capability abstraction (one model spans MCP, bash, browser, skill, sub-agent) | 🚧 **not yet** | — |
-| Unified policy engine (one decision rule applies regardless of adapter origin) | 🚧 **not yet** | — |
+| Cross-adapter capability abstraction (one model spans MCP, bash, browser, skill, sub-agent) | ✅ shipped | `Capability` sealed type, `CapabilityAware` on every active adapter incl. `McpToolBridge` |
+| Unified policy engine (one decision rule applies regardless of adapter origin) | ✅ shipped | `PermissionPolicy.evaluate(Capability, Provenance, description)` — single decision pipeline |
 | OS-level enforcement (Seatbelt / bubblewrap / equivalent for bash + subprocess + MCP stdio) | 🚧 **not yet** | — |
 | Capability-level audit schema (every capability use is signed, queryable, replayable) | 🚧 **partial** | (only memory tier today) |
 | Eval / regression harness for governance behavior under adversarial prompts | 🚧 **not yet** | — |
 
-**Today AceClaw governs at the runtime layer for its built-in tools and primitive operations. It does not yet have a unified capability abstraction across every adapter.** That's the gap.
+**AceClaw now governs every adapter through one capability model and one policy decision.** Every built-in tool, MCP server, browser action, skill invocation, sub-agent spawn, and HTTP fetch enters the pipeline as a structured `Capability`, gets evaluated by a single `PermissionPolicy`, and produces one signed audit record. The remaining gap is moving from *approval* to *enforcement*: an OS-level sandbox that constrains the running process after the decision, plus the audit-schema and adversarial-eval work to make the pipeline observable and testable end-to-end.
 
 ## What "complete" runtime governance looks like
 


### PR DESCRIPTION
## Summary

Closes the two gaps `docs/runtime-governance.md` flagged as 🚧:

- **Cross-adapter capability abstraction** — `McpToolBridge` migrated to `CapabilityAware`. Every active adapter (Bash, File, Browser, Skill, HTTP, OsScript, Memory, SubAgentSpawn, ScreenCapture, MCP) now enters the structured permission pipeline.
- **Unified policy engine** — `PermissionPolicy.evaluate` takes `(Capability, Provenance, description)` instead of a flat `PermissionRequest`. Policies pattern-match on the sealed variant and can reach `FileWrite.path`, `HttpFetch.url`, `McpInvoke.server`, etc.

Adds:

- **Opt-in structural hard-denial layer** (off by default — `security.denySensitivePaths` in `~/.aceclaw/config.json`). When enabled, overrides every mode (including `auto-accept`) and every approval (session blanket, sub-agent dispatch) for writes/deletes targeting credentials and operator-critical paths: `.env*`, `.ssh/`, `.aws/`, `.gnupg/`, `.kube/`, `.docker/`, `credentials.json`, `id_rsa`/`id_ed25519`/`id_ecdsa`, `.netrc`, `.npmrc`, `.pypirc`, `service-account.json`, `.git/config`, `/etc/*`. Paths are normalized and case-folded under `Locale.ROOT` so `/tmp/../etc/hosts` and `/repo/.ENV` cannot bypass. Default-off is deliberate — an upgrade past #480 must not silently start refusing writes that prior agent flows depended on.
- **`SensitivePaths` utility** — policy-independent rule set. Both `DefaultPermissionPolicy.evaluateStructural` and `McpCapabilityInference` call it so MCP-side classification isn't coupled to a specific policy implementation.
- **`Capability.FileMove(source, destination, deletesSource)` variant** — carries both endpoints of a move/copy so `evaluateStructural` can check both sides in one pass. Audit log now records `@type=FileMove` for actual moves/copies (previously misclassified as `FileDelete` by the inference-side coercion).
- **Best-effort MCP capability inference** at the bridge boundary. MCP method names matching write/delete/move/copy verbs (snake/camel/kebab/PascalCase) get classified as `FileWrite`/`FileDelete`/`FileMove` so the structural rules fire uniformly across built-in tools and MCP servers.
- **Sub-agent dispatch** now runs the structural-denial probe **before** the session-blanket lookup. A prior "always allow `write_file`" approval cannot route a sub-agent past the hard-denial layer. Denials are audited under the originating session's provenance.

`docs/runtime-governance.md` status table flipped: both rows now ✅ shipped.

## Test plan

- [x] `./gradlew build` — all 13 modules pass
- [x] `./gradlew :aceclaw-security:test` — ~150 tests including `DefaultPermissionPolicyTest` (50), `SensitivePathsTest` (29), `PermissionManagerAuditTest` (10), `CapabilityTest` (29)
- [x] `./gradlew :aceclaw-mcp:test` — 44 tests including the full MCP capability inference surface
- [x] `./gradlew :aceclaw-daemon:test` — all integration tests pass with updated `ToolPermissionRouterTest`
- [x] `./gradlew :aceclaw-core:test` — `SubAgentPermissionCheckerTest` (8) covers the structural-denial-overrides-allowlist invariant

## Known limitations

These are intentional and tracked as follow-ups, not bugs:

- **MCP capability inference is pattern-based.** Method names are matched against verb regexes (`write_*`, `move_file`, `copyFile`, …) and JSON args are looked up by canonical field names (`path`, `destination`, …). False positives possible — e.g. `write_log(path=...)` would be classified as `FileWrite` even if it's a logging API. False negatives possible — an obscurely named file op that doesn't match the patterns falls back to `McpInvoke` and gets the standard prompt. The standard prompt is also the floor protection, so false negatives are never bypasses. Follow-up #496 tracks moving to schema-aware classification.
- **No symlink resolution.** Path matching is purely lexical. An adversarial actor planting a symlink whose alias name looks safe but whose target is sensitive (e.g. `/repo/tmp_link → ~/.ssh/config`) could route a write through. Considered and explicitly rejected at the application layer because (a) LLM-generated paths are literal, not symlink-bypass-shaped; (b) MCP trust is given at install time, not call time; (c) any application-layer resolver has a TOCTOU window that defeats it against an actual adversary. True enforcement needs the OS-level sandbox (Seatbelt/bubblewrap, still 🚧 in `runtime-governance.md`), which closes this at the syscall boundary without TOCTOU.
- **macOS `/private/etc/...`** (canonical resolution of `/etc/`) is not in the `/etc/` rule's match set. Agents normally use the `/etc/` form directly.
- **Nested args not probed.** MCP servers that wrap path under `params.path` or `options.path` won't have inference fire. Top-level keys cover the common case.

## Follow-up issues

- Schema-aware MCP capability inference — #496
- Production observation of MCP inference false positives — #498

🤖 Generated with [Claude Code](https://claude.com/claude-code)




