### PR TITLE
refactor(daemon): extract AdaptiveContinuation + SkillDraftValidation (AceClawConfig batch 2)

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
@@ -61,11 +61,8 @@ public final class AceClawConfig {
     private static final int DEFAULT_MAX_TOKENS = 16384;
     private static final int DEFAULT_THINKING_BUDGET = 10240;
     private static final int DEFAULT_MAX_TURNS = AgentLoopConfig.DEFAULT_MAX_ITERATIONS;
-    private static final boolean DEFAULT_ADAPTIVE_CONTINUATION_ENABLED = true;
-    private static final int DEFAULT_ADAPTIVE_CONTINUATION_MAX_SEGMENTS = 3;
-    private static final int DEFAULT_ADAPTIVE_CONTINUATION_NO_PROGRESS_THRESHOLD = 2;
-    private static final int DEFAULT_ADAPTIVE_CONTINUATION_MAX_TOTAL_TOKENS = 0;
-    private static final int DEFAULT_ADAPTIVE_CONTINUATION_MAX_WALL_CLOCK_SECONDS = 0;
+    // AdaptiveContinuation defaults moved to AdaptiveContinuationSettings.defaults()
+    // (batch 2 of the AceClawConfig decomposition).
     private static final int DEFAULT_CONTEXT_WINDOW = 0;
     private static final String DEFAULT_LOG_LEVEL = "INFO";
     private static final boolean DEFAULT_BOOT_ENABLED = true;
@@ -106,12 +103,8 @@ public final class AceClawConfig {
     private static final int DEFAULT_CANDIDATE_INJECTION_MAX_TOKENS = 1200;
     private static final int DEFAULT_ANTI_PATTERN_GATE_MIN_BLOCKED_BEFORE_ROLLBACK = 2;
     private static final double DEFAULT_ANTI_PATTERN_GATE_MAX_FALSE_POSITIVE_RATE = 0.50;
-    private static final boolean DEFAULT_SKILL_DRAFT_VALIDATION_ENABLED = true;
-    private static final boolean DEFAULT_SKILL_DRAFT_VALIDATION_STRICT_MODE = false;
-    private static final boolean DEFAULT_SKILL_DRAFT_VALIDATION_REPLAY_REQUIRED = true;
-    private static final String DEFAULT_SKILL_DRAFT_VALIDATION_REPLAY_REPORT =
-            ".aceclaw/metrics/continuous-learning/replay-latest.json";
-    private static final double DEFAULT_SKILL_DRAFT_VALIDATION_MAX_TOKEN_ESTIMATION_ERROR_RATIO = 0.65;
+    // SkillDraftValidation defaults moved to SkillDraftValidationSettings.defaults()
+    // (batch 2 of the AceClawConfig decomposition).
     // Skill auto-release defaults live on SkillAutoReleaseSettings.defaults().
     // 13 individual DEFAULT_SKILL_AUTO_RELEASE_* constants used to live here —
     // grouped into the SkillAutoReleaseSettings record as part of the
@@ -168,11 +161,13 @@ public final class AceClawConfig {
     private int maxTokens;
     private int thinkingBudget;
     private int maxTurns;
-    private boolean adaptiveContinuationEnabled;
-    private int adaptiveContinuationMaxSegments;
-    private int adaptiveContinuationNoProgressThreshold;
-    private int adaptiveContinuationMaxTotalTokens;
-    private int adaptiveContinuationMaxWallClockSeconds;
+    /**
+     * Adaptive continuation config — was 5 individual scalar fields, now
+     * grouped under one {@link AdaptiveContinuationSettings} record
+     * (batch 2 of the AceClawConfig decomposition).
+     */
+    private final AdaptiveContinuationSettings.Builder adaptiveContinuationBuilder =
+            AdaptiveContinuationSettings.builder();
     private int contextWindowTokens;
     private String logLevel;
     private String braveSearchApiKey;
@@ -217,11 +212,13 @@ public final class AceClawConfig {
     private int candidateInjectionMaxTokens;
     private int antiPatternGateMinBlockedBeforeRollback;
     private double antiPatternGateMaxFalsePositiveRate;
-    private boolean skillDraftValidationEnabled;
-    private boolean skillDraftValidationStrictMode;
-    private boolean skillDraftValidationReplayRequired;
-    private String skillDraftValidationReplayReport;
-    private double skillDraftValidationMaxTokenEstimationErrorRatio;
+    /**
+     * Skill draft validation config — was 5 individual scalar fields, now
+     * grouped under one {@link SkillDraftValidationSettings} record
+     * (batch 2 of the AceClawConfig decomposition).
+     */
+    private final SkillDraftValidationSettings.Builder skillDraftValidationBuilder =
+            SkillDraftValidationSettings.builder();
     /**
      * Skill auto-release config — was 12 individual scalar fields, now
      * grouped under one {@link SkillAutoReleaseSettings} record (batch 1 of
@@ -283,11 +280,7 @@ public final class AceClawConfig {
         this.maxTokens = DEFAULT_MAX_TOKENS;
         this.thinkingBudget = DEFAULT_THINKING_BUDGET;
         this.maxTurns = DEFAULT_MAX_TURNS;
-        this.adaptiveContinuationEnabled = DEFAULT_ADAPTIVE_CONTINUATION_ENABLED;
-        this.adaptiveContinuationMaxSegments = DEFAULT_ADAPTIVE_CONTINUATION_MAX_SEGMENTS;
-        this.adaptiveContinuationNoProgressThreshold = DEFAULT_ADAPTIVE_CONTINUATION_NO_PROGRESS_THRESHOLD;
-        this.adaptiveContinuationMaxTotalTokens = DEFAULT_ADAPTIVE_CONTINUATION_MAX_TOTAL_TOKENS;
-        this.adaptiveContinuationMaxWallClockSeconds = DEFAULT_ADAPTIVE_CONTINUATION_MAX_WALL_CLOCK_SECONDS;
+        // adaptiveContinuation defaults seeded by AdaptiveContinuationSettings.builder()
         this.contextWindowTokens = DEFAULT_CONTEXT_WINDOW;
         this.logLevel = DEFAULT_LOG_LEVEL;
         this.permissionMode = "normal";
@@ -309,12 +302,7 @@ public final class AceClawConfig {
         this.candidateInjectionMaxTokens = DEFAULT_CANDIDATE_INJECTION_MAX_TOKENS;
         this.antiPatternGateMinBlockedBeforeRollback = DEFAULT_ANTI_PATTERN_GATE_MIN_BLOCKED_BEFORE_ROLLBACK;
         this.antiPatternGateMaxFalsePositiveRate = DEFAULT_ANTI_PATTERN_GATE_MAX_FALSE_POSITIVE_RATE;
-        this.skillDraftValidationEnabled = DEFAULT_SKILL_DRAFT_VALIDATION_ENABLED;
-        this.skillDraftValidationStrictMode = DEFAULT_SKILL_DRAFT_VALIDATION_STRICT_MODE;
-        this.skillDraftValidationReplayRequired = DEFAULT_SKILL_DRAFT_VALIDATION_REPLAY_REQUIRED;
-        this.skillDraftValidationReplayReport = DEFAULT_SKILL_DRAFT_VALIDATION_REPLAY_REPORT;
-        this.skillDraftValidationMaxTokenEstimationErrorRatio =
-                DEFAULT_SKILL_DRAFT_VALIDATION_MAX_TOKEN_ESTIMATION_ERROR_RATIO;
+        // skillDraftValidation defaults seeded by SkillDraftValidationSettings.builder()
         // skillAutoRelease defaults are seeded by SkillAutoReleaseSettings.builder()
         // at field-initialization time. 14 individual setter calls removed here.
         this.maxAgentTurns = DEFAULT_MAX_AGENT_TURNS;
@@ -468,42 +456,17 @@ public final class AceClawConfig {
                 log.warn("Invalid ACECLAW_MAX_PLAN_TOTAL_WALL_TIME_SEC: {}", envMaxPlanTotalWallTime);
             }
         }
-        var envAdaptiveContinuation = System.getenv("ACECLAW_ADAPTIVE_CONTINUATION");
-        if (envAdaptiveContinuation != null && !envAdaptiveContinuation.isBlank()) {
-            config.adaptiveContinuationEnabled = Boolean.parseBoolean(envAdaptiveContinuation);
-        }
-        var envAdaptiveSegments = System.getenv("ACECLAW_ADAPTIVE_CONTINUATION_MAX_SEGMENTS");
-        if (envAdaptiveSegments != null && !envAdaptiveSegments.isBlank()) {
-            try {
-                config.adaptiveContinuationMaxSegments = Math.max(1, Integer.parseInt(envAdaptiveSegments));
-            } catch (NumberFormatException e) {
-                log.warn("Invalid ACECLAW_ADAPTIVE_CONTINUATION_MAX_SEGMENTS: {}", envAdaptiveSegments);
-            }
-        }
-        var envAdaptiveNoProgress = System.getenv("ACECLAW_ADAPTIVE_CONTINUATION_NO_PROGRESS_THRESHOLD");
-        if (envAdaptiveNoProgress != null && !envAdaptiveNoProgress.isBlank()) {
-            try {
-                config.adaptiveContinuationNoProgressThreshold = Math.max(1, Integer.parseInt(envAdaptiveNoProgress));
-            } catch (NumberFormatException e) {
-                log.warn("Invalid ACECLAW_ADAPTIVE_CONTINUATION_NO_PROGRESS_THRESHOLD: {}", envAdaptiveNoProgress);
-            }
-        }
-        var envAdaptiveMaxTokens = System.getenv("ACECLAW_ADAPTIVE_CONTINUATION_MAX_TOTAL_TOKENS");
-        if (envAdaptiveMaxTokens != null && !envAdaptiveMaxTokens.isBlank()) {
-            try {
-                config.adaptiveContinuationMaxTotalTokens = Math.max(0, Integer.parseInt(envAdaptiveMaxTokens));
-            } catch (NumberFormatException e) {
-                log.warn("Invalid ACECLAW_ADAPTIVE_CONTINUATION_MAX_TOTAL_TOKENS: {}", envAdaptiveMaxTokens);
-            }
-        }
-        var envAdaptiveMaxWallClock = System.getenv("ACECLAW_ADAPTIVE_CONTINUATION_MAX_WALL_CLOCK_SECONDS");
-        if (envAdaptiveMaxWallClock != null && !envAdaptiveMaxWallClock.isBlank()) {
-            try {
-                config.adaptiveContinuationMaxWallClockSeconds = Math.max(0, Integer.parseInt(envAdaptiveMaxWallClock));
-            } catch (NumberFormatException e) {
-                log.warn("Invalid ACECLAW_ADAPTIVE_CONTINUATION_MAX_WALL_CLOCK_SECONDS: {}", envAdaptiveMaxWallClock);
-            }
-        }
+        // -- Adaptive continuation env vars (batch 2) ------------------------
+        applyEnvBoolean("ACECLAW_ADAPTIVE_CONTINUATION",
+                v -> config.adaptiveContinuationBuilder.enabled(v));
+        applyEnvInt("ACECLAW_ADAPTIVE_CONTINUATION_MAX_SEGMENTS",
+                v -> config.adaptiveContinuationBuilder.maxSegments(Math.max(1, v)));
+        applyEnvInt("ACECLAW_ADAPTIVE_CONTINUATION_NO_PROGRESS_THRESHOLD",
+                v -> config.adaptiveContinuationBuilder.noProgressThreshold(Math.max(1, v)));
+        applyEnvInt("ACECLAW_ADAPTIVE_CONTINUATION_MAX_TOTAL_TOKENS",
+                v -> config.adaptiveContinuationBuilder.maxTotalTokens(Math.max(0, v)));
+        applyEnvInt("ACECLAW_ADAPTIVE_CONTINUATION_MAX_WALL_CLOCK_SECONDS",
+                v -> config.adaptiveContinuationBuilder.maxWallClockSeconds(Math.max(0, v)));
         var envLogLevel = System.getenv("ACECLAW_LOG_LEVEL");
         if (envLogLevel != null && !envLogLevel.isBlank()) {
             config.logLevel = envLogLevel;
@@ -548,34 +511,20 @@ public final class AceClawConfig {
                 log.warn("Invalid ACECLAW_ANTI_PATTERN_GATE_MAX_FALSE_POSITIVE_RATE: {}", envAntiPatternMaxFpRate);
             }
         }
-        var envSkillDraftValidation = System.getenv("ACECLAW_SKILL_DRAFT_VALIDATION");
-        if (envSkillDraftValidation != null && !envSkillDraftValidation.isBlank()) {
-            config.skillDraftValidationEnabled = Boolean.parseBoolean(envSkillDraftValidation);
-        }
-        var envSkillDraftValidationStrict = System.getenv("ACECLAW_SKILL_DRAFT_VALIDATION_STRICT_MODE");
-        if (envSkillDraftValidationStrict != null && !envSkillDraftValidationStrict.isBlank()) {
-            config.skillDraftValidationStrictMode = Boolean.parseBoolean(envSkillDraftValidationStrict);
-        }
-        var envSkillDraftValidationReplayRequired =
-                System.getenv("ACECLAW_SKILL_DRAFT_VALIDATION_REPLAY_REQUIRED");
-        if (envSkillDraftValidationReplayRequired != null && !envSkillDraftValidationReplayRequired.isBlank()) {
-            config.skillDraftValidationReplayRequired = Boolean.parseBoolean(envSkillDraftValidationReplayRequired);
-        }
+        // -- Skill draft validation env vars (batch 2) -----------------------
+        applyEnvBoolean("ACECLAW_SKILL_DRAFT_VALIDATION",
+                v -> config.skillDraftValidationBuilder.enabled(v));
+        applyEnvBoolean("ACECLAW_SKILL_DRAFT_VALIDATION_STRICT_MODE",
+                v -> config.skillDraftValidationBuilder.strictMode(v));
+        applyEnvBoolean("ACECLAW_SKILL_DRAFT_VALIDATION_REPLAY_REQUIRED",
+                v -> config.skillDraftValidationBuilder.replayRequired(v));
+        // ACECLAW_REPLAY_REPORT_PATH is a String — no parse step.
         var envReplayReportPath = System.getenv("ACECLAW_REPLAY_REPORT_PATH");
         if (envReplayReportPath != null && !envReplayReportPath.isBlank()) {
-            config.skillDraftValidationReplayReport = envReplayReportPath;
+            config.skillDraftValidationBuilder.replayReportPath(envReplayReportPath);
         }
-        var envSkillDraftValidationMaxTokenError =
-                System.getenv("ACECLAW_SKILL_DRAFT_VALIDATION_MAX_TOKEN_ESTIMATION_ERROR_RATIO");
-        if (envSkillDraftValidationMaxTokenError != null && !envSkillDraftValidationMaxTokenError.isBlank()) {
-            try {
-                config.skillDraftValidationMaxTokenEstimationErrorRatio =
-                        Double.parseDouble(envSkillDraftValidationMaxTokenError);
-            } catch (NumberFormatException e) {
-                log.warn("Invalid ACECLAW_SKILL_DRAFT_VALIDATION_MAX_TOKEN_ESTIMATION_ERROR_RATIO: {}",
-                        envSkillDraftValidationMaxTokenError);
-            }
-        }
+        applyEnvDouble("ACECLAW_SKILL_DRAFT_VALIDATION_MAX_TOKEN_ESTIMATION_ERROR_RATIO",
+                v -> config.skillDraftValidationBuilder.maxTokenEstimationErrorRatio(v));
         // -- Skill auto-release env vars -------------------------------------
         // Was 12 nearly-identical try/catch blocks (130 LoC) updating 12
         // individual scalar fields on `config`. Each one now folds into a
@@ -660,9 +609,10 @@ public final class AceClawConfig {
             config.webSocketEnabled = false;
         }
 
+        var ac = config.adaptiveContinuation();
         log.info("Config loaded: provider={}, model={}, maxTokens={}, thinkingBudget={}, maxTurns={}, adaptiveContinuationEnabled={}, adaptiveMaxSegments={}, contextWindow={}, logLevel={}, baseUrl={}, apiKey={}, refreshToken={}",
                 config.provider, config.model, config.maxTokens, config.thinkingBudget, config.maxTurns,
-                config.adaptiveContinuationEnabled, config.adaptiveContinuationMaxSegments,
+                ac.enabled(), ac.maxSegments(),
                 config.contextWindowTokens, config.logLevel,
                 config.baseUrl != null ? config.baseUrl : "(default)",
                 config.apiKey != null ? "(set)" : "(not set)",
@@ -739,24 +689,13 @@ public final class AceClawConfig {
         return maxTurns;
     }
 
-    public boolean adaptiveContinuationEnabled() {
-        return adaptiveContinuationEnabled;
-    }
-
-    public int adaptiveContinuationMaxSegments() {
-        return adaptiveContinuationMaxSegments;
-    }
-
-    public int adaptiveContinuationNoProgressThreshold() {
-        return adaptiveContinuationNoProgressThreshold;
-    }
-
-    public int adaptiveContinuationMaxTotalTokens() {
-        return adaptiveContinuationMaxTotalTokens;
-    }
-
-    public int adaptiveContinuationMaxWallClockSeconds() {
-        return adaptiveContinuationMaxWallClockSeconds;
+    /**
+     * Returns the adaptive-continuation config — the feature gate plus the
+     * 4 budget scalars the agent loop reads. Replaces 5 individual getters
+     * as part of batch 2 of the AceClawConfig decomposition.
+     */
+    public AdaptiveContinuationSettings adaptiveContinuation() {
+        return adaptiveContinuationBuilder.build();
     }
 
     /**
@@ -1068,38 +1007,13 @@ public final class AceClawConfig {
     }
 
     /**
-     * Returns whether autonomous skill draft validation is enabled.
+     * Returns the skill-draft-validation config — the feature gate plus the
+     * 4 scalars the {@code ValidationGateEngine} consumes. Replaces 5
+     * individual getters as part of batch 2 of the AceClawConfig
+     * decomposition.
      */
-    public boolean skillDraftValidationEnabled() {
-        return skillDraftValidationEnabled;
-    }
-
-    /**
-     * Returns whether validation gate strict mode is enabled.
-     */
-    public boolean skillDraftValidationStrictMode() {
-        return skillDraftValidationStrictMode;
-    }
-
-    /**
-     * Returns whether replay checks are required for draft validation.
-     */
-    public boolean skillDraftValidationReplayRequired() {
-        return skillDraftValidationReplayRequired;
-    }
-
-    /**
-     * Returns replay report path for draft validation.
-     */
-    public String skillDraftValidationReplayReport() {
-        return skillDraftValidationReplayReport;
-    }
-
-    /**
-     * Returns max token-estimation error ratio accepted by draft validation replay gate.
-     */
-    public double skillDraftValidationMaxTokenEstimationErrorRatio() {
-        return skillDraftValidationMaxTokenEstimationErrorRatio;
+    public SkillDraftValidationSettings skillDraftValidation() {
+        return skillDraftValidationBuilder.build();
     }
 
     /**
@@ -1479,24 +1393,13 @@ public final class AceClawConfig {
         if (fileConfig.maxTurns > 0) {
             this.maxTurns = fileConfig.maxTurns;
         }
-        if (fileConfig.adaptiveContinuationEnabled != null) {
-            this.adaptiveContinuationEnabled = fileConfig.adaptiveContinuationEnabled;
-        }
-        if (fileConfig.adaptiveContinuationMaxSegments != null && fileConfig.adaptiveContinuationMaxSegments > 0) {
-            this.adaptiveContinuationMaxSegments = fileConfig.adaptiveContinuationMaxSegments;
-        }
-        if (fileConfig.adaptiveContinuationNoProgressThreshold != null
-                && fileConfig.adaptiveContinuationNoProgressThreshold > 0) {
-            this.adaptiveContinuationNoProgressThreshold = fileConfig.adaptiveContinuationNoProgressThreshold;
-        }
-        if (fileConfig.adaptiveContinuationMaxTotalTokens != null
-                && fileConfig.adaptiveContinuationMaxTotalTokens >= 0) {
-            this.adaptiveContinuationMaxTotalTokens = fileConfig.adaptiveContinuationMaxTotalTokens;
-        }
-        if (fileConfig.adaptiveContinuationMaxWallClockSeconds != null
-                && fileConfig.adaptiveContinuationMaxWallClockSeconds >= 0) {
-            this.adaptiveContinuationMaxWallClockSeconds = fileConfig.adaptiveContinuationMaxWallClockSeconds;
-        }
+        // -- Adaptive continuation file overrides (batch 2) -----------------
+        adaptiveContinuationBuilder
+                .enabled(fileConfig.adaptiveContinuationEnabled)
+                .maxSegments(fileConfig.adaptiveContinuationMaxSegments)
+                .noProgressThreshold(fileConfig.adaptiveContinuationNoProgressThreshold)
+                .maxTotalTokens(fileConfig.adaptiveContinuationMaxTotalTokens)
+                .maxWallClockSeconds(fileConfig.adaptiveContinuationMaxWallClockSeconds);
         if (fileConfig.contextWindowTokens > 0) {
             this.contextWindowTokens = fileConfig.contextWindowTokens;
         }
@@ -1573,24 +1476,13 @@ public final class AceClawConfig {
                 && fileConfig.antiPatternGateMaxFalsePositiveRate >= 0) {
             this.antiPatternGateMaxFalsePositiveRate = clampRate(fileConfig.antiPatternGateMaxFalsePositiveRate);
         }
-        if (fileConfig.skillDraftValidationEnabled != null) {
-            this.skillDraftValidationEnabled = fileConfig.skillDraftValidationEnabled;
-        }
-        if (fileConfig.skillDraftValidationStrictMode != null) {
-            this.skillDraftValidationStrictMode = fileConfig.skillDraftValidationStrictMode;
-        }
-        if (fileConfig.skillDraftValidationReplayRequired != null) {
-            this.skillDraftValidationReplayRequired = fileConfig.skillDraftValidationReplayRequired;
-        }
-        if (fileConfig.skillDraftValidationReplayReport != null
-                && !fileConfig.skillDraftValidationReplayReport.isBlank()) {
-            this.skillDraftValidationReplayReport = fileConfig.skillDraftValidationReplayReport;
-        }
-        if (fileConfig.skillDraftValidationMaxTokenEstimationErrorRatio != null
-                && fileConfig.skillDraftValidationMaxTokenEstimationErrorRatio >= 0) {
-            this.skillDraftValidationMaxTokenEstimationErrorRatio =
-                    fileConfig.skillDraftValidationMaxTokenEstimationErrorRatio;
-        }
+        // -- Skill draft validation file overrides (batch 2) -----------------
+        skillDraftValidationBuilder
+                .enabled(fileConfig.skillDraftValidationEnabled)
+                .strictMode(fileConfig.skillDraftValidationStrictMode)
+                .replayRequired(fileConfig.skillDraftValidationReplayRequired)
+                .replayReportPath(fileConfig.skillDraftValidationReplayReport)
+                .maxTokenEstimationErrorRatio(fileConfig.skillDraftValidationMaxTokenEstimationErrorRatio);
         // -- Skill auto-release file overrides -------------------------------
         // Was 13 individual nullable-then-set blocks (~55 LoC) updating 13
         // scalar fields. Now folds into builder setters that each validate

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -622,12 +622,13 @@ public final class AceClawDaemon {
                 skillRegistry::formatDescriptions);
         agentHandler.setMcpInitFuture(mcpInitFuture);
         agentHandler.setRetryConfig(config.retryConfig());
+        var adaptiveContinuation = config.adaptiveContinuation();
         agentHandler.setAdaptiveContinuationConfig(
-                config.adaptiveContinuationEnabled(),
-                config.adaptiveContinuationMaxSegments(),
-                config.adaptiveContinuationNoProgressThreshold(),
-                config.adaptiveContinuationMaxTotalTokens(),
-                config.adaptiveContinuationMaxWallClockSeconds());
+                adaptiveContinuation.enabled(),
+                adaptiveContinuation.maxSegments(),
+                adaptiveContinuation.noProgressThreshold(),
+                adaptiveContinuation.maxTotalTokens(),
+                adaptiveContinuation.maxWallClockSeconds());
         agentHandler.setPlannerConfig(config.plannerEnabled(), config.plannerThreshold());
         agentHandler.setAdaptiveReplanEnabled(config.adaptiveReplanEnabled());
         agentHandler.setWatchdogConfig(
@@ -677,12 +678,13 @@ public final class AceClawDaemon {
             var patternDetector = new PatternDetector(memoryStore);
             var failureSignalDetector = new FailureSignalDetector();
             var strategyRefiner = new StrategyRefiner(memoryStore);
-            if (config.skillDraftValidationEnabled()) {
+            var skillDraftValidation = config.skillDraftValidation();
+            if (skillDraftValidation.enabled()) {
                 validationGateEngine = new ValidationGateEngine(
-                        config.skillDraftValidationStrictMode(),
-                        config.skillDraftValidationReplayRequired(),
-                        Path.of(config.skillDraftValidationReplayReport()),
-                        config.skillDraftValidationMaxTokenEstimationErrorRatio());
+                        skillDraftValidation.strictMode(),
+                        skillDraftValidation.replayRequired(),
+                        Path.of(skillDraftValidation.replayReportPath()),
+                        skillDraftValidation.maxTokenEstimationErrorRatio());
             }
 
             // Candidate store for learning pipeline (promotion/demotion state machine)

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AdaptiveContinuationSettings.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AdaptiveContinuationSettings.java
@@ -1,0 +1,81 @@
+package dev.aceclaw.daemon;
+
+/**
+ * Thematic config grouping for the adaptive-continuation behaviour — the
+ * 5 scalars the agent loop reads to decide whether to extend a turn past
+ * a {@code max_tokens} stop, and when to give up. Batch 2 of the
+ * AceClawConfig decomposition.
+ *
+ * <p>Shape:
+ * <ul>
+ *   <li>{@code enabled} — feature gate. When {@code false} the agent loop
+ *       falls back to single-segment behaviour ({@code maxSegments == 1}).</li>
+ *   <li>{@code maxSegments} — hard ceiling on continuation rounds within one
+ *       turn (default 3).</li>
+ *   <li>{@code noProgressThreshold} — consecutive no-progress segments
+ *       before bailing out (default 2).</li>
+ *   <li>{@code maxTotalTokens} — combined input+output token budget across
+ *       segments; 0 disables the check.</li>
+ *   <li>{@code maxWallClockSeconds} — wall-clock budget across segments;
+ *       0 disables the check.</li>
+ * </ul>
+ */
+public record AdaptiveContinuationSettings(
+        boolean enabled,
+        int maxSegments,
+        int noProgressThreshold,
+        int maxTotalTokens,
+        int maxWallClockSeconds) {
+
+    /** Defaults matched 1:1 to the prior {@code DEFAULT_ADAPTIVE_CONTINUATION_*} constants. */
+    public static AdaptiveContinuationSettings defaults() {
+        return new AdaptiveContinuationSettings(
+                true,   // enabled
+                3,      // maxSegments
+                2,      // noProgressThreshold
+                0,      // maxTotalTokens — disabled
+                0       // maxWallClockSeconds — disabled
+        );
+    }
+
+    /** Fresh builder pre-loaded with {@link #defaults()}. */
+    static Builder builder() {
+        return new Builder(defaults());
+    }
+
+    /**
+     * Mutable builder used during config load. Setters accept {@code null} as
+     * "leave the previous value alone" — matches the {@code if (fileConfig.x
+     * != null)} pattern AceClawConfig used to inline for each scalar.
+     */
+    static final class Builder {
+        private boolean enabled;
+        private int maxSegments;
+        private int noProgressThreshold;
+        private int maxTotalTokens;
+        private int maxWallClockSeconds;
+
+        Builder(AdaptiveContinuationSettings seed) {
+            this.enabled = seed.enabled();
+            this.maxSegments = seed.maxSegments();
+            this.noProgressThreshold = seed.noProgressThreshold();
+            this.maxTotalTokens = seed.maxTotalTokens();
+            this.maxWallClockSeconds = seed.maxWallClockSeconds();
+        }
+
+        Builder enabled(Boolean v) { if (v != null) this.enabled = v; return this; }
+        // Pre-decomp clamps: maxSegments >= 1, noProgress >= 1, the two
+        // budgets >= 0 (zero means disabled). Preserved here so the builder
+        // contract matches the prior behaviour exactly.
+        Builder maxSegments(Integer v) { if (v != null && v >= 1) this.maxSegments = v; return this; }
+        Builder noProgressThreshold(Integer v) { if (v != null && v >= 1) this.noProgressThreshold = v; return this; }
+        Builder maxTotalTokens(Integer v) { if (v != null && v >= 0) this.maxTotalTokens = v; return this; }
+        Builder maxWallClockSeconds(Integer v) { if (v != null && v >= 0) this.maxWallClockSeconds = v; return this; }
+
+        AdaptiveContinuationSettings build() {
+            return new AdaptiveContinuationSettings(
+                    enabled, maxSegments, noProgressThreshold,
+                    maxTotalTokens, maxWallClockSeconds);
+        }
+    }
+}

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/SkillDraftValidationSettings.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/SkillDraftValidationSettings.java
@@ -1,0 +1,94 @@
+package dev.aceclaw.daemon;
+
+/**
+ * Thematic config grouping for the skill draft validation gate — the 5
+ * scalars AceClawConfig used to hold one-by-one for the
+ * {@code ValidationGateEngine} constructor. Batch 2 of the AceClawConfig
+ * decomposition (batch 1 lifted SkillAutoRelease).
+ *
+ * <p>Shape:
+ * <ul>
+ *   <li>{@code enabled} — feature gate. When {@code false} the daemon
+ *       skips constructing {@code ValidationGateEngine} entirely and the
+ *       draft pipeline runs without the durable-validation step.</li>
+ *   <li>{@code strictMode} — fail-closed on missing replay reports etc.</li>
+ *   <li>{@code replayRequired} — gate draft promotion on a recent replay
+ *       comparison.</li>
+ *   <li>{@code replayReportPath} — string path to the replay report JSON
+ *       (resolved with {@code Path.of} at the consumer).</li>
+ *   <li>{@code maxTokenEstimationErrorRatio} — replay-comparison tolerance
+ *       for token-count drift between drafts.</li>
+ * </ul>
+ *
+ * <p>Builder lives here for incremental population during env-var loading +
+ * {@code mergeFromFormat}. Package-private setters — only AceClawConfig uses
+ * the builder; consumers receive the immutable record.
+ */
+public record SkillDraftValidationSettings(
+        boolean enabled,
+        boolean strictMode,
+        boolean replayRequired,
+        String replayReportPath,
+        double maxTokenEstimationErrorRatio) {
+
+    static final String DEFAULT_REPLAY_REPORT_PATH =
+            ".aceclaw/metrics/continuous-learning/replay-latest.json";
+
+    /** Defaults matched 1:1 to the prior {@code DEFAULT_SKILL_DRAFT_VALIDATION_*} constants. */
+    public static SkillDraftValidationSettings defaults() {
+        return new SkillDraftValidationSettings(
+                true,                            // enabled
+                false,                           // strictMode
+                true,                            // replayRequired
+                DEFAULT_REPLAY_REPORT_PATH,      // replayReportPath
+                0.65                             // maxTokenEstimationErrorRatio
+        );
+    }
+
+    /** Fresh builder pre-loaded with {@link #defaults()}. */
+    static Builder builder() {
+        return new Builder(defaults());
+    }
+
+    /**
+     * Mutable builder used during config load. Setters accept {@code null} as
+     * "leave the previous value alone" — matches the {@code if (fileConfig.x
+     * != null)} pattern AceClawConfig used to inline for each scalar.
+     */
+    static final class Builder {
+        private boolean enabled;
+        private boolean strictMode;
+        private boolean replayRequired;
+        private String replayReportPath;
+        private double maxTokenEstimationErrorRatio;
+
+        Builder(SkillDraftValidationSettings seed) {
+            this.enabled = seed.enabled();
+            this.strictMode = seed.strictMode();
+            this.replayRequired = seed.replayRequired();
+            this.replayReportPath = seed.replayReportPath();
+            this.maxTokenEstimationErrorRatio = seed.maxTokenEstimationErrorRatio();
+        }
+
+        Builder enabled(Boolean v) { if (v != null) this.enabled = v; return this; }
+        Builder strictMode(Boolean v) { if (v != null) this.strictMode = v; return this; }
+        Builder replayRequired(Boolean v) { if (v != null) this.replayRequired = v; return this; }
+        Builder replayReportPath(String v) {
+            if (v != null && !v.isBlank()) this.replayReportPath = v;
+            return this;
+        }
+        Builder maxTokenEstimationErrorRatio(Double v) {
+            // Negative ratio would be nonsensical; preserve the pre-decomp behaviour
+            // of accepting non-negative values unmodified (no upper clamp — the
+            // original code didn't clamp this one either; tolerance can exceed 1.0).
+            if (v != null && v >= 0) this.maxTokenEstimationErrorRatio = v;
+            return this;
+        }
+
+        SkillDraftValidationSettings build() {
+            return new SkillDraftValidationSettings(
+                    enabled, strictMode, replayRequired,
+                    replayReportPath, maxTokenEstimationErrorRatio);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Continues the **AceClawConfig decomposition** started in #506. Two more
thematic clusters lifted into their own records, same pattern.

| | Origin | After #506 | After this |
|---|---|---|---|
| `AceClawConfig.java` | 2,038 LoC | 1,879 LoC | **1,771 LoC (-13% from origin)** |

## What moved

**`AdaptiveContinuationSettings`** (5 fields) — feature gate + 4 budget
scalars (maxSegments, noProgressThreshold, maxTotalTokens,
maxWallClockSeconds) the agent loop reads to decide whether to extend a
turn past a `max_tokens` stop.

**`SkillDraftValidationSettings`** (5 fields) — feature gate + 4 scalars
the `ValidationGateEngine` constructor consumes (strictMode, replayRequired,
replayReportPath, maxTokenEstimationErrorRatio).

Each follows the batch-1 pattern:
- record + package-private Builder for incremental `load()` population
- 5 `DEFAULT_*` constants per cluster → `settings.defaults()`
- 5 instance fields → 1 builder field
- 5 individual getters → 1 record-returning getter
- env-var loading uses the `applyEnvBoolean/Int/Double` helpers added in #506
- `mergeFromFormat` folds into a single builder chain per cluster

## Daemon call site changes

```java
// AdaptiveContinuation: before — 5 scalars passed by hand
agentHandler.setAdaptiveContinuationConfig(
    config.adaptiveContinuationEnabled(),
    config.adaptiveContinuationMaxSegments(),
    config.adaptiveContinuationNoProgressThreshold(),
    config.adaptiveContinuationMaxTotalTokens(),
    config.adaptiveContinuationMaxWallClockSeconds());

// After
var ac = config.adaptiveContinuation();
agentHandler.setAdaptiveContinuationConfig(
    ac.enabled(), ac.maxSegments(), ac.noProgressThreshold(),
    ac.maxTotalTokens(), ac.maxWallClockSeconds());
```

The `setAdaptiveContinuationConfig(...)` signature on
`StreamingAgentHandler` is left alone — flipping that to take the record
would touch SAH's own internal `adaptiveContinuation*` fields and is out
of scope for this PR.

```java
// SkillDraftValidation: before
if (config.skillDraftValidationEnabled()) {
    validationGateEngine = new ValidationGateEngine(
        config.skillDraftValidationStrictMode(),
        config.skillDraftValidationReplayRequired(),
        Path.of(config.skillDraftValidationReplayReport()),
        config.skillDraftValidationMaxTokenEstimationErrorRatio());
}

// After
var sdv = config.skillDraftValidation();
if (sdv.enabled()) {
    validationGateEngine = new ValidationGateEngine(
        sdv.strictMode(), sdv.replayRequired(),
        Path.of(sdv.replayReportPath()),
        sdv.maxTokenEstimationErrorRatio());
}
```

## Backward compat

- Config file JSON shape unchanged — same flat top-level keys for both
  clusters
- All 9 env var names preserved (including the asymmetric
  `ACECLAW_REPLAY_REPORT_PATH` which differs from the config-file key)
- `AceClawConfigTest` passes unchanged (17/0)

## Diff stats

**+258 / -189 = +69 net** across 4 files (2 new record files +
AceClawConfig + AceClawDaemon). The 69 net is per-file headers / javadocs
on the new record files; the AceClawConfig shrink is real.

## Test plan

- [x] `:aceclaw-daemon:compileJava` — clean
- [x] `:aceclaw-daemon:compileTestJava` — clean
- [x] `AceClawConfigTest` — 17/0 (covers config file loading, env var
  overrides, persistence, security.denySensitivePaths toggle)
- [x] Same builder/applyEnv pattern as #506 — no new idioms

## Remaining batches (out of scope)

| Cluster | Fields | Status |
|---|---|---|
| Candidate (injection + promotion) | 7 | next |
| Retry | 4 | has existing RetryConfigFormat |
| Agent + Plan budgets | 4 + 2 | watchdog cluster |
| AntiPatternGate | 2 | smallest |
| Lifecycle (boot / scheduler / heartbeat / deferred) | ~9 | tiny clusters, could bundle |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
