### PR TITLE
refactor(daemon): extract Candidate + AntiPatternGate (AceClawConfig batch 3)

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
@@ -94,15 +94,9 @@ public final class AceClawConfig {
      */
     private static final int DEFAULT_PLANNER_THRESHOLD = 5;
     private static final boolean DEFAULT_ADAPTIVE_REPLAN_ENABLED = true;
-    private static final boolean DEFAULT_CANDIDATE_INJECTION_ENABLED = true;
-    private static final boolean DEFAULT_CANDIDATE_PROMOTION_ENABLED = true;
-    private static final int DEFAULT_CANDIDATE_PROMOTION_MIN_EVIDENCE = 2;
-    private static final double DEFAULT_CANDIDATE_PROMOTION_MIN_SCORE = 0.75;
-    private static final double DEFAULT_CANDIDATE_PROMOTION_MAX_FAILURE_RATE = 0.2;
-    private static final int DEFAULT_CANDIDATE_INJECTION_MAX_COUNT = 10;
-    private static final int DEFAULT_CANDIDATE_INJECTION_MAX_TOKENS = 1200;
-    private static final int DEFAULT_ANTI_PATTERN_GATE_MIN_BLOCKED_BEFORE_ROLLBACK = 2;
-    private static final double DEFAULT_ANTI_PATTERN_GATE_MAX_FALSE_POSITIVE_RATE = 0.50;
+    // Candidate / anti-pattern-gate defaults moved to their respective
+    // *Settings.defaults() factories (batch 3 of the AceClawConfig
+    // decomposition).
     // SkillDraftValidation defaults moved to SkillDraftValidationSettings.defaults()
     // (batch 2 of the AceClawConfig decomposition).
     // Skill auto-release defaults live on SkillAutoReleaseSettings.defaults().
@@ -203,15 +197,19 @@ public final class AceClawConfig {
     private boolean plannerEnabled;
     private int plannerThreshold;
     private boolean adaptiveReplanEnabled;
-    private boolean candidateInjectionEnabled;
-    private boolean candidatePromotionEnabled;
-    private int candidatePromotionMinEvidence;
-    private double candidatePromotionMinScore;
-    private double candidatePromotionMaxFailureRate;
-    private int candidateInjectionMaxCount;
-    private int candidateInjectionMaxTokens;
-    private int antiPatternGateMinBlockedBeforeRollback;
-    private double antiPatternGateMaxFalsePositiveRate;
+    /**
+     * Candidate / anti-pattern-gate config — was 9 individual scalar fields,
+     * now grouped under three records (batch 3 of the AceClawConfig
+     * decomposition). Held as mutable builders during {@link #load} so the
+     * env-var + file-merge passes can update incrementally; the public
+     * getters call {@code build()} on demand.
+     */
+    private final CandidatePromotionSettings.Builder candidatePromotionBuilder =
+            CandidatePromotionSettings.builder();
+    private final CandidateInjectionSettings.Builder candidateInjectionBuilder =
+            CandidateInjectionSettings.builder();
+    private final AntiPatternGateSettings.Builder antiPatternGateBuilder =
+            AntiPatternGateSettings.builder();
     /**
      * Skill draft validation config — was 5 individual scalar fields, now
      * grouped under one {@link SkillDraftValidationSettings} record
@@ -293,15 +291,7 @@ public final class AceClawConfig {
         this.plannerEnabled = DEFAULT_PLANNER_ENABLED;
         this.plannerThreshold = DEFAULT_PLANNER_THRESHOLD;
         this.adaptiveReplanEnabled = DEFAULT_ADAPTIVE_REPLAN_ENABLED;
-        this.candidateInjectionEnabled = DEFAULT_CANDIDATE_INJECTION_ENABLED;
-        this.candidatePromotionEnabled = DEFAULT_CANDIDATE_PROMOTION_ENABLED;
-        this.candidatePromotionMinEvidence = DEFAULT_CANDIDATE_PROMOTION_MIN_EVIDENCE;
-        this.candidatePromotionMinScore = DEFAULT_CANDIDATE_PROMOTION_MIN_SCORE;
-        this.candidatePromotionMaxFailureRate = DEFAULT_CANDIDATE_PROMOTION_MAX_FAILURE_RATE;
-        this.candidateInjectionMaxCount = DEFAULT_CANDIDATE_INJECTION_MAX_COUNT;
-        this.candidateInjectionMaxTokens = DEFAULT_CANDIDATE_INJECTION_MAX_TOKENS;
-        this.antiPatternGateMinBlockedBeforeRollback = DEFAULT_ANTI_PATTERN_GATE_MIN_BLOCKED_BEFORE_ROLLBACK;
-        this.antiPatternGateMaxFalsePositiveRate = DEFAULT_ANTI_PATTERN_GATE_MAX_FALSE_POSITIVE_RATE;
+        // Candidate / anti-pattern-gate defaults seeded by *Settings.builder()
         // skillDraftValidation defaults seeded by SkillDraftValidationSettings.builder()
         // skillAutoRelease defaults are seeded by SkillAutoReleaseSettings.builder()
         // at field-initialization time. 14 individual setter calls removed here.
@@ -479,38 +469,17 @@ public final class AceClawConfig {
         if (envPermMode != null && !envPermMode.isBlank()) {
             config.permissionMode = envPermMode.toLowerCase();
         }
-        var envCandidateInjection = System.getenv("ACECLAW_CANDIDATE_INJECTION");
-        if (envCandidateInjection != null && !envCandidateInjection.isBlank()) {
-            config.candidateInjectionEnabled = Boolean.parseBoolean(envCandidateInjection);
-        }
-        var envCandidatePromotion = System.getenv("ACECLAW_CANDIDATE_PROMOTION");
-        if (envCandidatePromotion != null && !envCandidatePromotion.isBlank()) {
-            config.candidatePromotionEnabled = Boolean.parseBoolean(envCandidatePromotion);
-        }
-        var envCandidateInjectionMaxTokens = System.getenv("ACECLAW_CANDIDATE_INJECTION_MAX_TOKENS");
-        if (envCandidateInjectionMaxTokens != null && !envCandidateInjectionMaxTokens.isBlank()) {
-            try {
-                config.candidateInjectionMaxTokens = Math.max(0, Integer.parseInt(envCandidateInjectionMaxTokens));
-            } catch (NumberFormatException e) {
-                log.warn("Invalid ACECLAW_CANDIDATE_INJECTION_MAX_TOKENS: {}", envCandidateInjectionMaxTokens);
-            }
-        }
-        var envAntiPatternMinBlocked = System.getenv("ACECLAW_ANTI_PATTERN_GATE_MIN_BLOCKED_BEFORE_ROLLBACK");
-        if (envAntiPatternMinBlocked != null && !envAntiPatternMinBlocked.isBlank()) {
-            try {
-                config.antiPatternGateMinBlockedBeforeRollback = Math.max(1, Integer.parseInt(envAntiPatternMinBlocked));
-            } catch (NumberFormatException e) {
-                log.warn("Invalid ACECLAW_ANTI_PATTERN_GATE_MIN_BLOCKED_BEFORE_ROLLBACK: {}", envAntiPatternMinBlocked);
-            }
-        }
-        var envAntiPatternMaxFpRate = System.getenv("ACECLAW_ANTI_PATTERN_GATE_MAX_FALSE_POSITIVE_RATE");
-        if (envAntiPatternMaxFpRate != null && !envAntiPatternMaxFpRate.isBlank()) {
-            try {
-                config.antiPatternGateMaxFalsePositiveRate = clampRate(Double.parseDouble(envAntiPatternMaxFpRate));
-            } catch (NumberFormatException e) {
-                log.warn("Invalid ACECLAW_ANTI_PATTERN_GATE_MAX_FALSE_POSITIVE_RATE: {}", envAntiPatternMaxFpRate);
-            }
-        }
+        // -- Candidate + anti-pattern-gate env vars (batch 3) ----------------
+        applyEnvBoolean("ACECLAW_CANDIDATE_INJECTION",
+                v -> config.candidateInjectionBuilder.enabled(v));
+        applyEnvBoolean("ACECLAW_CANDIDATE_PROMOTION",
+                v -> config.candidatePromotionBuilder.enabled(v));
+        applyEnvInt("ACECLAW_CANDIDATE_INJECTION_MAX_TOKENS",
+                v -> config.candidateInjectionBuilder.maxTokens(Math.max(0, v)));
+        applyEnvInt("ACECLAW_ANTI_PATTERN_GATE_MIN_BLOCKED_BEFORE_ROLLBACK",
+                v -> config.antiPatternGateBuilder.minBlockedBeforeRollback(Math.max(1, v)));
+        applyEnvDouble("ACECLAW_ANTI_PATTERN_GATE_MAX_FALSE_POSITIVE_RATE",
+                v -> config.antiPatternGateBuilder.maxFalsePositiveRate(v));
         // -- Skill draft validation env vars (batch 2) -----------------------
         applyEnvBoolean("ACECLAW_SKILL_DRAFT_VALIDATION",
                 v -> config.skillDraftValidationBuilder.enabled(v));
@@ -943,67 +912,32 @@ public final class AceClawConfig {
     }
 
     /**
-     * Returns whether candidate injection into the system prompt is enabled.
-     * Defaults to true.
+     * Returns the candidate-promotion config — the feature gate plus the
+     * 3 promotion-threshold scalars (minEvidence, minScore, maxFailureRate)
+     * that feed the {@code CandidateStateMachine.Config} constructor.
+     * Batch 3 of the AceClawConfig decomposition.
      */
-    public boolean candidateInjectionEnabled() {
-        return candidateInjectionEnabled;
+    public CandidatePromotionSettings candidatePromotion() {
+        return candidatePromotionBuilder.build();
     }
 
     /**
-     * Returns whether automatic candidate state transitions (promotion/demotion) are enabled.
-     * Defaults to true.
+     * Returns the candidate-injection config — the feature gate plus the
+     * 2 per-prompt budget scalars (maxCount, maxTokens). Batch 3 of the
+     * AceClawConfig decomposition.
      */
-    public boolean candidatePromotionEnabled() {
-        return candidatePromotionEnabled;
+    public CandidateInjectionSettings candidateInjection() {
+        return candidateInjectionBuilder.build();
     }
 
     /**
-     * Returns the minimum evidence count for candidate promotion.
-     * Defaults to 3.
+     * Returns the anti-pattern-gate config — the 2 rollback-threshold
+     * scalars (minBlockedBeforeRollback, maxFalsePositiveRate). No
+     * {@code enabled} flag; the gate is always on. Batch 3 of the
+     * AceClawConfig decomposition.
      */
-    public int candidatePromotionMinEvidence() {
-        return candidatePromotionMinEvidence;
-    }
-
-    /**
-     * Returns the minimum score for candidate promotion.
-     * Defaults to 0.75.
-     */
-    public double candidatePromotionMinScore() {
-        return candidatePromotionMinScore;
-    }
-
-    /**
-     * Returns the maximum failure rate for candidate promotion.
-     * Defaults to 0.2.
-     */
-    public double candidatePromotionMaxFailureRate() {
-        return candidatePromotionMaxFailureRate;
-    }
-
-    /**
-     * Returns the maximum number of candidates to inject into the system prompt.
-     * Defaults to 10.
-     */
-    public int candidateInjectionMaxCount() {
-        return candidateInjectionMaxCount;
-    }
-
-    /**
-     * Returns the maximum token budget for candidate injection.
-     * Defaults to 1200.
-     */
-    public int candidateInjectionMaxTokens() {
-        return candidateInjectionMaxTokens;
-    }
-
-    public int antiPatternGateMinBlockedBeforeRollback() {
-        return antiPatternGateMinBlockedBeforeRollback;
-    }
-
-    public double antiPatternGateMaxFalsePositiveRate() {
-        return antiPatternGateMaxFalsePositiveRate;
+    public AntiPatternGateSettings antiPatternGate() {
+        return antiPatternGateBuilder.build();
     }
 
     /**
@@ -1444,38 +1378,30 @@ public final class AceClawConfig {
         if (fileConfig.adaptiveReplanEnabled != null) {
             this.adaptiveReplanEnabled = fileConfig.adaptiveReplanEnabled;
         }
-        if (fileConfig.candidateInjectionEnabled != null) {
-            this.candidateInjectionEnabled = fileConfig.candidateInjectionEnabled;
-        }
-        if (fileConfig.candidatePromotionEnabled != null) {
-            this.candidatePromotionEnabled = fileConfig.candidatePromotionEnabled;
-        }
-        if (fileConfig.candidatePromotionMinEvidence != null && fileConfig.candidatePromotionMinEvidence > 0) {
-            this.candidatePromotionMinEvidence = fileConfig.candidatePromotionMinEvidence;
-        }
-        if (fileConfig.candidatePromotionMinScore != null && fileConfig.candidatePromotionMinScore >= 0) {
-            this.candidatePromotionMinScore = fileConfig.candidatePromotionMinScore;
-        }
-        if (fileConfig.candidatePromotionMaxFailureRate != null && fileConfig.candidatePromotionMaxFailureRate >= 0) {
-            this.candidatePromotionMaxFailureRate = fileConfig.candidatePromotionMaxFailureRate;
-        }
-        if (fileConfig.candidateInjectionMaxCount != null && fileConfig.candidateInjectionMaxCount >= 0) {
-            this.candidateInjectionMaxCount = fileConfig.candidateInjectionMaxCount;
-        }
+        // -- Candidate file overrides (batch 3) ------------------------------
+        candidatePromotionBuilder
+                .enabled(fileConfig.candidatePromotionEnabled)
+                .minEvidence(fileConfig.candidatePromotionMinEvidence)
+                .minScore(fileConfig.candidatePromotionMinScore)
+                .maxFailureRate(fileConfig.candidatePromotionMaxFailureRate);
+        candidateInjectionBuilder
+                .enabled(fileConfig.candidateInjectionEnabled)
+                .maxCount(fileConfig.candidateInjectionMaxCount);
+        // Token budget priority: explicit maxTokens wins; otherwise fall back
+        // to the legacy maxChars (char-to-token approximation 4:1). Preserves
+        // the pre-decomp behaviour where setting maxTokens to a valid value
+        // takes precedence over a stale maxChars, but a config that ONLY has
+        // the older maxChars key still works.
         if (fileConfig.candidateInjectionMaxTokens != null && fileConfig.candidateInjectionMaxTokens >= 0) {
-            this.candidateInjectionMaxTokens = fileConfig.candidateInjectionMaxTokens;
+            candidateInjectionBuilder.maxTokens(fileConfig.candidateInjectionMaxTokens);
         } else if (fileConfig.candidateInjectionMaxChars != null && fileConfig.candidateInjectionMaxChars >= 0) {
-            // Backward compatibility: old char-based setting converts to approximate token budget.
-            this.candidateInjectionMaxTokens = Math.max(0, fileConfig.candidateInjectionMaxChars / 4);
+            candidateInjectionBuilder.maxTokens(Math.max(0, fileConfig.candidateInjectionMaxChars / 4));
         }
-        if (fileConfig.antiPatternGateMinBlockedBeforeRollback != null
-                && fileConfig.antiPatternGateMinBlockedBeforeRollback > 0) {
-            this.antiPatternGateMinBlockedBeforeRollback = fileConfig.antiPatternGateMinBlockedBeforeRollback;
-        }
-        if (fileConfig.antiPatternGateMaxFalsePositiveRate != null
-                && fileConfig.antiPatternGateMaxFalsePositiveRate >= 0) {
-            this.antiPatternGateMaxFalsePositiveRate = clampRate(fileConfig.antiPatternGateMaxFalsePositiveRate);
-        }
+
+        // -- Anti-pattern gate file overrides (batch 3) ----------------------
+        antiPatternGateBuilder
+                .minBlockedBeforeRollback(fileConfig.antiPatternGateMinBlockedBeforeRollback)
+                .maxFalsePositiveRate(fileConfig.antiPatternGateMaxFalsePositiveRate);
         // -- Skill draft validation file overrides (batch 2) -----------------
         skillDraftValidationBuilder
                 .enabled(fileConfig.skillDraftValidationEnabled)

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -646,10 +646,11 @@ public final class AceClawDaemon {
 
         agentHandler.setCompactor(compactor);
         agentHandler.setMemoryStore(memoryStore, workingDir);
+        var antiPatternGate = config.antiPatternGate();
         agentHandler.setAntiPatternGateFeedbackStore(new AntiPatternGateFeedbackStore(
                 workingDir,
-                config.antiPatternGateMinBlockedBeforeRollback(),
-                config.antiPatternGateMaxFalsePositiveRate()));
+                antiPatternGate.minBlockedBeforeRollback(),
+                antiPatternGate.maxFalsePositiveRate()));
         if (journal != null) {
             agentHandler.setDailyJournal(journal);
         }
@@ -688,13 +689,15 @@ public final class AceClawDaemon {
             }
 
             // Candidate store for learning pipeline (promotion/demotion state machine)
+            var candidatePromotion = config.candidatePromotion();
+            var candidateInjection = config.candidateInjection();
             CandidateStore cs = null;
-            if (config.candidatePromotionEnabled() || config.candidateInjectionEnabled()) {
+            if (candidatePromotion.enabled() || candidateInjection.enabled()) {
                 try {
                     var smConfig = new CandidateStateMachine.Config(
-                            config.candidatePromotionMinEvidence(),
-                            config.candidatePromotionMinScore(),
-                            config.candidatePromotionMaxFailureRate(),
+                            candidatePromotion.minEvidence(),
+                            candidatePromotion.minScore(),
+                            candidatePromotion.maxFailureRate(),
                             3, java.util.Set.of());
                     cs = new CandidateStore(homeDir, smConfig);
                     cs.load();
@@ -717,7 +720,7 @@ public final class AceClawDaemon {
             final var autoReleaseForAuto = autoReleaseController;
             var selfImprovementEngine = new SelfImprovementEngine(
                     errorDetector, patternDetector, failureSignalDetector, memoryStore, strategyRefiner, cs,
-                    config.candidatePromotionEnabled(),
+                    candidatePromotion.enabled(),
                     (validationGateForAuto != null || candidateStoreForAuto != null) ? projectPath -> {
                         draftPipelineLock.lock();
                         try {
@@ -751,11 +754,11 @@ public final class AceClawDaemon {
             candidateStoreRef = cs;
 
             // Pass candidate store to agent handler for prompt injection
-            if (cs != null && config.candidateInjectionEnabled()) {
+            if (cs != null && candidateInjection.enabled()) {
                 agentHandler.setCandidateStore(cs);
                 agentHandler.setCandidateInjectionEnabled(true);
                 agentHandler.setCandidateInjectionConfig(
-                        config.candidateInjectionMaxCount(), config.candidateInjectionMaxTokens());
+                        candidateInjection.maxCount(), candidateInjection.maxTokens());
             } else {
                 agentHandler.setCandidateInjectionEnabled(false);
             }
@@ -844,7 +847,7 @@ public final class AceClawDaemon {
                 : null;
         final var crossSessionPatternMiner = historicalLogIndex != null ? new CrossSessionPatternMiner() : null;
         final var trendDetector = historicalLogIndex != null ? new TrendDetector() : null;
-        final var maintenanceCandidateBridge = config.candidatePromotionEnabled() && candidateStoreRef != null
+        final var maintenanceCandidateBridge = config.candidatePromotion().enabled() && candidateStoreRef != null
                 ? new LearningMaintenanceCandidateBridge(candidateStoreRef)
                 : null;
         final var maintenanceCandidateStore = candidateStoreRef;
@@ -1090,7 +1093,8 @@ public final class AceClawDaemon {
             Integer maxTokens = params != null && params.has("maxTokens")
                     ? Math.max(0, params.get("maxTokens").asInt()) : null;
             if (maxTokens != null) {
-                agentHandlerRef.setCandidateInjectionConfig(config.candidateInjectionMaxCount(), maxTokens);
+                agentHandlerRef.setCandidateInjectionConfig(
+                        config.candidateInjection().maxCount(), maxTokens);
             }
             boolean persist = params != null && params.has("persist") && params.get("persist").asBoolean(false);
             String scope = params != null && params.has("scope") ? params.get("scope").asText() : "project";

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AntiPatternGateSettings.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AntiPatternGateSettings.java
@@ -40,6 +40,7 @@ public record AntiPatternGateSettings(
         private double maxFalsePositiveRate;
 
         Builder(AntiPatternGateSettings seed) {
+            java.util.Objects.requireNonNull(seed, "seed");
             this.minBlockedBeforeRollback = seed.minBlockedBeforeRollback();
             this.maxFalsePositiveRate = seed.maxFalsePositiveRate();
         }
@@ -49,8 +50,13 @@ public record AntiPatternGateSettings(
             return this;
         }
         Builder maxFalsePositiveRate(Double v) {
-            // The pre-decomp code clamped this one (clampRate); preserve.
-            if (v != null && v >= 0) this.maxFalsePositiveRate = clampRate(v);
+            // Pre-decomp env-var path called clampRate(parsed) unconditionally,
+            // so a negative env value (e.g. "-0.1") became 0.0 rather than
+            // being silently ignored. The original `v >= 0` guard here
+            // diverged from that — a Codex P2 + CodeRabbit minor on #508.
+            // Now: any non-null input is clamped to [0, 1] before being
+            // stored, matching the pre-decomp env-var behaviour.
+            if (v != null) this.maxFalsePositiveRate = clampRate(v);
             return this;
         }
 

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AntiPatternGateSettings.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AntiPatternGateSettings.java
@@ -1,0 +1,67 @@
+package dev.aceclaw.daemon;
+
+/**
+ * Thematic config grouping for the anti-pattern pre-execution gate's
+ * feedback / rollback thresholds. Batch 3 of the AceClawConfig
+ * decomposition.
+ *
+ * <p>Shape:
+ * <ul>
+ *   <li>{@code minBlockedBeforeRollback} — minimum number of times a
+ *       candidate rule must block before its false-positive rate is
+ *       evaluated for auto-rollback. Avoids over-rolling-back rules
+ *       that have only fired once or twice.</li>
+ *   <li>{@code maxFalsePositiveRate} — false-positive rate threshold
+ *       above which a candidate-derived rule is auto-rolled-back
+ *       (clamped to [0, 1]).</li>
+ * </ul>
+ *
+ * <p>No {@code enabled} flag — the anti-pattern gate is always on; these
+ * two scalars only tune its rollback behaviour. Consumers that need to
+ * disable the gate entirely do so via the underlying feature module's
+ * own switches (candidate promotion, candidate store presence).
+ */
+public record AntiPatternGateSettings(
+        int minBlockedBeforeRollback,
+        double maxFalsePositiveRate) {
+
+    /** Defaults matched 1:1 to the prior {@code DEFAULT_ANTI_PATTERN_GATE_*} constants. */
+    public static AntiPatternGateSettings defaults() {
+        return new AntiPatternGateSettings(2, 0.50);
+    }
+
+    /** Fresh builder pre-loaded with {@link #defaults()}. */
+    static Builder builder() {
+        return new Builder(defaults());
+    }
+
+    static final class Builder {
+        private int minBlockedBeforeRollback;
+        private double maxFalsePositiveRate;
+
+        Builder(AntiPatternGateSettings seed) {
+            this.minBlockedBeforeRollback = seed.minBlockedBeforeRollback();
+            this.maxFalsePositiveRate = seed.maxFalsePositiveRate();
+        }
+
+        Builder minBlockedBeforeRollback(Integer v) {
+            if (v != null && v > 0) this.minBlockedBeforeRollback = v;
+            return this;
+        }
+        Builder maxFalsePositiveRate(Double v) {
+            // The pre-decomp code clamped this one (clampRate); preserve.
+            if (v != null && v >= 0) this.maxFalsePositiveRate = clampRate(v);
+            return this;
+        }
+
+        AntiPatternGateSettings build() {
+            return new AntiPatternGateSettings(minBlockedBeforeRollback, maxFalsePositiveRate);
+        }
+
+        private static double clampRate(double v) {
+            if (v < 0.0) return 0.0;
+            if (v > 1.0) return 1.0;
+            return v;
+        }
+    }
+}

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/CandidateInjectionSettings.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/CandidateInjectionSettings.java
@@ -46,6 +46,7 @@ public record CandidateInjectionSettings(
         private int maxTokens;
 
         Builder(CandidateInjectionSettings seed) {
+            java.util.Objects.requireNonNull(seed, "seed");
             this.enabled = seed.enabled();
             this.maxCount = seed.maxCount();
             this.maxTokens = seed.maxTokens();

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/CandidateInjectionSettings.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/CandidateInjectionSettings.java
@@ -1,0 +1,62 @@
+package dev.aceclaw.daemon;
+
+/**
+ * Thematic config grouping for candidate prompt injection — the 3 scalars
+ * AceClawConfig used to hold for the agent handler's per-prompt candidate
+ * injection budget. Batch 3 of the AceClawConfig decomposition.
+ *
+ * <p>Shape:
+ * <ul>
+ *   <li>{@code enabled} — feature gate. When {@code false} the agent loop
+ *       doesn't pull candidates from the store into the prompt; the rest
+ *       of the candidate pipeline (promotion, etc.) may still run.</li>
+ *   <li>{@code maxCount} — upper bound on number of candidates injected
+ *       per prompt.</li>
+ *   <li>{@code maxTokens} — upper bound on token budget consumed by the
+ *       injected candidate block.</li>
+ * </ul>
+ *
+ * <p>Legacy: the {@code candidateInjectionMaxChars} JSON key (pre-token-
+ * counter days) maps to {@code maxTokens} via approximate char-to-token
+ * conversion ({@code chars / 4}). Handled at the merge call site, not
+ * here, so the builder API stays clean.
+ */
+public record CandidateInjectionSettings(
+        boolean enabled,
+        int maxCount,
+        int maxTokens) {
+
+    /** Defaults matched 1:1 to the prior {@code DEFAULT_CANDIDATE_INJECTION_*} constants. */
+    public static CandidateInjectionSettings defaults() {
+        return new CandidateInjectionSettings(
+                true,   // enabled
+                10,     // maxCount
+                1200    // maxTokens
+        );
+    }
+
+    /** Fresh builder pre-loaded with {@link #defaults()}. */
+    static Builder builder() {
+        return new Builder(defaults());
+    }
+
+    static final class Builder {
+        private boolean enabled;
+        private int maxCount;
+        private int maxTokens;
+
+        Builder(CandidateInjectionSettings seed) {
+            this.enabled = seed.enabled();
+            this.maxCount = seed.maxCount();
+            this.maxTokens = seed.maxTokens();
+        }
+
+        Builder enabled(Boolean v) { if (v != null) this.enabled = v; return this; }
+        Builder maxCount(Integer v) { if (v != null && v >= 0) this.maxCount = v; return this; }
+        Builder maxTokens(Integer v) { if (v != null && v >= 0) this.maxTokens = v; return this; }
+
+        CandidateInjectionSettings build() {
+            return new CandidateInjectionSettings(enabled, maxCount, maxTokens);
+        }
+    }
+}

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/CandidatePromotionSettings.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/CandidatePromotionSettings.java
@@ -1,0 +1,77 @@
+package dev.aceclaw.daemon;
+
+/**
+ * Thematic config grouping for candidate promotion — the 4 scalars
+ * AceClawConfig used to hold for the {@code CandidateStateMachine.Config}
+ * thresholds and the SelfImprovementEngine feature gate. Batch 3 of the
+ * AceClawConfig decomposition.
+ *
+ * <p>Shape:
+ * <ul>
+ *   <li>{@code enabled} — feature gate. When {@code false} the daemon
+ *       skips constructing the CandidateStore entirely (provided injection
+ *       is also off) and the self-improvement engine doesn't run promotion
+ *       passes.</li>
+ *   <li>{@code minEvidence} — minimum evidence count before a candidate
+ *       can be considered for promotion.</li>
+ *   <li>{@code minScore} — minimum aggregate score for promotion.</li>
+ *   <li>{@code maxFailureRate} — upper bound on observed failure rate that
+ *       still allows promotion.</li>
+ * </ul>
+ *
+ * <p>Note: {@code minEvidence}, {@code minScore}, {@code maxFailureRate}
+ * feed directly into a {@code CandidateStateMachine.Config} constructor at
+ * the call site. We don't reuse that record here (unlike SkillAutoRelease)
+ * because {@code CandidateStateMachine.Config} carries additional state
+ * (decay parameters, kind allowlist) that lives outside the AceClawConfig
+ * surface — exposing it would couple daemon-side config to memory-side
+ * details the user doesn't tune via env vars.
+ */
+public record CandidatePromotionSettings(
+        boolean enabled,
+        int minEvidence,
+        double minScore,
+        double maxFailureRate) {
+
+    /** Defaults matched 1:1 to the prior {@code DEFAULT_CANDIDATE_PROMOTION_*} constants. */
+    public static CandidatePromotionSettings defaults() {
+        return new CandidatePromotionSettings(
+                true,   // enabled
+                2,      // minEvidence
+                0.75,   // minScore
+                0.20    // maxFailureRate
+        );
+    }
+
+    /** Fresh builder pre-loaded with {@link #defaults()}. */
+    static Builder builder() {
+        return new Builder(defaults());
+    }
+
+    static final class Builder {
+        private boolean enabled;
+        private int minEvidence;
+        private double minScore;
+        private double maxFailureRate;
+
+        Builder(CandidatePromotionSettings seed) {
+            this.enabled = seed.enabled();
+            this.minEvidence = seed.minEvidence();
+            this.minScore = seed.minScore();
+            this.maxFailureRate = seed.maxFailureRate();
+        }
+
+        Builder enabled(Boolean v) { if (v != null) this.enabled = v; return this; }
+        Builder minEvidence(Integer v) { if (v != null && v > 0) this.minEvidence = v; return this; }
+        // minScore / maxFailureRate: the pre-decomp code didn't clamp these
+        // to [0,1]. Preserve that behaviour exactly — accept any non-negative
+        // value. Clamping would silently change the semantics of an out-of-
+        // range config entry from "honor the user's value" to "silently cap."
+        Builder minScore(Double v) { if (v != null && v >= 0) this.minScore = v; return this; }
+        Builder maxFailureRate(Double v) { if (v != null && v >= 0) this.maxFailureRate = v; return this; }
+
+        CandidatePromotionSettings build() {
+            return new CandidatePromotionSettings(enabled, minEvidence, minScore, maxFailureRate);
+        }
+    }
+}

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/CandidatePromotionSettings.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/CandidatePromotionSettings.java
@@ -55,6 +55,7 @@ public record CandidatePromotionSettings(
         private double maxFailureRate;
 
         Builder(CandidatePromotionSettings seed) {
+            java.util.Objects.requireNonNull(seed, "seed");
             this.enabled = seed.enabled();
             this.minEvidence = seed.minEvidence();
             this.minScore = seed.minScore();


### PR DESCRIPTION
## Summary

Third pass of the **AceClawConfig decomposition**. Three more thematic
clusters lifted into their own records: 9 fields total.

| | Origin | After #506 | After #507 | After this |
|---|---|---|---|---|
| `AceClawConfig.java` | 2,038 | 1,879 | 1,771 | **1,697 LoC (-17% from origin)** |

## What moved

| Record | Fields | Notes |
|---|---|---|
| `CandidatePromotionSettings` | 4 | feeds `CandidateStateMachine.Config` |
| `CandidateInjectionSettings` | 3 | per-prompt budget for the agent loop |
| `AntiPatternGateSettings` | 2 | no `enabled` flag — gate is always on |

### Why split Candidate into 2 records?

Promotion (state machine for candidate→active transitions) and Injection
(per-prompt budget for inserting candidates into the system prompt) are
conceptually distinct features that happen to share the `candidate*`
prefix. Grouping them under one `CandidateSettings(promotion, injection)`
would add a `.promotion()` / `.injection()` indirection at every call
site without conveying anything meaningful — you never wire one without
the other's gate having been checked.

## Daemon call site changes (5 sites updated)

Candidate store creation:
```java
var candidatePromotion = config.candidatePromotion();
var candidateInjection = config.candidateInjection();
if (candidatePromotion.enabled() || candidateInjection.enabled()) {
    var smConfig = new CandidateStateMachine.Config(
            candidatePromotion.minEvidence(),
            candidatePromotion.minScore(),
            candidatePromotion.maxFailureRate(),
            3, java.util.Set.of());
    cs = new CandidateStore(homeDir, smConfig);
}
```

Anti-pattern gate feedback store:
```java
var antiPatternGate = config.antiPatternGate();
agentHandler.setAntiPatternGateFeedbackStore(new AntiPatternGateFeedbackStore(
        workingDir,
        antiPatternGate.minBlockedBeforeRollback(),
        antiPatternGate.maxFalsePositiveRate()));
```

## Legacy compat: `candidateInjectionMaxChars`

The deprecated `candidateInjectionMaxChars` JSON key (pre-token-counter
days, char-to-token approximation 4:1) is preserved at the merge site:

```java
if (fileConfig.candidateInjectionMaxTokens != null && fileConfig.candidateInjectionMaxTokens >= 0) {
    candidateInjectionBuilder.maxTokens(fileConfig.candidateInjectionMaxTokens);
} else if (fileConfig.candidateInjectionMaxChars != null && fileConfig.candidateInjectionMaxChars >= 0) {
    candidateInjectionBuilder.maxTokens(Math.max(0, fileConfig.candidateInjectionMaxChars / 4));
}
```

Same priority order as pre-decomp. The legacy key stays in
`ConfigFileFormat` for forward-rollback safety.

## Diff stats

**+81 / -151 = -70 net** across 2 modified + 3 new files.

## Test plan

- [x] `:aceclaw-daemon:compileJava` — clean
- [x] `AceClawConfigTest` — 17/0
- [x] candidateInjectionMaxChars legacy path preserved
- [x] All 5 daemon call sites updated

## Cumulative progress

| Batch | PR | Fields moved | AceClawConfig LoC |
|---|---|---|---|
| 1 (SkillAutoRelease) | #506 | 12 | 1,879 (-159) |
| 2 (AdaptiveContinuation + SkillDraftValidation) | #507 | 10 | 1,771 (-108) |
| **3 (Candidate + AntiPatternGate)** | **this** | **9** | **1,697 (-74)** |
| **Total** | | **31 fields** | **-341 LoC (-17%)** |

## Remaining (out of scope)

- **Retry** (4) — already has `retryConfig()` facade; public surface is
  already clean. Could migrate internal storage in a small batch.
- **Agent + Plan budgets / watchdog** (4 + 2)
- **Lifecycle small clusters** (boot/scheduler/heartbeat/deferred ~9) —
  could bundle as one `DaemonLifecycleSettings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Configuration for candidate promotion, candidate injection, and anti-pattern gating has been consolidated into structured settings groups with preserved defaults and validated builders.
* **New Features**
  * Runtime config loading and merging now populate the grouped settings; system wiring and runtime gates/readers use the new structured settings.
* **Chores**
  * RPC persistence now reads default injection limits from the consolidated settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xinhuagu/AceClaw/pull/508?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->