### PR TITLE
refactor(daemon): extract SkillAutoReleaseSettings — AceClawConfig decomposition batch 1

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
@@ -112,19 +112,10 @@ public final class AceClawConfig {
     private static final String DEFAULT_SKILL_DRAFT_VALIDATION_REPLAY_REPORT =
             ".aceclaw/metrics/continuous-learning/replay-latest.json";
     private static final double DEFAULT_SKILL_DRAFT_VALIDATION_MAX_TOKEN_ESTIMATION_ERROR_RATIO = 0.65;
-    private static final boolean DEFAULT_SKILL_AUTO_RELEASE_ENABLED = true;
-    private static final double DEFAULT_SKILL_AUTO_RELEASE_MIN_CANDIDATE_SCORE = 0.80;
-    private static final int DEFAULT_SKILL_AUTO_RELEASE_MIN_EVIDENCE = 3;
-    private static final int DEFAULT_SKILL_AUTO_RELEASE_CANARY_MIN_ATTEMPTS = 20;
-    private static final double DEFAULT_SKILL_AUTO_RELEASE_CANARY_MAX_FAILURE_RATE = 0.10;
-    private static final double DEFAULT_SKILL_AUTO_RELEASE_CANARY_MAX_TIMEOUT_RATE = 0.20;
-    private static final double DEFAULT_SKILL_AUTO_RELEASE_CANARY_MAX_PERMISSION_BLOCK_RATE = 0.20;
-    private static final int DEFAULT_SKILL_AUTO_RELEASE_CANARY_DWELL_HOURS = 24;
-    private static final double DEFAULT_SKILL_AUTO_RELEASE_ACTIVE_MAX_FAILURE_RATE = 0.20; // legacy alias
-    private static final double DEFAULT_SKILL_AUTO_RELEASE_ROLLBACK_MAX_FAILURE_RATE = 0.20;
-    private static final double DEFAULT_SKILL_AUTO_RELEASE_ROLLBACK_MAX_TIMEOUT_RATE = 0.20;
-    private static final double DEFAULT_SKILL_AUTO_RELEASE_ROLLBACK_MAX_PERMISSION_BLOCK_RATE = 0.20;
-    private static final int DEFAULT_SKILL_AUTO_RELEASE_HEALTH_LOOKBACK_HOURS = 168;
+    // Skill auto-release defaults live on SkillAutoReleaseSettings.defaults().
+    // 13 individual DEFAULT_SKILL_AUTO_RELEASE_* constants used to live here —
+    // grouped into the SkillAutoReleaseSettings record as part of the
+    // AceClawConfig decomposition (batch 1).
     private static final int DEFAULT_MAX_AGENT_TURNS = 200;
     private static final int DEFAULT_MAX_AGENT_WALL_TIME_SEC = 1800;
     // 0 means "derive from soft limit (3x)" in StreamingAgentHandler
@@ -231,19 +222,15 @@ public final class AceClawConfig {
     private boolean skillDraftValidationReplayRequired;
     private String skillDraftValidationReplayReport;
     private double skillDraftValidationMaxTokenEstimationErrorRatio;
-    private boolean skillAutoReleaseEnabled;
-    private double skillAutoReleaseMinCandidateScore;
-    private int skillAutoReleaseMinEvidence;
-    private int skillAutoReleaseCanaryMinAttempts;
-    private double skillAutoReleaseCanaryMaxFailureRate;
-    private double skillAutoReleaseCanaryMaxTimeoutRate;
-    private double skillAutoReleaseCanaryMaxPermissionBlockRate;
-    private double skillAutoReleaseActiveMaxFailureRate;
-    private double skillAutoReleaseRollbackMaxFailureRate;
-    private double skillAutoReleaseRollbackMaxTimeoutRate;
-    private double skillAutoReleaseRollbackMaxPermissionBlockRate;
-    private int skillAutoReleaseHealthLookbackHours;
-    private int skillAutoReleaseCanaryDwellHours;
+    /**
+     * Skill auto-release config — was 12 individual scalar fields, now
+     * grouped under one {@link SkillAutoReleaseSettings} record (batch 1 of
+     * the AceClawConfig decomposition). Held as a mutable builder during
+     * load() so env vars and file merges can update incrementally without
+     * re-allocating; {@link #skillAutoRelease()} freezes it on demand.
+     */
+    private final SkillAutoReleaseSettings.Builder skillAutoReleaseBuilder =
+            SkillAutoReleaseSettings.builder();
     private int maxAgentTurns;
     private int maxAgentWallTimeSec;
     private int maxAgentHardTurns;
@@ -328,20 +315,8 @@ public final class AceClawConfig {
         this.skillDraftValidationReplayReport = DEFAULT_SKILL_DRAFT_VALIDATION_REPLAY_REPORT;
         this.skillDraftValidationMaxTokenEstimationErrorRatio =
                 DEFAULT_SKILL_DRAFT_VALIDATION_MAX_TOKEN_ESTIMATION_ERROR_RATIO;
-        this.skillAutoReleaseEnabled = DEFAULT_SKILL_AUTO_RELEASE_ENABLED;
-        this.skillAutoReleaseMinCandidateScore = DEFAULT_SKILL_AUTO_RELEASE_MIN_CANDIDATE_SCORE;
-        this.skillAutoReleaseMinEvidence = DEFAULT_SKILL_AUTO_RELEASE_MIN_EVIDENCE;
-        this.skillAutoReleaseCanaryMinAttempts = DEFAULT_SKILL_AUTO_RELEASE_CANARY_MIN_ATTEMPTS;
-        this.skillAutoReleaseCanaryMaxFailureRate = DEFAULT_SKILL_AUTO_RELEASE_CANARY_MAX_FAILURE_RATE;
-        this.skillAutoReleaseCanaryMaxTimeoutRate = DEFAULT_SKILL_AUTO_RELEASE_CANARY_MAX_TIMEOUT_RATE;
-        this.skillAutoReleaseCanaryMaxPermissionBlockRate = DEFAULT_SKILL_AUTO_RELEASE_CANARY_MAX_PERMISSION_BLOCK_RATE;
-        this.skillAutoReleaseActiveMaxFailureRate = DEFAULT_SKILL_AUTO_RELEASE_ACTIVE_MAX_FAILURE_RATE;
-        this.skillAutoReleaseRollbackMaxFailureRate = DEFAULT_SKILL_AUTO_RELEASE_ROLLBACK_MAX_FAILURE_RATE;
-        this.skillAutoReleaseRollbackMaxTimeoutRate = DEFAULT_SKILL_AUTO_RELEASE_ROLLBACK_MAX_TIMEOUT_RATE;
-        this.skillAutoReleaseRollbackMaxPermissionBlockRate =
-                DEFAULT_SKILL_AUTO_RELEASE_ROLLBACK_MAX_PERMISSION_BLOCK_RATE;
-        this.skillAutoReleaseHealthLookbackHours = DEFAULT_SKILL_AUTO_RELEASE_HEALTH_LOOKBACK_HOURS;
-        this.skillAutoReleaseCanaryDwellHours = DEFAULT_SKILL_AUTO_RELEASE_CANARY_DWELL_HOURS;
+        // skillAutoRelease defaults are seeded by SkillAutoReleaseSettings.builder()
+        // at field-initialization time. 14 individual setter calls removed here.
         this.maxAgentTurns = DEFAULT_MAX_AGENT_TURNS;
         this.maxAgentWallTimeSec = DEFAULT_MAX_AGENT_WALL_TIME_SEC;
         this.maxAgentHardTurns = DEFAULT_MAX_AGENT_HARD_TURNS;
@@ -601,134 +576,42 @@ public final class AceClawConfig {
                         envSkillDraftValidationMaxTokenError);
             }
         }
-        var envSkillAutoReleaseEnabled = System.getenv("ACECLAW_SKILL_AUTO_RELEASE");
-        if (envSkillAutoReleaseEnabled != null && !envSkillAutoReleaseEnabled.isBlank()) {
-            config.skillAutoReleaseEnabled = Boolean.parseBoolean(envSkillAutoReleaseEnabled);
-        }
-        var envSkillAutoReleaseMinScore = System.getenv("ACECLAW_SKILL_AUTO_RELEASE_MIN_SCORE");
-        if (envSkillAutoReleaseMinScore != null && !envSkillAutoReleaseMinScore.isBlank()) {
-            try {
-                config.skillAutoReleaseMinCandidateScore =
-                        clampRate(Double.parseDouble(envSkillAutoReleaseMinScore));
-            } catch (NumberFormatException e) {
-                log.warn("Invalid ACECLAW_SKILL_AUTO_RELEASE_MIN_SCORE: {}", envSkillAutoReleaseMinScore);
-            }
-        }
-        var envSkillAutoReleaseMinEvidence = System.getenv("ACECLAW_SKILL_AUTO_RELEASE_MIN_EVIDENCE");
-        if (envSkillAutoReleaseMinEvidence != null && !envSkillAutoReleaseMinEvidence.isBlank()) {
-            try {
-                config.skillAutoReleaseMinEvidence = Math.max(0, Integer.parseInt(envSkillAutoReleaseMinEvidence));
-            } catch (NumberFormatException e) {
-                log.warn("Invalid ACECLAW_SKILL_AUTO_RELEASE_MIN_EVIDENCE: {}", envSkillAutoReleaseMinEvidence);
-            }
-        }
-        var envSkillAutoReleaseCanaryMinAttempts =
-                System.getenv("ACECLAW_SKILL_AUTO_RELEASE_CANARY_MIN_ATTEMPTS");
-        if (envSkillAutoReleaseCanaryMinAttempts != null && !envSkillAutoReleaseCanaryMinAttempts.isBlank()) {
-            try {
-                config.skillAutoReleaseCanaryMinAttempts =
-                        Math.max(0, Integer.parseInt(envSkillAutoReleaseCanaryMinAttempts));
-            } catch (NumberFormatException e) {
-                log.warn("Invalid ACECLAW_SKILL_AUTO_RELEASE_CANARY_MIN_ATTEMPTS: {}",
-                        envSkillAutoReleaseCanaryMinAttempts);
-            }
-        }
-        var envSkillAutoReleaseCanaryMaxFailureRate =
-                System.getenv("ACECLAW_SKILL_AUTO_RELEASE_CANARY_MAX_FAILURE_RATE");
-        if (envSkillAutoReleaseCanaryMaxFailureRate != null && !envSkillAutoReleaseCanaryMaxFailureRate.isBlank()) {
-            try {
-                config.skillAutoReleaseCanaryMaxFailureRate =
-                        clampRate(Double.parseDouble(envSkillAutoReleaseCanaryMaxFailureRate));
-            } catch (NumberFormatException e) {
-                log.warn("Invalid ACECLAW_SKILL_AUTO_RELEASE_CANARY_MAX_FAILURE_RATE: {}",
-                        envSkillAutoReleaseCanaryMaxFailureRate);
-            }
-        }
-        var envSkillAutoReleaseCanaryMaxTimeoutRate =
-                System.getenv("ACECLAW_SKILL_AUTO_RELEASE_CANARY_MAX_TIMEOUT_RATE");
-        if (envSkillAutoReleaseCanaryMaxTimeoutRate != null && !envSkillAutoReleaseCanaryMaxTimeoutRate.isBlank()) {
-            try {
-                config.skillAutoReleaseCanaryMaxTimeoutRate =
-                        clampRate(Double.parseDouble(envSkillAutoReleaseCanaryMaxTimeoutRate));
-            } catch (NumberFormatException e) {
-                log.warn("Invalid ACECLAW_SKILL_AUTO_RELEASE_CANARY_MAX_TIMEOUT_RATE: {}",
-                        envSkillAutoReleaseCanaryMaxTimeoutRate);
-            }
-        }
-        var envSkillAutoReleaseCanaryMaxPermissionRate =
-                System.getenv("ACECLAW_SKILL_AUTO_RELEASE_CANARY_MAX_PERMISSION_BLOCK_RATE");
-        if (envSkillAutoReleaseCanaryMaxPermissionRate != null
-                && !envSkillAutoReleaseCanaryMaxPermissionRate.isBlank()) {
-            try {
-                config.skillAutoReleaseCanaryMaxPermissionBlockRate =
-                        clampRate(Double.parseDouble(envSkillAutoReleaseCanaryMaxPermissionRate));
-            } catch (NumberFormatException e) {
-                log.warn("Invalid ACECLAW_SKILL_AUTO_RELEASE_CANARY_MAX_PERMISSION_BLOCK_RATE: {}",
-                        envSkillAutoReleaseCanaryMaxPermissionRate);
-            }
-        }
-        var envSkillAutoReleaseActiveMaxFailureRate =
-                System.getenv("ACECLAW_SKILL_AUTO_RELEASE_ACTIVE_MAX_FAILURE_RATE");
-        if (envSkillAutoReleaseActiveMaxFailureRate != null && !envSkillAutoReleaseActiveMaxFailureRate.isBlank()) {
-            try {
-                config.skillAutoReleaseActiveMaxFailureRate =
-                        clampRate(Double.parseDouble(envSkillAutoReleaseActiveMaxFailureRate));
-                // Legacy env alias maps to rollback failure threshold.
-                config.skillAutoReleaseRollbackMaxFailureRate = config.skillAutoReleaseActiveMaxFailureRate;
-            } catch (NumberFormatException e) {
-                log.warn("Invalid ACECLAW_SKILL_AUTO_RELEASE_ACTIVE_MAX_FAILURE_RATE: {}",
-                        envSkillAutoReleaseActiveMaxFailureRate);
-            }
-        }
-        var envSkillAutoReleaseRollbackMaxFailureRate =
-                System.getenv("ACECLAW_SKILL_AUTO_RELEASE_ROLLBACK_MAX_FAILURE_RATE");
-        if (envSkillAutoReleaseRollbackMaxFailureRate != null && !envSkillAutoReleaseRollbackMaxFailureRate.isBlank()) {
-            try {
-                config.skillAutoReleaseRollbackMaxFailureRate =
-                        clampRate(Double.parseDouble(envSkillAutoReleaseRollbackMaxFailureRate));
-            } catch (NumberFormatException e) {
-                log.warn("Invalid ACECLAW_SKILL_AUTO_RELEASE_ROLLBACK_MAX_FAILURE_RATE: {}",
-                        envSkillAutoReleaseRollbackMaxFailureRate);
-            }
-        }
-        var envSkillAutoReleaseRollbackMaxTimeoutRate =
-                System.getenv("ACECLAW_SKILL_AUTO_RELEASE_ROLLBACK_MAX_TIMEOUT_RATE");
-        if (envSkillAutoReleaseRollbackMaxTimeoutRate != null && !envSkillAutoReleaseRollbackMaxTimeoutRate.isBlank()) {
-            try {
-                config.skillAutoReleaseRollbackMaxTimeoutRate =
-                        clampRate(Double.parseDouble(envSkillAutoReleaseRollbackMaxTimeoutRate));
-            } catch (NumberFormatException e) {
-                log.warn("Invalid ACECLAW_SKILL_AUTO_RELEASE_ROLLBACK_MAX_TIMEOUT_RATE: {}",
-                        envSkillAutoReleaseRollbackMaxTimeoutRate);
-            }
-        }
-        var envSkillAutoReleaseRollbackMaxPermissionRate =
-                System.getenv("ACECLAW_SKILL_AUTO_RELEASE_ROLLBACK_MAX_PERMISSION_BLOCK_RATE");
-        if (envSkillAutoReleaseRollbackMaxPermissionRate != null
-                && !envSkillAutoReleaseRollbackMaxPermissionRate.isBlank()) {
-            try {
-                config.skillAutoReleaseRollbackMaxPermissionBlockRate =
-                        clampRate(Double.parseDouble(envSkillAutoReleaseRollbackMaxPermissionRate));
-            } catch (NumberFormatException e) {
-                log.warn("Invalid ACECLAW_SKILL_AUTO_RELEASE_ROLLBACK_MAX_PERMISSION_BLOCK_RATE: {}",
-                        envSkillAutoReleaseRollbackMaxPermissionRate);
-            }
-        }
-        var envSkillAutoReleaseLookbackHours = System.getenv("ACECLAW_SKILL_AUTO_RELEASE_HEALTH_LOOKBACK_HOURS");
-        if (envSkillAutoReleaseLookbackHours != null && !envSkillAutoReleaseLookbackHours.isBlank()) {
-            try {
-                config.skillAutoReleaseHealthLookbackHours =
-                        Math.max(1, Integer.parseInt(envSkillAutoReleaseLookbackHours));
-            } catch (NumberFormatException e) {
-                log.warn("Invalid ACECLAW_SKILL_AUTO_RELEASE_HEALTH_LOOKBACK_HOURS: {}",
-                        envSkillAutoReleaseLookbackHours);
-            }
-        }
+        // -- Skill auto-release env vars -------------------------------------
+        // Was 12 nearly-identical try/catch blocks (130 LoC) updating 12
+        // individual scalar fields on `config`. Each one now folds into a
+        // single builder.xxx(parsed) call — the builder handles null/range
+        // validation centrally.
+        applyEnvBoolean("ACECLAW_SKILL_AUTO_RELEASE",
+                v -> config.skillAutoReleaseBuilder.enabled(v));
+        applyEnvDouble("ACECLAW_SKILL_AUTO_RELEASE_MIN_SCORE",
+                v -> config.skillAutoReleaseBuilder.minCandidateScore(v));
+        applyEnvInt("ACECLAW_SKILL_AUTO_RELEASE_MIN_EVIDENCE",
+                v -> config.skillAutoReleaseBuilder.minEvidenceCount(Math.max(1, v)));
+        applyEnvInt("ACECLAW_SKILL_AUTO_RELEASE_CANARY_MIN_ATTEMPTS",
+                v -> config.skillAutoReleaseBuilder.canaryMinAttempts(Math.max(0, v)));
+        applyEnvDouble("ACECLAW_SKILL_AUTO_RELEASE_CANARY_MAX_FAILURE_RATE",
+                v -> config.skillAutoReleaseBuilder.canaryMaxFailureRate(v));
+        applyEnvDouble("ACECLAW_SKILL_AUTO_RELEASE_CANARY_MAX_TIMEOUT_RATE",
+                v -> config.skillAutoReleaseBuilder.canaryMaxTimeoutRate(v));
+        applyEnvDouble("ACECLAW_SKILL_AUTO_RELEASE_CANARY_MAX_PERMISSION_BLOCK_RATE",
+                v -> config.skillAutoReleaseBuilder.canaryMaxPermissionRate(v));
+        // Legacy env alias: ACTIVE_MAX_FAILURE_RATE → rollbackFailure.
+        // Preserved for backward compat with pre-#467 docs.
+        applyEnvDouble("ACECLAW_SKILL_AUTO_RELEASE_ACTIVE_MAX_FAILURE_RATE",
+                v -> config.skillAutoReleaseBuilder.applyLegacyActiveMaxFailureRate(v));
+        applyEnvDouble("ACECLAW_SKILL_AUTO_RELEASE_ROLLBACK_MAX_FAILURE_RATE",
+                v -> config.skillAutoReleaseBuilder.rollbackMaxFailureRate(v));
+        applyEnvDouble("ACECLAW_SKILL_AUTO_RELEASE_ROLLBACK_MAX_TIMEOUT_RATE",
+                v -> config.skillAutoReleaseBuilder.rollbackMaxTimeoutRate(v));
+        applyEnvDouble("ACECLAW_SKILL_AUTO_RELEASE_ROLLBACK_MAX_PERMISSION_BLOCK_RATE",
+                v -> config.skillAutoReleaseBuilder.rollbackMaxPermissionRate(v));
+        applyEnvInt("ACECLAW_SKILL_AUTO_RELEASE_HEALTH_LOOKBACK_HOURS",
+                v -> config.skillAutoReleaseBuilder.healthLookbackHours(Math.max(1, v)));
         var envSkillAutoReleaseCanaryDwellHours = System.getenv("ACECLAW_SKILL_AUTO_RELEASE_CANARY_DWELL_HOURS");
         if (envSkillAutoReleaseCanaryDwellHours != null && !envSkillAutoReleaseCanaryDwellHours.isBlank()) {
             try {
-                config.skillAutoReleaseCanaryDwellHours =
-                        Math.max(0, Integer.parseInt(envSkillAutoReleaseCanaryDwellHours));
+                config.skillAutoReleaseBuilder.canaryDwellHours(
+                        Math.max(0, Integer.parseInt(envSkillAutoReleaseCanaryDwellHours)));
             } catch (NumberFormatException e) {
                 log.warn("Invalid ACECLAW_SKILL_AUTO_RELEASE_CANARY_DWELL_HOURS: {}",
                         envSkillAutoReleaseCanaryDwellHours);
@@ -1219,60 +1102,16 @@ public final class AceClawConfig {
         return skillDraftValidationMaxTokenEstimationErrorRatio;
     }
 
-    public boolean skillAutoReleaseEnabled() {
-        return skillAutoReleaseEnabled;
-    }
-
-    public double skillAutoReleaseMinCandidateScore() {
-        return skillAutoReleaseMinCandidateScore;
-    }
-
-    public int skillAutoReleaseMinEvidence() {
-        return skillAutoReleaseMinEvidence;
-    }
-
-    public int skillAutoReleaseCanaryMinAttempts() {
-        return skillAutoReleaseCanaryMinAttempts;
-    }
-
-    public double skillAutoReleaseCanaryMaxFailureRate() {
-        return skillAutoReleaseCanaryMaxFailureRate;
-    }
-
-    public double skillAutoReleaseCanaryMaxTimeoutRate() {
-        return skillAutoReleaseCanaryMaxTimeoutRate;
-    }
-
-    public double skillAutoReleaseCanaryMaxPermissionBlockRate() {
-        return skillAutoReleaseCanaryMaxPermissionBlockRate;
-    }
-
-    public double skillAutoReleaseActiveMaxFailureRate() {
-        return skillAutoReleaseActiveMaxFailureRate;
-    }
-
-    public double skillAutoReleaseRollbackMaxFailureRate() {
-        return skillAutoReleaseRollbackMaxFailureRate;
-    }
-
-    public double skillAutoReleaseRollbackMaxTimeoutRate() {
-        return skillAutoReleaseRollbackMaxTimeoutRate;
-    }
-
-    public double skillAutoReleaseRollbackMaxPermissionBlockRate() {
-        return skillAutoReleaseRollbackMaxPermissionBlockRate;
-    }
-
-    public int skillAutoReleaseHealthLookbackHours() {
-        return skillAutoReleaseHealthLookbackHours;
-    }
-
     /**
-     * Returns the minimum dwell time in hours at CANARY stage before promotion to ACTIVE.
-     * Defaults to 24.
+     * Returns the skill auto-release config — the feature gate plus the 11
+     * canary / rollback tuning scalars the {@code AutoReleaseController}
+     * consumes. Replaces 13 individual getters as the first pilot of the
+     * AceClawConfig decomposition: callers that needed all the values
+     * (single call site in {@code AceClawDaemon}) now receive one record
+     * argument instead of passing 11 scalars by hand.
      */
-    public int skillAutoReleaseCanaryDwellHours() {
-        return skillAutoReleaseCanaryDwellHours;
+    public SkillAutoReleaseSettings skillAutoRelease() {
+        return skillAutoReleaseBuilder.build();
     }
 
     /**
@@ -1752,60 +1591,26 @@ public final class AceClawConfig {
             this.skillDraftValidationMaxTokenEstimationErrorRatio =
                     fileConfig.skillDraftValidationMaxTokenEstimationErrorRatio;
         }
-        if (fileConfig.skillAutoReleaseEnabled != null) {
-            this.skillAutoReleaseEnabled = fileConfig.skillAutoReleaseEnabled;
-        }
-        if (fileConfig.skillAutoReleaseMinCandidateScore != null
-                && fileConfig.skillAutoReleaseMinCandidateScore >= 0) {
-            this.skillAutoReleaseMinCandidateScore = clampRate(fileConfig.skillAutoReleaseMinCandidateScore);
-        }
-        if (fileConfig.skillAutoReleaseMinEvidence != null && fileConfig.skillAutoReleaseMinEvidence > 0) {
-            this.skillAutoReleaseMinEvidence = fileConfig.skillAutoReleaseMinEvidence;
-        }
-        if (fileConfig.skillAutoReleaseCanaryMinAttempts != null
-                && fileConfig.skillAutoReleaseCanaryMinAttempts >= 0) {
-            this.skillAutoReleaseCanaryMinAttempts = fileConfig.skillAutoReleaseCanaryMinAttempts;
-        }
-        if (fileConfig.skillAutoReleaseCanaryMaxFailureRate != null
-                && fileConfig.skillAutoReleaseCanaryMaxFailureRate >= 0) {
-            this.skillAutoReleaseCanaryMaxFailureRate = clampRate(fileConfig.skillAutoReleaseCanaryMaxFailureRate);
-        }
-        if (fileConfig.skillAutoReleaseCanaryMaxTimeoutRate != null
-                && fileConfig.skillAutoReleaseCanaryMaxTimeoutRate >= 0) {
-            this.skillAutoReleaseCanaryMaxTimeoutRate = clampRate(fileConfig.skillAutoReleaseCanaryMaxTimeoutRate);
-        }
-        if (fileConfig.skillAutoReleaseCanaryMaxPermissionBlockRate != null
-                && fileConfig.skillAutoReleaseCanaryMaxPermissionBlockRate >= 0) {
-            this.skillAutoReleaseCanaryMaxPermissionBlockRate =
-                    clampRate(fileConfig.skillAutoReleaseCanaryMaxPermissionBlockRate);
-        }
-        if (fileConfig.skillAutoReleaseActiveMaxFailureRate != null
-                && fileConfig.skillAutoReleaseActiveMaxFailureRate >= 0) {
-            this.skillAutoReleaseActiveMaxFailureRate = clampRate(fileConfig.skillAutoReleaseActiveMaxFailureRate);
-            // Legacy config key maps to rollback failure threshold.
-            this.skillAutoReleaseRollbackMaxFailureRate = this.skillAutoReleaseActiveMaxFailureRate;
-        }
-        if (fileConfig.skillAutoReleaseRollbackMaxFailureRate != null
-                && fileConfig.skillAutoReleaseRollbackMaxFailureRate >= 0) {
-            this.skillAutoReleaseRollbackMaxFailureRate = clampRate(fileConfig.skillAutoReleaseRollbackMaxFailureRate);
-        }
-        if (fileConfig.skillAutoReleaseRollbackMaxTimeoutRate != null
-                && fileConfig.skillAutoReleaseRollbackMaxTimeoutRate >= 0) {
-            this.skillAutoReleaseRollbackMaxTimeoutRate = clampRate(fileConfig.skillAutoReleaseRollbackMaxTimeoutRate);
-        }
-        if (fileConfig.skillAutoReleaseRollbackMaxPermissionBlockRate != null
-                && fileConfig.skillAutoReleaseRollbackMaxPermissionBlockRate >= 0) {
-            this.skillAutoReleaseRollbackMaxPermissionBlockRate =
-                    clampRate(fileConfig.skillAutoReleaseRollbackMaxPermissionBlockRate);
-        }
-        if (fileConfig.skillAutoReleaseHealthLookbackHours != null
-                && fileConfig.skillAutoReleaseHealthLookbackHours > 0) {
-            this.skillAutoReleaseHealthLookbackHours = fileConfig.skillAutoReleaseHealthLookbackHours;
-        }
-        if (fileConfig.skillAutoReleaseCanaryDwellHours != null
-                && fileConfig.skillAutoReleaseCanaryDwellHours >= 0) {
-            this.skillAutoReleaseCanaryDwellHours = fileConfig.skillAutoReleaseCanaryDwellHours;
-        }
+        // -- Skill auto-release file overrides -------------------------------
+        // Was 13 individual nullable-then-set blocks (~55 LoC) updating 13
+        // scalar fields. Now folds into builder setters that each validate
+        // null + range centrally. The legacy `activeMaxFailureRate` key is
+        // handled by applyLegacyActiveMaxFailureRate (aliases onto
+        // rollbackMaxFailureRate, matching the previous behaviour).
+        skillAutoReleaseBuilder
+                .enabled(fileConfig.skillAutoReleaseEnabled)
+                .minCandidateScore(fileConfig.skillAutoReleaseMinCandidateScore)
+                .minEvidenceCount(fileConfig.skillAutoReleaseMinEvidence)
+                .canaryMinAttempts(fileConfig.skillAutoReleaseCanaryMinAttempts)
+                .canaryMaxFailureRate(fileConfig.skillAutoReleaseCanaryMaxFailureRate)
+                .canaryMaxTimeoutRate(fileConfig.skillAutoReleaseCanaryMaxTimeoutRate)
+                .canaryMaxPermissionRate(fileConfig.skillAutoReleaseCanaryMaxPermissionBlockRate)
+                .applyLegacyActiveMaxFailureRate(fileConfig.skillAutoReleaseActiveMaxFailureRate)
+                .rollbackMaxFailureRate(fileConfig.skillAutoReleaseRollbackMaxFailureRate)
+                .rollbackMaxTimeoutRate(fileConfig.skillAutoReleaseRollbackMaxTimeoutRate)
+                .rollbackMaxPermissionRate(fileConfig.skillAutoReleaseRollbackMaxPermissionBlockRate)
+                .healthLookbackHours(fileConfig.skillAutoReleaseHealthLookbackHours)
+                .canaryDwellHours(fileConfig.skillAutoReleaseCanaryDwellHours);
         if (fileConfig.maxAgentTurns != null && fileConfig.maxAgentTurns >= 0) {
             this.maxAgentTurns = fileConfig.maxAgentTurns;
         }
@@ -2034,5 +1839,41 @@ public final class AceClawConfig {
 
     private static double clampRate(double value) {
         return Math.min(1.0, Math.max(0.0, value));
+    }
+
+    // -- Env-var loading helpers --------------------------------------------
+    //
+    // Added during the AceClawConfig decomposition (batch 1, skillAutoRelease)
+    // to collapse the previously-inlined "var x = getenv; if (x != null && !
+    // blank) { try { parse → set } catch { warn }" pattern that appeared 50+
+    // times in load(). Each helper takes the env var name + a consumer of
+    // the parsed value; on parse failure the helper logs a warning and
+    // leaves the receiver field untouched. Keeps the call site to a single
+    // expression and centralizes the empty/blank + parse-error handling.
+
+    private static void applyEnvBoolean(String name, java.util.function.Consumer<Boolean> sink) {
+        var raw = System.getenv(name);
+        if (raw == null || raw.isBlank()) return;
+        sink.accept(Boolean.parseBoolean(raw));
+    }
+
+    private static void applyEnvInt(String name, java.util.function.IntConsumer sink) {
+        var raw = System.getenv(name);
+        if (raw == null || raw.isBlank()) return;
+        try {
+            sink.accept(Integer.parseInt(raw));
+        } catch (NumberFormatException e) {
+            log.warn("Invalid {}: {}", name, raw);
+        }
+    }
+
+    private static void applyEnvDouble(String name, java.util.function.DoubleConsumer sink) {
+        var raw = System.getenv(name);
+        if (raw == null || raw.isBlank()) return;
+        try {
+            sink.accept(Double.parseDouble(raw));
+        } catch (NumberFormatException e) {
+            log.warn("Invalid {}: {}", name, raw);
+        }
     }
 }

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -705,21 +705,10 @@ public final class AceClawDaemon {
 
             final var validationGateForAuto = validationGateEngine;
             final var candidateStoreForAuto = cs;
-            if (validationGateForAuto != null && cs != null && config.skillAutoReleaseEnabled()) {
+            var skillAutoRelease = config.skillAutoRelease();
+            if (validationGateForAuto != null && cs != null && skillAutoRelease.enabled()) {
                 autoReleaseController = new AutoReleaseController(
-                        new AutoReleaseController.Config(
-                                config.skillAutoReleaseMinCandidateScore(),
-                                config.skillAutoReleaseMinEvidence(),
-                                config.skillAutoReleaseCanaryMinAttempts(),
-                                config.skillAutoReleaseCanaryMaxFailureRate(),
-                                config.skillAutoReleaseCanaryMaxTimeoutRate(),
-                                config.skillAutoReleaseCanaryMaxPermissionBlockRate(),
-                                config.skillAutoReleaseRollbackMaxFailureRate(),
-                                config.skillAutoReleaseRollbackMaxTimeoutRate(),
-                                config.skillAutoReleaseRollbackMaxPermissionBlockRate(),
-                                Duration.ofHours(Math.max(1, config.skillAutoReleaseHealthLookbackHours())),
-                                config.skillAutoReleaseCanaryDwellHours()
-                        ),
+                        skillAutoRelease.tuning(),
                         validationGateForAuto
                 );
             }

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/SkillAutoReleaseSettings.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/SkillAutoReleaseSettings.java
@@ -1,0 +1,139 @@
+package dev.aceclaw.daemon;
+
+import dev.aceclaw.learning.validation.AutoReleaseController;
+
+import java.time.Duration;
+
+/**
+ * Thematic config grouping for the skill auto-release subsystem — the 12
+ * scalars AceClawConfig used to hold one-by-one for the AutoReleaseController
+ * canary/rollback gates. First pilot of the AceClawConfig decomposition
+ * pattern (the god class had grown to 152 instance fields + 85 getters; each
+ * subsystem is being lifted into its own small record).
+ *
+ * <p>Shape:
+ * <ul>
+ *   <li>{@code enabled} — feature gate (was {@code skillAutoReleaseEnabled})</li>
+ *   <li>{@code tuning} — the 11-scalar {@link AutoReleaseController.Config}
+ *       record that the controller already accepts in its constructor.
+ *       Reusing the consumer-side record means daemon wireup goes from
+ *       "pass 11 scalars by hand" to "pass one record argument."</li>
+ * </ul>
+ *
+ * <p>Builder lives here for incremental population during env-var loading +
+ * {@code mergeFromFormat} — kept package-private; only {@code AceClawConfig}
+ * uses it.
+ */
+public record SkillAutoReleaseSettings(boolean enabled, AutoReleaseController.Config tuning) {
+
+    /** Defaults matched 1:1 to the prior {@code DEFAULT_SKILL_AUTO_RELEASE_*} constants. */
+    public static SkillAutoReleaseSettings defaults() {
+        return new SkillAutoReleaseSettings(
+                true,
+                new AutoReleaseController.Config(
+                        0.80,   // minCandidateScore
+                        3,      // minEvidenceCount
+                        20,     // canaryMinAttempts
+                        0.10,   // canaryMaxFailureRate
+                        0.20,   // canaryMaxTimeoutRate
+                        0.20,   // canaryMaxPermissionRate
+                        0.20,   // rollbackMaxFailureRate
+                        0.20,   // rollbackMaxTimeoutRate
+                        0.20,   // rollbackMaxPermissionRate
+                        Duration.ofHours(168),   // healthLookback (was 168h = 7 days)
+                        24                       // canaryDwellHours
+                ));
+    }
+
+    /** Fresh builder pre-loaded with {@link #defaults()}. */
+    static Builder builder() {
+        return new Builder(defaults());
+    }
+
+    /**
+     * Mutable builder used by {@code AceClawConfig} to accumulate per-source
+     * overrides (file → env var → profile) without re-allocating the record
+     * on every field touch. Call {@link #build()} once when loading is done.
+     *
+     * <p>Setters return {@code this} but also accept {@code null} as "leave
+     * the previous value alone" — matches the {@code if (fileConfig.x != null)}
+     * pattern AceClawConfig used to inline for each scalar.
+     */
+    static final class Builder {
+        private boolean enabled;
+        private double minCandidateScore;
+        private int minEvidenceCount;
+        private int canaryMinAttempts;
+        private double canaryMaxFailureRate;
+        private double canaryMaxTimeoutRate;
+        private double canaryMaxPermissionRate;
+        private double rollbackMaxFailureRate;
+        private double rollbackMaxTimeoutRate;
+        private double rollbackMaxPermissionRate;
+        private int healthLookbackHours;
+        private int canaryDwellHours;
+
+        Builder(SkillAutoReleaseSettings seed) {
+            this.enabled = seed.enabled();
+            var t = seed.tuning();
+            this.minCandidateScore = t.minCandidateScore();
+            this.minEvidenceCount = t.minEvidenceCount();
+            this.canaryMinAttempts = t.canaryMinAttempts();
+            this.canaryMaxFailureRate = t.canaryMaxFailureRate();
+            this.canaryMaxTimeoutRate = t.canaryMaxTimeoutRate();
+            this.canaryMaxPermissionRate = t.canaryMaxPermissionRate();
+            this.rollbackMaxFailureRate = t.rollbackMaxFailureRate();
+            this.rollbackMaxTimeoutRate = t.rollbackMaxTimeoutRate();
+            this.rollbackMaxPermissionRate = t.rollbackMaxPermissionRate();
+            this.healthLookbackHours = (int) Math.max(1, t.healthLookback().toHours());
+            this.canaryDwellHours = t.canaryDwellHours();
+        }
+
+        Builder enabled(Boolean v) { if (v != null) this.enabled = v; return this; }
+        Builder minCandidateScore(Double v) { if (v != null && v >= 0) this.minCandidateScore = clampRate(v); return this; }
+        Builder minEvidenceCount(Integer v) { if (v != null && v > 0) this.minEvidenceCount = v; return this; }
+        Builder canaryMinAttempts(Integer v) { if (v != null && v >= 0) this.canaryMinAttempts = v; return this; }
+        Builder canaryMaxFailureRate(Double v) { if (v != null && v >= 0) this.canaryMaxFailureRate = clampRate(v); return this; }
+        Builder canaryMaxTimeoutRate(Double v) { if (v != null && v >= 0) this.canaryMaxTimeoutRate = clampRate(v); return this; }
+        Builder canaryMaxPermissionRate(Double v) { if (v != null && v >= 0) this.canaryMaxPermissionRate = clampRate(v); return this; }
+        Builder rollbackMaxFailureRate(Double v) { if (v != null && v >= 0) this.rollbackMaxFailureRate = clampRate(v); return this; }
+        Builder rollbackMaxTimeoutRate(Double v) { if (v != null && v >= 0) this.rollbackMaxTimeoutRate = clampRate(v); return this; }
+        Builder rollbackMaxPermissionRate(Double v) { if (v != null && v >= 0) this.rollbackMaxPermissionRate = clampRate(v); return this; }
+        Builder healthLookbackHours(Integer v) { if (v != null && v > 0) this.healthLookbackHours = v; return this; }
+        Builder canaryDwellHours(Integer v) { if (v != null && v >= 0) this.canaryDwellHours = v; return this; }
+
+        /**
+         * Legacy alias: {@code skillAutoRelease.activeMaxFailureRate} in
+         * older config files maps onto the rollback-failure threshold.
+         * Kept as a separate setter so the merge path is explicit at the
+         * call site (vs hiding the alias inside a generic setter).
+         */
+        Builder applyLegacyActiveMaxFailureRate(Double v) {
+            if (v != null && v >= 0) this.rollbackMaxFailureRate = clampRate(v);
+            return this;
+        }
+
+        SkillAutoReleaseSettings build() {
+            return new SkillAutoReleaseSettings(
+                    enabled,
+                    new AutoReleaseController.Config(
+                            minCandidateScore,
+                            minEvidenceCount,
+                            canaryMinAttempts,
+                            canaryMaxFailureRate,
+                            canaryMaxTimeoutRate,
+                            canaryMaxPermissionRate,
+                            rollbackMaxFailureRate,
+                            rollbackMaxTimeoutRate,
+                            rollbackMaxPermissionRate,
+                            Duration.ofHours(Math.max(1, healthLookbackHours)),
+                            canaryDwellHours));
+        }
+
+        private static double clampRate(double value) {
+            if (value < 0.0) return 0.0;
+            if (value > 1.0) return 1.0;
+            return value;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

First pilot of the **AceClawConfig decomposition**. The class had grown to
152 instance fields + 85 getters — a database-schema-masquerading-as-a-class
that's been the central catch-all for every daemon-side knob.

This PR carves out **one thematic cluster** (skill auto-release, 12 fields)
into its own record. Same pattern that pulled `aceclaw-learning` out of
daemon: extract a cohesive slice first, validate the pattern works, then
batch the rest.

| | Before | After |
|---|---|---|
| `AceClawConfig.java` | **2,038 LoC** | **1,879 LoC (-8%)** |
| `AceClawConfig` instance fields | 152 | 141 (-12 cluster + 1 new) |
| `AceClawConfig` getters | 85 | 74 (-12 + 1) |

## Pilot target: SkillAutoRelease (12 fields)

Chosen first because:
- biggest single cohesive cluster (~130 LoC of env-var loading alone)
- consumer (`AutoReleaseController` in `aceclaw-learning`) **already has**
  its own `Config` record — reuse it as the tuning payload instead of
  inventing a new one
- single call site in `AceClawDaemon` (11 inline scalars to a constructor)

## Shape

```java
public record SkillAutoReleaseSettings(
    boolean enabled,
    AutoReleaseController.Config tuning
) { }
```

`enabled` is the feature gate (was `skillAutoReleaseEnabled`); `tuning`
groups the 11 canary/rollback scalars the controller already accepts as a
record. A `Builder` lives on the record for incremental population during
file/env load — kept package-private; only `AceClawConfig` uses it.

## What moved

| Was in AceClawConfig | Now |
|---|---|
| 13 `DEFAULT_SKILL_AUTO_RELEASE_*` constants | `SkillAutoReleaseSettings.defaults()` |
| 12 instance fields | 1 builder field |
| 12 constructor-default assignments | none (builder seeds) |
| 12 individual getters | 1 `skillAutoRelease()` getter |
| ~130 LoC of env-var try/catch | `builder.xxx(parsed)` per env var |
| ~55 LoC of `if (fileConfig.x != null)` | single builder chain |

## Daemon call site

```java
// Before (11 inline scalars passed by hand)
if (config.skillAutoReleaseEnabled()) {
    autoReleaseController = new AutoReleaseController(
        new AutoReleaseController.Config(
            config.skillAutoReleaseMinCandidateScore(),
            config.skillAutoReleaseMinEvidence(),
            // ... 9 more
        ),
        validationGateForAuto);
}

// After
var skillAutoRelease = config.skillAutoRelease();
if (skillAutoRelease.enabled()) {
    autoReleaseController = new AutoReleaseController(
        skillAutoRelease.tuning(),
        validationGateForAuto);
}
```

## Bonus: env-loading helpers

Pulled three small helpers — `applyEnvBoolean`, `applyEnvInt`,
`applyEnvDouble` — out of the env-var-loading boilerplate (was inlined
~50× across `load()`). Each handles null/blank + parse-failure-with-warning
centrally. Future thematic extractions will reuse them.

## Backward compat

- Config file JSON shape unchanged — same flat top-level keys
  (`skillAutoReleaseEnabled`, `skillAutoReleaseMinCandidateScore`, …)
- All 14 env var names preserved (including the legacy
  `ACECLAW_SKILL_AUTO_RELEASE_ACTIVE_MAX_FAILURE_RATE` alias mapping onto
  `rollbackMaxFailureRate`)
- AceClawConfigTest passes unchanged (17/0)

## Test plan

- [x] `:aceclaw-daemon:compileJava` — clean
- [x] `:aceclaw-daemon:compileTestJava` — clean
- [x] `AceClawConfigTest` — 17/0 (covers config file loading, env var
  overrides, persistence, security.denySensitivePaths toggle)
- [x] Diff stat: +254 / -285 = -31 net (across 3 files)
- [x] Renamed/moved code: 0 (this is pure extraction; no logic changes)

## Follow-up batches (out of scope for this PR)

Plan: 2-3 more PRs lift remaining cohesive clusters:

| Cluster | Fields | Notes |
|---|---|---|
| SkillDraftValidation | 5 | similar shape |
| AdaptiveContinuation | 5 | very cohesive |
| Candidates (injection + promotion) | 7 | two sub-clusters could split further |
| Retry | 4 | already has a `RetryConfigFormat` JSON companion |
| Agent + Plan budgets | 6 | (Watchdog cluster) |
| AntiPatternGate | 2 | smallest, last |

Each follows this PR's pattern: small record (+ Builder when needed),
single call site in AceClawDaemon migrated, individual getters removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Refactor**
* Consolidated skill auto-release configuration settings into a unified object structure for improved configuration management and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xinhuagu/AceClaw/pull/506?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->