### PR TITLE
fix(core): recover text-based tool calls from open-weight models via Ollama

### DIFF
--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/StreamingAgentLoop.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/StreamingAgentLoop.java
@@ -1092,7 +1092,8 @@ public final class StreamingAgentLoop {
      *   <li>Bare JSON format: {@code {"name": "tool_name", "arguments": {...}}}</li>
      * </ol>
      */
-    private List<ContentBlock> tryConvertTextToToolUse(List<ContentBlock> blocks) {
+    // package-private for unit testing (see StreamingAgentLoopTextToolConversionTest)
+    List<ContentBlock> tryConvertTextToToolUse(List<ContentBlock> blocks) {
         boolean hasToolUse = blocks.stream().anyMatch(b -> b instanceof ContentBlock.ToolUse);
         if (hasToolUse) return null;
 
@@ -1138,8 +1139,9 @@ public final class StreamingAgentLoop {
 
     /**
      * Parses {@code [tool:start] tool_name {...args...} [tool:stop]} from model text output.
-     * The marker may appear anywhere in the text (e.g., after reasoning prose).
-     * Arguments are optional; if absent or unparseable, an empty object is used.
+     * The marker may appear anywhere in the text (e.g., after reasoning prose). If no argument
+     * object follows the tool name an empty object is used; if an argument object is present but
+     * malformed, {@code null} is returned so the text is not fired as a tool call with empty args.
      */
     private ContentBlock.ToolUse tryParseToolMarkerFormat(String fullText) {
         int markerIdx = fullText.indexOf("[tool:start]");
@@ -1157,19 +1159,21 @@ public final class StreamingAgentLoop {
         String toolName = afterMarker.substring(0, nameEnd);
         if (toolRegistry.get(toolName).isEmpty()) return null;
 
-        // Try to parse JSON arguments after the tool name
+        // Parse JSON arguments after the tool name, if present. readTree(parser) consumes exactly
+        // one complete JSON value and ignores any trailing text (the "[tool:stop]" marker or prose),
+        // so a literal "[tool:stop]" inside a string argument no longer truncates the object.
         String afterName = afterMarker.substring(nameEnd).stripLeading();
         String argsJson = "{}";
         if (!afterName.isEmpty() && afterName.charAt(0) == '{') {
-            int stopIdx = afterName.indexOf("[tool:stop]");
-            String candidate = stopIdx >= 0 ? afterName.substring(0, stopIdx).strip() : afterName.strip();
-            try {
-                JsonNode node = JSON.readTree(candidate);
-                if (node.isObject()) {
-                    argsJson = JSON.writeValueAsString(node);
-                }
-            } catch (Exception ignored) {
-                // Unparseable JSON — proceed with empty args
+            try (var parser = JSON.getFactory().createParser(afterName)) {
+                JsonNode node = JSON.readTree(parser);
+                if (node == null || !node.isObject()) return null;
+                argsJson = JSON.writeValueAsString(node);
+            } catch (Exception e) {
+                // Arguments were intended (text starts with '{') but are malformed. Don't fire a
+                // tool call with empty args — treat the whole thing as plain text instead.
+                log.debug("[tool:start] marker for {} has unparseable args, not treating as tool call", toolName);
+                return null;
             }
         }
 

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/StreamingAgentLoop.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/StreamingAgentLoop.java
@@ -452,9 +452,20 @@ public final class StreamingAgentLoop {
                 // Build assistant message from accumulated content
                 var contentBlocks = accumulator.buildContentBlocks();
 
-                // Fallback: some local models return tool calls as plain text JSON
+                // Fallbacks for open-weight / OpenAI-compatible providers that mishandle tool calls:
+                // (1) a native tool_calls block streamed but finish_reason was reported as "stop", or
+                // (2) the tool call was emitted as plain text ([tool:start] marker or bare JSON).
                 var stopReason = accumulator.stopReason != null ? accumulator.stopReason : StopReason.ERROR;
-                if (stopReason == StopReason.END_TURN) {
+                if (stopReason == StopReason.END_TURN
+                        && contentBlocks.stream().anyMatch(b -> b instanceof ContentBlock.ToolUse)) {
+                    // Some OpenAI-compatible providers (e.g. Ollama) stream a complete tool_calls
+                    // block but set finish_reason="stop" instead of "tool_calls", so the turn arrives
+                    // here as END_TURN even though the model asked to call a tool. Execute it instead
+                    // of silently ending the turn (which drops the call with no permission prompt).
+                    stopReason = StopReason.TOOL_USE;
+                    log.info("Promoted END_TURN to TOOL_USE: response carries a native tool_use block "
+                            + "(provider reported finish_reason=stop alongside tool_calls)");
+                } else if (stopReason == StopReason.END_TURN) {
                     // Concatenate the assistant text once and reuse it for both the conversion
                     // attempt and the diagnostic below — END_TURN is the normal terminal state for
                     // native-tool-calling providers, so this runs on every ordinary answer.
@@ -1112,15 +1123,27 @@ public final class StreamingAgentLoop {
 
         if (fullText.isEmpty()) return null;
 
-        // Try [tool:start] marker format first (used by open-weight models via Ollama/local)
+        // Prefer the bare-JSON interpretation when the entire response is a JSON object. A literal
+        // "[tool:start]" can legitimately appear inside a string argument (e.g. a write_file content
+        // value); trying the marker format first would hijack such a call and run a different tool.
+        if (fullText.charAt(0) == '{') {
+            var bareToolUse = tryParseBareJsonFormat(fullText);
+            if (bareToolUse != null) {
+                return buildToolUseBlocks(blocks, bareToolUse);
+            }
+        }
+
+        // Marker format (open-weight models via Ollama/local): [tool:start] name {json} [tool:stop]
         var markerToolUse = tryParseToolMarkerFormat(fullText);
         if (markerToolUse != null) {
             return buildToolUseBlocks(blocks, markerToolUse);
         }
 
-        // Fall back to bare JSON object: {"name": "tool_name", "arguments": {...}}
-        if (fullText.charAt(0) != '{') return null;
+        return null;
+    }
 
+    /** Parses a bare JSON tool call: {@code {"name": "tool_name", "arguments": {...}}}. */
+    private ContentBlock.ToolUse tryParseBareJsonFormat(String fullText) {
         try {
             JsonNode node = JSON.readTree(fullText);
             if (!node.isObject()) return null;
@@ -1134,10 +1157,9 @@ public final class StreamingAgentLoop {
 
             String toolId = "text-tool-" + UUID.randomUUID().toString().substring(0, 8);
             String argsJson = JSON.writeValueAsString(arguments);
-            var toolUse = new ContentBlock.ToolUse(toolId, toolName, argsJson);
 
             log.debug("Parsed bare-JSON tool call: tool={}, args={}", toolName, argsJson);
-            return buildToolUseBlocks(blocks, toolUse);
+            return new ContentBlock.ToolUse(toolId, toolName, argsJson);
 
         } catch (Exception e) {
             return null;
@@ -1146,9 +1168,14 @@ public final class StreamingAgentLoop {
 
     /**
      * Parses {@code [tool:start] tool_name {...args...} [tool:stop]} from model text output.
-     * The marker may appear anywhere in the text (e.g., after reasoning prose). If no argument
-     * object follows the tool name an empty object is used; if an argument object is present but
-     * malformed, {@code null} is returned so the text is not fired as a tool call with empty args.
+     *
+     * <p>Reasoning prose may precede the marker, but the marker tool call must be the <em>final</em>
+     * meaningful content: only whitespace and an optional {@code [tool:stop]} may follow the argument
+     * object. This prevents illustrative examples ("you'd call [tool:start] bash {...} to list files")
+     * or mixed responses from silently triggering real tool execution.
+     *
+     * <p>If no argument object follows the tool name an empty object is used; if an argument object is
+     * present but malformed, {@code null} is returned so the text is not fired with empty args.
      */
     private ContentBlock.ToolUse tryParseToolMarkerFormat(String fullText) {
         int markerIdx = fullText.indexOf("[tool:start]");
@@ -1172,20 +1199,38 @@ public final class StreamingAgentLoop {
 
         // Parse JSON arguments after the tool name, if present. readTree(parser) consumes exactly
         // one complete JSON value and ignores any trailing text (the "[tool:stop]" marker or prose),
-        // so a literal "[tool:stop]" inside a string argument no longer truncates the object.
+        // so a literal "[tool:stop]" inside a string argument no longer truncates the object. The
+        // parser's char offset tells us where the object ended so we can inspect what follows.
         String afterName = afterMarker.substring(nameEnd).stripLeading();
         String argsJson = "{}";
+        String remainder = afterName;
         if (!afterName.isEmpty() && afterName.charAt(0) == '{') {
             try (var parser = JSON.getFactory().createParser(afterName)) {
                 JsonNode node = JSON.readTree(parser);
                 if (node == null || !node.isObject()) return null;
                 argsJson = JSON.writeValueAsString(node);
+                long consumed = parser.currentLocation().getCharOffset();
+                remainder = (consumed >= 0 && consumed <= afterName.length())
+                        ? afterName.substring((int) consumed)
+                        : "";
             } catch (Exception e) {
                 // Arguments were intended (text starts with '{') but are malformed. Don't fire a
                 // tool call with empty args — treat the whole thing as plain text instead.
                 log.debug("[tool:start] marker for {} has unparseable args, not treating as tool call", toolName);
                 return null;
             }
+        }
+
+        // The marker call must be the final meaningful content: only whitespace and an optional
+        // [tool:stop] may follow. Anything else means the marker was an example/mixed prose, not a
+        // real invocation, so we must not execute it.
+        String tail = remainder.stripLeading();
+        if (tail.startsWith("[tool:stop]")) {
+            tail = tail.substring("[tool:stop]".length());
+        }
+        if (!tail.isBlank()) {
+            log.debug("[tool:start] marker for {} is followed by extra content, not treating as tool call", toolName);
+            return null;
         }
 
         String toolId = "text-tool-" + UUID.randomUUID().toString().substring(0, 8);
@@ -1237,18 +1282,27 @@ public final class StreamingAgentLoop {
      * otherwise-silent "model wanted a tool but we ended the turn" failure visible in the daemon log.
      */
     private void logUnrecognizedToolCallAttempt(String fullText) {
-        if (fullText.isEmpty()) return;
-
-        boolean looksLikeToolCall =
-                TOOL_CALL_TEXT_MARKERS.stream().anyMatch(m -> containsIgnoreCase(fullText, m))
-                || (fullText.charAt(0) == '{' && containsIgnoreCase(fullText, "\"name\""));
-        if (!looksLikeToolCall) return;
+        if (!looksLikeUnrecognizedToolCall(fullText)) return;
 
         int max = 300;
         String snippet = fullText.length() > max ? fullText.substring(0, max) + "..." : fullText;
         log.warn("Turn ended as END_TURN but model text looks like an unrecognized tool call "
                 + "(no native tool_use, unparseable by fallback). Provider={}. Snippet: {}",
                 llmClient.provider(), snippet);
+    }
+
+    /**
+     * Heuristic for whether END_TURN text resembles an unrecognized tool-call attempt. For
+     * JSON-shaped text it requires both {@code "name"} and {@code "arguments"} — the bare-JSON
+     * tool-call shape — so ordinary JSON answers like {@code {"name":"Alice"}} are not flagged.
+     */
+    // package-private for unit testing (see StreamingAgentLoopTextToolConversionTest)
+    static boolean looksLikeUnrecognizedToolCall(String fullText) {
+        if (fullText == null || fullText.isEmpty()) return false;
+        return TOOL_CALL_TEXT_MARKERS.stream().anyMatch(m -> containsIgnoreCase(fullText, m))
+                || (fullText.charAt(0) == '{'
+                        && containsIgnoreCase(fullText, "\"name\"")
+                        && containsIgnoreCase(fullText, "\"arguments\""));
     }
 
     /**

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/StreamingAgentLoop.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/StreamingAgentLoop.java
@@ -1130,7 +1130,9 @@ public final class StreamingAgentLoop {
      * path don't concatenate the assistant text twice (once here, once in the diagnostic).
      */
     private List<ContentBlock> tryConvertTextToToolUse(List<ContentBlock> blocks, String fullText) {
-        boolean hasToolUse = blocks.stream().anyMatch(b -> b instanceof ContentBlock.ToolUse);
+        // Keep the null-guard local so future callers of this overload can't introduce an NPE path.
+        var safeBlocks = blocks != null ? blocks : List.<ContentBlock>of();
+        boolean hasToolUse = safeBlocks.stream().anyMatch(b -> b instanceof ContentBlock.ToolUse);
         if (hasToolUse) return null;
 
         if (fullText.isEmpty()) return null;
@@ -1141,14 +1143,14 @@ public final class StreamingAgentLoop {
         if (fullText.charAt(0) == '{') {
             var bareToolUse = tryParseBareJsonFormat(fullText);
             if (bareToolUse != null) {
-                return buildToolUseBlocks(blocks, bareToolUse);
+                return buildToolUseBlocks(safeBlocks, bareToolUse);
             }
         }
 
         // Marker format (open-weight models via Ollama/local): [tool:start] name {json} [tool:stop]
         var markerToolUse = tryParseToolMarkerFormat(fullText);
         if (markerToolUse != null) {
-            return buildToolUseBlocks(blocks, markerToolUse);
+            return buildToolUseBlocks(safeBlocks, markerToolUse);
         }
 
         return null;
@@ -1157,8 +1159,9 @@ public final class StreamingAgentLoop {
     /** Parses a bare JSON tool call: {@code {"name": "tool_name", "arguments": {...}}}. */
     private ContentBlock.ToolUse tryParseBareJsonFormat(String fullText) {
         try {
+            // readTree returns null for empty/whitespace-only input; guard before dereferencing.
             JsonNode node = JSON.readTree(fullText);
-            if (!node.isObject()) return null;
+            if (node == null || !node.isObject()) return null;
 
             String toolName = node.path("name").asText(null);
             JsonNode arguments = node.get("arguments");

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/StreamingAgentLoop.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/StreamingAgentLoop.java
@@ -1075,8 +1075,13 @@ public final class StreamingAgentLoop {
     private static final ObjectMapper JSON = new ObjectMapper();
 
     /**
-     * Detects text content that is actually a tool call JSON from models that
-     * don't support native tool calling.
+     * Detects text content that is actually a tool call from models that don't support native
+     * tool calling. Handles two formats:
+     *
+     * <ol>
+     *   <li>Marker format (open-weight models): {@code [tool:start] tool_name {"arg":"val"} [tool:stop]}</li>
+     *   <li>Bare JSON format: {@code {"name": "tool_name", "arguments": {...}}}</li>
+     * </ol>
      */
     private List<ContentBlock> tryConvertTextToToolUse(List<ContentBlock> blocks) {
         boolean hasToolUse = blocks.stream().anyMatch(b -> b instanceof ContentBlock.ToolUse);
@@ -1088,7 +1093,16 @@ public final class StreamingAgentLoop {
                 .reduce("", (a, b) -> a + b)
                 .trim();
 
-        if (fullText.isEmpty() || fullText.charAt(0) != '{') return null;
+        if (fullText.isEmpty()) return null;
+
+        // Try [tool:start] marker format first (used by open-weight models via Ollama/local)
+        var markerToolUse = tryParseToolMarkerFormat(fullText);
+        if (markerToolUse != null) {
+            return buildToolUseBlocks(blocks, markerToolUse);
+        }
+
+        // Fall back to bare JSON object: {"name": "tool_name", "arguments": {...}}
+        if (fullText.charAt(0) != '{') return null;
 
         try {
             JsonNode node = JSON.readTree(fullText);
@@ -1103,23 +1117,68 @@ public final class StreamingAgentLoop {
 
             String toolId = "text-tool-" + UUID.randomUUID().toString().substring(0, 8);
             String argsJson = JSON.writeValueAsString(arguments);
+            var toolUse = new ContentBlock.ToolUse(toolId, toolName, argsJson);
 
-            var result = new ArrayList<ContentBlock>();
-            for (var block : blocks) {
-                if (block instanceof ContentBlock.Text) {
-                    // Skip — replaced by ToolUse
-                } else {
-                    result.add(block);
-                }
-            }
-            result.add(new ContentBlock.ToolUse(toolId, toolName, argsJson));
-
-            log.debug("Parsed text-based tool call: tool={}, args={}", toolName, argsJson);
-            return List.copyOf(result);
+            log.debug("Parsed bare-JSON tool call: tool={}, args={}", toolName, argsJson);
+            return buildToolUseBlocks(blocks, toolUse);
 
         } catch (Exception e) {
             return null;
         }
+    }
+
+    /**
+     * Parses {@code [tool:start] tool_name {...args...} [tool:stop]} from model text output.
+     * The marker may appear anywhere in the text (e.g., after reasoning prose).
+     * Arguments are optional; if absent or unparseable, an empty object is used.
+     */
+    private ContentBlock.ToolUse tryParseToolMarkerFormat(String fullText) {
+        int markerIdx = fullText.indexOf("[tool:start]");
+        if (markerIdx < 0) return null;
+
+        String afterMarker = fullText.substring(markerIdx + "[tool:start]".length()).stripLeading();
+
+        // Extract tool name (word characters: letters, digits, underscore)
+        int nameEnd = 0;
+        while (nameEnd < afterMarker.length()
+                && (Character.isLetterOrDigit(afterMarker.charAt(nameEnd)) || afterMarker.charAt(nameEnd) == '_')) {
+            nameEnd++;
+        }
+        if (nameEnd == 0) return null;
+        String toolName = afterMarker.substring(0, nameEnd);
+        if (toolRegistry.get(toolName).isEmpty()) return null;
+
+        // Try to parse JSON arguments after the tool name
+        String afterName = afterMarker.substring(nameEnd).stripLeading();
+        String argsJson = "{}";
+        if (!afterName.isEmpty() && afterName.charAt(0) == '{') {
+            int stopIdx = afterName.indexOf("[tool:stop]");
+            String candidate = stopIdx >= 0 ? afterName.substring(0, stopIdx).strip() : afterName.strip();
+            try {
+                JsonNode node = JSON.readTree(candidate);
+                if (node.isObject()) {
+                    argsJson = JSON.writeValueAsString(node);
+                }
+            } catch (Exception ignored) {
+                // Unparseable JSON — proceed with empty args
+            }
+        }
+
+        String toolId = "text-tool-" + UUID.randomUUID().toString().substring(0, 8);
+        log.debug("Parsed [tool:start] marker tool call: tool={}, args={}", toolName, argsJson);
+        return new ContentBlock.ToolUse(toolId, toolName, argsJson);
+    }
+
+    /** Replaces all Text blocks with {@code toolUse}, preserving non-Text blocks (e.g. Thinking). */
+    private List<ContentBlock> buildToolUseBlocks(List<ContentBlock> blocks, ContentBlock.ToolUse toolUse) {
+        var result = new ArrayList<ContentBlock>();
+        for (var block : blocks) {
+            if (!(block instanceof ContentBlock.Text)) {
+                result.add(block);
+            }
+        }
+        result.add(toolUse);
+        return List.copyOf(result);
     }
 
     /**

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/StreamingAgentLoop.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/StreamingAgentLoop.java
@@ -457,9 +457,18 @@ public final class StreamingAgentLoop {
                 if (stopReason == StopReason.END_TURN) {
                     var converted = tryConvertTextToToolUse(contentBlocks);
                     if (converted != null) {
+                        String convertedToolName = converted.stream()
+                                .filter(b -> b instanceof ContentBlock.ToolUse)
+                                .map(b -> ((ContentBlock.ToolUse) b).name())
+                                .findFirst().orElse("?");
                         contentBlocks = converted;
                         stopReason = StopReason.TOOL_USE;
-                        log.info("Converted text-based tool call to native ToolUse block");
+                        log.info("Recovered text-based tool call from END_TURN response: tool={}", convertedToolName);
+                    } else {
+                        // No native tool_use, no recoverable text tool call. If the model text
+                        // *looks* like it was attempting a tool call, surface it in the daemon log
+                        // so silent "END_TURN but wanted to call a tool" cases are diagnosable.
+                        logUnrecognizedToolCallAttempt(contentBlocks);
                     }
                 }
 
@@ -1179,6 +1188,35 @@ public final class StreamingAgentLoop {
         }
         result.add(toolUse);
         return List.copyOf(result);
+    }
+
+    /** Markers that suggest a model tried to call a tool via text instead of native tool_use. */
+    private static final List<String> TOOL_CALL_TEXT_MARKERS =
+            List.of("[tool:start]", "[tool_call", "<tool_call", "<function", "\"function\":", "\"tool_call");
+
+    /**
+     * When a turn ends as END_TURN with no tool call (native or recovered), checks whether the
+     * model's text output looks like an unrecognized tool-call attempt and logs it. This makes the
+     * otherwise-silent "model wanted a tool but we ended the turn" failure visible in the daemon log.
+     */
+    private void logUnrecognizedToolCallAttempt(List<ContentBlock> blocks) {
+        String fullText = blocks.stream()
+                .filter(b -> b instanceof ContentBlock.Text)
+                .map(b -> ((ContentBlock.Text) b).text())
+                .reduce("", (a, b) -> a + b)
+                .trim();
+        if (fullText.isEmpty()) return;
+
+        String lower = fullText.toLowerCase();
+        boolean looksLikeToolCall = TOOL_CALL_TEXT_MARKERS.stream().anyMatch(lower::contains)
+                || (fullText.charAt(0) == '{' && lower.contains("\"name\""));
+        if (!looksLikeToolCall) return;
+
+        int max = 300;
+        String snippet = fullText.length() > max ? fullText.substring(0, max) + "..." : fullText;
+        log.warn("Turn ended as END_TURN but model text looks like an unrecognized tool call "
+                + "(no native tool_use, unparseable by fallback). Provider={}. Snippet: {}",
+                llmClient.provider(), snippet);
     }
 
     /**

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/StreamingAgentLoop.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/StreamingAgentLoop.java
@@ -480,9 +480,21 @@ public final class StreamingAgentLoop {
                         stopReason = StopReason.TOOL_USE;
                         log.info("Recovered text-based tool call from END_TURN response: tool={}", convertedToolName);
                     } else {
-                        // No native tool_use, no recoverable text tool call. If the model text
-                        // *looks* like it was attempting a tool call, surface it in the daemon log
-                        // so silent "END_TURN but wanted to call a tool" cases are diagnosable.
+                        // Blind-spot safety net: dump the raw assistant text at TRACE so a model
+                        // using a tool-call format we don't recognize is still fully visible in the
+                        // daemon log (enable with ACECLAW_LOG_LEVEL=TRACE). Off by default to avoid
+                        // logging every ordinary answer's text.
+                        if (log.isTraceEnabled() && !endTurnText.isEmpty()) {
+                            int max = 4000;
+                            String raw = endTurnText.length() > max
+                                    ? endTurnText.substring(0, max) + "...(" + endTurnText.length() + " chars)"
+                                    : endTurnText;
+                            log.trace("END_TURN produced no tool call. Provider={}. Raw assistant text: {}",
+                                    llmClient.provider(), raw);
+                        }
+                        // If the model text *looks* like it was attempting a tool call in a known but
+                        // unparseable shape, surface it prominently (WARN) so silent "END_TURN but
+                        // wanted to call a tool" cases are diagnosable without raising the log level.
                         logUnrecognizedToolCallAttempt(endTurnText);
                     }
                 }

--- a/aceclaw-core/src/main/java/dev/aceclaw/core/agent/StreamingAgentLoop.java
+++ b/aceclaw-core/src/main/java/dev/aceclaw/core/agent/StreamingAgentLoop.java
@@ -455,7 +455,11 @@ public final class StreamingAgentLoop {
                 // Fallback: some local models return tool calls as plain text JSON
                 var stopReason = accumulator.stopReason != null ? accumulator.stopReason : StopReason.ERROR;
                 if (stopReason == StopReason.END_TURN) {
-                    var converted = tryConvertTextToToolUse(contentBlocks);
+                    // Concatenate the assistant text once and reuse it for both the conversion
+                    // attempt and the diagnostic below — END_TURN is the normal terminal state for
+                    // native-tool-calling providers, so this runs on every ordinary answer.
+                    String endTurnText = concatText(contentBlocks);
+                    var converted = tryConvertTextToToolUse(contentBlocks, endTurnText);
                     if (converted != null) {
                         String convertedToolName = converted.stream()
                                 .filter(b -> b instanceof ContentBlock.ToolUse)
@@ -468,7 +472,7 @@ public final class StreamingAgentLoop {
                         // No native tool_use, no recoverable text tool call. If the model text
                         // *looks* like it was attempting a tool call, surface it in the daemon log
                         // so silent "END_TURN but wanted to call a tool" cases are diagnosable.
-                        logUnrecognizedToolCallAttempt(contentBlocks);
+                        logUnrecognizedToolCallAttempt(endTurnText);
                     }
                 }
 
@@ -1094,14 +1098,17 @@ public final class StreamingAgentLoop {
      */
     // package-private for unit testing (see StreamingAgentLoopTextToolConversionTest)
     List<ContentBlock> tryConvertTextToToolUse(List<ContentBlock> blocks) {
+        var safeBlocks = blocks != null ? blocks : List.<ContentBlock>of();
+        return tryConvertTextToToolUse(safeBlocks, concatText(safeBlocks));
+    }
+
+    /**
+     * Variant that reuses an already-concatenated {@code fullText} so callers on the hot END_TURN
+     * path don't concatenate the assistant text twice (once here, once in the diagnostic).
+     */
+    private List<ContentBlock> tryConvertTextToToolUse(List<ContentBlock> blocks, String fullText) {
         boolean hasToolUse = blocks.stream().anyMatch(b -> b instanceof ContentBlock.ToolUse);
         if (hasToolUse) return null;
-
-        String fullText = blocks.stream()
-                .filter(b -> b instanceof ContentBlock.Text)
-                .map(b -> ((ContentBlock.Text) b).text())
-                .reduce("", (a, b) -> a + b)
-                .trim();
 
         if (fullText.isEmpty()) return null;
 
@@ -1149,10 +1156,14 @@ public final class StreamingAgentLoop {
 
         String afterMarker = fullText.substring(markerIdx + "[tool:start]".length()).stripLeading();
 
-        // Extract tool name (word characters: letters, digits, underscore)
+        // Extract the tool name: everything up to the first whitespace, '{' (args), or '[' (a
+        // following marker). Do NOT restrict to [A-Za-z0-9_] — MCP tools are named
+        // mcp__<server>__<tool> where <tool> may contain '-' or '.' (e.g. mcp__context7__query-docs),
+        // which the bare-JSON path already accepts; a char-class scan would truncate them.
         int nameEnd = 0;
-        while (nameEnd < afterMarker.length()
-                && (Character.isLetterOrDigit(afterMarker.charAt(nameEnd)) || afterMarker.charAt(nameEnd) == '_')) {
+        while (nameEnd < afterMarker.length()) {
+            char c = afterMarker.charAt(nameEnd);
+            if (Character.isWhitespace(c) || c == '{' || c == '[') break;
             nameEnd++;
         }
         if (nameEnd == 0) return null;
@@ -1182,6 +1193,28 @@ public final class StreamingAgentLoop {
         return new ContentBlock.ToolUse(toolId, toolName, argsJson);
     }
 
+    /** Concatenates the text of all {@link ContentBlock.Text} blocks, trimmed. */
+    private static String concatText(List<ContentBlock> blocks) {
+        var sb = new StringBuilder();
+        for (var block : blocks) {
+            if (block instanceof ContentBlock.Text t) {
+                sb.append(t.text());
+            }
+        }
+        return sb.toString().trim();
+    }
+
+    /** Case-insensitive containment that does not allocate a lowercased copy of {@code haystack}. */
+    private static boolean containsIgnoreCase(String haystack, String needle) {
+        int n = needle.length();
+        if (n == 0) return true;
+        int limit = haystack.length() - n;
+        for (int i = 0; i <= limit; i++) {
+            if (haystack.regionMatches(true, i, needle, 0, n)) return true;
+        }
+        return false;
+    }
+
     /** Replaces all Text blocks with {@code toolUse}, preserving non-Text blocks (e.g. Thinking). */
     private List<ContentBlock> buildToolUseBlocks(List<ContentBlock> blocks, ContentBlock.ToolUse toolUse) {
         var result = new ArrayList<ContentBlock>();
@@ -1203,17 +1236,12 @@ public final class StreamingAgentLoop {
      * model's text output looks like an unrecognized tool-call attempt and logs it. This makes the
      * otherwise-silent "model wanted a tool but we ended the turn" failure visible in the daemon log.
      */
-    private void logUnrecognizedToolCallAttempt(List<ContentBlock> blocks) {
-        String fullText = blocks.stream()
-                .filter(b -> b instanceof ContentBlock.Text)
-                .map(b -> ((ContentBlock.Text) b).text())
-                .reduce("", (a, b) -> a + b)
-                .trim();
+    private void logUnrecognizedToolCallAttempt(String fullText) {
         if (fullText.isEmpty()) return;
 
-        String lower = fullText.toLowerCase();
-        boolean looksLikeToolCall = TOOL_CALL_TEXT_MARKERS.stream().anyMatch(lower::contains)
-                || (fullText.charAt(0) == '{' && lower.contains("\"name\""));
+        boolean looksLikeToolCall =
+                TOOL_CALL_TEXT_MARKERS.stream().anyMatch(m -> containsIgnoreCase(fullText, m))
+                || (fullText.charAt(0) == '{' && containsIgnoreCase(fullText, "\"name\""));
         if (!looksLikeToolCall) return;
 
         int max = 300;

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/agent/StreamingAgentLoopTextToolConversionTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/agent/StreamingAgentLoopTextToolConversionTest.java
@@ -1,0 +1,200 @@
+package dev.aceclaw.core.agent;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.aceclaw.core.llm.ContentBlock;
+import dev.aceclaw.core.llm.LlmClient;
+import dev.aceclaw.core.llm.LlmException;
+import dev.aceclaw.core.llm.LlmRequest;
+import dev.aceclaw.core.llm.LlmResponse;
+import dev.aceclaw.core.llm.StreamSession;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link StreamingAgentLoop#tryConvertTextToToolUse}, the fallback that turns a
+ * text-only assistant turn into a native {@code ToolUse} for models without native tool calling.
+ * Covers both the {@code [tool:start]} marker format and the bare-JSON format.
+ */
+class StreamingAgentLoopTextToolConversionTest {
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    private StreamingAgentLoop newLoop() {
+        var registry = new ToolRegistry();
+        registry.register(new StubTool("bash"));
+        registry.register(new StubTool("read_file"));
+        registry.register(new StubTool("write_file"));
+        return new StreamingAgentLoop(new NoopLlmClient(), registry, "model", null);
+    }
+
+    private List<ContentBlock> convert(String text) {
+        return newLoop().tryConvertTextToToolUse(List.of(new ContentBlock.Text(text)));
+    }
+
+    private ContentBlock.ToolUse toolUseOf(List<ContentBlock> blocks) {
+        assertThat(blocks).isNotNull();
+        return (ContentBlock.ToolUse) blocks.stream()
+                .filter(b -> b instanceof ContentBlock.ToolUse)
+                .findFirst()
+                .orElseThrow();
+    }
+
+    // --- Marker format ---
+
+    @Test
+    void parsesMarkerFormatWithArgs() throws Exception {
+        var result = convert("[tool:start] bash {\"command\": \"ls -la\"} [tool:stop]");
+        var toolUse = toolUseOf(result);
+        assertThat(toolUse.name()).isEqualTo("bash");
+        assertThat(JSON.readTree(toolUse.inputJson()).path("command").asText()).isEqualTo("ls -la");
+    }
+
+    @Test
+    void parsesMarkerFormatAfterReasoningProse() {
+        var result = convert("I'll list the files first.\n\n[tool:start] bash {\"command\": \"ls\"} [tool:stop]");
+        assertThat(toolUseOf(result).name()).isEqualTo("bash");
+    }
+
+    @Test
+    void parsesMarkerFormatWithoutStopMarker() {
+        var result = convert("[tool:start] read_file {\"path\": \"a.txt\"}");
+        assertThat(toolUseOf(result).name()).isEqualTo("read_file");
+    }
+
+    @Test
+    void markerWithoutArgsUsesEmptyObject() {
+        var result = convert("[tool:start] bash [tool:stop]");
+        var toolUse = toolUseOf(result);
+        assertThat(toolUse.name()).isEqualTo("bash");
+        assertThat(toolUse.inputJson()).isEqualTo("{}");
+    }
+
+    /** Finding 1: a literal "[tool:stop]" inside a string argument must not truncate the JSON. */
+    @Test
+    void stopMarkerInsideStringArgIsNotTreatedAsBoundary() throws Exception {
+        String content = "before [tool:stop] after";
+        var result = convert("[tool:start] write_file {\"path\": \"d.md\", \"content\": \""
+                + content + "\"} [tool:stop]");
+        var toolUse = toolUseOf(result);
+        assertThat(toolUse.name()).isEqualTo("write_file");
+        var args = JSON.readTree(toolUse.inputJson());
+        assertThat(args.path("path").asText()).isEqualTo("d.md");
+        assertThat(args.path("content").asText()).isEqualTo(content);
+    }
+
+    /** Finding 2: malformed args must not fire a tool call with silently-empty args. */
+    @Test
+    void markerWithMalformedArgsIsNotConverted() {
+        var result = convert("[tool:start] bash {\"command\": \"ls\" broken");
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void markerWithUnknownToolIsNotConverted() {
+        var result = convert("[tool:start] not_a_real_tool {\"x\": 1} [tool:stop]");
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void markerPreservesNonTextBlocks() {
+        var loop = newLoop();
+        var blocks = List.<ContentBlock>of(
+                new ContentBlock.Thinking("reasoning"),
+                new ContentBlock.Text("[tool:start] bash {\"command\": \"ls\"} [tool:stop]"));
+        var result = loop.tryConvertTextToToolUse(blocks);
+        assertThat(result).anyMatch(b -> b instanceof ContentBlock.Thinking);
+        assertThat(result).noneMatch(b -> b instanceof ContentBlock.Text);
+        assertThat(toolUseOf(result).name()).isEqualTo("bash");
+    }
+
+    // --- Bare-JSON format ---
+
+    @Test
+    void parsesBareJsonFormat() throws Exception {
+        var result = convert("{\"name\": \"bash\", \"arguments\": {\"command\": \"pwd\"}}");
+        var toolUse = toolUseOf(result);
+        assertThat(toolUse.name()).isEqualTo("bash");
+        assertThat(JSON.readTree(toolUse.inputJson()).path("command").asText()).isEqualTo("pwd");
+    }
+
+    @Test
+    void bareJsonWithUnknownToolIsNotConverted() {
+        assertThat(convert("{\"name\": \"nope\", \"arguments\": {}}")).isNull();
+    }
+
+    // --- Non-matching / guard cases ---
+
+    @Test
+    void plainTextIsNotConverted() {
+        assertThat(convert("Here is a summary of what I found.")).isNull();
+    }
+
+    @Test
+    void emptyTextIsNotConverted() {
+        assertThat(convert("   ")).isNull();
+    }
+
+    @Test
+    void existingToolUseShortCircuits() {
+        var loop = newLoop();
+        var blocks = List.<ContentBlock>of(
+                new ContentBlock.Text("[tool:start] bash {\"command\": \"ls\"} [tool:stop]"),
+                new ContentBlock.ToolUse("existing", "bash", "{}"));
+        assertThat(loop.tryConvertTextToToolUse(blocks)).isNull();
+    }
+
+    // --- Test doubles ---
+
+    private static final class StubTool implements Tool {
+        private final String name;
+
+        StubTool(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
+        public String description() {
+            return name + " stub";
+        }
+
+        @Override
+        public com.fasterxml.jackson.databind.JsonNode inputSchema() {
+            return JSON.createObjectNode();
+        }
+
+        @Override
+        public ToolResult execute(String inputJson) {
+            return new ToolResult("ok", false);
+        }
+    }
+
+    private static final class NoopLlmClient implements LlmClient {
+        @Override
+        public LlmResponse sendMessage(LlmRequest request) throws LlmException {
+            throw new UnsupportedOperationException("not used in these tests");
+        }
+
+        @Override
+        public StreamSession streamMessage(LlmRequest request) throws LlmException {
+            throw new UnsupportedOperationException("not used in these tests");
+        }
+
+        @Override
+        public String provider() {
+            return "stub";
+        }
+
+        @Override
+        public String defaultModel() {
+            return "model";
+        }
+    }
+}

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/agent/StreamingAgentLoopTextToolConversionTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/agent/StreamingAgentLoopTextToolConversionTest.java
@@ -228,18 +228,7 @@ class StreamingAgentLoopTextToolConversionTest {
 
     // --- Test doubles ---
 
-    private static final class StubTool implements Tool {
-        private final String name;
-
-        StubTool(String name) {
-            this.name = name;
-        }
-
-        @Override
-        public String name() {
-            return name;
-        }
-
+    private record StubTool(String name) implements Tool {
         @Override
         public String description() {
             return name + " stub";

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/agent/StreamingAgentLoopTextToolConversionTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/agent/StreamingAgentLoopTextToolConversionTest.java
@@ -118,6 +118,28 @@ class StreamingAgentLoopTextToolConversionTest {
         assertThat(result).isNull();
     }
 
+    /** Finding (PR #519): an illustrative marker followed by more prose must not execute a tool. */
+    @Test
+    void markerFollowedByTrailingProseIsNotConverted() {
+        var result = convert("For example you'd call [tool:start] bash {\"command\": \"ls\"} "
+                + "and then read the output to decide what to do next.");
+        assertThat(result).isNull();
+    }
+
+    /** Trailing prose after an explicit [tool:stop] is still extra content and must be rejected. */
+    @Test
+    void markerWithProseAfterStopIsNotConverted() {
+        var result = convert("[tool:start] bash {\"command\": \"ls\"} [tool:stop] Now I'll analyze it.");
+        assertThat(result).isNull();
+    }
+
+    /** Trailing prose after an args-less marker call must also be rejected. */
+    @Test
+    void markerWithoutArgsButTrailingProseIsNotConverted() {
+        var result = convert("[tool:start] bash then something else happens");
+        assertThat(result).isNull();
+    }
+
     @Test
     void markerPreservesNonTextBlocks() {
         var loop = newLoop();
@@ -143,6 +165,44 @@ class StreamingAgentLoopTextToolConversionTest {
     @Test
     void bareJsonWithUnknownToolIsNotConverted() {
         assertThat(convert("{\"name\": \"nope\", \"arguments\": {}}")).isNull();
+    }
+
+    /**
+     * Finding (PR #519): a valid bare-JSON tool call whose argument contains a literal marker must
+     * be parsed as the outer call — the marker inside the string must not hijack execution.
+     */
+    @Test
+    void bareJsonIsNotHijackedByMarkerInsideStringArg() throws Exception {
+        var result = convert("{\"name\": \"write_file\", \"arguments\": {\"path\": \"a.md\", "
+                + "\"content\": \"[tool:start] read_file {} [tool:stop]\"}}");
+        var toolUse = toolUseOf(result);
+        assertThat(toolUse.name()).isEqualTo("write_file");
+        assertThat(JSON.readTree(toolUse.inputJson()).path("content").asText())
+                .isEqualTo("[tool:start] read_file {} [tool:stop]");
+    }
+
+    // --- Unrecognized-tool-call WARN heuristic (Finding: PR #519) ---
+
+    @Test
+    void ordinaryJsonWithNameFieldIsNotFlagged() {
+        assertThat(StreamingAgentLoop.looksLikeUnrecognizedToolCall("{\"name\":\"Alice\"}")).isFalse();
+    }
+
+    @Test
+    void bareJsonToolCallShapeIsFlagged() {
+        assertThat(StreamingAgentLoop.looksLikeUnrecognizedToolCall(
+                "{\"name\":\"bash\",\"arguments\":{\"command\":\"ls\"}}")).isTrue();
+    }
+
+    @Test
+    void markerTextIsFlagged() {
+        assertThat(StreamingAgentLoop.looksLikeUnrecognizedToolCall(
+                "some text [tool:start] bash")).isTrue();
+    }
+
+    @Test
+    void plainTextIsNotFlagged() {
+        assertThat(StreamingAgentLoop.looksLikeUnrecognizedToolCall("Here is your answer.")).isFalse();
     }
 
     // --- Non-matching / guard cases ---

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/agent/StreamingAgentLoopTextToolConversionTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/agent/StreamingAgentLoopTextToolConversionTest.java
@@ -27,6 +27,8 @@ class StreamingAgentLoopTextToolConversionTest {
         registry.register(new StubTool("bash"));
         registry.register(new StubTool("read_file"));
         registry.register(new StubTool("write_file"));
+        // MCP tools are named mcp__<server>__<tool>, and <tool> may contain '-' or '.'.
+        registry.register(new StubTool("mcp__context7__query-docs"));
         return new StreamingAgentLoop(new NoopLlmClient(), registry, "model", null);
     }
 
@@ -62,6 +64,24 @@ class StreamingAgentLoopTextToolConversionTest {
     void parsesMarkerFormatWithoutStopMarker() {
         var result = convert("[tool:start] read_file {\"path\": \"a.txt\"}");
         assertThat(toolUseOf(result).name()).isEqualTo("read_file");
+    }
+
+    /**
+     * Finding: the marker tool-name scan must not stop at '-' or '.' — MCP tool names
+     * (mcp__server__tool) frequently contain hyphens, and the bare-JSON path already accepts them.
+     */
+    @Test
+    void parsesMarkerFormatWithHyphenatedMcpToolName() throws Exception {
+        var result = convert("[tool:start] mcp__context7__query-docs {\"q\": \"streams\"} [tool:stop]");
+        var toolUse = toolUseOf(result);
+        assertThat(toolUse.name()).isEqualTo("mcp__context7__query-docs");
+        assertThat(JSON.readTree(toolUse.inputJson()).path("q").asText()).isEqualTo("streams");
+    }
+
+    @Test
+    void parsesMarkerFormatWithHyphenatedNameNoSpaceBeforeArgs() {
+        var result = convert("[tool:start] mcp__context7__query-docs{\"q\": \"x\"}");
+        assertThat(toolUseOf(result).name()).isEqualTo("mcp__context7__query-docs");
     }
 
     @Test

--- a/aceclaw-core/src/test/java/dev/aceclaw/core/agent/StreamingToolUseToolResultInvariantTest.java
+++ b/aceclaw-core/src/test/java/dev/aceclaw/core/agent/StreamingToolUseToolResultInvariantTest.java
@@ -212,6 +212,45 @@ class StreamingToolUseToolResultInvariantTest {
                 .containsExactlyInAnyOrder("tu-1", "tu-2");
     }
 
+    /**
+     * Ollama and some OpenAI-compatible providers stream a complete tool_calls block but report
+     * finish_reason="stop" (mapped to END_TURN) instead of "tool_calls". The loop must promote the
+     * turn to TOOL_USE and execute the tool, rather than silently ending with no permission prompt.
+     */
+    @Test
+    void streamingLoop_endTurnWithNativeToolUse_isPromotedAndExecuted() throws Exception {
+        var toolUseButEndTurn = new ArrayList<StreamEvent>();
+        toolUseButEndTurn.add(new StreamEvent.MessageStart("msg-1", "model"));
+        toolUseButEndTurn.add(new StreamEvent.ContentBlockStart(0,
+                new ContentBlock.ToolUse("tu-1", "web_search", "")));
+        toolUseButEndTurn.add(new StreamEvent.ToolUseDelta(0, "web_search", "{\"query\":\"weather\"}"));
+        toolUseButEndTurn.add(new StreamEvent.ContentBlockStop(0));
+        // Provider quirk: finish_reason="stop" -> END_TURN, even though a tool_calls block was sent.
+        toolUseButEndTurn.add(new StreamEvent.MessageDelta(StopReason.END_TURN, new Usage(10, 5, 0, 0)));
+        toolUseButEndTurn.add(new StreamEvent.StreamComplete());
+
+        var llm = new FakeStreamingLlmClient(List.of(
+                toolUseButEndTurn,
+                textStreamResponse("The weather is sunny.")));
+
+        var registry = new ToolRegistry();
+        registry.register(new StubTool("web_search", "search results"));
+
+        var loop = new StreamingAgentLoop(llm, registry, "model", null);
+        var turn = loop.runTurn("weather?", List.of(), new StreamEventHandler() {});
+
+        // The tool must have been executed: the tool_use is followed by a matching tool_result...
+        assertToolUseToolResultInvariant(turn.newMessages());
+        // ...and the loop continued to the follow-up text response instead of ending on the tool call.
+        var last = turn.newMessages().getLast();
+        assertThat(last).isInstanceOf(Message.AssistantMessage.class);
+        var text = ((Message.AssistantMessage) last).content().stream()
+                .filter(b -> b instanceof ContentBlock.Text)
+                .map(b -> ((ContentBlock.Text) b).text())
+                .findFirst().orElse("");
+        assertThat(text).contains("sunny");
+    }
+
     // ---- Invariant assertion (same logic as non-streaming test) ----
 
     private static void assertToolUseToolResultInvariant(List<Message> messages) {

--- a/aceclaw-daemon/src/main/resources/logback.xml
+++ b/aceclaw-daemon/src/main/resources/logback.xml
@@ -19,8 +19,10 @@
         </encoder>
     </appender>
 
-    <!-- Key daemon events at INFO, detailed debug available -->
-    <logger name="dev.aceclaw" level="DEBUG"/>
+    <!-- Key daemon events at INFO, detailed debug available. Level is overridable via the
+         ACECLAW_LOG_LEVEL env var (e.g. ACECLAW_LOG_LEVEL=TRACE) for diagnostics such as dumping
+         the raw model output on END_TURN turns that produced no tool call. Defaults to DEBUG. -->
+    <logger name="dev.aceclaw" level="${ACECLAW_LOG_LEVEL:-DEBUG}"/>
 
     <root level="INFO">
         <appender-ref ref="STDOUT"/>

--- a/aceclaw-llm/src/main/java/dev/aceclaw/llm/openai/OpenAIStreamSession.java
+++ b/aceclaw-llm/src/main/java/dev/aceclaw/llm/openai/OpenAIStreamSession.java
@@ -47,6 +47,12 @@ final class OpenAIStreamSession implements StreamSession {
     // Tool call accumulation: index -> state
     private final Map<Integer, ToolCallState> toolCallStates = new HashMap<>();
 
+    // The stop reason from the real finish_reason chunk, if one has been seen. A trailing
+    // usage-only chunk (some providers, e.g. Ollama) must not clobber this with END_TURN —
+    // otherwise a truncated response (finish_reason="length" -> MAX_TOKENS) is downgraded to
+    // END_TURN and its partial tool_use gets treated as a complete call.
+    private StopReason emittedStopReason;
+
     OpenAIStreamSession(HttpResponse<Stream<String>> response, OpenAIMapper mapper) {
         this.response = response;
         this.mapper = mapper;
@@ -149,17 +155,21 @@ final class OpenAIStreamSession implements StreamSession {
                 // Extract usage from top-level (OpenAI puts it at root when stream_options.include_usage=true)
                 Usage usage = mapper.parseUsage(root.path("usage"));
                 StopReason stopReason = StopReason.fromString(finishReason);
+                emittedStopReason = stopReason;
                 handler.onMessageDelta(new StreamEvent.MessageDelta(stopReason, usage));
             }
         }
 
-        // Some providers (Ollama, etc.) put usage in a separate final chunk with empty choices
+        // Some providers (Ollama, etc.) put usage in a separate final chunk with empty choices.
         if ((!choices.isArray() || choices.isEmpty()) && root.has("usage")) {
             Usage chunkUsage = mapper.parseUsage(root.path("usage"));
             if (chunkUsage.inputTokens() > 0 || chunkUsage.outputTokens() > 0) {
-                // Emit MessageDelta with usage so token counts reach the client
+                // Emit MessageDelta with usage so token counts reach the client. Preserve the real
+                // stop reason if a finish_reason chunk already set one (e.g. "length" -> MAX_TOKENS);
+                // only fall back to END_TURN when this trailing chunk is the sole terminator.
+                StopReason stopReason = emittedStopReason != null ? emittedStopReason : StopReason.END_TURN;
                 flushOpenBlocks(handler);
-                handler.onMessageDelta(new StreamEvent.MessageDelta(StopReason.END_TURN, chunkUsage));
+                handler.onMessageDelta(new StreamEvent.MessageDelta(stopReason, chunkUsage));
             }
         }
     }

--- a/aceclaw-llm/src/test/java/dev/aceclaw/llm/openai/OpenAIStreamSessionTest.java
+++ b/aceclaw-llm/src/test/java/dev/aceclaw/llm/openai/OpenAIStreamSessionTest.java
@@ -1,0 +1,104 @@
+package dev.aceclaw.llm.openai;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.aceclaw.core.llm.StopReason;
+import dev.aceclaw.core.llm.StreamEvent;
+import dev.aceclaw.core.llm.StreamEventHandler;
+import org.junit.jupiter.api.Test;
+
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link OpenAIStreamSession}'s handling of terminal stop reasons, in particular the
+ * OpenAI-compatible quirk where usage arrives in a trailing chunk with empty {@code choices}.
+ */
+class OpenAIStreamSessionTest {
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    private static List<StreamEvent.MessageDelta> run(List<String> sseData) {
+        var mapper = new OpenAIMapper(JSON);
+        var lines = sseData.stream().map(d -> "data: " + d).toList();
+        var session = new OpenAIStreamSession(new FakeStreamResponse(lines), mapper);
+
+        var deltas = new ArrayList<StreamEvent.MessageDelta>();
+        session.onEvent(new StreamEventHandler() {
+            @Override
+            public void onMessageDelta(StreamEvent.MessageDelta event) {
+                deltas.add(event);
+            }
+        });
+        return deltas;
+    }
+
+    /**
+     * P2 regression: a truncated response reports finish_reason="length" and then sends usage in a
+     * separate trailing chunk with empty choices. The trailing chunk must NOT clobber MAX_TOKENS
+     * with END_TURN — otherwise a partial tool_use in the truncated turn gets promoted+executed.
+     */
+    @Test
+    void trailingUsageChunkPreservesMaxTokensStopReason() {
+        var deltas = run(List.of(
+                "{\"id\":\"c1\",\"model\":\"m\",\"choices\":[{\"delta\":{\"content\":\"partial\"},"
+                        + "\"finish_reason\":\"length\"}]}",
+                // Trailing usage-only chunk with empty choices (Ollama/OpenAI-compat quirk)
+                "{\"id\":\"c1\",\"model\":\"m\",\"choices\":[],"
+                        + "\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5}}",
+                "[DONE]"));
+
+        // The final terminal stop reason the accumulator sees must remain MAX_TOKENS.
+        assertThat(deltas).isNotEmpty();
+        assertThat(deltas.getLast().stopReason()).isEqualTo(StopReason.MAX_TOKENS);
+        // Usage from the trailing chunk still reaches the client.
+        assertThat(deltas.getLast().usage().outputTokens()).isEqualTo(5);
+    }
+
+    /**
+     * When the trailing usage chunk is the sole terminator (no prior finish_reason), it falls back
+     * to END_TURN so token counts still reach the client.
+     */
+    @Test
+    void trailingUsageChunkWithNoPriorFinishReasonFallsBackToEndTurn() {
+        var deltas = run(List.of(
+                "{\"id\":\"c1\",\"model\":\"m\",\"choices\":[{\"delta\":{\"content\":\"hello\"}}]}",
+                "{\"id\":\"c1\",\"model\":\"m\",\"choices\":[],"
+                        + "\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":2}}",
+                "[DONE]"));
+
+        assertThat(deltas).isNotEmpty();
+        assertThat(deltas.getLast().stopReason()).isEqualTo(StopReason.END_TURN);
+    }
+
+    /** A normal tool-call response maps finish_reason="tool_calls" to TOOL_USE. */
+    @Test
+    void toolCallsFinishReasonMapsToToolUse() {
+        var deltas = run(List.of(
+                "{\"id\":\"c1\",\"model\":\"m\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,"
+                        + "\"id\":\"t1\",\"function\":{\"name\":\"web_search\",\"arguments\":\"{}\"}}]},"
+                        + "\"finish_reason\":\"tool_calls\"}]}",
+                "[DONE]"));
+
+        assertThat(deltas).isNotEmpty();
+        assertThat(deltas.getLast().stopReason()).isEqualTo(StopReason.TOOL_USE);
+    }
+
+    /** Minimal HttpResponse whose body() replays canned SSE lines as a Stream. */
+    private record FakeStreamResponse(List<String> lines) implements HttpResponse<Stream<String>> {
+        @Override public int statusCode() { return 200; }
+        @Override public HttpRequest request() { return null; }
+        @Override public Optional<HttpResponse<Stream<String>>> previousResponse() { return Optional.empty(); }
+        @Override public HttpHeaders headers() { return HttpHeaders.of(java.util.Map.of(), (a, b) -> true); }
+        @Override public Stream<String> body() { return lines.stream(); }
+        @Override public Optional<javax.net.ssl.SSLSession> sslSession() { return Optional.empty(); }
+        @Override public java.net.URI uri() { return java.net.URI.create("http://test"); }
+        @Override public java.net.http.HttpClient.Version version() { return java.net.http.HttpClient.Version.HTTP_1_1; }
+    }
+}


### PR DESCRIPTION
## Summary

Open-weight models (e.g. `north-mini-code-1.0` on a local Ollama endpoint) emit tool calls as **plain text** — `[tool:start] tool_name {json} [tool:stop]` — instead of the structured `delta.tool_calls` OpenAI format. AceClaw's existing text fallback only recognized a bare JSON object, so these turns ended as `END_TURN` with **no tool execution** and were silently recorded as a successful interaction (no permission prompt, nothing in the daemon log).

This PR makes those tool calls fire correctly and makes the failure mode diagnosable.

## Changes

- **Parse the `[tool:start]` marker format** in `tryConvertTextToToolUse` — extract the tool name and optional JSON arguments (anywhere in the text, after reasoning prose), synthesize a `ContentBlock.ToolUse`, and run it through the normal permission/execution pipeline. `readTree(parser)` consumes exactly one JSON value, so a literal `[tool:stop]` inside a string argument no longer truncates the object; malformed args are rejected rather than fired with empty args.
- **Support MCP tool names** (`mcp__<server>__<tool>`, where `<tool>` may contain `-`/`.`, e.g. `mcp__context7__query-docs`) — the name scan reads until whitespace/`{`/`[` instead of restricting to `[A-Za-z0-9_]`, matching what the bare-JSON path already accepted.
- **Diagnostic logging** — on successful recovery, INFO names the recovered tool; when a turn ends `END_TURN` but the text looks like an unrecognized tool call (`[tool:start]`, `<tool_call>`, `{"name":...}`, `"function":`…), WARN with the provider + a truncated snippet. Previously this failure was completely silent in the daemon log.
- **Hot-path hygiene** — `END_TURN` is the normal terminal state for native-tool-calling providers, so the fallback runs on every ordinary answer. Concatenate the assistant text once via a shared `concatText()` helper and match markers with an allocation-free `containsIgnoreCase()` instead of lowercasing the whole response.

## Testing

- New `StreamingAgentLoopTextToolConversionTest` covering: marker format with/without args, after reasoning prose, without a `[tool:stop]`, `[tool:stop]` inside a string arg, malformed args, unknown tool, non-Text block preservation, hyphenated MCP names (with and without a space before args), bare-JSON format, and the plain-text/empty/existing-tool_use guards.
- `./gradlew :aceclaw-core:test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery for streamed tool calls when model providers end streams in a way that would otherwise prevent tool execution.
  - Hardened text-to-tool-call recovery for marker-style and JSON-based syntaxes, with stricter validation to avoid false positives from mixed prose.
  - Preserved the real streamed stop reason across trailing usage-only updates, preventing incorrect end-turn handling.
  - Added clearer diagnostics and TRACE/WARN logging when a likely tool call cannot be safely recovered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->