### PR TITLE
refactor(daemon): extract WatchdogSettings + audit-fix already-merged Builders (batch 4)

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
@@ -103,13 +103,9 @@ public final class AceClawConfig {
     // 13 individual DEFAULT_SKILL_AUTO_RELEASE_* constants used to live here —
     // grouped into the SkillAutoReleaseSettings record as part of the
     // AceClawConfig decomposition (batch 1).
-    private static final int DEFAULT_MAX_AGENT_TURNS = 200;
-    private static final int DEFAULT_MAX_AGENT_WALL_TIME_SEC = 1800;
-    // 0 means "derive from soft limit (3x)" in StreamingAgentHandler
-    private static final int DEFAULT_MAX_AGENT_HARD_TURNS = 0;
-    private static final int DEFAULT_MAX_AGENT_HARD_WALL_TIME_SEC = 0;
-    private static final int DEFAULT_MAX_PLAN_STEP_WALL_TIME_SEC = 1800;
-    private static final int DEFAULT_MAX_PLAN_TOTAL_WALL_TIME_SEC = 3600;
+    // Watchdog defaults moved to WatchdogSettings.defaults() (batch 4).
+    // The "0 = derive from soft limit (3x)" convention on hard turns /
+    // wall-time is preserved at the StreamingAgentHandler consumer.
     private static final boolean DEFAULT_DEFERRED_ACTION_ENABLED = true;
     private static final int DEFAULT_DEFERRED_ACTION_TICK_SECONDS = 5;
     /**
@@ -226,12 +222,12 @@ public final class AceClawConfig {
      */
     private final SkillAutoReleaseSettings.Builder skillAutoReleaseBuilder =
             SkillAutoReleaseSettings.builder();
-    private int maxAgentTurns;
-    private int maxAgentWallTimeSec;
-    private int maxAgentHardTurns;
-    private int maxAgentHardWallTimeSec;
-    private int maxPlanStepWallTimeSec;
-    private int maxPlanTotalWallTimeSec;
+    /**
+     * Watchdog config — was 6 individual scalar fields (4 agent budgets + 2
+     * plan budgets), now grouped under one {@link WatchdogSettings} record
+     * (batch 4 of the AceClawConfig decomposition).
+     */
+    private final WatchdogSettings.Builder watchdogBuilder = WatchdogSettings.builder();
     private boolean deferredActionEnabled;
     private int deferredActionTickSeconds;
     private boolean webSocketEnabled;
@@ -295,12 +291,7 @@ public final class AceClawConfig {
         // skillDraftValidation defaults seeded by SkillDraftValidationSettings.builder()
         // skillAutoRelease defaults are seeded by SkillAutoReleaseSettings.builder()
         // at field-initialization time. 14 individual setter calls removed here.
-        this.maxAgentTurns = DEFAULT_MAX_AGENT_TURNS;
-        this.maxAgentWallTimeSec = DEFAULT_MAX_AGENT_WALL_TIME_SEC;
-        this.maxAgentHardTurns = DEFAULT_MAX_AGENT_HARD_TURNS;
-        this.maxAgentHardWallTimeSec = DEFAULT_MAX_AGENT_HARD_WALL_TIME_SEC;
-        this.maxPlanStepWallTimeSec = DEFAULT_MAX_PLAN_STEP_WALL_TIME_SEC;
-        this.maxPlanTotalWallTimeSec = DEFAULT_MAX_PLAN_TOTAL_WALL_TIME_SEC;
+        // Watchdog defaults seeded by WatchdogSettings.builder()
         this.deferredActionEnabled = DEFAULT_DEFERRED_ACTION_ENABLED;
         this.deferredActionTickSeconds = DEFAULT_DEFERRED_ACTION_TICK_SECONDS;
         this.webSocketEnabled = DEFAULT_WEBSOCKET_ENABLED;
@@ -398,54 +389,19 @@ public final class AceClawConfig {
                 log.warn("Invalid ACECLAW_MAX_TURNS: {}", envMaxTurns);
             }
         }
-        var envMaxAgentTurns = System.getenv("ACECLAW_MAX_AGENT_TURNS");
-        if (envMaxAgentTurns != null && !envMaxAgentTurns.isBlank()) {
-            try {
-                config.maxAgentTurns = Math.max(0, Integer.parseInt(envMaxAgentTurns));
-            } catch (NumberFormatException e) {
-                log.warn("Invalid ACECLAW_MAX_AGENT_TURNS: {}", envMaxAgentTurns);
-            }
-        }
-        var envMaxAgentWallTime = System.getenv("ACECLAW_MAX_AGENT_WALL_TIME_SEC");
-        if (envMaxAgentWallTime != null && !envMaxAgentWallTime.isBlank()) {
-            try {
-                config.maxAgentWallTimeSec = Math.max(0, Integer.parseInt(envMaxAgentWallTime));
-            } catch (NumberFormatException e) {
-                log.warn("Invalid ACECLAW_MAX_AGENT_WALL_TIME_SEC: {}", envMaxAgentWallTime);
-            }
-        }
-        var envMaxAgentHardTurns = System.getenv("ACECLAW_MAX_AGENT_HARD_TURNS");
-        if (envMaxAgentHardTurns != null && !envMaxAgentHardTurns.isBlank()) {
-            try {
-                config.maxAgentHardTurns = Math.max(0, Integer.parseInt(envMaxAgentHardTurns));
-            } catch (NumberFormatException e) {
-                log.warn("Invalid ACECLAW_MAX_AGENT_HARD_TURNS: {}", envMaxAgentHardTurns);
-            }
-        }
-        var envMaxAgentHardWallTime = System.getenv("ACECLAW_MAX_AGENT_HARD_WALL_TIME_SEC");
-        if (envMaxAgentHardWallTime != null && !envMaxAgentHardWallTime.isBlank()) {
-            try {
-                config.maxAgentHardWallTimeSec = Math.max(0, Integer.parseInt(envMaxAgentHardWallTime));
-            } catch (NumberFormatException e) {
-                log.warn("Invalid ACECLAW_MAX_AGENT_HARD_WALL_TIME_SEC: {}", envMaxAgentHardWallTime);
-            }
-        }
-        var envMaxPlanStepWallTime = System.getenv("ACECLAW_MAX_PLAN_STEP_WALL_TIME_SEC");
-        if (envMaxPlanStepWallTime != null && !envMaxPlanStepWallTime.isBlank()) {
-            try {
-                config.maxPlanStepWallTimeSec = Math.max(0, Integer.parseInt(envMaxPlanStepWallTime));
-            } catch (NumberFormatException e) {
-                log.warn("Invalid ACECLAW_MAX_PLAN_STEP_WALL_TIME_SEC: {}", envMaxPlanStepWallTime);
-            }
-        }
-        var envMaxPlanTotalWallTime = System.getenv("ACECLAW_MAX_PLAN_TOTAL_WALL_TIME_SEC");
-        if (envMaxPlanTotalWallTime != null && !envMaxPlanTotalWallTime.isBlank()) {
-            try {
-                config.maxPlanTotalWallTimeSec = Math.max(0, Integer.parseInt(envMaxPlanTotalWallTime));
-            } catch (NumberFormatException e) {
-                log.warn("Invalid ACECLAW_MAX_PLAN_TOTAL_WALL_TIME_SEC: {}", envMaxPlanTotalWallTime);
-            }
-        }
+        // -- Watchdog env vars (batch 4) -------------------------------------
+        applyEnvInt("ACECLAW_MAX_AGENT_TURNS",
+                v -> config.watchdogBuilder.agentTurns(Math.max(0, v)));
+        applyEnvInt("ACECLAW_MAX_AGENT_WALL_TIME_SEC",
+                v -> config.watchdogBuilder.agentWallTimeSec(Math.max(0, v)));
+        applyEnvInt("ACECLAW_MAX_AGENT_HARD_TURNS",
+                v -> config.watchdogBuilder.agentHardTurns(Math.max(0, v)));
+        applyEnvInt("ACECLAW_MAX_AGENT_HARD_WALL_TIME_SEC",
+                v -> config.watchdogBuilder.agentHardWallTimeSec(Math.max(0, v)));
+        applyEnvInt("ACECLAW_MAX_PLAN_STEP_WALL_TIME_SEC",
+                v -> config.watchdogBuilder.planStepWallTimeSec(Math.max(0, v)));
+        applyEnvInt("ACECLAW_MAX_PLAN_TOTAL_WALL_TIME_SEC",
+                v -> config.watchdogBuilder.planTotalWallTimeSec(Math.max(0, v)));
         // -- Adaptive continuation env vars (batch 2) ------------------------
         applyEnvBoolean("ACECLAW_ADAPTIVE_CONTINUATION",
                 v -> config.adaptiveContinuationBuilder.enabled(v));
@@ -1023,54 +979,12 @@ public final class AceClawConfig {
     }
 
     /**
-     * Returns the maximum number of agent ReAct iterations per request.
-     * Enforced by the watchdog timer. 0 = disabled (uses existing maxTurns only).
-     * Defaults to 200.
+     * Returns the watchdog config — agent + plan turn/wall-time budgets
+     * (6 scalars, see {@link WatchdogSettings}). Replaces 6 individual
+     * getters as part of batch 4 of the AceClawConfig decomposition.
      */
-    public int maxAgentTurns() {
-        return maxAgentTurns;
-    }
-
-    /**
-     * Returns the maximum wall-clock time in seconds per agent request.
-     * Enforced by the watchdog timer. 0 = disabled.
-     * Defaults to 3600 (60 minutes).
-     */
-    public int maxAgentWallTimeSec() {
-        return maxAgentWallTimeSec;
-    }
-
-    /**
-     * Returns the hard ceiling for agent ReAct iterations per request.
-     * 0 = use 3x soft limit. Unconditional stop, absolute safety net.
-     */
-    public int maxAgentHardTurns() {
-        return maxAgentHardTurns;
-    }
-
-    /**
-     * Returns the hard ceiling for wall-clock time in seconds per agent request.
-     * 0 = use 3x soft limit. Unconditional stop, absolute safety net.
-     */
-    public int maxAgentHardWallTimeSec() {
-        return maxAgentHardWallTimeSec;
-    }
-
-    /**
-     * Returns the maximum wall-clock time in seconds per plan step.
-     * The watchdog timer is reset before each step. 0 = disabled.
-     * Defaults to 1800 (30 minutes).
-     */
-    public int maxPlanStepWallTimeSec() {
-        return maxPlanStepWallTimeSec;
-    }
-
-    /**
-     * Returns the maximum total wall-clock time in seconds for an entire plan execution.
-     * 0 = disabled. Defaults to 3600 (1 hour).
-     */
-    public int maxPlanTotalWallTimeSec() {
-        return maxPlanTotalWallTimeSec;
+    public WatchdogSettings watchdog() {
+        return watchdogBuilder.build();
     }
 
     /**
@@ -1429,24 +1343,14 @@ public final class AceClawConfig {
                 .rollbackMaxPermissionRate(fileConfig.skillAutoReleaseRollbackMaxPermissionBlockRate)
                 .healthLookbackHours(fileConfig.skillAutoReleaseHealthLookbackHours)
                 .canaryDwellHours(fileConfig.skillAutoReleaseCanaryDwellHours);
-        if (fileConfig.maxAgentTurns != null && fileConfig.maxAgentTurns >= 0) {
-            this.maxAgentTurns = fileConfig.maxAgentTurns;
-        }
-        if (fileConfig.maxAgentWallTimeSec != null && fileConfig.maxAgentWallTimeSec >= 0) {
-            this.maxAgentWallTimeSec = fileConfig.maxAgentWallTimeSec;
-        }
-        if (fileConfig.maxAgentHardTurns != null && fileConfig.maxAgentHardTurns >= 0) {
-            this.maxAgentHardTurns = fileConfig.maxAgentHardTurns;
-        }
-        if (fileConfig.maxAgentHardWallTimeSec != null && fileConfig.maxAgentHardWallTimeSec >= 0) {
-            this.maxAgentHardWallTimeSec = fileConfig.maxAgentHardWallTimeSec;
-        }
-        if (fileConfig.maxPlanStepWallTimeSec != null && fileConfig.maxPlanStepWallTimeSec >= 0) {
-            this.maxPlanStepWallTimeSec = fileConfig.maxPlanStepWallTimeSec;
-        }
-        if (fileConfig.maxPlanTotalWallTimeSec != null && fileConfig.maxPlanTotalWallTimeSec >= 0) {
-            this.maxPlanTotalWallTimeSec = fileConfig.maxPlanTotalWallTimeSec;
-        }
+        // -- Watchdog file overrides (batch 4) -------------------------------
+        watchdogBuilder
+                .agentTurns(fileConfig.maxAgentTurns)
+                .agentWallTimeSec(fileConfig.maxAgentWallTimeSec)
+                .agentHardTurns(fileConfig.maxAgentHardTurns)
+                .agentHardWallTimeSec(fileConfig.maxAgentHardWallTimeSec)
+                .planStepWallTimeSec(fileConfig.maxPlanStepWallTimeSec)
+                .planTotalWallTimeSec(fileConfig.maxPlanTotalWallTimeSec);
         if (fileConfig.deferredActionEnabled != null) {
             this.deferredActionEnabled = fileConfig.deferredActionEnabled;
         }

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -631,12 +631,13 @@ public final class AceClawDaemon {
                 adaptiveContinuation.maxWallClockSeconds());
         agentHandler.setPlannerConfig(config.plannerEnabled(), config.plannerThreshold());
         agentHandler.setAdaptiveReplanEnabled(config.adaptiveReplanEnabled());
+        var watchdog = config.watchdog();
         agentHandler.setWatchdogConfig(
-                config.maxAgentTurns(), config.maxAgentWallTimeSec(),
-                config.maxAgentHardTurns(), config.maxAgentHardWallTimeSec());
+                watchdog.agentTurns(), watchdog.agentWallTimeSec(),
+                watchdog.agentHardTurns(), watchdog.agentHardWallTimeSec());
         agentHandler.setPlanBudgetConfig(
-                config.maxPlanStepWallTimeSec(),
-                config.maxPlanTotalWallTimeSec());
+                watchdog.planStepWallTimeSec(),
+                watchdog.planTotalWallTimeSec());
 
         // Plan checkpoint store for crash-safe plan progress persistence and resume
         var planCheckpointStore = new FilePlanCheckpointStore(

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AdaptiveContinuationSettings.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AdaptiveContinuationSettings.java
@@ -56,6 +56,7 @@ public record AdaptiveContinuationSettings(
         private int maxWallClockSeconds;
 
         Builder(AdaptiveContinuationSettings seed) {
+            java.util.Objects.requireNonNull(seed, "seed");
             this.enabled = seed.enabled();
             this.maxSegments = seed.maxSegments();
             this.noProgressThreshold = seed.noProgressThreshold();

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/SkillAutoReleaseSettings.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/SkillAutoReleaseSettings.java
@@ -74,6 +74,7 @@ public record SkillAutoReleaseSettings(boolean enabled, AutoReleaseController.Co
         private int canaryDwellHours;
 
         Builder(SkillAutoReleaseSettings seed) {
+            java.util.Objects.requireNonNull(seed, "seed");
             this.enabled = seed.enabled();
             var t = seed.tuning();
             this.minCandidateScore = t.minCandidateScore();
@@ -90,15 +91,15 @@ public record SkillAutoReleaseSettings(boolean enabled, AutoReleaseController.Co
         }
 
         Builder enabled(Boolean v) { if (v != null) this.enabled = v; return this; }
-        Builder minCandidateScore(Double v) { if (v != null && v >= 0) this.minCandidateScore = clampRate(v); return this; }
+        Builder minCandidateScore(Double v) { if (v != null) this.minCandidateScore = clampRate(v); return this; }
         Builder minEvidenceCount(Integer v) { if (v != null && v > 0) this.minEvidenceCount = v; return this; }
         Builder canaryMinAttempts(Integer v) { if (v != null && v >= 0) this.canaryMinAttempts = v; return this; }
-        Builder canaryMaxFailureRate(Double v) { if (v != null && v >= 0) this.canaryMaxFailureRate = clampRate(v); return this; }
-        Builder canaryMaxTimeoutRate(Double v) { if (v != null && v >= 0) this.canaryMaxTimeoutRate = clampRate(v); return this; }
-        Builder canaryMaxPermissionRate(Double v) { if (v != null && v >= 0) this.canaryMaxPermissionRate = clampRate(v); return this; }
-        Builder rollbackMaxFailureRate(Double v) { if (v != null && v >= 0) this.rollbackMaxFailureRate = clampRate(v); return this; }
-        Builder rollbackMaxTimeoutRate(Double v) { if (v != null && v >= 0) this.rollbackMaxTimeoutRate = clampRate(v); return this; }
-        Builder rollbackMaxPermissionRate(Double v) { if (v != null && v >= 0) this.rollbackMaxPermissionRate = clampRate(v); return this; }
+        Builder canaryMaxFailureRate(Double v) { if (v != null) this.canaryMaxFailureRate = clampRate(v); return this; }
+        Builder canaryMaxTimeoutRate(Double v) { if (v != null) this.canaryMaxTimeoutRate = clampRate(v); return this; }
+        Builder canaryMaxPermissionRate(Double v) { if (v != null) this.canaryMaxPermissionRate = clampRate(v); return this; }
+        Builder rollbackMaxFailureRate(Double v) { if (v != null) this.rollbackMaxFailureRate = clampRate(v); return this; }
+        Builder rollbackMaxTimeoutRate(Double v) { if (v != null) this.rollbackMaxTimeoutRate = clampRate(v); return this; }
+        Builder rollbackMaxPermissionRate(Double v) { if (v != null) this.rollbackMaxPermissionRate = clampRate(v); return this; }
         Builder healthLookbackHours(Integer v) { if (v != null && v > 0) this.healthLookbackHours = v; return this; }
         Builder canaryDwellHours(Integer v) { if (v != null && v >= 0) this.canaryDwellHours = v; return this; }
 
@@ -109,7 +110,7 @@ public record SkillAutoReleaseSettings(boolean enabled, AutoReleaseController.Co
          * call site (vs hiding the alias inside a generic setter).
          */
         Builder applyLegacyActiveMaxFailureRate(Double v) {
-            if (v != null && v >= 0) this.rollbackMaxFailureRate = clampRate(v);
+            if (v != null) this.rollbackMaxFailureRate = clampRate(v);
             return this;
         }
 

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/SkillDraftValidationSettings.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/SkillDraftValidationSettings.java
@@ -63,6 +63,7 @@ public record SkillDraftValidationSettings(
         private double maxTokenEstimationErrorRatio;
 
         Builder(SkillDraftValidationSettings seed) {
+            java.util.Objects.requireNonNull(seed, "seed");
             this.enabled = seed.enabled();
             this.strictMode = seed.strictMode();
             this.replayRequired = seed.replayRequired();

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/WatchdogSettings.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/WatchdogSettings.java
@@ -1,0 +1,106 @@
+package dev.aceclaw.daemon;
+
+/**
+ * Thematic config grouping for the agent + plan watchdog budgets — the 6
+ * scalars that wall-clock-bound and turn-bound a single user prompt and
+ * any plan steps it spawns. Batch 4 of the AceClawConfig decomposition.
+ *
+ * <h3>Shape</h3>
+ *
+ * <ul>
+ *   <li><b>Soft agent budgets</b>:
+ *     <ul>
+ *       <li>{@code agentTurns} — soft per-prompt turn limit (default 200);
+ *           past this the agent gets a hint to wrap up but the turn loop
+ *           keeps going up to the hard ceiling.</li>
+ *       <li>{@code agentWallTimeSec} — soft per-prompt wall-clock budget in
+ *           seconds (default 1800).</li>
+ *     </ul>
+ *   </li>
+ *   <li><b>Hard agent ceilings</b>:
+ *     <ul>
+ *       <li>{@code agentHardTurns} — hard turn ceiling. {@code 0} means
+ *           "derive from soft limit (3×)" — the daemon's StreamingAgentHandler
+ *           applies that derivation.</li>
+ *       <li>{@code agentHardWallTimeSec} — hard wall-clock ceiling. Same
+ *           "0 = 3× soft" convention.</li>
+ *     </ul>
+ *   </li>
+ *   <li><b>Plan budgets</b>:
+ *     <ul>
+ *       <li>{@code planStepWallTimeSec} — per-step wall-clock budget for
+ *           plan-mode prompts (default 1800).</li>
+ *       <li>{@code planTotalWallTimeSec} — total wall-clock budget across
+ *           all plan steps in one prompt (default 3600).</li>
+ *     </ul>
+ *   </li>
+ * </ul>
+ *
+ * <p>All 6 values are non-negative integers. {@code 0} on the hard
+ * ceilings has a special "derive from soft" meaning preserved here for
+ * compatibility — interpreting that is the StreamingAgentHandler's job,
+ * not this record's.
+ */
+public record WatchdogSettings(
+        int agentTurns,
+        int agentWallTimeSec,
+        int agentHardTurns,
+        int agentHardWallTimeSec,
+        int planStepWallTimeSec,
+        int planTotalWallTimeSec) {
+
+    /** Defaults matched 1:1 to the prior {@code DEFAULT_MAX_AGENT_*} / {@code DEFAULT_MAX_PLAN_*} constants. */
+    public static WatchdogSettings defaults() {
+        return new WatchdogSettings(
+                200,    // agentTurns         — soft per-prompt turn limit
+                1800,   // agentWallTimeSec   — soft per-prompt wall-clock budget
+                0,      // agentHardTurns     — 0 = derive 3× soft at consumer
+                0,      // agentHardWallTimeSec — same 0-as-derive convention
+                1800,   // planStepWallTimeSec — per-step wall-clock budget
+                3600    // planTotalWallTimeSec — total across all plan steps
+        );
+    }
+
+    /** Fresh builder pre-loaded with {@link #defaults()}. */
+    static Builder builder() {
+        return new Builder(defaults());
+    }
+
+    static final class Builder {
+        private int agentTurns;
+        private int agentWallTimeSec;
+        private int agentHardTurns;
+        private int agentHardWallTimeSec;
+        private int planStepWallTimeSec;
+        private int planTotalWallTimeSec;
+
+        Builder(WatchdogSettings seed) {
+            java.util.Objects.requireNonNull(seed, "seed");
+            this.agentTurns = seed.agentTurns();
+            this.agentWallTimeSec = seed.agentWallTimeSec();
+            this.agentHardTurns = seed.agentHardTurns();
+            this.agentHardWallTimeSec = seed.agentHardWallTimeSec();
+            this.planStepWallTimeSec = seed.planStepWallTimeSec();
+            this.planTotalWallTimeSec = seed.planTotalWallTimeSec();
+        }
+
+        // Pre-decomp validation: each field skipped on null OR negative
+        // (the file-merge path used `v >= 0` everywhere). Preserved here.
+        // The env-var paths used Math.max(0, parsed) — same effect on the
+        // observable stored value (negative gets clamped or skipped, never
+        // stored).
+        Builder agentTurns(Integer v) { if (v != null && v >= 0) this.agentTurns = v; return this; }
+        Builder agentWallTimeSec(Integer v) { if (v != null && v >= 0) this.agentWallTimeSec = v; return this; }
+        Builder agentHardTurns(Integer v) { if (v != null && v >= 0) this.agentHardTurns = v; return this; }
+        Builder agentHardWallTimeSec(Integer v) { if (v != null && v >= 0) this.agentHardWallTimeSec = v; return this; }
+        Builder planStepWallTimeSec(Integer v) { if (v != null && v >= 0) this.planStepWallTimeSec = v; return this; }
+        Builder planTotalWallTimeSec(Integer v) { if (v != null && v >= 0) this.planTotalWallTimeSec = v; return this; }
+
+        WatchdogSettings build() {
+            return new WatchdogSettings(
+                    agentTurns, agentWallTimeSec,
+                    agentHardTurns, agentHardWallTimeSec,
+                    planStepWallTimeSec, planTotalWallTimeSec);
+        }
+    }
+}

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/AceClawConfigTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/AceClawConfigTest.java
@@ -287,10 +287,11 @@ class AceClawConfigTest {
 
         var config = AceClawConfig.load(tempDir, null);
 
-        assertThat(config.maxPlanStepWallTimeSec())
+        var watchdog = config.watchdog();
+        assertThat(watchdog.planStepWallTimeSec())
                 .as("per-step plan budget default")
                 .isEqualTo(1800);
-        assertThat(config.maxPlanTotalWallTimeSec())
+        assertThat(watchdog.planTotalWallTimeSec())
                 .as("total plan budget default")
                 .isEqualTo(3600);
     }


### PR DESCRIPTION
## Summary

Continues the **AceClawConfig decomposition** + applies #508 review findings to already-merged Builders.

| | Origin | After #506-508 | After this |
|---|---|---|---|
| `AceClawConfig.java` | 2,038 LoC | 1,697 LoC | **1,601 LoC (-21% from origin)** |

## 1. Extract WatchdogSettings (6 fields)

Watchdog cluster (4 agent budgets + 2 plan budgets) lifted into one record. Single call site in AceClawDaemon migrated from 6 individual getters to one `config.watchdog()` record.

## 2. Audit fixes — apply #508 review findings to already-merged Builders

### Clamp regression in SkillAutoReleaseSettings (7 rate fields)

Same divergence the #508 review flagged for AntiPatternGateSettings was present in SkillAutoRelease's 7 rate setters — shipped silently in #506. Pre-decomp env-var paths called `clampRate(parsed)` unconditionally so a negative env (`-0.1`) became `0.0`; new `if (v != null && v >= 0)` guards silently ignored negatives. Now: any non-null input is clamped.

Affects: `minCandidateScore`, `canaryMaxFailureRate`, `canaryMaxTimeoutRate`, `canaryMaxPermissionRate`, `rollbackMaxFailureRate`, `rollbackMaxTimeoutRate`, `rollbackMaxPermissionRate`, plus `applyLegacyActiveMaxFailureRate`.

### Builder seed null-guards (3 already-merged records)

Per CLAUDE.md `Objects.requireNonNull` policy. Added to:
- `SkillAutoReleaseSettings.Builder(seed)`
- `AdaptiveContinuationSettings.Builder(seed)`
- `SkillDraftValidationSettings.Builder(seed)`

Plus the new `WatchdogSettings.Builder` at creation.

## Test plan

- [x] AceClawConfigTest 17/0 (one test updated from individual getters to `config.watchdog().planStepWallTimeSec()` etc.)
- [x] `:aceclaw-daemon:compileJava` clean
- [x] Same env var names, JSON keys, defaults, and "0 = derive 3× soft" convention preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)