### PR TITLE
fix(daemon): attribute auto-promotion audit records to candidate's workspace

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -737,13 +737,18 @@ public final class AceClawDaemon {
                                             summary.createdDrafts(), summary.skippedDrafts());
                                 }
                             }
-                            // Validate drafts and evaluate for auto-release
+                            // Validate drafts and evaluate for auto-release.
+                            // Use projectPath (the candidate's own workspace) for the publish calls,
+                            // not the daemon-startup workingDir. They can differ when a candidate
+                            // promotion fires for a workspace other than the one the daemon was
+                            // launched in; attributing audit/feed records to workingDir there
+                            // would write them under the wrong workspace.
                             if (validationGateForAuto != null) {
                                 var validation = validationGateForAuto.validateAll(projectPath, "auto-promotion");
-                                skillDraftEventPublisher.publishValidationChanged(validation, workingDir, "auto-promotion");
+                                skillDraftEventPublisher.publishValidationChanged(validation, projectPath, "auto-promotion");
                                 if (autoReleaseForAuto != null && candidateStoreForAuto != null) {
                                     var release = autoReleaseForAuto.evaluateAll(projectPath, candidateStoreForAuto, "auto-promotion");
-                                    skillDraftEventPublisher.publishReleaseChanged(release, workingDir, "auto-promotion");
+                                    skillDraftEventPublisher.publishReleaseChanged(release, projectPath, "auto-promotion");
                                 }
                             }
                         } catch (Exception e) {


### PR DESCRIPTION
## Summary

Follow-up to [#512](https://github.com/xinhuagu/AceClaw/pull/512). Fixes a pre-existing bug that CodeRabbit caught during the `SkillDraftEventPublisher` extraction review — that PR's scope was extract-method only (1:1 behavior preservation), so the fix lives here.

## The bug

In the candidate-promotion callback inside `wireAgentHandler`, the validate / evaluate calls operate on `projectPath` (the candidate's own workspace, passed in via the callback parameter), but the downstream publish calls were passing the daemon-startup `workingDir` instead:

```java
var validation = validationGateForAuto.validateAll(projectPath, "auto-promotion");
skillDraftEventPublisher.publishValidationChanged(validation, workingDir, "auto-promotion"); // wrong
```

When the two paths differ — a candidate promotion fires for a workspace other than the one the daemon was launched in — `LearningValidationRecorder` and `SkillDraftEventFeed` got the audit records attributed to the wrong workspace. So the per-workspace audit log and dashboard event stream both missed the entries for the actual project.

## Why it survived this long

The bug only bites when `projectPath != workingDir`. Local dev and the integration tests both run the daemon from the project they're working on (so they're equal), and the auto-promotion path is fairly cold. CodeRabbit caught it by reading the code, not by a failing test.

## Scope

Only the auto-promotion callback was wrong. Sister paths (`startup-catchup`, `draft-generated`, and all the RPC handlers) were already consistent — verified by grepping every `validateAll(...) + publishValidationChanged(...)` pair and every `evaluateAll(...) + publishReleaseChanged(...)` pair.

## Test plan

- [x] Compile clean
- [x] Smoke tests pass (38/0 across skill + config + audit-wiring)
- [ ] CI green
- [ ] Writing an integration test that exercises `projectPath != workingDir` would require pretty deep `wireAgentHandler` mocking — deferring until that path gets covered by the daemon-decomp batches later in the series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved incorrect attribution in the auto-promotion pipeline when promoting candidates across workspaces. Validation and release events now reference the candidate's project path so audit/feed records and operational tracking reflect the correct workspace.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xinhuagu/AceClaw/pull/513?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->