### PR TITLE
refactor(daemon): extract DaemonLifecycleSettings (batch 5)

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
@@ -65,11 +65,8 @@ public final class AceClawConfig {
     // (batch 2 of the AceClawConfig decomposition).
     private static final int DEFAULT_CONTEXT_WINDOW = 0;
     private static final String DEFAULT_LOG_LEVEL = "INFO";
-    private static final boolean DEFAULT_BOOT_ENABLED = true;
-    private static final int DEFAULT_BOOT_TIMEOUT_SECONDS = 120;
-    private static final boolean DEFAULT_SCHEDULER_ENABLED = true;
-    private static final int DEFAULT_SCHEDULER_TICK_SECONDS = 60;
-    private static final boolean DEFAULT_HEARTBEAT_ENABLED = true;
+    // boot/scheduler/heartbeat defaults moved to DaemonLifecycleSettings.defaults()
+    // (batch 5 of the AceClawConfig decomposition).
     private static final boolean DEFAULT_PLANNER_ENABLED = true;
     /**
      * Default complexity score for triggering the planner. Restored
@@ -106,8 +103,7 @@ public final class AceClawConfig {
     // Watchdog defaults moved to WatchdogSettings.defaults() (batch 4).
     // The "0 = derive from soft limit (3x)" convention on hard turns /
     // wall-time is preserved at the StreamingAgentHandler consumer.
-    private static final boolean DEFAULT_DEFERRED_ACTION_ENABLED = true;
-    private static final int DEFAULT_DEFERRED_ACTION_TICK_SECONDS = 5;
+    // deferredAction defaults moved to DaemonLifecycleSettings.defaults() (batch 5).
     /**
      * WebSocket bridge for browser dashboard (issue #431). Enabled by default since #446
      * <em>but only when the bind host is loopback</em> — the daemon now serves the
@@ -172,12 +168,6 @@ public final class AceClawConfig {
      * {@link dev.aceclaw.security.DefaultPermissionPolicy} for the rule set).
      */
     private boolean denySensitivePaths;
-    private boolean bootEnabled;
-    private int bootTimeoutSeconds;
-    private boolean schedulerEnabled;
-    private int schedulerTickSeconds;
-    private boolean heartbeatEnabled;
-    private String heartbeatActiveHours;
     private String defaultProfile;
     private Map<String, ConfigFileFormat> profiles;
     /**
@@ -228,8 +218,14 @@ public final class AceClawConfig {
      * (batch 4 of the AceClawConfig decomposition).
      */
     private final WatchdogSettings.Builder watchdogBuilder = WatchdogSettings.builder();
-    private boolean deferredActionEnabled;
-    private int deferredActionTickSeconds;
+    /**
+     * Daemon lifecycle config — was 8 individual scalar fields (boot/scheduler/
+     * heartbeat/deferred-action gates + tick cadences), now grouped under one
+     * {@link DaemonLifecycleSettings} record (batch 5 of the AceClawConfig
+     * decomposition). Builder-based so file-merge overrides accumulate
+     * incrementally; the public {@link #lifecycle()} getter freezes it on demand.
+     */
+    private final DaemonLifecycleSettings.Builder lifecycleBuilder = DaemonLifecycleSettings.builder();
     private boolean webSocketEnabled;
     /**
      * Tracks whether any config file explicitly set {@code webSocket.enabled}.
@@ -279,11 +275,7 @@ public final class AceClawConfig {
         this.logLevel = DEFAULT_LOG_LEVEL;
         this.permissionMode = "normal";
         this.denySensitivePaths = false;
-        this.bootEnabled = DEFAULT_BOOT_ENABLED;
-        this.bootTimeoutSeconds = DEFAULT_BOOT_TIMEOUT_SECONDS;
-        this.schedulerEnabled = DEFAULT_SCHEDULER_ENABLED;
-        this.schedulerTickSeconds = DEFAULT_SCHEDULER_TICK_SECONDS;
-        this.heartbeatEnabled = DEFAULT_HEARTBEAT_ENABLED;
+        // boot/scheduler/heartbeat defaults seeded by DaemonLifecycleSettings.builder() (batch 5)
         this.plannerEnabled = DEFAULT_PLANNER_ENABLED;
         this.plannerThreshold = DEFAULT_PLANNER_THRESHOLD;
         this.adaptiveReplanEnabled = DEFAULT_ADAPTIVE_REPLAN_ENABLED;
@@ -292,8 +284,7 @@ public final class AceClawConfig {
         // skillAutoRelease defaults are seeded by SkillAutoReleaseSettings.builder()
         // at field-initialization time. 14 individual setter calls removed here.
         // Watchdog defaults seeded by WatchdogSettings.builder()
-        this.deferredActionEnabled = DEFAULT_DEFERRED_ACTION_ENABLED;
-        this.deferredActionTickSeconds = DEFAULT_DEFERRED_ACTION_TICK_SECONDS;
+        // deferredAction defaults seeded by DaemonLifecycleSettings.builder() (batch 5)
         this.webSocketEnabled = DEFAULT_WEBSOCKET_ENABLED;
         this.webSocketPort = DEFAULT_WEBSOCKET_PORT;
         this.webSocketHost = DEFAULT_WEBSOCKET_HOST;
@@ -795,51 +786,13 @@ public final class AceClawConfig {
     }
 
     /**
-     * Returns whether BOOT.md execution is enabled at daemon startup.
-     * Defaults to true.
+     * Returns the daemon lifecycle config — boot script, cron scheduler,
+     * heartbeat, and deferred-action scheduler gates + tick cadences (8
+     * scalars total). Batch 5 of the AceClawConfig decomposition; replaces
+     * 8 individual getters.
      */
-    public boolean bootEnabled() {
-        return bootEnabled;
-    }
-
-    /**
-     * Returns the maximum time in seconds for BOOT.md execution.
-     * Defaults to 120.
-     */
-    public int bootTimeoutSeconds() {
-        return bootTimeoutSeconds;
-    }
-
-    /**
-     * Returns whether the cron scheduler is enabled at daemon startup.
-     * Defaults to true.
-     */
-    public boolean schedulerEnabled() {
-        return schedulerEnabled;
-    }
-
-    /**
-     * Returns the cron scheduler tick interval in seconds.
-     * Defaults to 60.
-     */
-    public int schedulerTickSeconds() {
-        return schedulerTickSeconds;
-    }
-
-    /**
-     * Returns whether heartbeat tasks from HEARTBEAT.md are enabled.
-     * Defaults to true.
-     */
-    public boolean heartbeatEnabled() {
-        return heartbeatEnabled;
-    }
-
-    /**
-     * Returns the active hours window for heartbeat tasks in "HH:mm-HH:mm" format.
-     * Returns null if heartbeat tasks should always be active.
-     */
-    public String heartbeatActiveHours() {
-        return heartbeatActiveHours;
+    public DaemonLifecycleSettings lifecycle() {
+        return lifecycleBuilder.build();
     }
 
     /**
@@ -916,22 +869,6 @@ public final class AceClawConfig {
      */
     public SkillAutoReleaseSettings skillAutoRelease() {
         return skillAutoReleaseBuilder.build();
-    }
-
-    /**
-     * Returns whether the deferred action scheduler is enabled.
-     * Defaults to true.
-     */
-    public boolean deferredActionEnabled() {
-        return deferredActionEnabled;
-    }
-
-    /**
-     * Returns the deferred action scheduler tick interval in seconds.
-     * Defaults to 5.
-     */
-    public int deferredActionTickSeconds() {
-        return deferredActionTickSeconds;
     }
 
     /**
@@ -1263,26 +1200,18 @@ public final class AceClawConfig {
         if (fileConfig.permissionMode != null && !fileConfig.permissionMode.isBlank()) {
             this.permissionMode = fileConfig.permissionMode.toLowerCase();
         }
-        if (fileConfig.bootEnabled != null) {
-            this.bootEnabled = fileConfig.bootEnabled;
-        }
-        if (fileConfig.bootTimeoutSeconds > 0) {
-            this.bootTimeoutSeconds = fileConfig.bootTimeoutSeconds;
-        }
-        if (fileConfig.schedulerEnabled != null) {
-            this.schedulerEnabled = fileConfig.schedulerEnabled;
-        }
-        if (fileConfig.schedulerTickSeconds > 0) {
-            this.schedulerTickSeconds = fileConfig.schedulerTickSeconds;
-        }
-        if (fileConfig.heartbeatEnabled != null) {
-            this.heartbeatEnabled = fileConfig.heartbeatEnabled;
-        }
-        if (fileConfig.heartbeatActiveHours != null) {
-            // Blank value explicitly clears inherited activeHours (= always active)
-            this.heartbeatActiveHours = fileConfig.heartbeatActiveHours.isBlank()
-                    ? null : fileConfig.heartbeatActiveHours;
-        }
+        // -- Daemon lifecycle file overrides (batch 5) -----------------------
+        // Was 6 individual nullable/positive blocks (boot + scheduler +
+        // heartbeat halves of the lifecycle cluster). Setter contracts mirror
+        // the prior gates: bools skip null, int ticks require > 0, activeHours
+        // accepts null + treats blank as "clear" (always active).
+        lifecycleBuilder
+                .bootEnabled(fileConfig.bootEnabled)
+                .bootTimeoutSeconds(fileConfig.bootTimeoutSeconds)
+                .schedulerEnabled(fileConfig.schedulerEnabled)
+                .schedulerTickSeconds(fileConfig.schedulerTickSeconds)
+                .heartbeatEnabled(fileConfig.heartbeatEnabled)
+                .heartbeatActiveHours(fileConfig.heartbeatActiveHours);
         if (fileConfig.plannerEnabled != null) {
             this.plannerEnabled = fileConfig.plannerEnabled;
         }
@@ -1351,12 +1280,9 @@ public final class AceClawConfig {
                 .agentHardWallTimeSec(fileConfig.maxAgentHardWallTimeSec)
                 .planStepWallTimeSec(fileConfig.maxPlanStepWallTimeSec)
                 .planTotalWallTimeSec(fileConfig.maxPlanTotalWallTimeSec);
-        if (fileConfig.deferredActionEnabled != null) {
-            this.deferredActionEnabled = fileConfig.deferredActionEnabled;
-        }
-        if (fileConfig.deferredActionTickSeconds > 0) {
-            this.deferredActionTickSeconds = fileConfig.deferredActionTickSeconds;
-        }
+        lifecycleBuilder
+                .deferredActionEnabled(fileConfig.deferredActionEnabled)
+                .deferredActionTickSeconds(fileConfig.deferredActionTickSeconds);
         if (fileConfig.webSocket != null) {
             if (fileConfig.webSocket.enabled != null) {
                 this.webSocketEnabled = fileConfig.webSocket.enabled;

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -822,15 +822,16 @@ public final class AceClawDaemon {
         agentHandler.setDynamicSkillGenerator(dynamicSkillGenerator);
 
         // Wire deferred action scheduler (no turn lock dependency — uses isolated context)
-        if (config.deferredActionEnabled()) {
+        var lifecycle = config.lifecycle();
+        if (lifecycle.deferredActionEnabled()) {
             this.deferredActionScheduler = new DeferredActionScheduler(
                     deferredActionStore, sessionManager,
                     llmClient, toolRegistry, model, systemPrompt,
                     config.maxTokens(), config.thinkingBudget(),
-                    eventBus, config.deferredActionTickSeconds());
+                    eventBus, lifecycle.deferredActionTickSeconds());
             deferCheckTool.setScheduler(deferredActionScheduler);
             log.info("Deferred action scheduler wired (tick every {}s)",
-                    config.deferredActionTickSeconds());
+                    lifecycle.deferredActionTickSeconds());
         }
 
         agentHandler.register(router);
@@ -856,7 +857,7 @@ public final class AceClawDaemon {
         final var maintenanceAutoRelease = autoReleaseController;
         if (memoryStore != null) {
             learningMaintenanceScheduler = new LearningMaintenanceScheduler(
-                    LearningMaintenanceScheduler.Config.defaults(Duration.ofSeconds(config.schedulerTickSeconds())),
+                    LearningMaintenanceScheduler.Config.defaults(Duration.ofSeconds(lifecycle.schedulerTickSeconds())),
                     java.time.Clock.systemUTC(),
                     sessionManager::sessionCount,
                     scopes -> scopes.stream()
@@ -2438,7 +2439,8 @@ public final class AceClawDaemon {
         healthMonitor.start();
 
         // 3.5 Execute BOOT.md (best-effort, runs before accepting connections)
-        if (config.bootEnabled()) {
+        var lifecycle = config.lifecycle();
+        if (lifecycle.bootEnabled()) {
             try {
                 Path workingDir = Path.of(System.getProperty("user.dir"));
                 var bootResult = BootExecutor.execute(
@@ -2447,7 +2449,7 @@ public final class AceClawDaemon {
                         bootModel, bootSystemPrompt,
                         config.maxTokens(), config.thinkingBudget(),
                         config.maxTurns(),
-                        config.bootTimeoutSeconds());
+                        lifecycle.bootTimeoutSeconds());
                 if (bootResult.executed()) {
                     log.info("Boot completed: {}", bootResult.summary());
                 }
@@ -2527,13 +2529,13 @@ public final class AceClawDaemon {
         }
 
         // 5. Start cron scheduler (after listener is ready, jobs run in background)
-        if (config.schedulerEnabled()) {
+        if (lifecycle.schedulerEnabled()) {
             try {
                 cronScheduler = new CronScheduler(
                         cronJobStore, bootLlmClient, bootToolRegistry,
                         bootModel, bootSystemPrompt,
                         config.maxTokens(), config.thinkingBudget(),
-                        eventBus, config.schedulerTickSeconds());
+                        eventBus, lifecycle.schedulerTickSeconds());
                 // #459: dashboard sees a cron run as a session ("cron-{jobId}")
                 // with one turn per fire. The bridge ref is null when WS is
                 // disabled, in which case the scheduler falls back to the
@@ -2572,7 +2574,7 @@ public final class AceClawDaemon {
         }
 
         // 5.5. Start deferred action scheduler
-        if (config.deferredActionEnabled() && deferredActionScheduler != null) {
+        if (lifecycle.deferredActionEnabled() && deferredActionScheduler != null) {
             try {
                 deferredActionScheduler.start();
 
@@ -2584,17 +2586,17 @@ public final class AceClawDaemon {
             } catch (Exception e) {
                 log.error("Deferred action scheduler startup failed (daemon will continue): {}", e.getMessage(), e);
             }
-        } else if (!config.deferredActionEnabled()) {
+        } else if (!lifecycle.deferredActionEnabled()) {
             log.debug("Deferred action scheduler disabled via config");
         }
 
         // 6. Start heartbeat runner (after cron scheduler, syncs HEARTBEAT.md into cron jobs)
-        if (config.heartbeatEnabled() && cronScheduler != null) {
+        if (lifecycle.heartbeatEnabled() && cronScheduler != null) {
             try {
                 Path hbWorkingDir = Path.of(System.getProperty("user.dir"));
                 var heartbeatRunner = new HeartbeatRunner(
                         cronScheduler, homeDir, hbWorkingDir,
-                        config.heartbeatActiveHours(), config.schedulerTickSeconds());
+                        lifecycle.heartbeatActiveHours(), lifecycle.schedulerTickSeconds());
                 heartbeatRunner.start();
 
                 shutdownManager.register(new ShutdownManager.ShutdownParticipant() {
@@ -2605,7 +2607,7 @@ public final class AceClawDaemon {
             } catch (Exception e) {
                 log.error("Heartbeat runner startup failed (daemon will continue): {}", e.getMessage(), e);
             }
-        } else if (!config.heartbeatEnabled()) {
+        } else if (!lifecycle.heartbeatEnabled()) {
             log.debug("Heartbeat runner disabled via config");
         } else {
             log.debug("Heartbeat runner enabled but cron scheduler is disabled; skipping startup");

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/DaemonLifecycleSettings.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/DaemonLifecycleSettings.java
@@ -1,0 +1,128 @@
+package dev.aceclaw.daemon;
+
+/**
+ * Thematic config grouping for the daemon's per-subsystem lifecycle gates +
+ * tick cadences — the 8 small scalars that decide whether the boot script,
+ * cron scheduler, heartbeat tasks, and deferred-action scheduler run, and
+ * how often the tick-driven ones poll. Batch 5 of the AceClawConfig
+ * decomposition.
+ *
+ * <h3>Shape</h3>
+ *
+ * <ul>
+ *   <li><b>Boot</b>:
+ *     <ul>
+ *       <li>{@code bootEnabled} — run {@code BOOT.md} at daemon startup
+ *           (default true).</li>
+ *       <li>{@code bootTimeoutSeconds} — wall-clock cap on boot script
+ *           execution (default 120s).</li>
+ *     </ul>
+ *   </li>
+ *   <li><b>Cron scheduler</b>:
+ *     <ul>
+ *       <li>{@code schedulerEnabled} — start the cron scheduler at boot
+ *           (default true). The scheduler also feeds the heartbeat tasks
+ *           below — disabling it disables both.</li>
+ *       <li>{@code schedulerTickSeconds} — scheduler tick cadence
+ *           (default 60s).</li>
+ *     </ul>
+ *   </li>
+ *   <li><b>Heartbeat</b>:
+ *     <ul>
+ *       <li>{@code heartbeatEnabled} — run heartbeat tasks from
+ *           {@code HEARTBEAT.md} (default true). No-op if the cron
+ *           scheduler is disabled.</li>
+ *       <li>{@code heartbeatActiveHours} — optional {@code "HH:mm-HH:mm"}
+ *           window when heartbeat tasks may fire; {@code null} = always
+ *           active.</li>
+ *     </ul>
+ *   </li>
+ *   <li><b>Deferred-action scheduler</b>:
+ *     <ul>
+ *       <li>{@code deferredActionEnabled} — start the deferred-action
+ *           scheduler at boot (default true).</li>
+ *       <li>{@code deferredActionTickSeconds} — deferred-action tick
+ *           cadence (default 5s — much tighter than cron because deferred
+ *           actions are user-facing latency).</li>
+ *     </ul>
+ *   </li>
+ * </ul>
+ */
+public record DaemonLifecycleSettings(
+        boolean bootEnabled,
+        int bootTimeoutSeconds,
+        boolean schedulerEnabled,
+        int schedulerTickSeconds,
+        boolean heartbeatEnabled,
+        String heartbeatActiveHours,
+        boolean deferredActionEnabled,
+        int deferredActionTickSeconds) {
+
+    /** Defaults matched 1:1 to the prior {@code DEFAULT_BOOT_*} / {@code DEFAULT_SCHEDULER_*}
+     *  / {@code DEFAULT_HEARTBEAT_*} / {@code DEFAULT_DEFERRED_ACTION_*} constants. */
+    public static DaemonLifecycleSettings defaults() {
+        return new DaemonLifecycleSettings(
+                true,    // bootEnabled
+                120,     // bootTimeoutSeconds
+                true,    // schedulerEnabled
+                60,      // schedulerTickSeconds
+                true,    // heartbeatEnabled
+                null,    // heartbeatActiveHours — null = always active
+                true,    // deferredActionEnabled
+                5        // deferredActionTickSeconds
+        );
+    }
+
+    /** Fresh builder pre-loaded with {@link #defaults()}. */
+    static Builder builder() {
+        return new Builder(defaults());
+    }
+
+    static final class Builder {
+        private boolean bootEnabled;
+        private int bootTimeoutSeconds;
+        private boolean schedulerEnabled;
+        private int schedulerTickSeconds;
+        private boolean heartbeatEnabled;
+        private String heartbeatActiveHours;
+        private boolean deferredActionEnabled;
+        private int deferredActionTickSeconds;
+
+        Builder(DaemonLifecycleSettings seed) {
+            java.util.Objects.requireNonNull(seed, "seed");
+            this.bootEnabled = seed.bootEnabled();
+            this.bootTimeoutSeconds = seed.bootTimeoutSeconds();
+            this.schedulerEnabled = seed.schedulerEnabled();
+            this.schedulerTickSeconds = seed.schedulerTickSeconds();
+            this.heartbeatEnabled = seed.heartbeatEnabled();
+            this.heartbeatActiveHours = seed.heartbeatActiveHours();
+            this.deferredActionEnabled = seed.deferredActionEnabled();
+            this.deferredActionTickSeconds = seed.deferredActionTickSeconds();
+        }
+
+        // Pre-decomp file-merge gates were:
+        //   bool flags:   if (fileConfig.xxx != null)
+        //   int ticks:    if (fileConfig.xxx > 0)          (>0, not >=0 — 0 was treated as "unset")
+        //   activeHours:  if (s != null) set (blank → null)
+        // Preserved here so the builder contract matches observable behaviour.
+        Builder bootEnabled(Boolean v) { if (v != null) this.bootEnabled = v; return this; }
+        Builder bootTimeoutSeconds(int v) { if (v > 0) this.bootTimeoutSeconds = v; return this; }
+        Builder schedulerEnabled(Boolean v) { if (v != null) this.schedulerEnabled = v; return this; }
+        Builder schedulerTickSeconds(int v) { if (v > 0) this.schedulerTickSeconds = v; return this; }
+        Builder heartbeatEnabled(Boolean v) { if (v != null) this.heartbeatEnabled = v; return this; }
+        Builder heartbeatActiveHours(String v) {
+            if (v != null) this.heartbeatActiveHours = v.isBlank() ? null : v;
+            return this;
+        }
+        Builder deferredActionEnabled(Boolean v) { if (v != null) this.deferredActionEnabled = v; return this; }
+        Builder deferredActionTickSeconds(int v) { if (v > 0) this.deferredActionTickSeconds = v; return this; }
+
+        DaemonLifecycleSettings build() {
+            return new DaemonLifecycleSettings(
+                    bootEnabled, bootTimeoutSeconds,
+                    schedulerEnabled, schedulerTickSeconds,
+                    heartbeatEnabled, heartbeatActiveHours,
+                    deferredActionEnabled, deferredActionTickSeconds);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Batch 5 of the AceClawConfig god-class decomposition (after #506, #507, #508, #509). Bundles 8 small daemon-lifecycle scalars into one `DaemonLifecycleSettings` record + Builder, matching the pattern of the prior batches.

**Fields collapsed** (boot + cron scheduler + heartbeat + deferred-action gates and tick cadences):

| Old getter | New |
|---|---|
| `config.bootEnabled()` | `config.lifecycle().bootEnabled()` |
| `config.bootTimeoutSeconds()` | `config.lifecycle().bootTimeoutSeconds()` |
| `config.schedulerEnabled()` | `config.lifecycle().schedulerEnabled()` |
| `config.schedulerTickSeconds()` | `config.lifecycle().schedulerTickSeconds()` |
| `config.heartbeatEnabled()` | `config.lifecycle().heartbeatEnabled()` |
| `config.heartbeatActiveHours()` | `config.lifecycle().heartbeatActiveHours()` |
| `config.deferredActionEnabled()` | `config.lifecycle().deferredActionEnabled()` |
| `config.deferredActionTickSeconds()` | `config.lifecycle().deferredActionTickSeconds()` |

**Behavior preservation**

- Setter contracts mirror the prior file-merge gates: booleans skip on `null`, int ticks require `> 0` (zero was treated as "unset" pre-decomp), `heartbeatActiveHours` accepts `null` and treats blank as "clear" (always active).
- All 8 defaults unchanged: `bootEnabled=true / 120s`, `schedulerEnabled=true / 60s tick`, `heartbeatEnabled=true / null window`, `deferredActionEnabled=true / 5s tick`.
- No env vars touched (none of these 8 ever had env-var overrides).
- `Objects.requireNonNull(seed, "seed")` on the Builder constructor per the convention established in batch 4.

**LoC**

- `AceClawConfig.java`: 1601 → 1527 (-74)
- Cumulative decomp (batches 1-5): **2038 → 1527 LoC (-25%)**

**Daemon call sites migrated**

13 references in `AceClawDaemon.java` (boot exec block, deferred scheduler wiring, cron scheduler startup, heartbeat runner, learning-maintenance scheduler tick). Each section binds a local `var lifecycle = config.lifecycle();` once and reads from it.

## Test plan

- [x] `./gradlew -Pno-dashboard :aceclaw-daemon:test --tests AceClawConfigTest` — passes
- [x] Full `:aceclaw-daemon:test` — only `testAdaptiveReplan_revisesAndCompletes` fails, **also fails on main** (pre-existing flake, unrelated)
- [x] Cross-module compile (`./gradlew compileJava compileTestJava`) — clean
- [x] No stale references to old getters anywhere in main or test sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)
