### PR TITLE
refactor(daemon): migrate retry config to Builder (batch 6, final)

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawConfig.java
@@ -249,10 +249,14 @@ public final class AceClawConfig {
     private Map<String, List<HookMatcherFormat>> hooks;
     private boolean context1m;
     private List<String> extraAnthropicBetas;
-    private int retryMaxRetries;
-    private long retryInitialBackoffMs;
-    private long retryMaxBackoffMs;
-    private double retryJitterFactor;
+    /**
+     * Retry config — was 4 individual scalar fields, now held in a single
+     * builder that produces the consumer-side {@link dev.aceclaw.core.agent.RetryConfig}
+     * record on demand (batch 6 of the AceClawConfig decomposition). No new
+     * "Settings" wrapper because {@code RetryConfig} already covers the
+     * shape — consumers calling {@link #retryConfig()} see no API change.
+     */
+    private final RetryConfigBuilder retryBuilder = new RetryConfigBuilder();
 
     /**
      * Returns a default-valued config without touching {@code ~/.aceclaw/config.json}
@@ -293,10 +297,7 @@ public final class AceClawConfig {
         this.providerModels = new java.util.HashMap<>();
         this.context1m = DEFAULT_CONTEXT_1M;
         this.extraAnthropicBetas = List.of();
-        this.retryMaxRetries = (int) dev.aceclaw.core.agent.RetryConfig.DEFAULT.maxRetries();
-        this.retryInitialBackoffMs = dev.aceclaw.core.agent.RetryConfig.DEFAULT.initialBackoffMs();
-        this.retryMaxBackoffMs = dev.aceclaw.core.agent.RetryConfig.DEFAULT.maxBackoffMs();
-        this.retryJitterFactor = dev.aceclaw.core.agent.RetryConfig.DEFAULT.jitterFactor();
+        // retry defaults seeded by RetryConfigBuilder (batch 6)
     }
 
     /**
@@ -985,8 +986,7 @@ public final class AceClawConfig {
      * Returns the retry configuration assembled from config fields.
      */
     public dev.aceclaw.core.agent.RetryConfig retryConfig() {
-        return new dev.aceclaw.core.agent.RetryConfig(
-                retryMaxRetries, retryInitialBackoffMs, retryMaxBackoffMs, retryJitterFactor);
+        return retryBuilder.build();
     }
 
     /**
@@ -1323,20 +1323,15 @@ public final class AceClawConfig {
                     .filter(b -> b != null && !b.isBlank())
                     .toList();
         }
+        // -- Retry file overrides (batch 6) ----------------------------------
+        // Was 13 lines of nested null-and-range-check ifs. Builder setters
+        // bake in the same gates (null skipped + out-of-range silently kept).
         if (fileConfig.retry != null) {
-            if (fileConfig.retry.maxRetries != null && fileConfig.retry.maxRetries >= 0) {
-                this.retryMaxRetries = fileConfig.retry.maxRetries;
-            }
-            if (fileConfig.retry.initialBackoffMs != null && fileConfig.retry.initialBackoffMs >= 0) {
-                this.retryInitialBackoffMs = fileConfig.retry.initialBackoffMs;
-            }
-            if (fileConfig.retry.maxBackoffMs != null && fileConfig.retry.maxBackoffMs >= 0) {
-                this.retryMaxBackoffMs = fileConfig.retry.maxBackoffMs;
-            }
-            if (fileConfig.retry.jitterFactor != null
-                    && fileConfig.retry.jitterFactor >= 0.0 && fileConfig.retry.jitterFactor <= 1.0) {
-                this.retryJitterFactor = fileConfig.retry.jitterFactor;
-            }
+            retryBuilder
+                    .maxRetries(fileConfig.retry.maxRetries)
+                    .initialBackoffMs(fileConfig.retry.initialBackoffMs)
+                    .maxBackoffMs(fileConfig.retry.maxBackoffMs)
+                    .jitterFactor(fileConfig.retry.jitterFactor);
         }
         if (fileConfig.subAgentAutoApproveTools != null && !fileConfig.subAgentAutoApproveTools.isEmpty()) {
             // Project config appends to global config (not replaces)

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/RetryConfigBuilder.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/RetryConfigBuilder.java
@@ -1,0 +1,63 @@
+package dev.aceclaw.daemon;
+
+import dev.aceclaw.core.agent.RetryConfig;
+
+/**
+ * Mutable builder used by {@code AceClawConfig} to accumulate retry-config
+ * overrides during {@code load()}. Produces an immutable
+ * {@link RetryConfig} (the consumer-side record in {@code aceclaw-core}).
+ *
+ * <p>Batch 6 of the AceClawConfig decomposition. Unlike batches 1-5 there is
+ * no new "Settings" wrapper record — {@link RetryConfig} already covers it,
+ * and consumers (already going through {@code config.retryConfig()}) see no
+ * API change. This class only replaces the 4 flat retry fields + 4 ctor
+ * inits + 13-line file-merge block in {@code AceClawConfig} with a single
+ * builder pattern matching the other clusters.
+ *
+ * <p>Setters accept {@code null} as "leave previous value alone" and also
+ * skip out-of-range values (preserving the pre-decomp {@code if (x != null
+ * && x >= 0)} gates — invalid values silently keep the current default
+ * rather than throw, so a typo in {@code config.json} doesn't crash
+ * daemon startup).
+ */
+final class RetryConfigBuilder {
+    private int maxRetries;
+    private long initialBackoffMs;
+    private long maxBackoffMs;
+    private double jitterFactor;
+
+    RetryConfigBuilder() {
+        this(RetryConfig.DEFAULT);
+    }
+
+    RetryConfigBuilder(RetryConfig seed) {
+        java.util.Objects.requireNonNull(seed, "seed");
+        this.maxRetries = seed.maxRetries();
+        this.initialBackoffMs = seed.initialBackoffMs();
+        this.maxBackoffMs = seed.maxBackoffMs();
+        this.jitterFactor = seed.jitterFactor();
+    }
+
+    // Pre-decomp file-merge gates (verbatim): null skipped + range-checked;
+    // out-of-range silently leaves the current value (no clamp, no throw).
+    RetryConfigBuilder maxRetries(Integer v) {
+        if (v != null && v >= 0) this.maxRetries = v;
+        return this;
+    }
+    RetryConfigBuilder initialBackoffMs(Long v) {
+        if (v != null && v >= 0) this.initialBackoffMs = v;
+        return this;
+    }
+    RetryConfigBuilder maxBackoffMs(Long v) {
+        if (v != null && v >= 0) this.maxBackoffMs = v;
+        return this;
+    }
+    RetryConfigBuilder jitterFactor(Double v) {
+        if (v != null && v >= 0.0 && v <= 1.0) this.jitterFactor = v;
+        return this;
+    }
+
+    RetryConfig build() {
+        return new RetryConfig(maxRetries, initialBackoffMs, maxBackoffMs, jitterFactor);
+    }
+}

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/AceClawConfigTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/AceClawConfigTest.java
@@ -295,4 +295,90 @@ class AceClawConfigTest {
                 .as("total plan budget default")
                 .isEqualTo(3600);
     }
+
+    // -- Retry config (batch 6) -----------------------------------------------
+
+    @Test
+    void retryDefaultsMatchRetryConfigDEFAULT(@TempDir Path tempDir) throws Exception {
+        var projectConfig = tempDir.resolve(".aceclaw").resolve("config.json");
+        Files.createDirectories(projectConfig.getParent());
+        Files.writeString(projectConfig, "{}");
+
+        var config = AceClawConfig.load(tempDir, null);
+
+        assertThat(config.retryConfig())
+                .as("empty config must yield RetryConfig.DEFAULT verbatim")
+                .isEqualTo(dev.aceclaw.core.agent.RetryConfig.DEFAULT);
+    }
+
+    @Test
+    void retryFileOverrideAppliesAllFourFields(@TempDir Path tempDir) throws Exception {
+        var projectConfig = tempDir.resolve(".aceclaw").resolve("config.json");
+        Files.createDirectories(projectConfig.getParent());
+        Files.writeString(projectConfig, """
+                {
+                  "retry": {
+                    "maxRetries": 7,
+                    "initialBackoffMs": 250,
+                    "maxBackoffMs": 30000,
+                    "jitterFactor": 0.5
+                  }
+                }
+                """);
+
+        var config = AceClawConfig.load(tempDir, null);
+
+        var retry = config.retryConfig();
+        assertThat(retry.maxRetries()).isEqualTo(7);
+        assertThat(retry.initialBackoffMs()).isEqualTo(250L);
+        assertThat(retry.maxBackoffMs()).isEqualTo(30_000L);
+        assertThat(retry.jitterFactor()).isEqualTo(0.5);
+    }
+
+    @Test
+    void retryInvalidValuesSilentlyKeepDefaults(@TempDir Path tempDir) throws Exception {
+        // Pre-decomp contract preserved: out-of-range values are silently
+        // skipped (not thrown/clamped). A typo in config.json must not crash
+        // daemon startup; valid sibling fields still apply.
+        var projectConfig = tempDir.resolve(".aceclaw").resolve("config.json");
+        Files.createDirectories(projectConfig.getParent());
+        Files.writeString(projectConfig, """
+                {
+                  "retry": {
+                    "maxRetries": -1,
+                    "initialBackoffMs": -100,
+                    "maxBackoffMs": -1,
+                    "jitterFactor": 1.5
+                  }
+                }
+                """);
+
+        var config = AceClawConfig.load(tempDir, null);
+
+        assertThat(config.retryConfig())
+                .as("all-invalid retry block must leave RetryConfig.DEFAULT unmodified")
+                .isEqualTo(dev.aceclaw.core.agent.RetryConfig.DEFAULT);
+    }
+
+    @Test
+    void retryPartialOverrideKeepsUnsetFieldsAtDefault(@TempDir Path tempDir) throws Exception {
+        var projectConfig = tempDir.resolve(".aceclaw").resolve("config.json");
+        Files.createDirectories(projectConfig.getParent());
+        Files.writeString(projectConfig, """
+                {
+                  "retry": {
+                    "jitterFactor": 0.0
+                  }
+                }
+                """);
+
+        var config = AceClawConfig.load(tempDir, null);
+
+        var retry = config.retryConfig();
+        var def = dev.aceclaw.core.agent.RetryConfig.DEFAULT;
+        assertThat(retry.maxRetries()).isEqualTo(def.maxRetries());
+        assertThat(retry.initialBackoffMs()).isEqualTo(def.initialBackoffMs());
+        assertThat(retry.maxBackoffMs()).isEqualTo(def.maxBackoffMs());
+        assertThat(retry.jitterFactor()).isEqualTo(0.0);
+    }
 }


