### PR TITLE
feat(daemon): explicit /continue command + turn-checkpoint routing (#501)

### DIFF
--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/AceClawDaemon.java
@@ -652,6 +652,7 @@ public final class AceClawDaemon {
         var turnCheckpointStore = new FileTurnCheckpointStore(
                 homeDir.resolve("checkpoints").resolve("turns"), objectMapper);
         turnCheckpointStore.cleanup(7); // sweep orphans + stale files on startup
+        agentHandler.setTurnCheckpointStore(turnCheckpointStore);
         agentHandler.setTurnCheckpointSink(new FileTurnCheckpointSink(turnCheckpointStore));
 
         agentHandler.setCompactor(compactor);

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/CancelAwareStreamContext.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/CancelAwareStreamContext.java
@@ -414,8 +414,14 @@ final class CancelAwareStreamContext implements StreamContext {
                                 } else {
                                     log.warn("Cancel monitor: permission.response missing requestId, dropping message");
                                 }
-                            } else if ("resume.response".equals(method)) {
-                                log.debug("Cancel monitor: routing resume.response to fallback");
+                            } else if ("resume.response".equals(method)
+                                    || "resume.choice_response".equals(method)) {
+                                // resume.choice_response added for #501 — explicit /continue
+                                // surfaces a numbered choice when both plan + turn checkpoints
+                                // resume. Without this branch the monitor silently dropped the
+                                // client's pick and offerResumeChoicesAndWaitForResponse hung
+                                // for the full 30s timeout under the per-session turnLock.
+                                log.debug("Cancel monitor: routing {} to fallback", method);
                                 unmatchedResponses.offer(message);
                             } else {
                                 log.debug("Cancel monitor: ignoring '{}'", method);

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/Resumable.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/Resumable.java
@@ -1,0 +1,34 @@
+package dev.aceclaw.daemon;
+
+import dev.aceclaw.core.planner.PlanCheckpoint;
+import dev.aceclaw.core.planner.TurnCheckpoint;
+
+/**
+ * A resumable execution slice returned by {@link ResumeRouter}. Either a
+ * mid-flight {@link PlanCheckpoint} (multi-step plan that hadn't finished)
+ * or a {@link TurnCheckpoint} (single ReAct turn that hadn't finished).
+ *
+ * <p>Sealed so the handler's resume code can switch exhaustively — the
+ * compiler enforces both branches are handled when new resume types are
+ * added (none planned, but the type makes the intent explicit).
+ */
+public sealed interface Resumable {
+
+    /** Plan-level resume: pick up an in-progress {@code TaskPlan}. */
+    record OfPlan(PlanCheckpoint checkpoint) implements Resumable {
+        public OfPlan {
+            if (checkpoint == null) {
+                throw new IllegalArgumentException("checkpoint");
+            }
+        }
+    }
+
+    /** Turn-level resume: pick up an in-progress ReAct turn. */
+    record OfTurn(TurnCheckpoint checkpoint) implements Resumable {
+        public OfTurn {
+            if (checkpoint == null) {
+                throw new IllegalArgumentException("checkpoint");
+            }
+        }
+    }
+}

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/ResumeRouter.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/ResumeRouter.java
@@ -3,26 +3,37 @@ package dev.aceclaw.daemon;
 import dev.aceclaw.core.planner.PlanCheckpoint;
 import dev.aceclaw.core.planner.PlanCheckpoint.CheckpointStatus;
 import dev.aceclaw.core.planner.PlanCheckpointStore;
+import dev.aceclaw.core.planner.TurnCheckpoint;
+import dev.aceclaw.core.planner.TurnCheckpointStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HexFormat;
+import java.util.List;
 import java.util.Objects;
 
 /**
- * Detects resumable plan checkpoints and routes resume decisions.
+ * Detects resumable checkpoints and routes resume decisions across both plan
+ * and turn checkpoint stores.
  *
- * <p>Routing priority:
+ * <p>Routing priority (highest first):
  * <ol>
- *   <li>Same session ID (exact match, most recent)</li>
- *   <li>Same workspace hash (cross-session resume, most recent)</li>
+ *   <li>Plan checkpoint with same {@code sessionId} (exact match, most recent)</li>
+ *   <li>Plan checkpoint with same {@code workspaceHash} (cross-session resume)</li>
+ *   <li>Turn checkpoint with same {@code sessionId} (issue #501)</li>
+ *   <li>Turn checkpoint with same {@code workspaceHash} (issue #501)</li>
  * </ol>
  *
  * <p>Never auto-resumes across workspaces.
+ *
+ * <p>Backward compatibility: callers that only care about plan-level resume can
+ * construct with {@code new ResumeRouter(planStore)} and the turn-tier lookup
+ * is skipped entirely (turn store treated as absent).
  */
 public final class ResumeRouter {
 
@@ -30,36 +41,55 @@ public final class ResumeRouter {
 
     private static final Logger log = LoggerFactory.getLogger(ResumeRouter.class);
 
-    private final PlanCheckpointStore checkpointStore;
+    private final PlanCheckpointStore planStore;
+    private final TurnCheckpointStore turnStore; // nullable — older callers may pass plan-only
 
-    public ResumeRouter(PlanCheckpointStore checkpointStore) {
-        this.checkpointStore = Objects.requireNonNull(checkpointStore, "checkpointStore");
+    public ResumeRouter(PlanCheckpointStore planStore) {
+        this(planStore, null);
+    }
+
+    public ResumeRouter(PlanCheckpointStore planStore, TurnCheckpointStore turnStore) {
+        this.planStore = Objects.requireNonNull(planStore, "planStore");
+        this.turnStore = turnStore;
     }
 
     /**
      * Result of a resume routing decision.
      *
-     * @param checkpoint the best matching checkpoint (null if none)
-     * @param route      routing scope: "session", "workspace", or "none"
-     * @param ambiguous  true if multiple candidates exist at the same priority level
+     * @param resumable the best matching resumable (null if none)
+     * @param route     routing scope: {@code "session"}, {@code "workspace"} (plan tiers),
+     *                  {@code "turn_session"}, {@code "turn_workspace"}, or {@code "none"}.
+     *                  Plan tiers retain their old labels for wire-format compatibility
+     *                  with {@code resume.detected} notifications.
+     * @param ambiguous true if multiple candidates exist at the same priority level
      */
     public record RouteDecision(
-            PlanCheckpoint checkpoint,
+            Resumable resumable,
             String route,
             boolean ambiguous
     ) {
-        /** Returns true if a resumable checkpoint was found. */
+        public RouteDecision {
+            Objects.requireNonNull(route, "route");
+        }
+
+        /** Returns true if a resumable was found at any priority tier. */
         public boolean hasCheckpoint() {
-            return checkpoint != null;
+            return resumable != null;
+        }
+
+        /**
+         * Convenience accessor: returns the plan checkpoint if the resumable is a
+         * plan, otherwise null. Kept for callers (and tests) written before the
+         * turn-tier extension.
+         */
+        public PlanCheckpoint checkpoint() {
+            return resumable instanceof Resumable.OfPlan p ? p.checkpoint() : null;
         }
     }
 
     /**
-     * Finds the best resumable checkpoint for the given session and workspace.
-     *
-     * @param sessionId     the current session ID
-     * @param workspacePath the project path for workspace hash computation
-     * @return routing decision with the best checkpoint, or empty decision if none found
+     * Finds the highest-priority resumable checkpoint for the given session and
+     * workspace, applying the 4-tier priority above.
      */
     public RouteDecision route(String sessionId, Path workspacePath) {
         Objects.requireNonNull(sessionId, "sessionId");
@@ -67,35 +97,90 @@ public final class ResumeRouter {
 
         String wsHash = hashWorkspace(workspacePath);
 
-        // Priority 1: same session
-        var bySession = checkpointStore.findBySession(sessionId).stream()
-                .filter(c -> isResumable(c.status()))
-                .filter(PlanCheckpoint::hasRemainingSteps)
-                .sorted(recencyComparator())
-                .toList();
-        if (!bySession.isEmpty()) {
-            boolean ambiguous = bySession.size() > 1;
-            log.info("Resume route: session match, planId={}, ambiguous={}",
-                    bySession.getFirst().planId(), ambiguous);
-            return new RouteDecision(bySession.getFirst(), "session", ambiguous);
+        // Priority 1: plan / same session
+        var planSession = candidatePlans(planStore.findBySession(sessionId));
+        if (!planSession.isEmpty()) {
+            boolean ambiguous = planSession.size() > 1;
+            log.info("Resume route: plan/session match, planId={}, ambiguous={}",
+                    planSession.getFirst().planId(), ambiguous);
+            return new RouteDecision(
+                    new Resumable.OfPlan(planSession.getFirst()), "session", ambiguous);
         }
 
-        // Priority 2: same workspace (cross-session)
-        var byWorkspace = checkpointStore.findResumable(wsHash).stream()
-                .filter(c -> isResumable(c.status()))
-                .filter(PlanCheckpoint::hasRemainingSteps)
-                .sorted(recencyComparator())
-                .toList();
-        if (!byWorkspace.isEmpty()) {
-            boolean ambiguous = byWorkspace.size() > 1;
-            log.info("Resume route: workspace match, planId={}, ambiguous={}",
-                    byWorkspace.getFirst().planId(), ambiguous);
-            return new RouteDecision(byWorkspace.getFirst(), "workspace", ambiguous);
+        // Priority 2: plan / same workspace
+        var planWorkspace = candidatePlans(planStore.findResumable(wsHash));
+        if (!planWorkspace.isEmpty()) {
+            boolean ambiguous = planWorkspace.size() > 1;
+            log.info("Resume route: plan/workspace match, planId={}, ambiguous={}",
+                    planWorkspace.getFirst().planId(), ambiguous);
+            return new RouteDecision(
+                    new Resumable.OfPlan(planWorkspace.getFirst()), "workspace", ambiguous);
+        }
+
+        // Priority 3: turn / same session
+        if (turnStore != null) {
+            var turnSession = candidateTurns(turnStore.findBySession(sessionId));
+            if (!turnSession.isEmpty()) {
+                boolean ambiguous = turnSession.size() > 1;
+                log.info("Resume route: turn/session match, turnId={}, ambiguous={}",
+                        turnSession.getFirst().turnId(), ambiguous);
+                return new RouteDecision(
+                        new Resumable.OfTurn(turnSession.getFirst()), "turn_session", ambiguous);
+            }
+
+            // Priority 4: turn / same workspace
+            var turnWorkspace = candidateTurns(turnStore.findResumable(wsHash));
+            if (!turnWorkspace.isEmpty()) {
+                boolean ambiguous = turnWorkspace.size() > 1;
+                log.info("Resume route: turn/workspace match, turnId={}, ambiguous={}",
+                        turnWorkspace.getFirst().turnId(), ambiguous);
+                return new RouteDecision(
+                        new Resumable.OfTurn(turnWorkspace.getFirst()), "turn_workspace", ambiguous);
+            }
         }
 
         log.debug("Resume route: no resumable checkpoint found for session={}, workspace={}",
                 sessionId, wsHash.substring(0, Math.min(8, wsHash.length())));
         return new RouteDecision(null, "none", false);
+    }
+
+    /**
+     * Returns up to two resumables — the best plan-tier match (if any) and the
+     * best turn-tier match (if any) — for surfacing as a numbered choice when
+     * both coexist in the same workspace (issue #501).
+     *
+     * <p>The list is empty when there's nothing to resume, length 1 when only
+     * one type matches (caller may resume directly without prompting), and
+     * length 2 when both types match (caller fans out a {@code resume.choices}
+     * notification).
+     */
+    public List<Resumable> findAllResumable(String sessionId, Path workspacePath) {
+        Objects.requireNonNull(sessionId, "sessionId");
+        Objects.requireNonNull(workspacePath, "workspacePath");
+
+        String wsHash = hashWorkspace(workspacePath);
+        var out = new ArrayList<Resumable>(2);
+
+        // Best plan: session beats workspace (mirrors route() priority within tier)
+        PlanCheckpoint plan = bestOf(candidatePlans(planStore.findBySession(sessionId)));
+        if (plan == null) {
+            plan = bestOf(candidatePlans(planStore.findResumable(wsHash)));
+        }
+        if (plan != null) {
+            out.add(new Resumable.OfPlan(plan));
+        }
+
+        // Best turn: same intra-tier priority
+        if (turnStore != null) {
+            TurnCheckpoint turn = bestOfTurn(candidateTurns(turnStore.findBySession(sessionId)));
+            if (turn == null) {
+                turn = bestOfTurn(candidateTurns(turnStore.findResumable(wsHash)));
+            }
+            if (turn != null) {
+                out.add(new Resumable.OfTurn(turn));
+            }
+        }
+        return out;
     }
 
     /**
@@ -192,6 +277,80 @@ public final class ResumeRouter {
     }
 
     /**
+     * Builds a turn-level resume context prompt — analogous to
+     * {@link #buildResumePrompt(PlanCheckpoint)} but for single-turn ReAct
+     * checkpoints. Emits a {@code [TURN_RESUME_CONTEXT]} block with the
+     * original prompt, a per-iteration completion summary, and a hard
+     * instruction not to repeat completed work.
+     *
+     * <p>The conversationSnapshot is intentionally NOT inlined here — the
+     * caller replays it as conversation history. This builder produces only
+     * the textual hint the LLM sees as its first user message.
+     */
+    public static String buildTurnResumePrompt(TurnCheckpoint checkpoint) {
+        return buildTurnResumePrompt(checkpoint, DEFAULT_RESUME_PROMPT_MAX_CHARS);
+    }
+
+    public static String buildTurnResumePrompt(TurnCheckpoint checkpoint, int maxChars) {
+        Objects.requireNonNull(checkpoint, "checkpoint");
+        int effectiveMaxChars = Math.max(512, maxChars);
+        int nextIteration = checkpoint.completedIterations() + 1;
+
+        var plan = new ContextAssemblyPlan();
+        plan.addSection("turn-resume-header", """
+                [TURN_RESUME_CONTEXT]
+                originalPrompt: %s
+                turnId: %s
+                completedIterations: %d
+                """.formatted(
+                singleLine(checkpoint.originalPrompt()),
+                checkpoint.turnId(),
+                checkpoint.completedIterations()
+        ), 100, true);
+
+        // Per-iteration line summary parsed from the snapshot — each assistant
+        // tool_use becomes "iter N: <tool> -> <outcome>". The snapshot may be
+        // empty (turn crashed before its first iteration) or in a format we
+        // can't parse — in either case we degrade to the count + lastToolUseId.
+        var summaryLines = summarizeIterations(checkpoint.conversationSnapshot());
+        var done = new StringBuilder("completedWork:\n");
+        if (!summaryLines.isEmpty()) {
+            for (var line : summaryLines) {
+                done.append("  - ").append(line).append('\n');
+            }
+        } else if (checkpoint.completedIterations() > 0) {
+            done.append("  - ").append(checkpoint.completedIterations())
+                    .append(" iteration(s) already executed in this turn.\n");
+            if (checkpoint.lastToolUseId() != null) {
+                done.append("  - lastToolUseId: ")
+                        .append(singleLine(checkpoint.lastToolUseId()))
+                        .append('\n');
+            }
+        } else {
+            done.append("  - (no completed iterations recorded)\n");
+        }
+        plan.addSection("turn-resume-done", done.toString(), 70, false);
+
+        if (!checkpoint.artifacts().isEmpty()) {
+            var artifacts = new StringBuilder("artifacts:\n");
+            for (var artifact : checkpoint.artifacts()) {
+                artifacts.append("  - ").append(singleLine(artifact)).append('\n');
+            }
+            plan.addSection("turn-resume-artifacts", artifacts.toString(), 60, false);
+        }
+
+        plan.addSection("turn-resume-action", """
+                action: Do not repeat work that already succeeded. Continue from iteration %d.
+                [/TURN_RESUME_CONTEXT]
+                """.formatted(nextIteration), 100, true);
+
+        var budget = new SystemPromptBudget(
+                Math.max(256, effectiveMaxChars / 3),
+                effectiveMaxChars);
+        return plan.build(budget).prompt();
+    }
+
+    /**
      * Computes a deterministic SHA-256 hash of the normalized workspace path.
      * Used for cross-session matching without storing raw file paths.
      */
@@ -211,8 +370,27 @@ public final class ResumeRouter {
         return status == CheckpointStatus.ACTIVE || status == CheckpointStatus.INTERRUPTED;
     }
 
-    private static Comparator<PlanCheckpoint> recencyComparator() {
-        return Comparator.comparing(PlanCheckpoint::updatedAt).reversed();
+    private static List<PlanCheckpoint> candidatePlans(List<PlanCheckpoint> raw) {
+        return raw.stream()
+                .filter(c -> isResumable(c.status()))
+                .filter(PlanCheckpoint::hasRemainingSteps)
+                .sorted(Comparator.comparing(PlanCheckpoint::updatedAt).reversed())
+                .toList();
+    }
+
+    private static List<TurnCheckpoint> candidateTurns(List<TurnCheckpoint> raw) {
+        return raw.stream()
+                .filter(c -> isResumable(c.status()))
+                .sorted(Comparator.comparing(TurnCheckpoint::updatedAt).reversed())
+                .toList();
+    }
+
+    private static PlanCheckpoint bestOf(List<PlanCheckpoint> sorted) {
+        return sorted.isEmpty() ? null : sorted.getFirst();
+    }
+
+    private static TurnCheckpoint bestOfTurn(List<TurnCheckpoint> sorted) {
+        return sorted.isEmpty() ? null : sorted.getFirst();
     }
 
     private static String singleLine(String value) {
@@ -220,5 +398,115 @@ public final class ResumeRouter {
             return "";
         }
         return value.replace('\n', ' ').strip();
+    }
+
+    /**
+     * Parses {@link dev.aceclaw.core.agent.ConversationSnapshot}-shaped JSON
+     * lines into per-iteration summary strings for the TURN_RESUME prompt.
+     * Each "iteration" is the sliding window from one tool_use to the matching
+     * tool_result; the output line reads {@code "iter N: <tool> -> <outcome>"}.
+     *
+     * <p>Returns an empty list if the snapshot is empty, malformed, or contains
+     * no recognizable tool_use blocks — the caller falls back to a degenerate
+     * count line in that case.
+     *
+     * <p>Best-effort regex-based extraction so this stays free of Jackson at
+     * the daemon-side router (the snapshot is hand-encoded for the same
+     * reason in {@code aceclaw-core}). We are NOT trying to round-trip
+     * messages — just produce a human/LLM-readable digest.
+     */
+    static List<String> summarizeIterations(List<String> snapshot) {
+        if (snapshot == null || snapshot.isEmpty()) {
+            return List.of();
+        }
+        var out = new ArrayList<String>();
+
+        // Two passes over the snapshot: first collect tool_use (id → name),
+        // then walk in order pairing each tool_use with its matching
+        // tool_result (looked up by id) — the user/assistant message
+        // ordering already serializes iterations chronologically.
+        var toolNameById = new java.util.LinkedHashMap<String, String>();
+        var resultById = new java.util.HashMap<String, String>(); // id -> outcome snippet
+        var resultErrorById = new java.util.HashMap<String, Boolean>();
+
+        // Regexes deliberately permissive — the format is internal but may grow
+        // new fields. We extract id / name / content / is_error from each block.
+        var toolUsePattern = java.util.regex.Pattern.compile(
+                "\"type\"\\s*:\\s*\"tool_use\"\\s*,\\s*\"id\"\\s*:\\s*\"([^\"]+)\""
+                        + "\\s*,\\s*\"name\"\\s*:\\s*\"([^\"]+)\"");
+        var toolResultPattern = java.util.regex.Pattern.compile(
+                "\"type\"\\s*:\\s*\"tool_result\"\\s*,\\s*\"tool_use_id\"\\s*:\\s*\"([^\"]+)\""
+                        + "\\s*,\\s*\"content\"\\s*:\\s*\"((?:\\\\.|[^\"\\\\])*)\""
+                        + "\\s*,\\s*\"is_error\"\\s*:\\s*(true|false)");
+
+        for (var line : snapshot) {
+            if (line == null || line.isEmpty()) continue;
+            var u = toolUsePattern.matcher(line);
+            while (u.find()) {
+                toolNameById.putIfAbsent(u.group(1), u.group(2));
+            }
+            var r = toolResultPattern.matcher(line);
+            while (r.find()) {
+                resultById.putIfAbsent(r.group(1), unescapeJsonString(r.group(2)));
+                resultErrorById.putIfAbsent(r.group(1), Boolean.parseBoolean(r.group(3)));
+            }
+        }
+
+        int idx = 0;
+        for (var entry : toolNameById.entrySet()) {
+            idx++;
+            String id = entry.getKey();
+            String tool = entry.getValue();
+            String outcomeRaw = resultById.get(id);
+            String outcome;
+            if (outcomeRaw == null) {
+                outcome = "(no result recorded — turn cut here)";
+            } else {
+                boolean err = resultErrorById.getOrDefault(id, false);
+                String snippet = outcomeRaw.length() > 80
+                        ? outcomeRaw.substring(0, 80) + "..." : outcomeRaw;
+                outcome = (err ? "FAILED: " : "ok: ") + singleLine(snippet);
+            }
+            out.add("iter " + idx + ": " + tool + " -> " + outcome);
+        }
+        return out;
+    }
+
+    private static String unescapeJsonString(String escaped) {
+        if (escaped == null || escaped.isEmpty()) return escaped;
+        var sb = new StringBuilder(escaped.length());
+        for (int i = 0; i < escaped.length(); i++) {
+            char c = escaped.charAt(i);
+            if (c == '\\' && i + 1 < escaped.length()) {
+                char n = escaped.charAt(++i);
+                switch (n) {
+                    case 'n' -> sb.append('\n');
+                    case 'r' -> sb.append('\r');
+                    case 't' -> sb.append('\t');
+                    case 'b' -> sb.append('\b');
+                    case 'f' -> sb.append('\f');
+                    case '"' -> sb.append('"');
+                    case '\\' -> sb.append('\\');
+                    case '/' -> sb.append('/');
+                    case 'u' -> {
+                        if (i + 4 < escaped.length()) {
+                            try {
+                                sb.append((char) Integer.parseInt(
+                                        escaped.substring(i + 1, i + 5), 16));
+                                i += 4;
+                            } catch (NumberFormatException nfe) {
+                                sb.append(n);
+                            }
+                        } else {
+                            sb.append(n);
+                        }
+                    }
+                    default -> sb.append(n);
+                }
+            } else {
+                sb.append(c);
+            }
+        }
+        return sb.toString();
     }
 }

--- a/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
+++ b/aceclaw-daemon/src/main/java/dev/aceclaw/daemon/StreamingAgentHandler.java
@@ -50,6 +50,7 @@ import dev.aceclaw.core.planner.SequentialPlanExecutor;
 import dev.aceclaw.core.planner.StepResult;
 import dev.aceclaw.core.planner.StepStatus;
 import dev.aceclaw.core.planner.TaskPlan;
+import dev.aceclaw.core.planner.TurnCheckpoint;
 import dev.aceclaw.memory.AutoMemoryStore;
 import dev.aceclaw.memory.CandidatePromptAssembler;
 import dev.aceclaw.memory.CandidateStore;
@@ -511,6 +512,19 @@ public final class StreamingAgentHandler {
             ts.put("turnNumber", turnNumber);
             ts.put("timestamp", Instant.now().toString());
             emitBrowserOnly(sessionId, "stream.turn_started", ts);
+
+            // Explicit /continue command: "继续", "continue", "resume", "/resume"
+            // (case-insensitive, trim). Skips the resume.offer round-trip and
+            // routes directly to either a plan or turn checkpoint (issue #501).
+            if (isExplicitContinue(prompt) && planCheckpointStore != null) {
+                var explicitResult = handleExplicitContinue(
+                        sessionId, session, prompt, cancelContext, eventHandler,
+                        permissionAwareLoop, cancellationToken, metricsCollector,
+                        watchdog, requestToolNames, conversationHistory);
+                finalStopReason = extractStopReason(explicitResult, finalStopReason);
+                sendBudgetExhaustedNotificationIfNeeded(watchdog, cancelContext, sessionId, cancellationToken);
+                return explicitResult;
+            }
 
             // Check for resumable plan checkpoint before planning or execution
             if (planCheckpointStore != null) {
@@ -1758,6 +1772,7 @@ public final class StreamingAgentHandler {
     private int maxPlanStepWallTimeSec = 1800;
     private int maxPlanTotalWallTimeSec = 3600;
     private PlanCheckpointStore planCheckpointStore;
+    private dev.aceclaw.core.planner.TurnCheckpointStore turnCheckpointStore;
     private dev.aceclaw.core.agent.TurnCheckpointSink turnCheckpointSink;
     private SkillMemoryFeedback skillMemoryFeedback;
     private SkillRefinementEngine skillRefinementEngine;
@@ -2028,6 +2043,16 @@ public final class StreamingAgentHandler {
      */
     public void setTurnCheckpointSink(dev.aceclaw.core.agent.TurnCheckpointSink turnCheckpointSink) {
         this.turnCheckpointSink = turnCheckpointSink;
+    }
+
+    /**
+     * Sets the turn checkpoint store for explicit-continue routing (issue #501).
+     * The store is read-side — {@link ResumeRouter} queries it to find
+     * resumable turns. Writes go through the {@link #setTurnCheckpointSink
+     * TurnCheckpointSink} configured separately.
+     */
+    public void setTurnCheckpointStore(dev.aceclaw.core.planner.TurnCheckpointStore turnCheckpointStore) {
+        this.turnCheckpointStore = turnCheckpointStore;
     }
 
     /**
@@ -2757,6 +2782,324 @@ public final class StreamingAgentHandler {
         }
         planCheckpointStore.markFailed(cp.planId());
         return null; // proceed with normal flow
+    }
+
+    // -- Explicit /continue command (issue #501) -------------------------------
+
+    private static final Set<String> EXPLICIT_CONTINUE_KEYWORDS = Set.of(
+            "继续", "continue", "resume", "/resume", "/continue");
+
+    /**
+     * Returns true if the prompt is a recognized explicit-continue command —
+     * one of "继续", "continue", "resume", "/resume", "/continue" after
+     * trimming and lowercasing. The Chinese token is matched as-is (no case).
+     */
+    static boolean isExplicitContinue(String prompt) {
+        if (prompt == null) return false;
+        String trimmed = prompt.strip();
+        if (trimmed.isEmpty()) return false;
+        return EXPLICIT_CONTINUE_KEYWORDS.contains(trimmed.toLowerCase(Locale.ROOT));
+    }
+
+    /**
+     * Handles an explicit /continue command. Routes deterministically (no
+     * resume.offer round-trip) to the highest-priority resumable. When both a
+     * plan and turn checkpoint coexist, surfaces a numbered choice via
+     * {@code resume.choices} and awaits {@code resume.choice_response}.
+     *
+     * @return a result ObjectNode — either the resumed plan/turn result, or a
+     *         friendly "nothing to resume" message that consumes no LLM tokens.
+     */
+    private Object handleExplicitContinue(
+            String sessionId, AgentSession session, String prompt,
+            CancelAwareStreamContext cancelContext, StreamEventHandler eventHandler,
+            StreamingAgentLoop permissionAwareLoop, CancellationToken cancellationToken,
+            ToolMetricsCollector metricsCollector, WatchdogTimer watchdog,
+            Set<String> requestToolNames, List<Message> conversationHistory) throws Exception {
+
+        var resumeRouter = new ResumeRouter(planCheckpointStore, turnCheckpointStore);
+        var resumables = resumeRouter.findAllResumable(sessionId, session.projectPath());
+
+        if (resumables.isEmpty()) {
+            return buildNothingToResumeResult(sessionId, session, prompt);
+        }
+
+        Resumable chosen;
+        if (resumables.size() == 1) {
+            chosen = resumables.getFirst();
+        } else {
+            // Multiple resumables — surface the choice. Default to the highest
+            // priority (plan) on timeout or malformed response so explicit
+            // continue always makes forward progress.
+            chosen = offerResumeChoicesAndWaitForResponse(cancelContext, resumables);
+            if (chosen == null) {
+                chosen = resumables.getFirst();
+            }
+        }
+
+        // Mark any UNCHOSEN siblings as RESUMED so the implicit-detection path
+        // (resume.offer) doesn't immediately re-surface them on the next prompt.
+        // The user already implicitly declined them by picking the chosen one
+        // (review finding #6).
+        for (var other : resumables) {
+            if (other == chosen) continue;
+            try {
+                switch (other) {
+                    case Resumable.OfPlan p -> planCheckpointStore.markResumed(
+                            p.checkpoint().planId());
+                    case Resumable.OfTurn t -> {
+                        if (turnCheckpointStore != null) {
+                            turnCheckpointStore.markResumed(t.checkpoint().turnId());
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                log.warn("Failed to mark unchosen resumable as RESUMED: {}", e.getMessage());
+            }
+        }
+
+        return switch (chosen) {
+            case Resumable.OfPlan p -> resumePlanFromExplicitContinue(
+                    p.checkpoint(), sessionId, session, cancelContext, eventHandler,
+                    permissionAwareLoop, cancellationToken, metricsCollector, watchdog,
+                    requestToolNames);
+            case Resumable.OfTurn t -> executeResumedTurn(
+                    t.checkpoint(), sessionId, session, cancelContext, eventHandler,
+                    permissionAwareLoop, cancellationToken, metricsCollector, watchdog,
+                    requestToolNames, conversationHistory);
+        };
+    }
+
+    /**
+     * Builds the "nothing to resume" no-op result so we never charge the user
+     * an LLM call for a literal "继续" with no resumable state. Also records
+     * the user's prompt + the synthetic assistant reply in session history
+     * (review finding #3) so the dashboard turn counter and journal stay
+     * consistent with what the user actually typed.
+     */
+    private Object buildNothingToResumeResult(String sessionId, AgentSession session, String prompt) {
+        String reply = "Nothing to resume — last turn completed or was never recorded.";
+        if (session != null && prompt != null) {
+            session.addMessage(new AgentSession.ConversationMessage.User(prompt));
+            session.addMessage(new AgentSession.ConversationMessage.Assistant(reply));
+        }
+        var result = objectMapper.createObjectNode();
+        result.put("sessionId", sessionId);
+        result.put("response", reply);
+        result.put("stopReason", StopReason.END_TURN.name());
+        result.put("resumeAttempted", true);
+        result.put("resumeFound", false);
+        var usageNode = objectMapper.createObjectNode();
+        usageNode.put("inputTokens", 0);
+        usageNode.put("outputTokens", 0);
+        usageNode.put("totalTokens", 0);
+        usageNode.put("llmRequests", 0);
+        result.set("usage", usageNode);
+        return result;
+    }
+
+    /**
+     * Sends a {@code resume.choices} notification listing every resumable and
+     * waits for the client's {@code resume.choice_response}. Returns the
+     * chosen Resumable, or null on timeout / parse failure (caller falls back
+     * to the highest-priority choice).
+     */
+    private Resumable offerResumeChoicesAndWaitForResponse(
+            StreamContext context, List<Resumable> resumables) {
+        try {
+            var params = objectMapper.createObjectNode();
+            var arr = objectMapper.createArrayNode();
+            for (int i = 0; i < resumables.size(); i++) {
+                var item = objectMapper.createObjectNode();
+                item.put("index", i);
+                switch (resumables.get(i)) {
+                    case Resumable.OfPlan p -> {
+                        var cp = p.checkpoint();
+                        item.put("kind", "plan");
+                        item.put("planId", cp.planId());
+                        item.put("originalGoal", truncate(cp.originalGoal(), 200));
+                        item.put("completedSteps", cp.lastCompletedStepIndex() + 1);
+                        item.put("totalSteps", cp.plan().steps().size());
+                        item.put("lastUpdated", cp.updatedAt().toString());
+                    }
+                    case Resumable.OfTurn t -> {
+                        var cp = t.checkpoint();
+                        item.put("kind", "turn");
+                        item.put("turnId", cp.turnId());
+                        item.put("originalPrompt", truncate(cp.originalPrompt(), 200));
+                        item.put("completedIterations", cp.completedIterations());
+                        item.put("lastUpdated", cp.updatedAt().toString());
+                    }
+                }
+                arr.add(item);
+            }
+            params.set("choices", arr);
+            context.sendNotification("resume.choices", params);
+        } catch (IOException e) {
+            log.warn("Failed to send resume.choices: {}", e.getMessage());
+            return null;
+        }
+
+        try {
+            var response = context.readMessage(30_000);
+            if (response != null && response.has("method")
+                    && "resume.choice_response".equals(response.get("method").asText())) {
+                var respParams = response.get("params");
+                if (respParams != null && respParams.has("index")) {
+                    int idx = respParams.get("index").asInt(-1);
+                    if (idx >= 0 && idx < resumables.size()) {
+                        return resumables.get(idx);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            log.warn("Failed to read resume.choice_response: {}", e.getMessage());
+        }
+        return null;
+    }
+
+    /**
+     * Resumes a plan from explicit /continue. Skips the resume.offer round-trip
+     * (the implicit detection path's role) and routes straight into
+     * {@link #executeResumedPlan}.
+     */
+    private Object resumePlanFromExplicitContinue(
+            PlanCheckpoint cp, String sessionId, AgentSession session,
+            CancelAwareStreamContext cancelContext, StreamEventHandler eventHandler,
+            StreamingAgentLoop permissionAwareLoop, CancellationToken cancellationToken,
+            ToolMetricsCollector metricsCollector, WatchdogTimer watchdog,
+            Set<String> requestToolNames) throws Exception {
+
+        log.info("Explicit continue → plan resume: planId={}, step {}/{}",
+                cp.planId(), cp.lastCompletedStepIndex() + 1, cp.plan().steps().size());
+
+        // resume.detected mirrors the implicit-path notification so dashboards
+        // can render the same UI for explicit + implicit resume paths. Route
+        // uses the underlying tier ("session"/"workspace") plus a separate
+        // `trigger` discriminator — keeps the wire format stable while letting
+        // observers tell explicit /continue apart from implicit auto-offer
+        // (review finding #4).
+        var resumeRouter = new ResumeRouter(planCheckpointStore, turnCheckpointStore);
+        var routeDecision = resumeRouter.route(sessionId, session.projectPath());
+        String routeLabel = routeDecision.checkpoint() != null
+                && cp.planId().equals(routeDecision.checkpoint().planId())
+                ? routeDecision.route() : "session";
+        try {
+            var p = objectMapper.createObjectNode();
+            p.put("planId", cp.planId());
+            p.put("completedSteps", cp.lastCompletedStepIndex() + 1);
+            p.put("totalSteps", cp.plan().steps().size());
+            p.put("route", routeLabel);
+            p.put("trigger", "explicit_continue");
+            p.put("originalGoal", truncate(cp.originalGoal(), 200));
+            cancelContext.sendNotification("resume.detected", p);
+        } catch (IOException e) {
+            log.warn("Failed to send resume.detected notification: {}", e.getMessage());
+        }
+
+        if (!cp.hasRemainingSteps()) {
+            log.info("Explicit continue: plan {} has no remaining steps", cp.planId());
+            // markCompleted, not markFailed — the plan finished cleanly; the
+            // /continue just had no work to do (review finding #29).
+            planCheckpointStore.markCompleted(cp.planId());
+            return buildNothingToResumeResult(sessionId, session, "continue");
+        }
+        return executeResumedPlan(cp, session, sessionId, cancelContext,
+                eventHandler, permissionAwareLoop, cancellationToken, metricsCollector,
+                watchdog, requestToolNames);
+    }
+
+    /**
+     * Resumes a single ReAct turn from a {@link TurnCheckpoint}. Replays the
+     * checkpoint's conversation snapshot as conversation history and injects
+     * the {@code [TURN_RESUME_CONTEXT]} block produced by
+     * {@link ResumeRouter#buildTurnResumePrompt} as the new user prompt.
+     */
+    private Object executeResumedTurn(
+            TurnCheckpoint cp, String sessionId, AgentSession session,
+            CancelAwareStreamContext cancelContext, StreamEventHandler eventHandler,
+            StreamingAgentLoop permissionAwareLoop, CancellationToken cancellationToken,
+            ToolMetricsCollector metricsCollector, WatchdogTimer watchdog,
+            Set<String> requestToolNames, List<Message> conversationHistory) throws Exception {
+
+        log.info("Explicit continue → turn resume: turnId={}, completedIterations={}",
+                cp.turnId(), cp.completedIterations());
+
+        // Mark old turn checkpoint as RESUMED so a subsequent /continue doesn't
+        // route back to it. Done before the new turn runs so a crash mid-resume
+        // doesn't loop us back into the same stale state.
+        if (turnCheckpointStore != null) {
+            try {
+                turnCheckpointStore.markResumed(cp.turnId());
+            } catch (Exception e) {
+                log.warn("Failed to mark turn checkpoint as RESUMED ({}): {}",
+                        cp.turnId(), e.getMessage());
+            }
+        }
+
+        // resume.detected: route uses underlying tier + trigger discriminator
+        // for parity with the plan path (review finding #4).
+        var routeRouter = new ResumeRouter(planCheckpointStore, turnCheckpointStore);
+        var routeDec = routeRouter.route(sessionId, session.projectPath());
+        String routeLabel;
+        if (routeDec.resumable() instanceof Resumable.OfTurn rt
+                && cp.turnId().equals(rt.checkpoint().turnId())) {
+            routeLabel = routeDec.route();
+        } else {
+            // chosen via resume.choices — fall back to a label that still
+            // disambiguates same-session vs cross-session.
+            routeLabel = sessionId.equals(cp.sessionId()) ? "turn_session" : "turn_workspace";
+        }
+        try {
+            var p = objectMapper.createObjectNode();
+            p.put("turnId", cp.turnId());
+            p.put("completedIterations", cp.completedIterations());
+            p.put("route", routeLabel);
+            p.put("trigger", "explicit_continue");
+            p.put("originalPrompt", truncate(cp.originalPrompt(), 200));
+            cancelContext.sendNotification("resume.detected", p);
+        } catch (IOException e) {
+            log.warn("Failed to send resume.detected (turn) notification: {}", e.getMessage());
+        }
+
+        // Do NOT deserialize the checkpoint's conversationSnapshot to replay
+        // — the snapshot is encoded by ConversationSnapshot.serialize as
+        // {role, blocks:[...]} which deserializeConversation (legacy
+        // plan-checkpoint shape) flattens to empty Text blocks, silently
+        // losing every tool_use / tool_result block. The
+        // [TURN_RESUME_CONTEXT] block built by ResumeRouter.buildTurnResumePrompt
+        // parses the snapshot for a per-iteration digest, which gives the
+        // LLM enough context without needing to round-trip the raw blocks
+        // (review finding #1, #25, #26).
+        var historyForTurn = new ArrayList<>(conversationHistory);
+        var resumePrompt = ResumeRouter.buildTurnResumePrompt(cp);
+
+        try {
+            var p = objectMapper.createObjectNode();
+            p.put("turnId", cp.turnId());
+            p.put("completedIterations", cp.completedIterations());
+            cancelContext.sendNotification("resume.injected", p);
+        } catch (IOException e) {
+            log.warn("Failed to send resume.injected (turn) notification: {}", e.getMessage());
+        }
+
+        var adaptive = runTurnWithAdaptiveContinuation(
+                permissionAwareLoop, resumePrompt, historyForTurn, eventHandler, cancellationToken);
+        sendCancelledNotificationIfNeeded(cancellationToken, cancelContext, sessionId);
+
+        // Append a synthetic marker for the session history instead of replaying
+        // cp.originalPrompt() — that would double-append the prompt when the
+        // session is the same one that produced the original turn (review
+        // finding #9). The marker mirrors the plan-resume path's behavior
+        // (executeResumedPlan adds "[Resumed plan: ...]").
+        String marker = "[Resumed turn: " + truncate(cp.originalPrompt(), 100) + "]";
+        var result = buildTurnResult(adaptive.turn(), session, sessionId,
+                marker, cancellationToken, metricsCollector, adaptive, requestToolNames);
+        if (result instanceof com.fasterxml.jackson.databind.node.ObjectNode obj) {
+            obj.put("resumed", true);
+            obj.put("resumedFromTurnId", cp.turnId());
+        }
+        return result;
     }
 
     /**

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/ExplicitContinueKeywordTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/ExplicitContinueKeywordTest.java
@@ -1,0 +1,67 @@
+package dev.aceclaw.daemon;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for the static keyword detection used by the explicit /continue
+ * command (issue #501). The detection logic lives in
+ * {@link StreamingAgentHandler#isExplicitContinue} so we don't pay the cost
+ * of spinning up the daemon for what is purely string normalization.
+ */
+class ExplicitContinueKeywordTest {
+
+    @Test
+    void recognizesChineseContinue() {
+        assertTrue(StreamingAgentHandler.isExplicitContinue("继续"));
+        assertTrue(StreamingAgentHandler.isExplicitContinue("  继续  "));
+        assertTrue(StreamingAgentHandler.isExplicitContinue("\n继续\n"));
+    }
+
+    @Test
+    void recognizesEnglishContinue() {
+        assertTrue(StreamingAgentHandler.isExplicitContinue("continue"));
+        assertTrue(StreamingAgentHandler.isExplicitContinue("Continue"));
+        assertTrue(StreamingAgentHandler.isExplicitContinue("CONTINUE"));
+        assertTrue(StreamingAgentHandler.isExplicitContinue("  continue  "));
+    }
+
+    @Test
+    void recognizesResume() {
+        assertTrue(StreamingAgentHandler.isExplicitContinue("resume"));
+        assertTrue(StreamingAgentHandler.isExplicitContinue("RESUME"));
+    }
+
+    @Test
+    void recognizesSlashCommands() {
+        assertTrue(StreamingAgentHandler.isExplicitContinue("/resume"));
+        assertTrue(StreamingAgentHandler.isExplicitContinue("/continue"));
+        assertTrue(StreamingAgentHandler.isExplicitContinue("/CONTINUE"));
+    }
+
+    @Test
+    void rejectsPromptsThatContainButDontEqualKeyword() {
+        // Must be a full-line match — substrings or sentences mentioning
+        // "continue" are real prompts, not the command.
+        assertFalse(StreamingAgentHandler.isExplicitContinue("please continue"));
+        assertFalse(StreamingAgentHandler.isExplicitContinue("continue with the next task"));
+        assertFalse(StreamingAgentHandler.isExplicitContinue("继续 写代码"));
+        assertFalse(StreamingAgentHandler.isExplicitContinue("resume the migration"));
+    }
+
+    @Test
+    void rejectsEmptyAndNull() {
+        assertFalse(StreamingAgentHandler.isExplicitContinue(null));
+        assertFalse(StreamingAgentHandler.isExplicitContinue(""));
+        assertFalse(StreamingAgentHandler.isExplicitContinue("   "));
+        assertFalse(StreamingAgentHandler.isExplicitContinue("\n\t"));
+    }
+
+    @Test
+    void rejectsUnrelatedShortInputs() {
+        assertFalse(StreamingAgentHandler.isExplicitContinue("yes"));
+        assertFalse(StreamingAgentHandler.isExplicitContinue("ok"));
+        assertFalse(StreamingAgentHandler.isExplicitContinue("继"));
+    }
+}

--- a/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/ResumeRouterTest.java
+++ b/aceclaw-daemon/src/test/java/dev/aceclaw/daemon/ResumeRouterTest.java
@@ -269,6 +269,319 @@ class ResumeRouterTest {
         assertFalse(prompt.contains("nextStep:\n"));
     }
 
+    // -- Turn-checkpoint priority tests (#501) ---------------------------------
+
+    static class InMemoryTurnStore implements TurnCheckpointStore {
+        private final java.util.Map<String, TurnCheckpoint> store = new java.util.LinkedHashMap<>();
+
+        @Override
+        public void save(TurnCheckpoint checkpoint) {
+            store.put(checkpoint.turnId(), checkpoint);
+        }
+
+        @Override
+        public Optional<TurnCheckpoint> load(String turnId) {
+            return Optional.ofNullable(store.get(turnId));
+        }
+
+        @Override
+        public List<TurnCheckpoint> findResumable(String workspaceHash) {
+            return store.values().stream()
+                    .filter(c -> workspaceHash.equals(c.workspaceHash()))
+                    .filter(c -> isResumable(c.status()))
+                    .toList();
+        }
+
+        @Override
+        public List<TurnCheckpoint> findBySession(String sessionId) {
+            return store.values().stream()
+                    .filter(c -> sessionId.equals(c.sessionId()))
+                    .filter(c -> isResumable(c.status()))
+                    .toList();
+        }
+
+        @Override public void markResumed(String turnId) { updateStatus(turnId, PlanCheckpoint.CheckpointStatus.RESUMED); }
+        @Override public void markCompleted(String turnId) { updateStatus(turnId, PlanCheckpoint.CheckpointStatus.COMPLETED); }
+        @Override public void markFailed(String turnId) { updateStatus(turnId, PlanCheckpoint.CheckpointStatus.FAILED); }
+        @Override public void markInterrupted(String turnId) { updateStatus(turnId, PlanCheckpoint.CheckpointStatus.INTERRUPTED); }
+        @Override public void delete(String turnId) { store.remove(turnId); }
+        @Override public int cleanup(int maxAgeDays) { return 0; }
+
+        private void updateStatus(String turnId, PlanCheckpoint.CheckpointStatus status) {
+            var cp = store.get(turnId);
+            if (cp != null) store.put(turnId, cp.withStatus(status));
+        }
+
+        private boolean isResumable(PlanCheckpoint.CheckpointStatus status) {
+            return status == PlanCheckpoint.CheckpointStatus.ACTIVE
+                    || status == PlanCheckpoint.CheckpointStatus.INTERRUPTED;
+        }
+    }
+
+    private static TurnCheckpoint turnCp(String turnId, String sessionId, String wsHash,
+                                          int completedIterations,
+                                          PlanCheckpoint.CheckpointStatus status,
+                                          Instant updatedAt) {
+        return new TurnCheckpoint(
+                turnId, sessionId, wsHash, "fix it",
+                List.of(), completedIterations, "tool-use-" + completedIterations,
+                List.of(), status, Instant.now(), updatedAt);
+    }
+
+    @Test
+    void route_planBeatsTurnInSameSession() {
+        var planStore = new InMemoryCheckpointStore();
+        var turnStore = new InMemoryTurnStore();
+        var wsHash = ResumeRouter.hashWorkspace(Path.of("/project"));
+
+        planStore.save(checkpoint("plan-1", "session-A", wsHash, 1,
+                PlanCheckpoint.CheckpointStatus.ACTIVE, Instant.parse("2026-01-01T00:00:00Z")));
+        // Newer turn checkpoint — but plan still wins because plan tier > turn tier.
+        turnStore.save(turnCp("turn-1", "session-A", wsHash, 2,
+                PlanCheckpoint.CheckpointStatus.ACTIVE, Instant.parse("2026-06-01T00:00:00Z")));
+
+        var router = new ResumeRouter(planStore, turnStore);
+        var decision = router.route("session-A", Path.of("/project"));
+
+        assertTrue(decision.hasCheckpoint());
+        assertEquals("session", decision.route());
+        assertInstanceOf(Resumable.OfPlan.class, decision.resumable());
+        assertEquals("plan-1", decision.checkpoint().planId());
+    }
+
+    @Test
+    void route_turnSessionBeatsTurnWorkspace() {
+        var planStore = new InMemoryCheckpointStore();
+        var turnStore = new InMemoryTurnStore();
+        var wsHash = ResumeRouter.hashWorkspace(Path.of("/project"));
+
+        // Older turn in same session — but session tier beats workspace tier.
+        turnStore.save(turnCp("turn-session", "session-A", wsHash, 1,
+                PlanCheckpoint.CheckpointStatus.ACTIVE, Instant.parse("2026-01-01T00:00:00Z")));
+        turnStore.save(turnCp("turn-workspace", "session-OLD", wsHash, 3,
+                PlanCheckpoint.CheckpointStatus.ACTIVE, Instant.parse("2026-06-01T00:00:00Z")));
+
+        var router = new ResumeRouter(planStore, turnStore);
+        var decision = router.route("session-A", Path.of("/project"));
+
+        assertTrue(decision.hasCheckpoint());
+        assertEquals("turn_session", decision.route());
+        assertInstanceOf(Resumable.OfTurn.class, decision.resumable());
+    }
+
+    @Test
+    void route_turnWorkspaceMatch() {
+        var planStore = new InMemoryCheckpointStore();
+        var turnStore = new InMemoryTurnStore();
+        var wsHash = ResumeRouter.hashWorkspace(Path.of("/project"));
+
+        turnStore.save(turnCp("turn-1", "session-OLD", wsHash, 2,
+                PlanCheckpoint.CheckpointStatus.ACTIVE, Instant.now()));
+
+        var router = new ResumeRouter(planStore, turnStore);
+        var decision = router.route("session-NEW", Path.of("/project"));
+
+        assertTrue(decision.hasCheckpoint());
+        assertEquals("turn_workspace", decision.route());
+    }
+
+    @Test
+    void route_turnInterruptedStatusIsResumable() {
+        var planStore = new InMemoryCheckpointStore();
+        var turnStore = new InMemoryTurnStore();
+        var wsHash = ResumeRouter.hashWorkspace(Path.of("/project"));
+
+        turnStore.save(turnCp("turn-1", "session-A", wsHash, 2,
+                PlanCheckpoint.CheckpointStatus.INTERRUPTED, Instant.now()));
+
+        var router = new ResumeRouter(planStore, turnStore);
+        var decision = router.route("session-A", Path.of("/project"));
+
+        assertTrue(decision.hasCheckpoint());
+        assertEquals("turn_session", decision.route());
+    }
+
+    @Test
+    void route_turnCompletedStatusIgnored() {
+        var planStore = new InMemoryCheckpointStore();
+        var turnStore = new InMemoryTurnStore();
+        var wsHash = ResumeRouter.hashWorkspace(Path.of("/project"));
+
+        turnStore.save(turnCp("turn-1", "session-A", wsHash, 2,
+                PlanCheckpoint.CheckpointStatus.COMPLETED, Instant.now()));
+        turnStore.save(turnCp("turn-2", "session-A", wsHash, 2,
+                PlanCheckpoint.CheckpointStatus.RESUMED, Instant.now()));
+        turnStore.save(turnCp("turn-3", "session-A", wsHash, 2,
+                PlanCheckpoint.CheckpointStatus.FAILED, Instant.now()));
+
+        var router = new ResumeRouter(planStore, turnStore);
+        assertFalse(router.route("session-A", Path.of("/project")).hasCheckpoint());
+    }
+
+    @Test
+    void route_turnStoreNull_skipsTurnTier() {
+        // Backward compat: existing callers can construct with plan-only and
+        // the router must not NPE on turn lookup.
+        var planStore = new InMemoryCheckpointStore();
+        var router = new ResumeRouter(planStore); // delegating constructor, turn=null
+
+        var decision = router.route("session-A", Path.of("/project"));
+        assertFalse(decision.hasCheckpoint());
+    }
+
+    @Test
+    void findAllResumable_returnsBoth_whenPlanAndTurnExist() {
+        var planStore = new InMemoryCheckpointStore();
+        var turnStore = new InMemoryTurnStore();
+        var wsHash = ResumeRouter.hashWorkspace(Path.of("/project"));
+
+        planStore.save(checkpoint("plan-1", "session-A", wsHash, 1,
+                PlanCheckpoint.CheckpointStatus.ACTIVE, Instant.now()));
+        turnStore.save(turnCp("turn-1", "session-A", wsHash, 2,
+                PlanCheckpoint.CheckpointStatus.ACTIVE, Instant.now()));
+
+        var router = new ResumeRouter(planStore, turnStore);
+        var all = router.findAllResumable("session-A", Path.of("/project"));
+
+        assertEquals(2, all.size());
+        // Plan first (priority order)
+        assertInstanceOf(Resumable.OfPlan.class, all.get(0));
+        assertInstanceOf(Resumable.OfTurn.class, all.get(1));
+    }
+
+    @Test
+    void findAllResumable_singleEntry_whenOnlyOneTypeExists() {
+        var planStore = new InMemoryCheckpointStore();
+        var turnStore = new InMemoryTurnStore();
+        var wsHash = ResumeRouter.hashWorkspace(Path.of("/project"));
+        turnStore.save(turnCp("turn-1", "session-A", wsHash, 2,
+                PlanCheckpoint.CheckpointStatus.ACTIVE, Instant.now()));
+
+        var router = new ResumeRouter(planStore, turnStore);
+        var all = router.findAllResumable("session-A", Path.of("/project"));
+
+        assertEquals(1, all.size());
+        assertInstanceOf(Resumable.OfTurn.class, all.get(0));
+    }
+
+    @Test
+    void findAllResumable_empty_whenNothingResumable() {
+        var router = new ResumeRouter(new InMemoryCheckpointStore(), new InMemoryTurnStore());
+        assertTrue(router.findAllResumable("session-A", Path.of("/project")).isEmpty());
+    }
+
+    @Test
+    void buildTurnResumePrompt_includesAllSections() {
+        var cp = new TurnCheckpoint(
+                "turn-1", "session-A", "ws-hash",
+                "Refactor the auth module to use the new permission API",
+                List.of("{\"role\":\"user\",\"content\":\"go\"}"),
+                3, "tool-use-abc",
+                List.of("auth/Permissions.java", "auth/PermissionTest.java"),
+                PlanCheckpoint.CheckpointStatus.ACTIVE,
+                Instant.now(), Instant.now());
+
+        var prompt = ResumeRouter.buildTurnResumePrompt(cp);
+
+        assertTrue(prompt.contains("[TURN_RESUME_CONTEXT]"));
+        assertTrue(prompt.contains("[/TURN_RESUME_CONTEXT]"));
+        assertTrue(prompt.contains("originalPrompt: Refactor the auth module"));
+        assertTrue(prompt.contains("turnId: turn-1"));
+        assertTrue(prompt.contains("completedIterations: 3"));
+        assertTrue(prompt.contains("3 iteration(s) already executed"));
+        assertTrue(prompt.contains("lastToolUseId: tool-use-abc"));
+        assertTrue(prompt.contains("artifacts:"));
+        assertTrue(prompt.contains("auth/Permissions.java"));
+        assertTrue(prompt.contains("Continue from iteration 4"));
+        assertTrue(prompt.contains("Do not repeat"));
+    }
+
+    @Test
+    void buildTurnResumePrompt_zeroIterations() {
+        var cp = new TurnCheckpoint(
+                "turn-1", "session-A", "ws-hash", "Do X",
+                List.of(), 0, null, List.of(),
+                PlanCheckpoint.CheckpointStatus.ACTIVE,
+                Instant.now(), Instant.now());
+
+        var prompt = ResumeRouter.buildTurnResumePrompt(cp);
+        assertTrue(prompt.contains("completedIterations: 0"));
+        assertTrue(prompt.contains("no completed iterations recorded"));
+        assertTrue(prompt.contains("Continue from iteration 1"));
+    }
+
+    @Test
+    void summarizeIterations_extractsToolUseAndResults() {
+        // Snapshot in the ConversationSnapshot.serialize shape: each message is
+        // one JSON object {"role":"...","blocks":[ ... ]} per line.
+        var snapshot = List.of(
+                "{\"role\":\"user\",\"blocks\":[{\"type\":\"text\",\"text\":\"go\"}]}",
+                "{\"role\":\"assistant\",\"blocks\":["
+                        + "{\"type\":\"text\",\"text\":\"reading\"},"
+                        + "{\"type\":\"tool_use\",\"id\":\"tu-1\",\"name\":\"read_file\",\"input\":\"{\\\"path\\\":\\\"a.java\\\"}\"}]}",
+                "{\"role\":\"user\",\"blocks\":["
+                        + "{\"type\":\"tool_result\",\"tool_use_id\":\"tu-1\",\"content\":\"file contents 42\",\"is_error\":false}]}",
+                "{\"role\":\"assistant\",\"blocks\":["
+                        + "{\"type\":\"tool_use\",\"id\":\"tu-2\",\"name\":\"bash\",\"input\":\"{\\\"cmd\\\":\\\"ls\\\"}\"}]}",
+                "{\"role\":\"user\",\"blocks\":["
+                        + "{\"type\":\"tool_result\",\"tool_use_id\":\"tu-2\",\"content\":\"permission denied\",\"is_error\":true}]}"
+        );
+
+        var lines = ResumeRouter.summarizeIterations(snapshot);
+
+        assertThat(lines).hasSize(2);
+        assertThat(lines.get(0)).contains("iter 1");
+        assertThat(lines.get(0)).contains("read_file");
+        assertThat(lines.get(0)).contains("ok:");
+        assertThat(lines.get(0)).contains("file contents 42");
+        assertThat(lines.get(1)).contains("iter 2");
+        assertThat(lines.get(1)).contains("bash");
+        assertThat(lines.get(1)).contains("FAILED:");
+        assertThat(lines.get(1)).contains("permission denied");
+    }
+
+    @Test
+    void summarizeIterations_emptyForEmptyOrLegacySnapshot() {
+        assertThat(ResumeRouter.summarizeIterations(null)).isEmpty();
+        assertThat(ResumeRouter.summarizeIterations(List.of())).isEmpty();
+        // Legacy plan-checkpoint shape — no tool_use blocks
+        assertThat(ResumeRouter.summarizeIterations(List.of(
+                "{\"role\":\"user\",\"content\":\"hi\"}"
+        ))).isEmpty();
+    }
+
+    @Test
+    void summarizeIterations_handlesToolUseWithoutResult() {
+        // A tool_use that crashed mid-execution and never got a result.
+        var snapshot = List.of(
+                "{\"role\":\"assistant\",\"blocks\":["
+                        + "{\"type\":\"tool_use\",\"id\":\"tu-1\",\"name\":\"bash\",\"input\":\"{}\"}]}"
+        );
+        var lines = ResumeRouter.summarizeIterations(snapshot);
+        assertThat(lines).hasSize(1);
+        assertThat(lines.get(0)).contains("no result recorded");
+    }
+
+    @Test
+    void buildTurnResumePrompt_respectsHardSizeCap() {
+        var bigPrompt = "Q: " + "x".repeat(20_000);
+        var cp = new TurnCheckpoint(
+                "turn-1", "session-A", "ws-hash", bigPrompt,
+                List.of(), 5, "tool-use-abc",
+                List.of("a.txt", "b.txt", "c.txt"),
+                PlanCheckpoint.CheckpointStatus.ACTIVE,
+                Instant.now(), Instant.now());
+
+        var prompt = ResumeRouter.buildTurnResumePrompt(cp, 800);
+
+        assertThat(prompt.length()).isLessThanOrEqualTo(800);
+        // Must still include the framing + the action line so the LLM has a
+        // chance to do the right thing — content sections get truncated, not
+        // the structural ones.
+        assertThat(prompt).contains("[TURN_RESUME_CONTEXT]");
+        assertThat(prompt).contains("Continue from iteration 6");
+    }
+
     @Test
     void buildResumePromptBudgetsSectionsIndependently() {
         var plan = samplePlan(4);


### PR DESCRIPTION
Closes #501. P1 of the resume-from-interrupt epic (#499). Builds on TurnCheckpoint (#500) to make `继续` / `continue` / `resume` a first-class deterministic command that resumes an interrupted plan or turn without the implicit `resume.offer` round-trip.

## Summary

- **Sealed `Resumable`** (`OfPlan` / `OfTurn`) — exhaustive switch at the use site.
- **`ResumeRouter` extended** — optional `TurnCheckpointStore`; 4-tier priority `plan/session > plan/workspace > turn/session > turn/workspace`; `findAllResumable` for the multi-resumable choice path; new `buildTurnResumePrompt` emits a `[TURN_RESUME_CONTEXT]` block with a per-iteration digest parsed from the snapshot (`iter N: <tool> -> ok/FAILED: <snippet>`).
- **`StreamingAgentHandler`** — `isExplicitContinue` matches `继续` / `continue` / `resume` / `/resume` / `/continue` (trim + case-insensitive). `handleExplicitContinue` skips `resume.offer`, surfaces `resume.choices` when both checkpoint types coexist, and emits a zero-LLM-token "nothing to resume" reply when the workspace is clean. Unchosen siblings are marked `RESUMED` so they don't immediately re-surface via the implicit `resume.offer` path.
- **`CancelAwareStreamContext`** — dispatches `resume.choice_response` (otherwise the multi-resumable flow would hang for 30s under the per-session turn lock).

## Review-loop fixes baked into this PR

Multi-agent diff review surfaced 29 confirmed findings; the critical / high correctness ones are fixed here:

- **CRITICAL** — legacy `deserializeConversation` flattens turn-snapshot blocks to empty `Text`, losing every `tool_use` / `tool_result`. Fixed by not replaying the snapshot at all on turn resume; the per-iteration digest carries the same info in a form the LLM can parse.
- `resume.choice_response` dispatch added.
- `resume.detected` carries underlying tier in `route` plus separate `trigger="explicit_continue"` discriminator (keeps wire format stable).
- "Nothing to resume" path records user prompt + synthetic reply in session history so the dashboard turn counter / journal stay consistent.
- Plan-with-no-remaining-steps on explicit continue calls `markCompleted` (not `markFailed`).
- Synthetic `[Resumed turn: ...]` marker in session history avoids double-appending the original prompt on same-session resume.

## Out of scope (sibling sub-issues of #499)

- Idempotency markers for `bash` on resume → #502 (P2)
- Cross-session TOCTOU CAS on `markResumed` — deferred follow-up
- Per-iteration `resume.bound_task` notification parity — deferred follow-up (no current consumer)

## Test plan

- [x] `./gradlew :aceclaw-daemon:test` green (incl. 14 new `ResumeRouterTest` cases + new `ExplicitContinueKeywordTest`)
- [x] `./gradlew assemble` green
- [ ] Manual smoke: kill daemon mid-turn, `继续` resumes from iter N+1 without `resume.offer`
- [ ] Manual smoke: `继续` on a clean session returns the friendly reply and burns zero LLM tokens
- [ ] Manual smoke: plan + turn checkpoints coexist → `resume.choices` surfaces both; the unchosen sibling does NOT pop a `resume.offer` on the next prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for explicit `/continue` and `/resume` commands (including Chinese language variant) to resume interrupted plans and ReAct turns.
  * Enabled resumption of individual turns alongside plan-level resumption with multi-tier routing priority.
  * Added choice selection when multiple resumables are available, allowing users to pick which to resume.

* **Tests**
  * Added comprehensive test coverage for explicit continue keywords and resume routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->