### PR DESCRIPTION
## Summary

Batch 6 — final batch of the AceClawConfig god-class decomposition (after #506, #507, #508, #509, #510). Internal-only storage migration for the retry cluster.

**Special shape**: unlike batches 1-5 there's **no new "Settings" wrapper record** — `dev.aceclaw.core.agent.RetryConfig` (in `aceclaw-core`) already covers it, and consumers already go through `config.retryConfig()` which returns that record. So this batch only collapses the 4 flat fields + 4 ctor inits + 13-line file-merge if-block in `AceClawConfig` into a single `RetryConfigBuilder` that produces the same `RetryConfig`. **Zero consumer-side change.**

| | Before | After |
|---|---|---|
| `AceClawConfig` flat fields | `int retryMaxRetries; long retryInitialBackoffMs; long retryMaxBackoffMs; double retryJitterFactor;` | `private final RetryConfigBuilder retryBuilder = new RetryConfigBuilder();` |
| ctor inits | 4 lines (each calls `RetryConfig.DEFAULT.fieldName()`) | seeded by builder |
| file-merge | 13-line nested if/range-check block | 5-line fluent chain |
| `retryConfig()` body | `new RetryConfig(4 args)` | `retryBuilder.build()` |

**Behavior preservation** — pre-decomp gates were `if (x != null && x >= 0)` (and `[0.0, 1.0]` for jitter); builder setters apply **exactly the same** range checks. Out-of-range values are silently skipped (no throw, no clamp), so a typo in `config.json` doesn't crash daemon startup. This contract is locked in by the new tests below.

## Test coverage (was 0 retry tests before this PR)

4 new tests in `AceClawConfigTest`:

1. **`retryDefaultsMatchRetryConfigDEFAULT`** — empty `config.json` ⇒ `RetryConfig.DEFAULT` verbatim.
2. **`retryFileOverrideAppliesAllFourFields`** — happy path; all 4 fields applied.
3. **`retryInvalidValuesSilentlyKeepDefaults`** — `maxRetries: -1`, `initialBackoffMs: -100`, `maxBackoffMs: -1`, `jitterFactor: 1.5` all skip silently; result == `DEFAULT`. Guards against a regression where a misconfigured file would either throw or be clamped.
4. **`retryPartialOverrideKeepsUnsetFieldsAtDefault`** — overriding only `jitterFactor` leaves the other three at `DEFAULT`. Guards against a regression where the builder accidentally resets unspecified fields.

Local run: 35/35 pass across `AceClawConfigTest` + `AceClawConfigPersistenceTest` + `AceClawDaemonAuditWiringTest` + `BootExecutorTest` + `CronSchedulerTest` + `DeferredActionSchedulerTest` + `HeartbeatRunnerTest`.

## LoC

- `AceClawConfig.java`: 1527 → 1522 (-5; smallest batch, internal-only storage shift)
- **Cumulative decomp (batches 1-6): 2038 → 1522 LoC (-25.3%)**

## Test plan

- [x] New tests: 4/4 pass locally
- [x] All lifecycle/config-touched classes pass
- [ ] CI green on full suite
- [x] `retryConfig()` consumer API unchanged — no caller migration needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal retry configuration handling for improved code organization.

* **Tests**
  * Expanded test coverage for retry configuration parsing, validation, and default behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xinhuagu/AceClaw/pull/511?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->